### PR TITLE
feat(cli-twl): twl --audit Section 9 で chain 整合性を機械検証 (#141)

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -260,12 +260,64 @@ def handle_deep_validate(args, deps, graph, plugin_root, plugin_name):
 
 
 def handle_audit(args, deps, plugin_root, plugin_name):
+    section_filter = getattr(args, 'section', None)
+    section_name_map = {
+        1: 'controller_size',
+        2: 'inline_implementation',
+        3: 'step0_routing',
+        4: 'tools_accuracy',
+        5: 'self_contained',
+        6: 'token_bloat',
+        7: 'prompt_compliance',  # audit_collect uses Section 7 = prompt_compliance (Model is report-only)
+        8: 'prompt_compliance',
+        9: 'chain_integrity',
+    }
+
     if args.format == 'json':
         items = audit_collect(deps, plugin_root)
+        if section_filter is not None:
+            target_section = section_name_map.get(section_filter)
+            if target_section:
+                items = [i for i in items if i['section'] == target_section]
         exit_code = 1 if any(i['severity'] == 'critical' for i in items) else 0
         envelope = build_envelope("audit", get_deps_version(deps), plugin_name, items, exit_code)
         output_json(envelope)
         sys.exit(exit_code)
+
+    if section_filter == 9:
+        from twl.validation.audit import audit_chain_integrity
+        print("=== TWiLL Compliance Audit (Section 9 only) ===")
+        print()
+        print("## 9. Chain Integrity")
+        print()
+        print("| Workflow → Target | Issue | Severity |")
+        print("|-------------------|-------|----------|")
+        chain_items = audit_chain_integrity(deps, plugin_root)
+        criticals = 0
+        warnings = 0
+        oks = 0
+        for item in chain_items:
+            sev = item['severity']
+            if sev == 'critical':
+                criticals += 1
+                print(f"| {item['component']} | {item['message']} | CRITICAL |")
+            elif sev == 'warning':
+                warnings += 1
+                print(f"| {item['component']} | {item['message']} | WARNING |")
+            else:
+                oks += 1
+        if not (criticals or warnings):
+            print(f"| (all {oks} entries) | OK | OK |")
+        print()
+        print(f"## Summary")
+        print(f"| Severity | Count |")
+        print(f"|----------|-------|")
+        print(f"| CRITICAL | {criticals} |")
+        print(f"| WARNING  | {warnings} |")
+        print(f"| OK       | {oks} |")
+        if criticals > 0:
+            sys.exit(1)
+        return
 
     print("=== TWiLL Compliance Audit ===")
     print()
@@ -389,7 +441,8 @@ def main():
     parser.add_argument('--tokens', action='store_true', help='Show token counts for all nodes')
     parser.add_argument('--no-tokens', action='store_true', help='Hide token counts in graph output')
     parser.add_argument('--deep-validate', action='store_true', help='Deep validation (controller bloat, ref placement, tools consistency)')
-    parser.add_argument('--audit', action='store_true', help='TWiLL compliance audit (5-section markdown report)')
+    parser.add_argument('--audit', action='store_true', help='TWiLL compliance audit (9-section markdown report)')
+    parser.add_argument('--section', type=int, metavar='N', help='Filter --audit output to a single section number (1-9)')
     parser.add_argument('--complexity', action='store_true', help='Complexity metrics report')
     parser.add_argument('--rename', nargs=2, metavar=('OLD', 'NEW'), help='Rename a component (updates deps.yaml, frontmatter, body refs)')
     parser.add_argument('--promote', nargs=2, metavar=('NAME', 'NEW_TYPE'), help='Change component type (promote/demote with section move, file move, can_spawn/spawnable_by adjustment)')

--- a/cli/twl/src/twl/validation/audit.py
+++ b/cli/twl/src/twl/validation/audit.py
@@ -95,8 +95,188 @@ def _compute_ref_prompt_guide_hash(plugin_root: Path) -> Optional[str]:
     return hashlib.sha1(ref_path.read_bytes()).hexdigest()[:8]
 
 
+def _parse_dispatch_table(runner_text: str) -> Set[str]:
+    """chain-runner.sh の case "$STEP" in ... esac から step 名を抽出する
+
+    認識パターン:
+        <step-name>)   step_<func> "$@" ;;
+        <step-name>)   record_current_step "..."; ok "..." "..." ;;
+    """
+    if not runner_text:
+        return set()
+    pattern = re.compile(
+        r'^\s*([a-z][a-z0-9-]*)\)\s*(?:record_current_step|step_[a-z_]+)',
+        re.M,
+    )
+    return set(pattern.findall(runner_text))
+
+
+def _read_skill_text(skills_root: Path, workflow_name: str) -> str:
+    """workflow の SKILL.md を読み込む（フロントマター含む全文）"""
+    skill_path = skills_root / workflow_name / "SKILL.md"
+    if not skill_path.exists():
+        return ""
+    try:
+        return skill_path.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def _skill_has_invocation(skill_text: str, target: str) -> bool:
+    """SKILL.md text 内に target component への明示的実行指示があるかを判定
+
+    Phase 1: 厳密マッチ（false positive 抑制）
+        - commands/<target>.md / agents/<target>.md / skills/<target>/ の Read 指示
+        - chain-runner.sh <target> / "$CR" <target> 等の実行指示
+        - bash chain-runner.sh <target>
+    """
+    if not skill_text or not target:
+        return False
+    if f"commands/{target}.md" in skill_text:
+        return True
+    if f"agents/{target}.md" in skill_text:
+        return True
+    if f"skills/{target}/" in skill_text:
+        return True
+    # chain-runner.sh の引数として呼ばれている明示パターン
+    invocation_patterns = [
+        rf'chain-runner\.sh\s+{re.escape(target)}\b',
+        rf'"\$CR"\s+{re.escape(target)}\b',
+        rf'\$CR\s+{re.escape(target)}\b',
+        rf'cr\s+{re.escape(target)}\b',
+    ]
+    for pat in invocation_patterns:
+        if re.search(pat, skill_text):
+            return True
+    return False
+
+
+def _lookup_component(deps: dict, target: str) -> Optional[dict]:
+    """deps.yaml の各セクションから target コンポーネントを検索"""
+    for section in ('skills', 'commands', 'agents', 'scripts'):
+        spec = deps.get(section, {}).get(target)
+        if spec is not None:
+            return spec
+    return None
+
+
+def _get_dispatch_mode(deps: dict, target: str) -> Optional[str]:
+    """target コンポーネントの dispatch_mode を返す（未宣言は None）"""
+    spec = _lookup_component(deps, target)
+    if spec is None:
+        return None
+    mode = spec.get('dispatch_mode')
+    if mode is None:
+        return None
+    return str(mode)
+
+
+def _is_llm_driven(deps: dict, target: str) -> bool:
+    """target が LLM 駆動として宣言されているかを判定"""
+    return _get_dispatch_mode(deps, target) == 'llm'
+
+
+def _is_trigger_only(deps: dict, target: str) -> bool:
+    """target が trigger 経由のみで起動されると宣言されているかを判定"""
+    return _get_dispatch_mode(deps, target) == 'trigger'
+
+
+def _iter_workflows(deps: dict):
+    """deps.yaml の skills セクションから type=workflow を yield する"""
+    for name, spec in deps.get('skills', {}).items():
+        if spec.get('type') == 'workflow':
+            yield name, spec
+
+
+def audit_chain_integrity(deps: dict, plugin_root: Path) -> List[dict]:
+    """Section 9: Chain Integrity
+
+    deps.yaml × chain-runner.sh × SKILL.md text の三者整合性を検証する。
+
+    検出対象:
+    - orphan_call (WARNING): step 番号なし + LLM 駆動宣言なし + trigger 宣言なし
+    - dispatch_gap (CRITICAL): step あり + chain-runner.sh dispatch なし
+                                + LLM 駆動宣言なし + SKILL.md 言及なし
+
+    Returns: items リスト（severity, component, message, section, value, threshold）
+    """
+    items: List[dict] = []
+
+    runner_path = plugin_root / "scripts" / "chain-runner.sh"
+    runner_text = ""
+    if runner_path.exists():
+        try:
+            runner_text = runner_path.read_text(encoding="utf-8")
+        except Exception:
+            runner_text = ""
+    dispatched_steps = _parse_dispatch_table(runner_text)
+
+    skills_root = plugin_root / "skills"
+
+    for wf_name, wf_spec in sorted(_iter_workflows(deps)):
+        skill_text = _read_skill_text(skills_root, wf_name)
+        for call in wf_spec.get('calls', []):
+            if not isinstance(call, dict):
+                continue
+            # ターゲットの型と名前を抽出（v3.0 type-name keys）
+            target = None
+            ctype = None
+            for k in ('atomic', 'composite', 'workflow', 'controller', 'specialist', 'reference', 'script'):
+                if k in call:
+                    target = call[k]
+                    ctype = k
+                    break
+            if not target:
+                continue
+            step = call.get('step')
+
+            llm = _is_llm_driven(deps, target)
+            trigger = _is_trigger_only(deps, target)
+            mentioned = _skill_has_invocation(skill_text, target)
+
+            # 1. Orphan call
+            if step is None and not llm and not trigger and not mentioned:
+                items.append({
+                    "severity": "warning",
+                    "component": f"{wf_name}→{target}",
+                    "message": f"orphan_call: step 番号なし、LLM/trigger 駆動宣言なし、SKILL.md 言及もなし",
+                    "section": "chain_integrity",
+                    "value": 0,
+                    "threshold": 1,
+                })
+                continue
+
+            # 2. Dispatch gap (atomic / script のみ)
+            if step is not None and ctype in ('atomic', 'script'):
+                if target not in dispatched_steps and not llm and not mentioned:
+                    items.append({
+                        "severity": "critical",
+                        "component": f"{wf_name}→{target}",
+                        "message": (
+                            f"dispatch_gap: step {step} 宣言、chain-runner.sh に "
+                            f"step_{target.replace('-', '_')} なし、SKILL.md 実行指示もなし"
+                        ),
+                        "section": "chain_integrity",
+                        "value": 0,
+                        "threshold": 1,
+                    })
+                    continue
+
+            # OK row（カウント用）
+            items.append({
+                "severity": "ok",
+                "component": f"{wf_name}→{target}",
+                "message": f"ok: step={step or '-'} type={ctype}",
+                "section": "chain_integrity",
+                "value": 1,
+                "threshold": 1,
+            })
+
+    return items
+
+
 def audit_collect(deps: dict, plugin_root: Path) -> List[dict]:
-    """7セクションの TWiLL 準拠度データを収集（print なし）
+    """9セクションの TWiLL 準拠度データを収集（print なし）
 
     Returns: items リスト（severity, component, message, section, value, threshold）
     """
@@ -316,6 +496,9 @@ def audit_collect(deps: dict, plugin_root: Path) -> List[dict]:
                 "threshold": 1,
             })
 
+    # Section 9: Chain Integrity
+    items.extend(audit_chain_integrity(deps, plugin_root))
+
     return items
 
 
@@ -383,7 +566,18 @@ def _scan_body_for_mcp_tools(file_path: Path) -> Set[str]:
 
 
 def audit_report(deps: dict, plugin_root: Path) -> Tuple[int, int, int]:
-    """8セクションの TWiLL 準拠度レポートを出力
+    """9セクションの TWiLL 準拠度レポートを出力
+
+    Sections:
+        1. Controller Size
+        2. Inline Implementation
+        3. 1C=1W (Step 0 Routing)
+        4. Tools Accuracy
+        5. Self-Contained
+        6. Token Bloat
+        7. Model Declaration
+        8. Prompt Compliance
+        9. Chain Integrity
 
     Returns: (critical_count, warning_count, ok_count)
     """
@@ -646,6 +840,30 @@ def audit_report(deps: dict, plugin_root: Path) -> Tuple[int, int, int]:
                     status_str = f'stale ({refined_by} → 現在={current_hash})'
                     severity = 'WARNING'
             print(f"| {name} | {status_str} | {severity} |")
+    print()
+
+    # === Section 9: Chain Integrity ===
+    print("## 9. Chain Integrity")
+    print()
+    print("| Workflow → Target | Issue | Severity |")
+    print("|-------------------|-------|----------|")
+    # Note: chain_integrity items are already included in audit_collect's items
+    # at the top of this function (and counted into criticals/warnings/oks).
+    chain_items = [i for i in items if i['section'] == 'chain_integrity']
+    has_issue = False
+    for item in chain_items:
+        sev = item['severity']
+        if sev == 'critical':
+            sev_label = 'CRITICAL'
+        elif sev == 'warning':
+            sev_label = 'WARNING'
+        else:
+            continue  # OK 行は非表示（量削減）
+        has_issue = True
+        print(f"| {item['component']} | {item['message']} | {sev_label} |")
+    if not has_issue:
+        ok_count_s9 = sum(1 for i in chain_items if i['severity'] in ('ok', 'info'))
+        print(f"| (all {ok_count_s9} entries) | OK | OK |")
     print()
 
     # === Summary ===

--- a/cli/twl/src/twl/validation/validate.py
+++ b/cli/twl/src/twl/validation/validate.py
@@ -252,6 +252,24 @@ def validate_v3_schema(deps: dict) -> Tuple[int, List[str]]:
 
     # 許可される v3.0 型名キー
     v3_type_keys = {'atomic', 'composite', 'workflow', 'controller', 'specialist', 'reference', 'script'}
+    valid_dispatch_modes = {'llm', 'runner', 'trigger'}
+
+    # Check: dispatch_mode フィールド (任意) の値検証
+    for section in ('skills', 'commands', 'agents', 'scripts'):
+        for comp_name, data in deps.get(section, {}).items():
+            if not isinstance(data, dict):
+                continue
+            mode = data.get('dispatch_mode')
+            if mode is None:
+                continue
+            if not isinstance(mode, str) or mode not in valid_dispatch_modes:
+                violations.append(
+                    f"[v3-dispatch-mode] {section}/{comp_name}: "
+                    f"dispatch_mode must be one of {sorted(valid_dispatch_modes)}, got {mode!r}"
+                )
+            else:
+                ok_count += 1
+
     # v2.0 セクション名キー（v3.0 では非推奨）
     v2_section_keys = {'command', 'skill', 'agent'}
 

--- a/cli/twl/tests/scenarios/test_audit_chain_integrity.py
+++ b/cli/twl/tests/scenarios/test_audit_chain_integrity.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Tests for audit_chain_integrity (Section 9: Chain Integrity).
+
+Coverage:
+- Normal case (dispatched + step) -> no findings
+- F1 orphan_call: step なし + LLM 駆動宣言なし + SKILL.md 言及なし -> WARNING
+- F2 dispatch_gap: step あり + chain-runner.sh dispatch なし + LLM 駆動宣言なし + SKILL.md 言及なし -> CRITICAL
+- LLM 駆動例外: dispatch_mode=llm -> finding 抑制
+- SKILL.md 言及あり例外 -> finding 抑制
+- Section 1-8 後方互換 PASS
+- Section 9 が --audit に表示される
+- --audit --section 9 で Section 9 のみ実行可能
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import yaml
+
+
+def _write_deps(plugin_dir: Path, deps: dict) -> None:
+    (plugin_dir / "deps.yaml").write_text(
+        yaml.dump(deps, default_flow_style=False, allow_unicode=True, sort_keys=False),
+        encoding="utf-8",
+    )
+
+
+def _create_md(plugin_dir: Path, rel_path: str, name: str, body: str = "") -> None:
+    fp = plugin_dir / rel_path
+    fp.parent.mkdir(parents=True, exist_ok=True)
+    fp.write_text(
+        f"---\nname: {name}\ndescription: Test\n---\n\n{body or 'Body for ' + name}\n",
+        encoding="utf-8",
+    )
+
+
+def _write_chain_runner(plugin_dir: Path, dispatched_steps: list[str]) -> None:
+    """シンプルな chain-runner.sh を生成する"""
+    runner_dir = plugin_dir / "scripts"
+    runner_dir.mkdir(parents=True, exist_ok=True)
+    case_lines = []
+    for step in dispatched_steps:
+        func = step.replace('-', '_')
+        case_lines.append(f'    {step})           step_{func} "$@" ;;')
+    case_block = "\n".join(case_lines) if case_lines else '    noop)            step_noop "$@" ;;'
+    content = f"""#!/usr/bin/env bash
+set -euo pipefail
+main() {{
+  local step="${{1:-}}"
+  shift || true
+  case "$step" in
+{case_block}
+    *) echo "unknown: $step" >&2; exit 1 ;;
+  esac
+}}
+main "$@"
+"""
+    (runner_dir / "chain-runner.sh").write_text(content, encoding="utf-8")
+
+
+def _make_plugin(tmpdir: Path, *, workflow_calls, dispatched, components=None, skill_body=""):
+    """fixture プラグインを生成
+
+    workflow_calls: list of dict (deps.yaml 形式の calls エントリ)
+    dispatched: list of step name (chain-runner.sh に登録する step)
+    components: dict {name: {'section': str, 'type': str, 'dispatch_mode': Optional[str]}}
+    skill_body: SKILL.md body text
+    """
+    plugin_dir = tmpdir / "test-plugin-chain"
+    plugin_dir.mkdir()
+
+    deps = {
+        "version": "3.0",
+        "plugin": "test-chain",
+        "chains": {},
+        "skills": {
+            "wf-target": {
+                "type": "workflow",
+                "path": "skills/wf-target/SKILL.md",
+                "description": "Test workflow",
+                "calls": workflow_calls,
+            },
+        },
+        "commands": {},
+        "agents": {},
+        "scripts": {},
+    }
+
+    if components:
+        for name, cfg in components.items():
+            section = cfg.get('section', 'commands')
+            entry: dict = {
+                "type": cfg.get('type', 'atomic'),
+                "path": cfg.get('path', f"{section}/{name}.md"),
+                "description": f"Component {name}",
+            }
+            if 'dispatch_mode' in cfg:
+                entry['dispatch_mode'] = cfg['dispatch_mode']
+            deps[section][name] = entry
+            _create_md(plugin_dir, entry['path'], name)
+
+    _write_deps(plugin_dir, deps)
+    _create_md(plugin_dir, "skills/wf-target/SKILL.md", "wf-target", body=skill_body)
+    _write_chain_runner(plugin_dir, dispatched)
+
+    return plugin_dir
+
+
+def _run(plugin_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "twl"] + list(args),
+        cwd=str(plugin_dir),
+        capture_output=True,
+        text=True,
+    )
+
+
+def _audit_json(plugin_dir: Path, *extra) -> list[dict]:
+    proc = _run(plugin_dir, "--audit", "--format", "json", *extra)
+    payload = json.loads(proc.stdout)
+    return payload.get("data", payload).get("items", [])
+
+
+def _chain_items(items: list[dict]) -> list[dict]:
+    return [i for i in items if i['section'] == 'chain_integrity']
+
+
+# ===========================================================================
+# F1: orphan_call (step なし + LLM/trigger 宣言なし + SKILL.md 言及なし)
+# ===========================================================================
+
+class TestOrphanCall:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_orphan_call_emits_warning(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "orphan-step"}],
+            dispatched=["other-step"],
+            components={"orphan-step": {"section": "commands", "type": "atomic"}},
+            skill_body="このワークフローは何もしない",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert any(
+            i['severity'] == 'warning' and 'orphan_call' in i['message']
+            for i in items
+        ), f"Expected orphan_call warning, got {items}"
+
+
+# ===========================================================================
+# F2: dispatch_gap (step あり + dispatch なし + LLM 宣言なし + SKILL.md 言及なし)
+# ===========================================================================
+
+class TestDispatchGap:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_dispatch_gap_emits_critical(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "ghost-step", "step": "1"}],
+            dispatched=["other-step"],
+            components={"ghost-step": {"section": "commands", "type": "atomic"}},
+            skill_body="このワークフローは何もしない",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert any(
+            i['severity'] == 'critical' and 'dispatch_gap' in i['message']
+            for i in items
+        ), f"Expected dispatch_gap critical, got {items}"
+
+
+# ===========================================================================
+# Normal case: dispatched + step あり -> finding なし
+# ===========================================================================
+
+class TestNormalCase:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_dispatched_step_no_finding(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "live-step", "step": "1"}],
+            dispatched=["live-step"],
+            components={"live-step": {"section": "commands", "type": "atomic"}},
+            skill_body="step 1: live-step を実行",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert all(i['severity'] == 'ok' for i in items), \
+            f"Expected only ok findings, got {items}"
+
+
+# ===========================================================================
+# LLM 駆動例外: dispatch_mode=llm -> finding 抑制
+# ===========================================================================
+
+class TestLlmExemption:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_llm_driven_exempts_dispatch_gap(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"composite": "llm-step", "step": "2"}],
+            dispatched=[],
+            components={
+                "llm-step": {
+                    "section": "commands",
+                    "type": "composite",
+                    "dispatch_mode": "llm",
+                }
+            },
+            skill_body="何も書かない",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert not any(
+            i['severity'] in ('warning', 'critical') for i in items
+        ), f"Expected no warnings/criticals, got {items}"
+
+    def test_llm_driven_exempts_orphan_call(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"composite": "llm-step"}],
+            dispatched=[],
+            components={
+                "llm-step": {
+                    "section": "commands",
+                    "type": "composite",
+                    "dispatch_mode": "llm",
+                }
+            },
+            skill_body="何も書かない",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert not any(
+            i['severity'] in ('warning', 'critical') for i in items
+        ), f"Expected no warnings/criticals (LLM exemption), got {items}"
+
+
+# ===========================================================================
+# SKILL.md 言及あり例外: target が SKILL.md に出現 -> finding 抑制
+# ===========================================================================
+
+class TestSkillMentionExemption:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_skill_mention_exempts_dispatch_gap(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "manual-step", "step": "1"}],
+            dispatched=[],
+            components={"manual-step": {"section": "commands", "type": "atomic"}},
+            skill_body="Step 1: commands/manual-step.md を Read してください。",
+        )
+        items = _chain_items(_audit_json(plugin))
+        assert not any(
+            i['severity'] in ('warning', 'critical') for i in items
+        ), f"Expected no warnings/criticals (skill mention), got {items}"
+
+
+# ===========================================================================
+# 後方互換: 既存 Section 1-8 が PASS する
+# ===========================================================================
+
+class TestBackwardCompatibility:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_section_1_through_8_still_present(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "live-step", "step": "1"}],
+            dispatched=["live-step"],
+            components={"live-step": {"section": "commands", "type": "atomic"}},
+            skill_body="step 1: live-step を実行",
+        )
+        proc = _run(plugin, "--audit")
+        for n in range(1, 10):
+            section_headers = [
+                f"## {n}.",
+            ]
+            assert any(h in proc.stdout for h in section_headers), \
+                f"Section {n} header missing in output. stdout=\n{proc.stdout}"
+
+
+# ===========================================================================
+# --audit --section 9 で Section 9 のみ実行可能
+# ===========================================================================
+
+class TestSectionFilter:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_section_9_only_text(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "live-step", "step": "1"}],
+            dispatched=["live-step"],
+            components={"live-step": {"section": "commands", "type": "atomic"}},
+            skill_body="step 1: live-step を実行",
+        )
+        proc = _run(plugin, "--audit", "--section", "9")
+        assert "## 9. Chain Integrity" in proc.stdout
+        # Section 1-8 ヘッダーは出力されない
+        assert "## 1. Controller" not in proc.stdout
+        assert "## 8. Prompt" not in proc.stdout
+
+    def test_section_9_only_json(self):
+        plugin = _make_plugin(
+            self.tmp,
+            workflow_calls=[{"atomic": "ghost-step", "step": "1"}],
+            dispatched=[],
+            components={"ghost-step": {"section": "commands", "type": "atomic"}},
+            skill_body="何もしない",
+        )
+        proc = _run(plugin, "--audit", "--format", "json", "--section", "9")
+        payload = json.loads(proc.stdout)
+        items = payload.get("data", payload).get("items", [])
+        assert items, f"Expected at least one item, got {items}"
+        assert all(i['section'] == 'chain_integrity' for i in items), items
+
+
+# ===========================================================================
+# main runner
+# ===========================================================================
+
+if __name__ == "__main__":
+    import traceback
+    classes = [
+        TestOrphanCall,
+        TestDispatchGap,
+        TestNormalCase,
+        TestLlmExemption,
+        TestSkillMentionExemption,
+        TestBackwardCompatibility,
+        TestSectionFilter,
+    ]
+    passed = failed = 0
+    errors = []
+    for cls in classes:
+        for m in sorted(dir(cls)):
+            if not m.startswith("test_"):
+                continue
+            inst = cls()
+            if hasattr(inst, "setup_method"):
+                inst.setup_method()
+            try:
+                getattr(inst, m)()
+                passed += 1
+                print(f"  PASS: {cls.__name__}.{m}")
+            except Exception as e:
+                failed += 1
+                errors.append((f"{cls.__name__}.{m}", e))
+                print(f"  FAIL: {cls.__name__}.{m}: {e}")
+                traceback.print_exc()
+            finally:
+                if hasattr(inst, "teardown_method"):
+                    inst.teardown_method()
+    print(f"\nResults: {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)

--- a/plugins/twl/tests/scenarios/audit-chain-integrity.test.sh
+++ b/plugins/twl/tests/scenarios/audit-chain-integrity.test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Scenario: twl --audit --section 9 (Chain Integrity)
+# Verifies that Layer 0 audit detects known chain integrity drift in this plugin.
+# =============================================================================
+set -uo pipefail
+# Note: twl --audit exits 1 when CRITICAL findings exist; we want to inspect
+# its output without that exit propagating through pipefail.
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TWL="$(cd "$PLUGIN_ROOT/../../cli/twl" && pwd)/twl"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+run_test() {
+  local name="$1"; shift
+  if "$@"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$name")
+    echo "  FAIL: $name"
+  fi
+}
+
+# Run audit Section 9 from plugin root (exit code ignored: critical findings expected)
+audit_section9_output() {
+  ( cd "$PLUGIN_ROOT" && "$TWL" --audit --section 9 2>&1 ) || true
+}
+
+# 1. Section 9 header is emitted
+test_section9_header() {
+  audit_section9_output | grep -qF "## 9. Chain Integrity"
+}
+
+# 2. Known dead code (ac-verify) is detected as orphan_call
+test_ac_verify_detected() {
+  audit_section9_output | grep -qE "workflow-pr-verify→ac-verify.*orphan_call.*WARNING"
+}
+
+# 3. Known dispatch gaps (e.g., workflow-plugin-create→plugin-interview) are CRITICAL
+test_dispatch_gap_critical() {
+  audit_section9_output | grep -qE "dispatch_gap.*CRITICAL"
+}
+
+# 4. Summary table shows non-zero CRITICAL count
+test_summary_present() {
+  audit_section9_output | grep -qE "^\| CRITICAL\s*\|\s*[1-9]"
+}
+
+# 5. Section 9 only mode does not include other sections
+test_section9_only() {
+  local out
+  out=$(audit_section9_output)
+  ! echo "$out" | grep -qF "## 1. Controller" && \
+  ! echo "$out" | grep -qF "## 8. Prompt"
+}
+
+run_test "section_9_header"        test_section9_header
+run_test "ac_verify_detected"      test_ac_verify_detected
+run_test "dispatch_gap_critical"   test_dispatch_gap_critical
+run_test "summary_present"         test_summary_present
+run_test "section_9_only_mode"     test_section9_only
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  echo "Failures: ${ERRORS[*]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

`cli/twl` の `twl --audit` に **Section 9: Chain Integrity** を追加し、`deps.yaml` × `chain-runner.sh` × `SKILL.md text` の三者整合性を Layer 0 静的検査として捕捉する。

親 epic #140 の **Phase 1** 実装。

## 実装内容

### 検出パターン

- **orphan_call (WARNING)**: `step` 番号なし、LLM/trigger 駆動宣言なし、SKILL.md 言及もない calls エントリ
- **dispatch_gap (CRITICAL)**: `step` あり、`chain-runner.sh` dispatch なし、LLM 駆動宣言もなく SKILL.md 実行指示もない calls エントリ

### 主な変更

| File | 変更 |
|---|---|
| `cli/twl/src/twl/validation/audit.py` | `audit_chain_integrity()` + ヘルパー (`_parse_dispatch_table` / `_skill_has_invocation` / `_is_llm_driven` / `_is_trigger_only`) を追加。`audit_collect` / `audit_report` に Section 9 を統合。docstring を 9 sections に更新 |
| `cli/twl/src/twl/validation/validate.py` | `validate_v3_schema` に `dispatch_mode` フィールド (`llm` / `runner` / `trigger`) のバリデーションを追加 |
| `cli/twl/src/twl/cli.py` | `--section N` フィルターを追加。`--audit --section 9` で Section 9 のみ実行可能 |
| `cli/twl/tests/scenarios/test_audit_chain_integrity.py` | pytest 9 ケース |
| `plugins/twl/tests/scenarios/audit-chain-integrity.test.sh` | bats シナリオ |

### LLM 駆動例外

`dispatch_mode: llm` を component に宣言すると Section 9 から exempt される。Phase 1 ではフィールドのバリデーションのみ追加。既存 component への一括付与は Phase 2 で実施する。

## 検証結果

```
$ cd plugins/twl && twl --check && twl --validate
=== File Check Results ===
OK: 192, Missing: 0
=== Type Validation Results ===
OK: 1888, Violations: 0

$ twl --audit
## 9. Chain Integrity
| workflow-dead-cleanup→dead-component-detect | dispatch_gap ... | CRITICAL |
| workflow-plugin-create→plugin-interview | dispatch_gap ... | CRITICAL |
... (合計 14 CRITICAL + 13 WARNING)
```

Phase 1 完了の証明として 27 件の dead code/orphan を可視化。Phase 2 で順次解消予定。

### Tests

- `cli/twl && pytest tests/scenarios/test_audit_chain_integrity.py` → 9 passed
- `cli/twl && pytest tests/` → 885 passed, 4 pre-existing failures (本 PR と無関係)
- `bash plugins/twl/tests/scenarios/audit-chain-integrity.test.sh` → 5 passed

## 受け入れ基準

- [x] `audit_chain_integrity()` 関数が追加されている
- [x] docstring が「9 sections」に更新されている
- [x] `validate.py` に `dispatch_mode` バリデーション追加
- [x] `twl --audit` に Section 9 が出力される
- [x] `twl --audit --section 9` で Section 9 のみ実行可能
- [x] pytest テスト全 PASS（正常 / F1 / F2 / LLM 例外 / SKILL.md 言及例外 / 後方互換 / フィルター）
- [x] bats シナリオテスト PASS
- [x] Section 1-8 後方互換 PASS
- [x] `twl --check && twl --validate` PASS
- [x] `twl --audit` が現存 27 件の dead code/orphan を CRITICAL/WARNING として可視化

Closes #141