### PR TITLE
refactor(cli): main()を427行からハンドラー関数に責務分離

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -6,7 +6,7 @@ from twl.core.types import print_rules, sync_check, sync_docs
 from twl.core.plugin import get_plugin_root, load_deps, get_plugin_name, build_graph
 from twl.core.plugin import get_deps_version
 from twl.core.graph import find_node, get_reverse_dependencies, print_tree
-from twl.core.output import build_envelope, output_json, _violations_to_items, _check_results_to_items, _deep_validate_to_items
+from twl.core.output import build_envelope, output_json, violations_to_items, check_results_to_items, deep_validate_to_items
 from twl.validation.check import check_files, find_orphans
 from twl.validation.validate import validate_types, validate_body_refs, validate_v3_schema
 from twl.validation.deep import deep_validate
@@ -19,6 +19,348 @@ from twl.viz.mermaid import print_mermaid
 from twl.viz.tree import print_rich_tree
 from twl.refactor.rename import rename_component
 from twl.refactor.promote import promote_component
+
+
+def handle_complexity(args, graph, deps, plugin_root, plugin_name):
+    if args.format == 'json':
+        items = complexity_collect(graph, deps, plugin_root)
+        exit_code = 0
+        envelope = build_envelope("complexity", get_deps_version(deps), plugin_name, items, exit_code)
+        output_json(envelope)
+        sys.exit(exit_code)
+    complexity_report(graph, deps, plugin_root)
+
+
+def handle_tokens(args, graph):
+    print("=== Token Counts ===")
+    print()
+
+    total_tokens = 0
+    sections = [
+        ('Skills', 'skill'),
+        ('Commands', 'command'),
+        ('Agents', 'agent'),
+        ('Scripts', 'script'),
+    ]
+
+    for section_name, node_type in sections:
+        print(f"## {section_name}")
+        section_total = 0
+        items = []
+        for node_id, node_data in sorted(graph.items()):
+            if node_data['type'] == node_type:
+                tokens = node_data.get('tokens', 0)
+                items.append((node_data['name'], tokens))
+                section_total += tokens
+
+        items.sort(key=lambda x: x[1], reverse=True)
+        for name, tokens in items:
+            print(f"  {name}: {tokens:,} tokens")
+
+        print(f"  --- subtotal: {section_total:,} tokens")
+        print()
+        total_tokens += section_total
+
+    print(f"=== Total: {total_tokens:,} tokens ===")
+
+
+def handle_check(args, graph, deps, plugin_root, plugin_name):
+    results, check_xref_warnings = check_files(graph, plugin_root)
+
+    ok_count = sum(1 for r in results if r[0] == 'ok')
+    missing_count = sum(1 for r in results if r[0] == 'missing')
+    no_path_count = sum(1 for r in results if r[0] == 'no_path')
+    external_count = sum(1 for r in results if r[0] == 'external')
+
+    chain_items = []
+    cv_criticals_check = []
+    cv_warnings_check = []
+    if get_deps_version(deps).startswith('3'):
+        cv_criticals_check, cv_warnings_check, cv_infos_check = chain_validate(deps, plugin_root)
+        chain_items = deep_validate_to_items(cv_criticals_check, cv_warnings_check, cv_infos_check)
+
+    exit_code = 1 if (missing_count > 0 or cv_criticals_check) else 0
+
+    if args.format == 'json':
+        items = check_results_to_items(results)
+        items.extend(violations_to_items(check_xref_warnings, "warning"))
+        items.extend(chain_items)
+        envelope = build_envelope("check", get_deps_version(deps), plugin_name, items, exit_code)
+        output_json(envelope)
+        sys.exit(exit_code)
+
+    print(f"=== File Check Results ===")
+    print(f"OK: {ok_count}, Missing: {missing_count}, No path: {no_path_count}, External: {external_count}")
+    print()
+
+    if check_xref_warnings:
+        print("Warnings:")
+        for w in check_xref_warnings:
+            print(f"  - {w}")
+        print()
+
+    if missing_count > 0:
+        print("Missing files:")
+        for status, node_id, path in results:
+            if status == 'missing':
+                print(f"  - {node_id}: {path}")
+        sys.exit(1)
+    else:
+        print("All files exist.")
+
+    if chain_items and (cv_criticals_check or cv_warnings_check):
+        print()
+        print("=== Chain Validation Results ===")
+        if cv_criticals_check:
+            print("Critical:")
+            for c in cv_criticals_check:
+                print(f"  - {c}")
+        if cv_warnings_check:
+            print("Warning:")
+            for w in cv_warnings_check:
+                print(f"  - {w}")
+        if cv_criticals_check:
+            sys.exit(1)
+
+
+def handle_validate(args, deps, graph, plugin_root, plugin_name):
+    ok_count, violations, xref_warnings = validate_types(deps, graph, plugin_root)
+    body_ok, body_violations = validate_body_refs(deps, plugin_root)
+    ok_count += body_ok
+    violations.extend(body_violations)
+    v3_ok, v3_violations = validate_v3_schema(deps)
+    ok_count += v3_ok
+    violations.extend(v3_violations)
+    cv_criticals, cv_warnings, _cv_infos = chain_validate(deps, plugin_root)
+    violations.extend(cv_criticals)
+    violations.extend(cv_warnings)
+
+    exit_code = 1 if violations else 0
+
+    if args.format == 'json':
+        items = violations_to_items(violations)
+        items.extend(violations_to_items(xref_warnings, "warning"))
+        envelope = build_envelope("validate", get_deps_version(deps), plugin_name, items, exit_code)
+        output_json(envelope)
+        sys.exit(exit_code)
+
+    print(f"=== Type Validation Results ===")
+    print(f"OK: {ok_count}, Violations: {len(violations)}")
+    print()
+
+    if xref_warnings:
+        print("Warnings:")
+        for w in xref_warnings:
+            print(f"  - {w}")
+        print()
+
+    if violations:
+        print("Violations:")
+        for v in violations:
+            print(f"  - {v}")
+        sys.exit(1)
+    else:
+        print("All type constraints satisfied.")
+
+
+def handle_orphans(args, graph, deps):
+    orphans = find_orphans(graph, deps)
+
+    print("=== Orphan Analysis ===")
+    print()
+
+    if orphans['isolated']:
+        print("## Isolated (no callers, no deps):")
+        for node_id in orphans['isolated']:
+            node = graph.get(node_id)
+            desc = node['description'][:40] if node['description'] else ''
+            print(f"  - {node_id}: {desc}...")
+        print()
+
+    if orphans['unused']:
+        print("## Unused (no callers):")
+        for node_id in orphans['unused']:
+            if node_id not in orphans['isolated']:
+                node = graph.get(node_id)
+                desc = node['description'][:40] if node['description'] else ''
+                print(f"  - {node_id}: {desc}...")
+        print()
+
+    leaf_commands = [n for n in orphans['no_deps'] if graph[n]['type'] == 'command']
+    if leaf_commands:
+        print("## Leaf commands (no outgoing deps):")
+        for node_id in leaf_commands:
+            print(f"  - {node_id}")
+        print()
+
+    total_orphans = len(orphans['unused'])
+    if total_orphans == 0:
+        print("No orphan nodes found.")
+    else:
+        print(f"Total unused: {total_orphans}")
+
+
+def handle_deep_validate(args, deps, graph, plugin_root, plugin_name):
+    ok_count, violations, xref_warnings = validate_types(deps, graph, plugin_root)
+    body_ok, body_violations = validate_body_refs(deps, plugin_root)
+    ok_count += body_ok
+    violations.extend(body_violations)
+    v3_ok, v3_violations = validate_v3_schema(deps)
+    ok_count += v3_ok
+    violations.extend(v3_violations)
+
+    criticals, dv_warnings, dv_infos = deep_validate(deps, plugin_root)
+    dv_warnings.extend(xref_warnings)
+    cv_criticals, cv_warnings, cv_infos = chain_validate(deps, plugin_root)
+    criticals.extend(cv_criticals)
+    dv_warnings.extend(cv_warnings)
+    dv_infos.extend(cv_infos)
+
+    exit_code = 1 if (violations or criticals) else 0
+
+    if args.format == 'json':
+        items = violations_to_items(violations)
+        items.extend(deep_validate_to_items(criticals, dv_warnings, dv_infos))
+        envelope = build_envelope("deep-validate", get_deps_version(deps), plugin_name, items, exit_code)
+        output_json(envelope)
+        sys.exit(exit_code)
+
+    print("=== Deep Validation Results ===")
+    print()
+
+    print(f"## Type Validation: OK={ok_count}, Violations={len(violations)}")
+    if violations:
+        for v in violations:
+            print(f"  - {v}")
+    print()
+
+    has_issues = False
+    if criticals:
+        has_issues = True
+        print("## Critical:")
+        for c in criticals:
+            print(f"  - {c}")
+        print()
+    if dv_warnings:
+        has_issues = True
+        print("## Warning:")
+        for w in dv_warnings:
+            print(f"  - {w}")
+        print()
+    if dv_infos:
+        print("## Info:")
+        for i in dv_infos:
+            print(f"  - {i}")
+        print()
+
+    if not has_issues and not violations:
+        print("All deep validation checks passed.")
+    elif violations or criticals:
+        sys.exit(1)
+
+
+def handle_audit(args, deps, plugin_root, plugin_name):
+    if args.format == 'json':
+        items = audit_collect(deps, plugin_root)
+        exit_code = 1 if any(i['severity'] == 'critical' for i in items) else 0
+        envelope = build_envelope("audit", get_deps_version(deps), plugin_name, items, exit_code)
+        output_json(envelope)
+        sys.exit(exit_code)
+
+    print("=== TWiLL Compliance Audit ===")
+    print()
+    audit_criticals, audit_warnings, audit_oks = audit_report(deps, plugin_root)
+    if audit_criticals > 0:
+        sys.exit(1)
+
+
+def handle_list(args, graph):
+    print("=== All Nodes ===")
+    for section in ['skills', 'commands', 'agents']:
+        print(f"\n## {section.upper()}")
+        for node_id in sorted(graph):
+            if graph[node_id]['type'] == section.rstrip('s'):
+                node = graph[node_id]
+                skill_type = f" [{node.get('skill_type')}]" if node.get('skill_type') else ""
+                desc = node['description'][:50] if node['description'] else ''
+                print(f"  {node['name']}{skill_type}: {desc}...")
+
+    print("\n## SCRIPTS")
+    for node_id in sorted(graph):
+        if graph[node_id]['type'] == 'script':
+            node = graph[node_id]
+            desc = node['description'][:50] if node['description'] else ''
+            print(f"  {node['name']}: {desc}...")
+
+    print("\n## EXTERNAL")
+    for node_id in sorted(graph):
+        if graph[node_id]['type'] == 'external':
+            print(f"  {graph[node_id]['name']}")
+
+
+def handle_target(args, graph):
+    node_id = find_node(graph, args.target)
+    if not node_id:
+        print(f"Error: '{args.target}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    if args.rich:
+        print_rich_tree(graph, node_id)
+    else:
+        print(f"=== Dependencies of {args.target} ===")
+        print()
+        print_tree(graph, node_id)
+
+
+def handle_reverse(args, graph):
+    node_id = find_node(graph, args.reverse)
+    if not node_id:
+        print(f"Error: '{args.reverse}' not found", file=sys.stderr)
+        sys.exit(1)
+
+    reverse = get_reverse_dependencies(graph, node_id)
+    print(f"=== What uses {args.reverse} ===")
+    print()
+    if reverse:
+        for (nid, rel) in reverse:
+            node = graph.get(nid)
+            if node:
+                print(f"  {node['type']}:{node['name']}")
+    else:
+        print("  (nothing)")
+
+
+def handle_viz(args, graph, deps, plugin_root, plugin_name, show_tokens):
+    if args.tree:
+        entry_points = deps.get('entry_points', [])
+        if entry_points:
+            skill_name = Path(entry_points[0]).parent.name
+        else:
+            skill_name = 'entry-workflow'
+            for sname, sdata in deps.get('skills', {}).items():
+                if sdata.get('type') == 'controller':
+                    skill_name = sname
+                    break
+        node_id = f"skill:{skill_name}"
+        print(f"=== Dependency Tree from {skill_name} ===")
+        print()
+        print_tree(graph, node_id)
+    elif args.rich:
+        entry_points = deps.get('entry_points', [])
+        if entry_points:
+            skill_name = Path(entry_points[0]).parent.name
+        else:
+            skill_name = 'entry-workflow'
+            for sname, sdata in deps.get('skills', {}).items():
+                if sdata.get('type') == 'controller':
+                    skill_name = sname
+                    break
+        node_id = f"skill:{skill_name}"
+        print_rich_tree(graph, node_id)
+    elif args.mermaid:
+        print_mermaid(graph, deps, plugin_name)
+    else:
+        print_graphviz(graph, deps, plugin_name, show_tokens)
 
 
 def main():
@@ -59,7 +401,6 @@ def main():
 
     args = parser.parse_args()
 
-    # rules / sync-check / sync-docs は deps.yaml 不要の独立コマンド
     if args.rules:
         print_rules()
         sys.exit(0)
@@ -77,65 +418,24 @@ def main():
     graph = build_graph(deps, plugin_root)
     plugin_name = get_plugin_name(deps, plugin_root)
 
-    # rename は独立コマンド
     if args.rename:
         old_name, new_name = args.rename
-        success = rename_component(plugin_root, deps, old_name, new_name, args.dry_run)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if rename_component(plugin_root, deps, old_name, new_name, args.dry_run) else 1)
 
