### PR TITLE
fix(autopilot): orchestrator launch_worker 失敗時のエラーガード追加 (#53)

### DIFF
--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -885,7 +885,10 @@ for ((BATCH_START=0; BATCH_START < TOTAL; BATCH_START += MAX_PARALLEL)); do
     fi
 
     echo "[orchestrator] Issue #${local_issue}: Worker 起動" >&2
-    launch_worker "$entry"
+    launch_worker "$entry" || {
+      echo "[orchestrator] Issue #${local_issue}: Worker 起動失敗（スキップ）" >&2
+      continue
+    }
     BATCH_ISSUES+=("$local_issue")
     BATCH_LAUNCHED_ENTRIES+=("$entry")
   done


### PR DESCRIPTION
Closes #53

## 変更内容
- `autopilot-orchestrator.sh:888`: `launch_worker` に `|| continue` ガード追加

1つの Worker 起動失敗が Phase 全体を停止させる問題を修正。