### PR TITLE
fix: orchestrator/launch の worktree-create.sh 呼び出しを Python モジュールに移行

### DIFF
--- a/cli/twl/src/twl/autopilot/launcher.py
+++ b/cli/twl/src/twl/autopilot/launcher.py
@@ -230,7 +230,7 @@ class WorkerLauncher:
             create_args += ["-R", f"{repo_owner}/{repo_name}"]
 
         result = subprocess.run(
-            ["bash", str(self.scripts_root / "worktree-create.sh")] + create_args,
+            ["python3", "-m", "twl.autopilot.worktree", "create"] + create_args,
             capture_output=True, text=True,
             cwd=str(Path(effective_project_dir) / "main"),
         )

--- a/cli/twl/src/twl/autopilot/orchestrator.py
+++ b/cli/twl/src/twl/autopilot/orchestrator.py
@@ -309,7 +309,7 @@ class PhaseOrchestrator:
                 create_args += ["-R", f"{repo_owner}/{repo_name}"]
 
             r = subprocess.run(
-                ["bash", str(self.scripts_root / "worktree-create.sh")] + create_args,
+                ["python3", "-m", "twl.autopilot.worktree", "create"] + create_args,
                 capture_output=True, text=True,
             )
             if r.returncode == 0:

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -241,7 +241,7 @@ fi
 # bare repo かつ --worktree-dir 未指定時、Pilot が worktree を事前作成して Worker をそこで起動する。
 # Worker の CWD が worktree になるため、deltaspec 等が main/ に書き込む汚染を防止する。
 if [[ -z "$WORKTREE_DIR" ]] && [[ -d "$EFFECTIVE_PROJECT_DIR/.bare" ]]; then
-  WT_OUTPUT=$(cd "$EFFECTIVE_PROJECT_DIR/main" && bash "$SCRIPTS_ROOT/worktree-create.sh" "#${ISSUE}" 2>&1)
+  WT_OUTPUT=$(cd "$EFFECTIVE_PROJECT_DIR/main" && python3 -m twl.autopilot.worktree create "#${ISSUE}" 2>&1)
   WT_EXIT=$?
   if [[ $WT_EXIT -eq 0 ]]; then
     WORKTREE_DIR=$(echo "$WT_OUTPUT" | grep "^パス:" | sed 's/^パス: //')

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -237,7 +237,7 @@ launch_worker() {
     fi
   fi
 
-  # 既存 worktree が見つからない場合は worktree-create.sh で作成
+  # 既存 worktree が見つからない場合は Python モジュールで作成
   if [[ -z "$worktree_dir" ]]; then
     local create_args=("#${ISSUE}")
     if [[ -n "$ISSUE_REPO_PATH" ]]; then
@@ -247,7 +247,7 @@ launch_worker() {
       create_args+=(-R "${ISSUE_REPO_OWNER}/${ISSUE_REPO_NAME}")
     fi
     local wt_output
-    wt_output=$(bash "$SCRIPTS_ROOT/worktree-create.sh" "${create_args[@]}" 2>&1) || {
+    wt_output=$(python3 -m twl.autopilot.worktree create "${create_args[@]}" 2>&1) || {
       echo "[orchestrator] Issue #${ISSUE}: worktree 作成失敗: $wt_output" >&2
       python3 -m twl.autopilot.state write --type issue --issue "$ISSUE" --role pilot \
         --set "status=failed" \


### PR DESCRIPTION
## 概要

autopilot-orchestrator.sh, autopilot-launch.sh, launcher.py, orchestrator.py の `worktree-create.sh` 呼び出しを `python3 -m twl.autopilot.worktree create` に置換。

### 検証
`grep -r 'worktree-create.sh' plugins/twl/scripts/ cli/twl/src/` で機能的参照が 0 件

Closes #65