-    # promote は独立コマンド
     if args.promote:
         comp_name, new_type = args.promote
-        success = promote_component(plugin_root, deps, comp_name, new_type, args.dry_run)
-        sys.exit(0 if success else 1)
+        sys.exit(0 if promote_component(plugin_root, deps, comp_name, new_type, args.dry_run) else 1)
 
-    # デフォルトはGraphviz
     if not any([args.tree, args.rich, args.mermaid, args.graphviz, args.target, args.reverse, args.check, args.validate, args.list, args.update_readme, args.orphans, args.tokens, args.deep_validate, args.audit, args.complexity]):
         args.graphviz = True
 
     show_tokens = not args.no_tokens
 
     if args.complexity:
-        if args.format == 'json':
-            items = complexity_collect(graph, deps, plugin_root)
-            exit_code = 0  # complexity は warning でも exit 0
-            envelope = build_envelope("complexity", get_deps_version(deps), plugin_name, items, exit_code)
-            output_json(envelope)
-            sys.exit(exit_code)
-
-        complexity_report(graph, deps, plugin_root)
+        handle_complexity(args, graph, deps, plugin_root, plugin_name)
 
     if args.tokens:
-        print("=== Token Counts ===")
-        print()
-
-        total_tokens = 0
-        sections = [
-            ('Skills', 'skill'),
-            ('Commands', 'command'),
-            ('Agents', 'agent'),
-            ('Scripts', 'script'),
-        ]
-
-        for section_name, node_type in sections:
-            print(f"## {section_name}")
-            section_total = 0
-            items = []
-            for node_id, node_data in sorted(graph.items()):
-                if node_data['type'] == node_type:
-                    tokens = node_data.get('tokens', 0)
-                    items.append((node_data['name'], tokens))
-                    section_total += tokens
-
-            items.sort(key=lambda x: x[1], reverse=True)
-            for name, tokens in items:
-                print(f"  {name}: {tokens:,} tokens")
-
-            print(f"  --- subtotal: {section_total:,} tokens")
-            print()
-            total_tokens += section_total
-
-        print(f"=== Total: {total_tokens:,} tokens ===")
+        handle_tokens(args, graph)
 
     if args.update_readme:
         success = update_readme(plugin_root, graph, deps, plugin_name, show_tokens)
