### PR TITLE
feat(plugins-twl): spec-review 3 specialist spawn の機械的保証（マニフェスト + hook）

### DIFF
--- a/plugins/twl/commands/issue-spec-review.md
+++ b/plugins/twl/commands/issue-spec-review.md
@@ -46,9 +46,15 @@ ELSE:
   quick_tag = ""
 ```
 
-### Step 4: 3 specialist 並列 spawn（MUST）
+### Step 4: specialist 並列 spawn（MUST）
 
-**単一メッセージで正確に 3 つの Agent tool call を同時発行すること（MUST）。2 つだけで止めてはならない。issue-critic, issue-feasibility, worker-codex-reviewer の 3 つ全てが必須。**
+まず manifest からリストを取得する:
+
+```bash
+specialists=$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/spec-review-manifest.sh")
+```
+
+**manifest の各行に対して Agent tool call を生成すること（MUST）。manifest に含まれる全 specialist を単一メッセージで同時発行した後でのみ Step 5 に進むこと（MUST）。manifest 外の specialist を追加・削除してはならない。**
 
 ```
 Agent(subagent_type="twl:twl:issue-critic", prompt="

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -693,6 +693,7 @@ commands:
       - specialist: issue-feasibility
       - specialist: worker-codex-reviewer
       - script: escape-issue-body
+      - script: spec-review-manifest
     description: "1 Issue × 3 specialist 並列レビュー（chain 分割）"
 
   issue-review-aggregate:
@@ -1619,6 +1620,11 @@ scripts:
     type: script
     path: scripts/escape-issue-body.sh
     description: "Issue body の HTML エスケープ（& → &amp;、< → &lt;、> → &gt;）"
+
+  spec-review-manifest:
+    type: script
+    path: scripts/spec-review-manifest.sh
+    description: "issue-spec-review 必須 specialist リスト出力（3 行 = 3 agent type）"
 
   checkpoint-write:
     type: script

--- a/plugins/twl/scripts/hooks/check-spec-review-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-spec-review-completeness.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# PostToolUse hook: issue-spec-review specialist spawn の完全性検証
+#
+# Agent tool 呼び出し後に発火。
+# manifest の全 specialist が spawn されたかを追跡し、
+# 漏れがある状態で非 specialist agent が呼ばれた場合に警告を出力。
+
+INPUT=$(cat)
+
+TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
+[[ "$TOOL_NAME" != "Agent" ]] && exit 0
+
+SUBAGENT_TYPE=$(printf '%s' "$INPUT" | jq -r '.tool_input.subagent_type // empty' 2>/dev/null)
+[[ -z "$SUBAGENT_TYPE" ]] && exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+MANIFEST="$SCRIPT_DIR/../spec-review-manifest.sh"
+[[ ! -f "$MANIFEST" ]] && exit 0
+
+MANIFEST_SPECIALISTS=$(bash "$MANIFEST")
+TOTAL_COUNT=$(printf '%s\n' "$MANIFEST_SPECIALISTS" | wc -l)
+
+# プロジェクト固有のトラッキングファイル（CWD ベースのハッシュでスコープ）
+TRACKING_HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+TRACKING_FILE="/tmp/.spec-review-tracking-${TRACKING_HASH}.txt"
+
+if printf '%s\n' "$MANIFEST_SPECIALISTS" | grep -qxF "$SUBAGENT_TYPE"; then
+  # manifest に含まれる specialist を記録
+  echo "$SUBAGENT_TYPE" >> "$TRACKING_FILE"
+  # 重複除去
+  sort -u "$TRACKING_FILE" -o "$TRACKING_FILE"
+
+  SPAWNED_COUNT=$(wc -l < "$TRACKING_FILE")
+  if [[ "$SPAWNED_COUNT" -ge "$TOTAL_COUNT" ]]; then
+    # 全 specialist 完了 → トラッキングファイルを削除（次回の spec-review のためにリセット）
+    rm -f "$TRACKING_FILE"
+  fi
+else
+  # manifest 外の agent が呼ばれた場合 → 漏れチェック
+  if [[ -f "$TRACKING_FILE" ]]; then
+    SPAWNED_COUNT=$(wc -l < "$TRACKING_FILE")
+    if [[ "$SPAWNED_COUNT" -lt "$TOTAL_COUNT" ]]; then
+      MISSING=$(comm -23 \
+        <(printf '%s\n' "$MANIFEST_SPECIALISTS" | sort) \
+        <(sort "$TRACKING_FILE"))
+      echo "⚠ spec-review-completeness: 以下の specialist が未 spawn です:" >&2
+      while IFS= read -r s; do
+        echo "  - $s" >&2
+      done <<< "$MISSING"
+      echo "  issue-spec-review Step 4 に戻り、全 specialist を spawn してください。" >&2
+    fi
+  fi
+fi
+
+exit 0

--- a/plugins/twl/scripts/spec-review-manifest.sh
+++ b/plugins/twl/scripts/spec-review-manifest.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# spec-review-manifest.sh - issue-spec-review の必須 specialist リスト出力
+#
+# issue-spec-review.md が読み取り、Agent tool に渡す。
+# specialist の追加・削除はこのファイルの編集のみで反映される。
+# LLM が「どの specialist を呼ぶか」を判断する余地をなくす。
+
+cat << 'EOF'
+twl:twl:issue-critic
+twl:twl:issue-feasibility
+twl:twl:worker-codex-reviewer
+EOF

--- a/plugins/twl/tests/bats/scripts/spec-review-manifest.bats
+++ b/plugins/twl/tests/bats/scripts/spec-review-manifest.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+# spec-review-manifest.bats - unit tests for scripts/spec-review-manifest.sh
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: spec-review-manifest.sh が正確に3行出力すること
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: specialist リスト出力
+# WHEN spec-review-manifest.sh を実行する
+# THEN 正確に3行出力される
+# ---------------------------------------------------------------------------
+
+@test "spec-review-manifest outputs exactly 3 lines" {
+  run bash "$SANDBOX/scripts/spec-review-manifest.sh"
+
+  assert_success
+  assert [ "$(echo "$output" | wc -l)" -eq 3 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: issue-critic が含まれる
+# WHEN spec-review-manifest.sh を実行する
+# THEN "twl:twl:issue-critic" が出力に含まれる
+# ---------------------------------------------------------------------------
+
+@test "spec-review-manifest includes twl:twl:issue-critic" {
+  run bash "$SANDBOX/scripts/spec-review-manifest.sh"
+
+  assert_success
+  assert_output --partial "twl:twl:issue-critic"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: issue-feasibility が含まれる
+# WHEN spec-review-manifest.sh を実行する
+# THEN "twl:twl:issue-feasibility" が出力に含まれる
+# ---------------------------------------------------------------------------
+
+@test "spec-review-manifest includes twl:twl:issue-feasibility" {
+  run bash "$SANDBOX/scripts/spec-review-manifest.sh"
+
+  assert_success
+  assert_output --partial "twl:twl:issue-feasibility"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: worker-codex-reviewer が含まれる
+# WHEN spec-review-manifest.sh を実行する
+# THEN "twl:twl:worker-codex-reviewer" が出力に含まれる
+# ---------------------------------------------------------------------------
+
+@test "spec-review-manifest includes twl:twl:worker-codex-reviewer" {
+  run bash "$SANDBOX/scripts/spec-review-manifest.sh"
+
+  assert_success
+  assert_output --partial "twl:twl:worker-codex-reviewer"
+}
+
+# ===========================================================================
+# Requirement: 出力の各行が有効な agent type であること
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: 各行が agents/ ディレクトリに存在する agent type を指す
+# WHEN spec-review-manifest.sh の各行を確認する
+# THEN twl/twl/ プレフィックスを除いた agent 名が agents/ に存在する
+# ---------------------------------------------------------------------------
+
+@test "spec-review-manifest each line corresponds to an existing agent file" {
+  # REPO_ROOT は common_setup で設定される（sandbox/scripts/../ = sandbox）
+  # 実際の agents/ ディレクトリはリポジトリルートにある
+  HELPERS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../helpers" && pwd)"
+  BATS_TEST_DIR="$(cd "$HELPERS_DIR/.." && pwd)"
+  TESTS_DIR="$(cd "$BATS_TEST_DIR/.." && pwd)"
+  ACTUAL_REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+
+  run bash "$SANDBOX/scripts/spec-review-manifest.sh"
+  assert_success
+
+  while IFS= read -r agent_type; do
+    # "twl:twl:foo" → "foo"
+    agent_name="${agent_type##*:}"
+    agent_file="$ACTUAL_REPO_ROOT/agents/${agent_name}.md"
+    assert [ -f "$agent_file" ] \
+      "agent file not found: $agent_file (from agent type: $agent_type)"
+  done <<< "$output"
+}


### PR DESCRIPTION
- scripts/spec-review-manifest.sh: 必須 specialist 3名を出力（SSOT）
- scripts/hooks/check-spec-review-completeness.sh: PostToolUse hook で spawn 漏れを警告
- commands/issue-spec-review.md: Step 4 を manifest 読み取りベースに変更
- deps.yaml: spec-review-manifest スクリプトエントリ追加
- tests/bats/scripts/spec-review-manifest.bats: 3行出力・各行 agent ファイル存在確認

Closes #101
