### PR TITLE
fix: project-board 系スクリプトに python-env.sh source 追加

### DIFF
--- a/plugins/twl/scripts/autopilot-plan.sh
+++ b/plugins/twl/scripts/autopilot-plan.sh
@@ -11,6 +11,8 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/python-env.sh
+source "${SCRIPT_DIR}/lib/python-env.sh"
 
 # --- 引数解析 ---
 MODE=""

--- a/plugins/twl/scripts/project-board-archive.sh
+++ b/plugins/twl/scripts/project-board-archive.sh
@@ -10,6 +10,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/python-env.sh
+source "${SCRIPT_DIR}/lib/python-env.sh"
+
 # ── 引数解析 ───────────────────────────────────────────────────
 DRY_RUN=false
 for arg in "$@"; do

--- a/plugins/twl/scripts/project-board-backfill.sh
+++ b/plugins/twl/scripts/project-board-backfill.sh
@@ -9,6 +9,10 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./lib/python-env.sh
+source "${SCRIPT_DIR}/lib/python-env.sh"
+
 # ── 引数バリデーション ──────────────────────────────────────
 START="${1:-}"
 END="${2:-}"


### PR DESCRIPTION
## 概要

project-board-archive.sh, project-board-backfill.sh, autopilot-plan.sh が python3 -m twl.autopilot.github を呼び出すが、PYTHONPATH 未設定で ModuleNotFoundError になる問題を修正。

### 変更内容
- 3ファイルに既存パターン（SCRIPT_DIR + shellcheck source + source python-env.sh）を追加

### 検証
`grep -L 'python-env.sh' plugins/twl/scripts/project-board-archive.sh plugins/twl/scripts/project-board-backfill.sh plugins/twl/scripts/autopilot-plan.sh` が 0 件

Closes #66