@@ -143,308 +443,23 @@ def main():
             sys.exit(1)
 
     if args.check:
-        results, check_xref_warnings = check_files(graph, plugin_root)
-
-        ok_count = sum(1 for r in results if r[0] == 'ok')
-        missing_count = sum(1 for r in results if r[0] == 'missing')
-        no_path_count = sum(1 for r in results if r[0] == 'no_path')
-        external_count = sum(1 for r in results if r[0] == 'external')
-
-        # v3.0 chain 検証（JSON/テキスト共通で実行）
-        chain_items = []
-        cv_criticals_check = []
-        cv_warnings_check = []
-        if get_deps_version(deps).startswith('3'):
-            cv_criticals_check, cv_warnings_check, cv_infos_check = chain_validate(deps, plugin_root)
-            chain_items = _deep_validate_to_items(cv_criticals_check, cv_warnings_check, cv_infos_check)
-
-        exit_code = 1 if (missing_count > 0 or cv_criticals_check) else 0
-
-        if args.format == 'json':
-            items = _check_results_to_items(results)
-            items.extend(_violations_to_items(check_xref_warnings, "warning"))
-            items.extend(chain_items)
-            envelope = build_envelope("check", get_deps_version(deps), plugin_name, items, exit_code)
-            output_json(envelope)
-            sys.exit(exit_code)
-
-        print(f"=== File Check Results ===")
-        print(f"OK: {ok_count}, Missing: {missing_count}, No path: {no_path_count}, External: {external_count}")
-        print()
-
-        if check_xref_warnings:
-            print("Warnings:")
-            for w in check_xref_warnings:
-                print(f"  - {w}")
-            print()
-
-        if missing_count > 0:
-            print("Missing files:")
-            for status, node_id, path in results:
-                if status == 'missing':
-                    print(f"  - {node_id}: {path}")
-            sys.exit(1)
-        else:
-            print("All files exist.")
-
-        # v3.0 chain 検証結果のテキスト出力
-        if chain_items and (cv_criticals_check or cv_warnings_check):
-            print()
-            print("=== Chain Validation Results ===")
-            if cv_criticals_check:
-                print("Critical:")
-                for c in cv_criticals_check:
-                    print(f"  - {c}")
-            if cv_warnings_check:
-                print("Warning:")
-                for w in cv_warnings_check:
-                    print(f"  - {w}")
-            if cv_criticals_check:
-                sys.exit(1)
+        handle_check(args, graph, deps, plugin_root, plugin_name)
 
     if args.validate:
