### PR TITLE
feat(autopilot): merge-gate コンフリクト検出 + conflict ステータス導入 (#54)

### DIFF
--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -312,17 +312,37 @@ class MergeGate:
         raw_err = re.sub(r"Bearer\s+\S+", "Bearer ***MASKED***", raw_err)
         raw_err = raw_err[:500]
 
-        failure = json.dumps({
-            "reason": "merge_failed",
-            "details": raw_err,
-            "step": "merge-gate",
-            "pr": f"#{self.pr_number}",
-        })
-        _state_write(self.issue, "pilot", status="failed", failure=failure)
-        print(
-            f"[merge-gate] Issue #{self.issue}: マージ失敗 - {raw_err}",
-            file=sys.stderr,
+        # Detect merge conflict vs other failures
+        is_conflict = any(
+            kw in raw_err.lower()
+            for kw in ("conflict", "not mergeable", "merge conflict")
         )
+
+        if is_conflict:
+            failure = json.dumps({
+                "reason": "merge_conflict",
+                "details": raw_err,
+                "step": "merge-gate",
+                "pr": f"#{self.pr_number}",
+            })
+            _state_write(self.issue, "pilot", status="conflict", failure=failure)
+            print(
+                f"[merge-gate] Issue #{self.issue}: コンフリクト検出 - "
+                f"Pilot がリベース→push 後に status=merge-ready に戻してリトライ可能",
+                file=sys.stderr,
+            )
+        else:
+            failure = json.dumps({
+                "reason": "merge_failed",
+                "details": raw_err,
+                "step": "merge-gate",
+                "pr": f"#{self.pr_number}",
+            })
+            _state_write(self.issue, "pilot", status="failed", failure=failure)
+            print(
+                f"[merge-gate] Issue #{self.issue}: マージ失敗 - {raw_err}",
+                file=sys.stderr,
+            )
         return False
 
     def _post_merge_cleanup(self, repo_mode: str, autopilot_status: str) -> None:

--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -26,8 +26,9 @@ _VALID_REPO_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 # Allowed state transitions: {current: {next, ...}}
 _TRANSITIONS: dict[str, set[str]] = {
     "running": {"merge-ready", "failed"},
-    "merge-ready": {"done", "failed"},
+    "merge-ready": {"done", "failed", "conflict"},
     "failed": {"running"},
+    "conflict": {"merge-ready", "failed"},
 }
 
 _PILOT_ISSUE_ALLOWED_KEYS = {"status", "merged_at", "failure"}
@@ -229,6 +230,15 @@ class StateManager:
                 )
             data = dict(data)
             data["retry_count"] = retry + 1
+        if current == "conflict" and new_status == "merge-ready":
+            conflict_retry = data.get("conflict_retry_count", 0)
+            if conflict_retry >= 1:
+                raise StateError(
+                    f"conflict リトライ上限に達しています (conflict_retry_count={conflict_retry} >= 1)。"
+                    "conflict → merge-ready への遷移は不可"
+                )
+            data = dict(data)
+            data["conflict_retry_count"] = conflict_retry + 1
         return data
 
     def _set_field(self, data: dict[str, Any], key: str, raw: str) -> dict[str, Any]:

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -356,6 +356,9 @@ poll_single() {
       merge-ready)
         echo "[orchestrator] Issue #${issue}: merge-ready" >&2
         return 0 ;;
+      conflict)
+        echo "[orchestrator] Issue #${issue}: コンフリクト検出 — Pilot のリベース待ち" >&2
+        return 0 ;;
       running)
         # クラッシュ検知
         local crash_exit=0
@@ -434,7 +437,7 @@ poll_phase() {
             cleaned_up[$entry]=1
           fi
           continue ;;
-        merge-ready)
+        merge-ready|conflict)
           continue ;;
         running)
           all_resolved=false


### PR DESCRIPTION
Closes #54

## 変更内容
- `state.py`: `conflict` ステータスの遷移ルール追加
  - `merge-ready → conflict`（コンフリクト検出時）
  - `conflict → merge-ready`（Pilot リベース後、最大1回）
  - `conflict → failed`（リトライ断念時）
- `mergegate.py`: `_run_merge` で stderr のコンフリクト判定、`status=conflict` で記録
- `orchestrator`: ポーリングで `conflict` ステータスをログ出力

不変条件 F（自動 rebase 禁止）は維持。