### PR TITLE
fix(autopilot): tmux new-window に -d フラグ追加 (#52)

### DIFF
--- a/cli/twl/src/twl/autopilot/launcher.py
+++ b/cli/twl/src/twl/autopilot/launcher.py
@@ -188,7 +188,7 @@ class WorkerLauncher:
         cld_args.append(prompt)
 
         tmux_argv = (
-            ["tmux", "new-window", "-n", window_name, "-c", launch_dir]
+            ["tmux", "new-window", "-d", "-n", window_name, "-c", launch_dir]
             + env_flags
             + ["--"]
             + cld_args

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -292,7 +292,7 @@ fi
 QUOTED_CLD=$(printf '%q' "$CLD_PATH")
 QUOTED_PROMPT=$(printf '%q' "$PROMPT")
 # プロンプトは positional arg で渡す。-p/--print は禁止（非対話モードで即終了する）
-tmux new-window -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
+tmux new-window -d -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
   "env ${AUTOPILOT_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
 
 # --- クラッシュ検知フック設定 (Task 1.10) ---


### PR DESCRIPTION
Closes #52

## 変更内容
- `autopilot-launch.sh`: `tmux new-window` に `-d` フラグ追加
- `launcher.py`: 同様に `-d` フラグ追加

Worker 起動時に Pilot のウィンドウコンテキストが奪われる問題を修正。