-        ok_count, violations, xref_warnings = validate_types(deps, graph, plugin_root)
-        # body 参照チェック
-        body_ok, body_violations = validate_body_refs(deps, plugin_root)
-        ok_count += body_ok
-        violations.extend(body_violations)
-        # v3.0 スキーマ検証
-        v3_ok, v3_violations = validate_v3_schema(deps)
-        ok_count += v3_ok
-        violations.extend(v3_violations)
-        # chain 双方向整合性検証
-        cv_criticals, cv_warnings, _cv_infos = chain_validate(deps, plugin_root)
-        violations.extend(cv_criticals)
-        violations.extend(cv_warnings)
-
-        exit_code = 1 if violations else 0
-
-        if args.format == 'json':
-            items = _violations_to_items(violations)
-            items.extend(_violations_to_items(xref_warnings, "warning"))
-            envelope = build_envelope("validate", get_deps_version(deps), plugin_name, items, exit_code)
-            output_json(envelope)
-            sys.exit(exit_code)
-
-        print(f"=== Type Validation Results ===")
-        print(f"OK: {ok_count}, Violations: {len(violations)}")
-        print()
-
-        if xref_warnings:
-            print("Warnings:")
-            for w in xref_warnings:
-                print(f"  - {w}")
-            print()
-
-        if violations:
-            print("Violations:")
-            for v in violations:
-                print(f"  - {v}")
-            sys.exit(1)
-        else:
-            print("All type constraints satisfied.")
+        handle_validate(args, deps, graph, plugin_root, plugin_name)
 
     if args.orphans:
