### PR TITLE
fix(autopilot): merge-ready 宣言時に pr/branch を state に記録

### DIFF
--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -103,7 +103,7 @@ fi
 # 将来のリファクタリング時の安全弁として、矛盾を検出した場合は merge を中止する。
 if [[ "$IS_AUTOPILOT" == "false" && "$AUTOPILOT_STATUS" == "running" ]]; then
   echo "[auto-merge] ⚠️ 状態矛盾検出: IS_AUTOPILOT=false だが status=running" >&2
-  python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready 2>/dev/null || true
+  python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready --set "pr=$PR_NUMBER" --set "branch=$BRANCH" 2>/dev/null || true
   echo "[auto-merge] autopilot 配下（状態矛盾検出）: merge-ready 宣言。Pilot による merge-gate を待機。"
   exit 0
 fi
@@ -118,7 +118,7 @@ if [[ "$IS_AUTOPILOT" == "false" ]]; then
     MAIN_AUTOPILOT_DIR="${MAIN_WORKTREE_PATH}/.autopilot"
     if [[ -f "${MAIN_AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}.json" ]]; then
       echo "[auto-merge] ⚠️ フォールバックガード発動: issue-${ISSUE_NUM}.json が存在するため merge を禁止" >&2
-      python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready 2>/dev/null || true
+      python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready --set "pr=$PR_NUMBER" --set "branch=$BRANCH" 2>/dev/null || true
       echo "[auto-merge] autopilot 配下（フォールバック検出）: merge-ready 宣言。Pilot による merge-gate を待機。"
       exit 0
     fi
@@ -129,7 +129,7 @@ fi
 # autopilot 配下: merge-ready 宣言のみ（merge 禁止）
 # ============================================================
 if [[ "$IS_AUTOPILOT" == "true" ]]; then
-  python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready 2>/dev/null || true
+  python3 -m twl.autopilot.state write --type issue --issue "$ISSUE_NUM" --role worker --set status=merge-ready --set "pr=$PR_NUMBER" --set "branch=$BRANCH" 2>/dev/null || true
   echo "[auto-merge] autopilot 配下: merge-ready 宣言。Pilot による merge-gate を待機。"
   exit 0
 fi

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -655,7 +655,7 @@ run_merge_gate() {
 
   # PR 番号とブランチを state から取得
   local pr_number branch
-  pr_number=$(python3 -m twl.autopilot.state read --type issue "${_state_read_repo_args[@]}" --issue "$issue" --field pr_number 2>/dev/null || echo "")
+  pr_number=$(python3 -m twl.autopilot.state read --type issue "${_state_read_repo_args[@]}" --issue "$issue" --field pr 2>/dev/null || echo "")
   branch=$(python3 -m twl.autopilot.state read --type issue "${_state_read_repo_args[@]}" --issue "$issue" --field branch 2>/dev/null || echo "")
 
   if [[ -z "$pr_number" || -z "$branch" ]]; then

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -603,7 +603,10 @@ step_all_pass_check() {
   [[ "$autopilot_status" == "running" ]] && is_autopilot=true
 
   if [[ "$overall_result" == "PASS" ]]; then
-    python3 -m twl.autopilot.state write --type issue --issue "$issue_num" --role worker --set "status=merge-ready" 2>/dev/null || true
+    local _cr_branch _cr_pr
+    _cr_branch=$(git branch --show-current 2>/dev/null || echo "")
+    _cr_pr=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+    python3 -m twl.autopilot.state write --type issue --issue "$issue_num" --role worker --set "status=merge-ready" --set "pr=$_cr_pr" --set "branch=$_cr_branch" 2>/dev/null || true
     if $is_autopilot; then
       ok "all-pass-check" "PASS — autopilot 配下: merge-ready 宣言。Pilot による merge-gate を待機"
     else


### PR DESCRIPTION
## 概要

auto-merge.sh の merge-ready 宣言時に pr/branch が state に記録されない問題を修正。

## 変更内容

- **auto-merge.sh**: 3箇所の merge-ready write に `--set "pr=$PR_NUMBER" --set "branch=$BRANCH"` を追加
- **autopilot-orchestrator.sh**: `run_merge_gate()` の `--field pr_number` → `--field pr` に修正（スキーマフィールド名と一致）
- **chain-runner.sh**: `step_all_pass_check()` の merge-ready write に pr/branch を追加（`gh pr view` と `git branch --show-current` で取得）

Close #88