### PR TITLE
feat(autopilot): worktree list/cd/start サブコマンドを追加

### DIFF
--- a/cli/twl/src/twl/autopilot/worktree.py
+++ b/cli/twl/src/twl/autopilot/worktree.py
@@ -289,11 +289,12 @@ class WorktreeManager:
 
         return worktree_dir
 
-    def _list_worktrees(self, project_dir: Path) -> list[tuple[str, Path]]:
+    def _list_worktrees(self, project_dir: Path, git_common_dir: Path) -> list[tuple[str, Path]]:
         """Return [(branch_name, worktree_path)] for entries under worktrees/."""
+        git_dir = _resolve_git_dir(project_dir, git_common_dir)
         result = subprocess.run(
-            ["git", "worktree", "list", "--porcelain"],
-            capture_output=True, text=True, cwd=project_dir,
+            ["git", "--git-dir", str(git_dir), "worktree", "list", "--porcelain"],
+            capture_output=True, text=True,
         )
         if result.returncode != 0:
             raise WorktreeError("git worktree list に失敗しました")
@@ -332,16 +333,19 @@ class WorktreeManager:
         return entries
 
     def _resolve_worktree(
-        self, branch_query: str, project_dir: Path
+        self, branch_query: str, project_dir: Path, git_common_dir: Path
     ) -> tuple[str, Path]:
         """Resolve a (possibly partial) branch name to (branch, path).
 
-        Raises WorktreeError if no match or multiple matches.
+        Exact match takes priority over substring match.
+        Raises WorktreeError if no match or multiple substring matches.
         """
-        entries = self._list_worktrees(project_dir)
-        matches = [
-            (b, p) for b, p in entries if branch_query in b
-        ]
+        entries = self._list_worktrees(project_dir, git_common_dir)
+        # Exact match takes priority
+        exact = [(b, p) for b, p in entries if b == branch_query]
+        if exact:
+            return exact[0]
+        matches = [(b, p) for b, p in entries if branch_query in b]
         if not matches:
             raise WorktreeError(
                 f"worktree が見つかりません: {branch_query!r}\n"
@@ -356,8 +360,8 @@ class WorktreeManager:
 
     def list(self) -> None:
         """Print worktrees under worktrees/ with optional autopilot state."""
-        _, project_dir = _resolve_git_common_dir(self.repo_path)
-        entries = self._list_worktrees(project_dir)
+        git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
+        entries = self._list_worktrees(project_dir, git_common_dir)
         if not entries:
             print("(worktree なし)")
             return
@@ -379,14 +383,14 @@ class WorktreeManager:
 
     def cd(self, branch_query: str) -> None:
         """Print the path of a worktree matching branch_query to stdout."""
-        _, project_dir = _resolve_git_common_dir(self.repo_path)
-        _, worktree_path = self._resolve_worktree(branch_query, project_dir)
+        git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
+        _, worktree_path = self._resolve_worktree(branch_query, project_dir, git_common_dir)
         print(worktree_path)
 
     def start(self, branch_query: str) -> None:
         """Exec into a worktree and resume the Claude Code session (claude -c)."""
-        _, project_dir = _resolve_git_common_dir(self.repo_path)
-        _, worktree_path = self._resolve_worktree(branch_query, project_dir)
+        git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
+        _, worktree_path = self._resolve_worktree(branch_query, project_dir, git_common_dir)
         if not worktree_path.is_dir():
             raise WorktreeError(f"worktree ディレクトリが存在しません: {worktree_path}")
         os.chdir(worktree_path)

--- a/cli/twl/tests/test_autopilot_worktree.py
+++ b/cli/twl/tests/test_autopilot_worktree.py
@@ -14,7 +14,7 @@ import re
 import subprocess
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -563,3 +563,32 @@ class TestWorktreeManagerList:
             mgr = WorktreeManager(repo_path=str(tmp_path))
             with pytest.raises(WorktreeError, match="複数"):
                 mgr.cd("10")
+
+    def test_cd_exact_match_takes_priority(self, tmp_path: Path, capsys: Any) -> None:
+        """Exact match wins over substring: cd feat/10-foo should not fail when feat/100-bar exists."""
+        worktrees_dir = tmp_path / "worktrees"
+        wt1 = worktrees_dir / "feat" / "10-foo"
+        wt2 = worktrees_dir / "feat" / "100-bar"
+        wt1.mkdir(parents=True)
+        wt2.mkdir(parents=True)
+
+        porcelain = _make_porcelain([
+            ("feat/10-foo", str(wt1)),
+            ("feat/100-bar", str(wt2)),
+        ])
+
+        def fake_run(args, **kwargs):  # type: ignore[no-untyped-def]
+            cmd = " ".join(str(a) for a in args)
+            if "git-common-dir" in cmd:
+                return self._make_completed(0, stdout=str(tmp_path / ".bare"))
+            if "worktree list" in cmd:
+                return self._make_completed(0, stdout=porcelain)
+            return self._make_completed(0)
+
+        (tmp_path / ".bare").mkdir()
+        with patch("subprocess.run", side_effect=fake_run):
+            mgr = WorktreeManager(repo_path=str(tmp_path))
+            mgr.cd("feat/10-foo")  # exact match — should not raise
+
+        out = capsys.readouterr().out.strip()
+        assert out == str(wt1)


### PR DESCRIPTION
WorktreeManager に list/cd/start メソッドを追加し、
手動 worktree 操作の UX を改善する。

- list: worktrees/ 配下の worktree 一覧を表示（autopilot state 付与）
- cd: 部分一致でパスを標準出力（シェル関数と組み合わせて利用）
- start: worktree 内で `claude -c` を execvp で起動
- 複数マッチ時は候補一覧を表示してエラー
- pytest テストを追加（63 passed）

Co-Authored-By: Claude <noreply@anthropic.com>