-        orphans = find_orphans(graph, deps)
-
-        print("=== Orphan Analysis ===")
-        print()
-
-        if orphans['isolated']:
-            print("## Isolated (no callers, no deps):")
-            for node_id in orphans['isolated']:
-                node = graph.get(node_id)
-                desc = node['description'][:40] if node['description'] else ''
-                print(f"  - {node_id}: {desc}...")
-            print()
-
-        if orphans['unused']:
-            print("## Unused (no callers):")
-            for node_id in orphans['unused']:
-                if node_id not in orphans['isolated']:
-                    node = graph.get(node_id)
-                    desc = node['description'][:40] if node['description'] else ''
-                    print(f"  - {node_id}: {desc}...")
-            print()
-
-        leaf_commands = [n for n in orphans['no_deps'] if graph[n]['type'] == 'command']
-        if leaf_commands:
-            print("## Leaf commands (no outgoing deps):")
-            for node_id in leaf_commands:
-                print(f"  - {node_id}")
-            print()
-
-        total_orphans = len(orphans['unused'])
-        if total_orphans == 0:
-            print("No orphan nodes found.")
-        else:
-            print(f"Total unused: {total_orphans}")
+        handle_orphans(args, graph, deps)
 
     if args.deep_validate:
-        # --validate の全チェックも実行
-        ok_count, violations, xref_warnings = validate_types(deps, graph, plugin_root)
-        # body 参照チェック
-        body_ok, body_violations = validate_body_refs(deps, plugin_root)
-        ok_count += body_ok
-        violations.extend(body_violations)
-        # v3.0 スキーマ検証
-        v3_ok, v3_violations = validate_v3_schema(deps)
-        ok_count += v3_ok
-        violations.extend(v3_violations)
-
-        # deep-validate 固有チェック
-        criticals, dv_warnings, dv_infos = deep_validate(deps, plugin_root)
-        dv_warnings.extend(xref_warnings)
-        # chain 双方向整合性検証
-        cv_criticals, cv_warnings, cv_infos = chain_validate(deps, plugin_root)
-        criticals.extend(cv_criticals)
-        dv_warnings.extend(cv_warnings)
-        dv_infos.extend(cv_infos)
-
-        exit_code = 1 if (violations or criticals) else 0
-
-        if args.format == 'json':
-            items = _violations_to_items(violations)
-            items.extend(_deep_validate_to_items(criticals, dv_warnings, dv_infos))
-            envelope = build_envelope("deep-validate", get_deps_version(deps), plugin_name, items, exit_code)
-            output_json(envelope)
-            sys.exit(exit_code)
-
-        print("=== Deep Validation Results ===")
-        print()
-
-        # --validate 結果
-        print(f"## Type Validation: OK={ok_count}, Violations={len(violations)}")
-        if violations:
-            for v in violations:
-                print(f"  - {v}")
-        print()
-
-        # deep-validate 結果
-        has_issues = False
-        if criticals:
-            has_issues = True
-            print("## Critical:")
-            for c in criticals:
-                print(f"  - {c}")
-            print()
-        if dv_warnings:
-            has_issues = True
-            print("## Warning:")
-            for w in dv_warnings:
-                print(f"  - {w}")
-            print()
-        if dv_infos:
-            print("## Info:")
-            for i in dv_infos:
-                print(f"  - {i}")
-            print()
-
-        if not has_issues and not violations:
-            print("All deep validation checks passed.")
-        elif violations or criticals:
-            sys.exit(1)
-
+        handle_deep_validate(args, deps, graph, plugin_root, plugin_name)
     elif args.audit:
-        if args.format == 'json':
-            items = audit_collect(deps, plugin_root)
-            exit_code = 1 if any(i['severity'] == 'critical' for i in items) else 0
-            envelope = build_envelope("audit", get_deps_version(deps), plugin_name, items, exit_code)
-            output_json(envelope)
-            sys.exit(exit_code)
-
-        print("=== TWiLL Compliance Audit ===")
-        print()
-        audit_criticals, audit_warnings, audit_oks = audit_report(deps, plugin_root)
-        if audit_criticals > 0:
-            sys.exit(1)
-
+        handle_audit(args, deps, plugin_root, plugin_name)
     elif args.list:
-        print("=== All Nodes ===")
-        for section in ['skills', 'commands', 'agents']:
-            print(f"\n## {section.upper()}")
-            for node_id in sorted(graph):
-                if graph[node_id]['type'] == section.rstrip('s'):
-                    node = graph[node_id]
-                    skill_type = f" [{node.get('skill_type')}]" if node.get('skill_type') else ""
-                    desc = node['description'][:50] if node['description'] else ''
-                    print(f"  {node['name']}{skill_type}: {desc}...")
-
-        print("\n## SCRIPTS")
-        for node_id in sorted(graph):
-            if graph[node_id]['type'] == 'script':
-                node = graph[node_id]
-                desc = node['description'][:50] if node['description'] else ''
-                print(f"  {node['name']}: {desc}...")
-
-        print("\n## EXTERNAL")
-        for node_id in sorted(graph):
-            if graph[node_id]['type'] == 'external':
-                print(f"  {graph[node_id]['name']}")
-
+        handle_list(args, graph)
     elif args.target:
-        node_id = find_node(graph, args.target)
-        if not node_id:
-            print(f"Error: '{args.target}' not found", file=sys.stderr)
-            sys.exit(1)
-
-        if args.rich:
-            print_rich_tree(graph, node_id)
-        else:
-            print(f"=== Dependencies of {args.target} ===")
-            print()
-            print_tree(graph, node_id)
-
+        handle_target(args, graph)
     elif args.reverse:
-        node_id = find_node(graph, args.reverse)
-        if not node_id:
-            print(f"Error: '{args.reverse}' not found", file=sys.stderr)
-            sys.exit(1)
-
-        reverse = get_reverse_dependencies(graph, node_id)
-        print(f"=== What uses {args.reverse} ===")
-        print()
-        if reverse:
-            for (nid, rel) in reverse:
-                node = graph.get(nid)
-                if node:
-                    print(f"  {node['type']}:{node['name']}")
-        else:
-            print("  (nothing)")
-
-    elif args.tree:
-        # エントリポイントからツリー表示
-        entry_points = deps.get('entry_points', [])
-        if entry_points:
-            skill_name = Path(entry_points[0]).parent.name
-        else:
-            # フォールバック: controller タイプのスキルを検索
-            skill_name = 'entry-workflow'
-            for sname, sdata in deps.get('skills', {}).items():
-                if sdata.get('type') == 'controller':
-                    skill_name = sname
-                    break
-        node_id = f"skill:{skill_name}"
-
-        print(f"=== Dependency Tree from {skill_name} ===")
-        print()
-        print_tree(graph, node_id)
-
-    elif args.rich:
-        entry_points = deps.get('entry_points', [])
-        if entry_points:
-            skill_name = Path(entry_points[0]).parent.name
-        else:
-            skill_name = 'entry-workflow'
-            for sname, sdata in deps.get('skills', {}).items():
-                if sdata.get('type') == 'controller':
-                    skill_name = sname
-                    break
-        node_id = f"skill:{skill_name}"
-        print_rich_tree(graph, node_id)
-
-    elif args.mermaid:
-        print_mermaid(graph, deps, plugin_name)
-
-    elif args.graphviz:
-        print_graphviz(graph, deps, plugin_name, show_tokens)
+        handle_reverse(args, graph)
+    elif args.tree or args.rich or args.mermaid or args.graphviz:
+        handle_viz(args, graph, deps, plugin_root, plugin_name, show_tokens)

--- a/cli/twl/src/twl/core/output.py
+++ b/cli/twl/src/twl/core/output.py
@@ -46,12 +46,12 @@ def _parse_violation_to_item(violation: str, default_severity: str = "critical")
     return item
 
 
-def _violations_to_items(violations: List[str], severity: str = "critical") -> List[dict]:
+def violations_to_items(violations: List[str], severity: str = "critical") -> List[dict]:
     """violation 文字列リストを items リストに変換"""
     return [_parse_violation_to_item(v, severity) for v in violations]
 
 
-def _check_results_to_items(results: List[Tuple[str, str, str]]) -> List[dict]:
+def check_results_to_items(results: List[Tuple[str, str, str]]) -> List[dict]:
     """check_files() の結果を items 形式に変換"""
     severity_map = {"missing": "critical", "no_path": "warning", "ok": "ok", "external": "info"}
     message_map = {"missing": "File missing", "no_path": "No path defined", "ok": "File exists", "external": "External component"}
@@ -90,7 +90,7 @@ def _extract_check_label(msg: str) -> str:
     return code
 
 
-def _deep_validate_to_items(criticals: List[str], warnings: List[str], infos: List[str]) -> List[dict]:
+def deep_validate_to_items(criticals: List[str], warnings: List[str], infos: List[str]) -> List[dict]:
     """deep_validate() の結果を items 形式に変換"""
     items = []
     for msg in criticals:


### PR DESCRIPTION
- output.py の3関数から _ プレフィックスを除去しパブリックAPI化:
  _violations_to_items → violations_to_items
  _check_results_to_items → check_results_to_items
  _deep_validate_to_items → deep_validate_to_items
- cli.py の main() を99行のディスパッチャに削減（元427行）
- 11個のハンドラー関数に分割:
  handle_complexity, handle_tokens, handle_check, handle_validate,
  handle_orphans, handle_deep_validate, handle_audit, handle_list,
  handle_target, handle_reverse, handle_viz

Co-Authored-By: Claude <noreply@anthropic.com>
