### PR TITLE
feat(plugins-twl): worker-issue-pr-alignment specialist 新規作成

### DIFF
--- a/cli/twl/src/twl/autopilot/parser.py
+++ b/cli/twl/src/twl/autopilot/parser.py
@@ -11,9 +11,20 @@ CLI usage:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from typing import Any
+
+# ac-alignment categories handled by worker-issue-pr-alignment specialist
+_AC_ALIGNMENT_CATEGORIES = frozenset(["ac-alignment", "ac-alignment-unknown"])
+# Markdown blockquote, Japanese 「」 quotes, or pair of " quotes
+_QUOTE_PATTERNS = [
+    re.compile(r"^>\s+.+$", re.MULTILINE),
+    re.compile(r"「[^」]+」"),
+    re.compile(r"\"[^\"]{2,}\""),
+    re.compile(r"`[^`\n]{2,}`"),
+]
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +106,102 @@ def parse_specialist_output(text: str) -> ParseResult:
         # No JSON block → empty findings (status line alone is valid)
         findings = []
 
+    # Post-process ac-alignment findings (downgrade unsubstantiated CRITICALs,
+    # honour PR_LABELS=alignment-override skip).
+    new_findings, alignment_modified = _process_alignment_findings(findings)
+    if alignment_modified:
+        findings = new_findings
+        # 後処理で severity 構成が変わったので status を機械的に再導出
+        status = _derive_status(findings)
+
     return ParseResult(status=status, findings=findings, parse_error=False)
+
+
+def _has_quote_evidence(message: str) -> bool:
+    """Heuristic: at least 2 quoted segments (Issue 引用 + diff 引用)."""
+    if not message:
+        return False
+    total = 0
+    for pat in _QUOTE_PATTERNS:
+        total += len(pat.findall(message))
+        if total >= 2:
+            return True
+    return False
+
+
+def _alignment_override_active() -> bool:
+    """Check whether the PR has the `alignment-override` label.
+
+    Reads the PR_LABELS env var (comma-separated list of label names),
+    typically set by autopilot-launch.sh / merge-gate from `gh pr view`.
+    """
+    raw = os.environ.get("PR_LABELS", "")
+    if not raw:
+        return False
+    labels = {lbl.strip() for lbl in raw.split(",") if lbl.strip()}
+    return "alignment-override" in labels
+
+
+def _process_alignment_findings(
+    findings: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], bool]:
+    """Apply ac-alignment-specific post-processing.
+
+    1. If PR has `alignment-override` label → drop all ac-alignment findings.
+    2. CRITICAL findings without verbatim quotes → downgrade to WARNING (parser
+       cannot block on un-evidenced LLM judgements).
+
+    Returns (new_findings, modified_flag). modified_flag is True if any
+    alignment finding was dropped or downgraded.
+    """
+    # Fast path: no ac-alignment findings → no work
+    has_alignment = any(
+        isinstance(f, dict) and f.get("category") in _AC_ALIGNMENT_CATEGORIES
+        for f in findings
+    )
+    if not has_alignment:
+        return findings, False
+
+    override = _alignment_override_active()
+    out: list[dict[str, Any]] = []
+    modified = False
+    for f in findings:
+        if not isinstance(f, dict):
+            out.append(f)
+            continue
+        category = f.get("category", "")
+        if category not in _AC_ALIGNMENT_CATEGORIES:
+            out.append(f)
+            continue
+        if override:
+            modified = True
+            continue
+        if f.get("severity") == "CRITICAL" and not _has_quote_evidence(str(f.get("message", ""))):
+            new_f = dict(f)
+            new_f["severity"] = "WARNING"
+            new_f["message"] = (
+                "[downgraded: 逐語引用なし] " + str(f.get("message", ""))
+            )
+            out.append(new_f)
+            modified = True
+            continue
+        out.append(f)
+    return out, modified
+
+
+def _derive_status(findings: list[dict[str, Any]]) -> str:
+    """Derive status from findings (CRITICAL → FAIL, WARNING → WARN, else PASS)."""
+    has_critical = any(
+        isinstance(f, dict) and f.get("severity") == "CRITICAL" for f in findings
+    )
+    if has_critical:
+        return "FAIL"
+    has_warning = any(
+        isinstance(f, dict) and f.get("severity") == "WARNING" for f in findings
+    )
+    if has_warning:
+        return "WARN"
+    return "PASS"
 
 
 def _fallback_result(raw_text: str) -> ParseResult:

--- a/cli/twl/tests/test_autopilot_parser.py
+++ b/cli/twl/tests/test_autopilot_parser.py
@@ -160,3 +160,118 @@ class TestClassifyFailure:
         finding = classify_failure("check", "Details")
         required_keys = {"severity", "confidence", "file", "line", "message", "category"}
         assert required_keys.issubset(finding.keys())
+
+
+# ---------------------------------------------------------------------------
+# ac-alignment post-processing (worker-issue-pr-alignment specialist)
+# ---------------------------------------------------------------------------
+
+
+class TestAcAlignmentProcessing:
+    def _make_finding(self, **overrides):
+        base = {
+            "severity": "CRITICAL",
+            "confidence": 80,
+            "file": "Issue body",
+            "line": 1,
+            "message": "AC が未達成",
+            "category": "ac-alignment",
+        }
+        base.update(overrides)
+        return base
+
+    def test_critical_without_quotes_downgraded_to_warning(self, monkeypatch):
+        monkeypatch.delenv("PR_LABELS", raising=False)
+        findings = [self._make_finding(message="AC が未達成（引用なし）")]
+        text = "status: FAIL\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        # Re-derived: only WARNING remains → WARN
+        assert result.status == "WARN"
+        assert result.findings[0]["severity"] == "WARNING"
+        assert "downgraded" in result.findings[0]["message"]
+
+    def test_critical_with_two_quote_segments_kept(self, monkeypatch):
+        monkeypatch.delenv("PR_LABELS", raising=False)
+        msg = "Issue 引用: 「worker-prompt-reviewer 実行」 / diff 引用: 「diff にゼロ言及」"
+        findings = [self._make_finding(message=msg)]
+        text = "status: FAIL\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        assert result.status == "FAIL"
+        assert result.findings[0]["severity"] == "CRITICAL"
+
+    def test_critical_with_blockquote_evidence_kept(self, monkeypatch):
+        monkeypatch.delenv("PR_LABELS", raising=False)
+        msg = "未達成。\n> Issue 行 1\n> diff hunk\n"
+        findings = [self._make_finding(message=msg)]
+        text = "status: FAIL\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        assert result.findings[0]["severity"] == "CRITICAL"
+
+    def test_alignment_override_drops_findings(self, monkeypatch):
+        monkeypatch.setenv("PR_LABELS", "enhancement,alignment-override,refined")
+        msg = "「Issue 引用」 / 「diff 引用」"
+        findings = [
+            self._make_finding(message=msg),
+            self._make_finding(category="ac-alignment-unknown", severity="INFO", confidence=50, message=msg),
+            # non-alignment finding should be preserved
+            {
+                "severity": "CRITICAL",
+                "confidence": 90,
+                "file": "src/x.py",
+                "line": 1,
+                "message": "real bug",
+                "category": "vulnerability",
+            },
+        ]
+        text = "status: FAIL\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        # alignment findings dropped, vulnerability kept → still FAIL
+        assert result.status == "FAIL"
+        assert len(result.findings) == 1
+        assert result.findings[0]["category"] == "vulnerability"
+
+    def test_unknown_category_passthrough(self):
+        # AC: 既存 parser が未知 category を WARNING 降格せず素通し
+        findings = [
+            {
+                "severity": "INFO",
+                "confidence": 50,
+                "file": "Issue body",
+                "line": 1,
+                "message": "判断不能",
+                "category": "ac-alignment-unknown",
+            }
+        ]
+        text = "status: PASS\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        assert result.status == "PASS"
+        assert len(result.findings) == 1
+        assert result.findings[0]["category"] == "ac-alignment-unknown"
+        assert result.findings[0]["severity"] == "INFO"
+
+    def test_warning_alignment_finding_unchanged(self, monkeypatch):
+        # WARNING level alignment findings are kept as-is regardless of quotes
+        monkeypatch.delenv("PR_LABELS", raising=False)
+        findings = [self._make_finding(severity="WARNING", confidence=75, message="部分達成")]
+        text = "status: WARN\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        assert result.status == "WARN"
+        assert result.findings[0]["severity"] == "WARNING"
+        assert "downgraded" not in result.findings[0]["message"]
+
+    def test_existing_specialist_unchanged(self):
+        # 後方互換: 既存 specialist (vulnerability category) は影響を受けない
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 90,
+                "file": "src/auth.ts",
+                "line": 42,
+                "message": "SQL injection",
+                "category": "vulnerability",
+            }
+        ]
+        text = "status: FAIL\n```json\n" + json.dumps(findings) + "\n```"
+        result = parse_specialist_output(text)
+        assert result.status == "FAIL"
+        assert result.findings[0]["severity"] == "CRITICAL"

--- a/plugins/twl/agents/worker-issue-pr-alignment.md
+++ b/plugins/twl/agents/worker-issue-pr-alignment.md
@@ -1,0 +1,129 @@
+---
+name: twl:worker-issue-pr-alignment
+description: |
+  Issue body と PR diff の意味的整合性レビュー（specialist）。
+  Issue が要求する AC が PR で実装されているかを LLM 判断で検証。
+type: specialist
+model: sonnet
+effort: medium
+maxTurns: 20
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+skills:
+  - ref-specialist-output-schema
+  - ref-specialist-few-shot
+---
+
+# worker-issue-pr-alignment: Issue/PR 整合性レビュー
+
+あなたは Issue body と PR diff の意味的整合性をレビューする specialist です。
+Issue が要求する AC・スコープが PR diff の変更内容で実際に達成されているかを判定します。
+
+**役割**: soft gate（可視化中心）。明確な未達成のみ CRITICAL とし、その他は WARNING として可視化に留めます。
+
+## 入力
+
+1. **Issue 番号**: 環境変数 `WORKER_ISSUE_NUM` または引数で指定（必須）
+2. **Issue body**: `gh issue view "$WORKER_ISSUE_NUM" --json body,title -q .body`
+3. **AC checklist** (存在すれば): `${SNAPSHOT_DIR}/01.5-ac-checklist.md` または `.autopilot/snapshots/<issue>/01.5-ac-checklist.md`
+4. **ac-verify checkpoint** (存在すれば): `.autopilot/checkpoints/ac-verify.json` — 既に CRITICAL 判定済みの AC を読み取り、**重複検出をスキップ**する
+5. **PR diff**: `git diff origin/main`
+6. **PR diff stat**: `git diff --stat origin/main`
+
+## 実行ロジック
+
+1. Issue 番号を解決（環境変数 `WORKER_ISSUE_NUM` を最優先、未設定時は `git branch --show-current` から `\d+(?=-)` を抽出）
+2. `gh issue view` で Issue body を取得
+3. Issue body から「## 受け入れ基準」「## スコープ」「含む / 含まない」セクションを構造化
+4. ac-verify checkpoint が存在すれば読み込み、CRITICAL 判定済み AC のリストを抽出
+5. PR diff と diff stat を取得
+6. 各 AC について以下を判定:
+   - **完全達成**: PR diff に明示的な実装変更がある → 出力しない
+   - **完全未達成（ゼロ言及）**: AC の主要キーワードが PR diff のどこにも見つからない → CRITICAL（confidence 80）
+   - **部分達成 / 軽量解釈 / 拡大解釈**: 一部のみ実装、メタデータのみ、Issue 範囲外の変更 → WARNING（confidence 70-75）
+   - **判断不能**: LLM が達成度を判定できない → INFO `ac-alignment-unknown`（confidence 50）
+7. ac-verify checkpoint で既に CRITICAL 判定済みの AC は **スキップ**（重複検出回避、MUST）
+8. ref-specialist-output-schema 準拠の JSON で出力
+
+## 必須項目（MUST）
+
+### 1. 逐語引用（CRITICAL/WARNING の Finding）
+
+各 Finding の `message` フィールドには、以下を **逐語引用**として含めること:
+
+- Issue body の該当行（`「...」` または `> ` で示す）
+- PR diff の該当 hunk（または「diff にゼロ言及」と明示）
+
+引用なしの Finding は parser が CRITICAL → WARNING に自動降格する（confidence は据え置き）。
+
+### 2. UNKNOWN 状態
+
+達成度が判断不能な AC については `category: ac-alignment-unknown` + `severity: INFO` + `confidence: 50` で出力し、人間レビューを促す。`message` に「判断不能の理由」を含めること。
+
+### 3. confidence 上限
+
+soft gate 役割を維持するため、原則 `confidence: 75` を上限とする。
+**例外（CRITICAL 専用）**: 以下 3 条件をすべて満たす場合のみ `severity: CRITICAL` + `confidence: 80` を許可する:
+
+1. ac-verify (Issue 1) が同一 AC を CRITICAL 判定していない（重複回避）
+2. 該当 AC が PR diff のどこにも言及されていない（逐語引用で「diff にゼロ言及」を証明）
+3. Issue body での該当 AC が明示的に書かれている（解釈の幅が小さい）
+
+部分達成 / 軽量解釈 / 拡大解釈はすべて WARNING に分類（CRITICAL にしてはならない）。
+
+### 4. confidence マトリクス
+
+| 状態 | severity | confidence | category |
+|---|---|---|---|
+| AC が完全に未達成（diff にゼロ言及）かつ ac-verify 未検出 | CRITICAL | 80 | ac-alignment |
+| AC が部分達成 | WARNING | 75 | ac-alignment |
+| AC が軽量解釈（メタデータのみ） | WARNING | 75 | ac-alignment |
+| AC が拡大解釈（scope 外） | WARNING | 70 | ac-alignment |
+| AC 達成度が判断不能 | INFO | 50 | ac-alignment-unknown |
+
+## 出力形式（MUST）
+
+ref-specialist-output-schema に従い、以下のサマリー行と JSON ブロックを出力すること:
+
+```
+worker-issue-pr-alignment 完了
+
+status: WARN
+```
+
+```json
+{
+  "status": "WARN",
+  "findings": [
+    {
+      "severity": "WARNING",
+      "confidence": 75,
+      "file": "Issue body",
+      "line": 1,
+      "message": "AC #3「~90 件のコンポーネントに worker-prompt-reviewer を実行し PASS 判定を得る」が PR diff で部分達成のみ。diff では `> deps.yaml に refined_by フィールドを一括追加` しているが、worker-prompt-reviewer の実行記録は含まれていない。",
+      "category": "ac-alignment"
+    }
+  ]
+}
+```
+
+- `file: "Issue body"` + `line: 1` を Issue 全体への参照として使用（schema は `line >= 1` を要求）
+- 該当する PR diff のファイルパスがある場合は `file: <該当ファイル>` + 該当行番号を使用
+- findings が空の場合: `"status": "PASS", "findings": []`
+
+## 救済路（運用ガイド）
+
+以下は本 Issue では実装スコープ外だが、運用上の救済路として記載:
+
+- **手動 override label**: PR に `alignment-override` ラベルを付けると次回 merge-gate で alignment specialist の Finding がスキップされる（parser が PR ラベルを参照）
+- **逐語引用未充足**: parser が CRITICAL→WARNING に自動降格（specialist の出力に Issue / diff 引用がなければ block 不能）
+- **再判定コマンド**: `gh pr comment $PR --body "/recheck-alignment"` で手動再 spawn（実装は将来の別 Issue）
+
+## 制約
+
+- **Read-only**: ファイル変更は行わない（Write, Edit 不可）
+- **Task tool 禁止**: 全チェックを自身で実行
+- **Bash は読み取り系のみ**: `gh issue view`, `git diff`, `git branch` などの参照系コマンドのみ

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1314,6 +1314,7 @@ commands:
       - specialist: worker-data-validator
       - specialist: worker-env-validator
       - specialist: worker-codex-reviewer
+      - specialist: worker-issue-pr-alignment
       - reference: ref-specialist-output-schema
       - reference: baseline-coding-style
       - reference: baseline-security-checklist
@@ -1387,6 +1388,7 @@ commands:
       - specialist: worker-env-validator
       - specialist: worker-codex-reviewer
       - specialist: worker-architecture
+      - specialist: worker-issue-pr-alignment
       - reference: ref-specialist-output-schema
       - reference: ref-dci
       - reference: baseline-coding-style
@@ -1869,7 +1871,8 @@ scripts:
     path: scripts/pr-review-manifest.sh
     calls:
       - script: tech-stack-detect
-    description: "PR review 系 specialist 選択の動的マニフェスト（phase-review / merge-gate / post-fix-verify）"
+      - script: resolve-issue-num
+    description: "PR review 系 specialist 選択の動的マニフェスト（phase-review / merge-gate / post-fix-verify）。phase-review/merge-gate モードで Issue 番号が解決可能な場合 worker-issue-pr-alignment を出力に含める"
 
   checkpoint-write:
     type: script
@@ -2105,6 +2108,19 @@ agents:
     can_spawn: []
     skills: [ref-specialist-output-schema, ref-architecture, ref-specialist-few-shot]
     description: "アーキテクチャパターン検証 (PR diff モード: architecture/domain/glossary.md, architecture/domain/model.md, architecture/vision.md を参照)"
+
+  worker-issue-pr-alignment:
+    type: specialist
+    refined_by: "ref-prompt-guide@2c7a62f2"
+    refined_at: "2026-04-07"
+    path: agents/worker-issue-pr-alignment.md
+    model: sonnet
+    effort: medium
+    gate_role: soft
+    spawnable_by: [workflow, composite, controller]
+    can_spawn: []
+    skills: [ref-specialist-output-schema, ref-specialist-few-shot]
+    description: "Issue body と PR diff の意味的整合性レビュー (soft gate、ac-alignment 専用 specialist)"
 
   worker-llm-output-reviewer:
     type: specialist

--- a/plugins/twl/refs/ref-specialist-few-shot.md
+++ b/plugins/twl/refs/ref-specialist-few-shot.md
@@ -44,6 +44,40 @@ findings:
 - status は findings から自動導出: CRITICAL あり → FAIL, WARNING あり → WARN, それ以外 → PASS
 - severity は CRITICAL / WARNING / INFO の 3 段階のみ
 - 各 finding に severity, confidence (0-100), file, line, message, category を必ず含める
-- category: vulnerability / bug / coding-convention / structure / principles
+- category: vulnerability / bug / coding-convention / structure / principles / ac-alignment / ac-alignment-unknown
 - findings が空の場合: `findings: []` と出力し status: PASS とする
 ````
+
+## ac-alignment 用 few-shot（worker-issue-pr-alignment 専用）
+
+`category: ac-alignment` および `ac-alignment-unknown` を出力する specialist は、以下の 2 例を参考にすること。
+**逐語引用は MUST**（引用なしの CRITICAL は parser が WARNING に自動降格する）。
+
+```json
+{
+  "status": "FAIL",
+  "findings": [
+    {
+      "severity": "CRITICAL",
+      "confidence": 80,
+      "file": "Issue body",
+      "line": 1,
+      "message": "AC「~90 件のコンポーネントに worker-prompt-reviewer を実行し PASS 判定を得る」が PR diff にゼロ言及。Issue 引用: 「worker-prompt-reviewer による品質レビュー PASS」。diff 引用: 「diff にゼロ言及（worker-prompt-reviewer の実行記録なし、deps.yaml への refined_by フィールド追加のみ）」。",
+      "category": "ac-alignment"
+    },
+    {
+      "severity": "INFO",
+      "confidence": 50,
+      "file": "Issue body",
+      "line": 1,
+      "message": "AC「運用初期の段階的導入用に gate_role: soft フィールドを追加」の達成度が判断不能。Issue 引用: 「deps.yaml の specialist エントリに gate_role: soft を追加」。判断不能の理由: gate_role フィールドの semantics が他コンポーネントで未定義のため、追加のみで運用効果が発揮されているか LLM 単独では判定できない。人間レビューを推奨。",
+      "category": "ac-alignment-unknown"
+    }
+  ]
+}
+```
+
+**ac-alignment ルール**:
+- CRITICAL は「diff にゼロ言及」かつ「ac-verify 未検出」かつ「Issue body の AC が明示的」の 3 条件を満たすときのみ
+- 部分達成 / 軽量解釈 / 拡大解釈はすべて WARNING（confidence 70-75）
+- 逐語引用が無い Finding は parser が CRITICAL → WARNING に自動降格する

--- a/plugins/twl/refs/ref-specialist-output-schema.md
+++ b/plugins/twl/refs/ref-specialist-output-schema.md
@@ -48,7 +48,7 @@ merge-gate / phase-review が機械的に消費可能な構造化出力を定義
           },
           "category": {
             "type": "string",
-            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles"],
+            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles", "ac-alignment", "ac-alignment-unknown"],
             "description": "finding の分類（merge-gate 共通）。co-issue specialist は co-issue 拡張 category を使用すること"
           },
           "finding_target": {
@@ -131,6 +131,17 @@ merge-gate specialist が使用する共通 category。
 | `coding-convention` | worker-code-reviewer |
 | `structure` | worker-structure |
 | `principles` | worker-principles |
+| `ac-alignment` | worker-issue-pr-alignment（Issue body と PR diff の意味的整合性 finding） |
+| `ac-alignment-unknown` | worker-issue-pr-alignment（達成度判断不能の AC、INFO のみ） |
+
+### ac-alignment specialist の追加要件（MUST）
+
+`category: ac-alignment` または `ac-alignment-unknown` を出力する specialist は以下を遵守すること:
+
+1. **逐語引用必須**: 各 Finding の `message` フィールドに Issue body / PR diff の逐語引用を含める。引用なしの Finding は parser が CRITICAL → WARNING に自動降格する
+2. **confidence 上限**: 原則 75（soft gate 役割を維持）。CRITICAL の場合のみ 80 を許可（明確なゼロ言及かつ ac-verify 未検出のケース）
+3. **Issue 1 (ac-verify) との重複回避**: ac-verify checkpoint を read し、既に CRITICAL 判定済みの AC については重複検出をスキップする
+4. **PR ラベル `alignment-override`**: 付与されている PR では parser がこれらの Finding をすべてスキップする
 
 ## category（co-issue 拡張）
 

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -123,6 +123,27 @@ if [[ "$MODE" == "merge-gate" ]]; then
   fi
 fi
 
+# --- 常時追加: AC alignment specialist (Issue 番号が解決可能な場合のみ) ---
+# phase-review / merge-gate モードで Issue 番号が解決可能な場合に worker-issue-pr-alignment を必須化。
+# 変更ファイルパターンに依存しない（コード変更ゼロでも Issue 内容と乖離している可能性があるため）。
+# Issue 番号が解決できない場合（chain 外で merge-gate 実行など）はスキップ + warning ログ。
+if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
+  ISSUE_NUM=""
+  resolver="$SCRIPT_DIR/resolve-issue-num.sh"
+  if [[ -f "$resolver" ]]; then
+    # shellcheck disable=SC1090
+    source "$resolver" 2>/dev/null || true
+    if declare -f resolve_issue_num >/dev/null 2>&1; then
+      ISSUE_NUM=$(resolve_issue_num 2>/dev/null || echo "")
+    fi
+  fi
+  if [[ -n "$ISSUE_NUM" ]]; then
+    SPECIALISTS["worker-issue-pr-alignment"]=1
+  else
+    echo "WARNING: pr-review-manifest: Issue 番号が解決不能のため worker-issue-pr-alignment をスキップします" >&2
+  fi
+fi
+
 # --- 結果出力（重複なし、ソート済み）---
 for specialist in "${!SPECIALISTS[@]}"; do
   echo "$specialist"

--- a/plugins/twl/tests/bats/scripts/pr-review-manifest.bats
+++ b/plugins/twl/tests/bats/scripts/pr-review-manifest.bats
@@ -172,3 +172,38 @@ EOF
   assert_success
   assert_output --partial "worker-supabase-migration-checker"
 }
+
+# ===========================================================================
+# Requirement: worker-issue-pr-alignment 常時必須（Issue 番号が解決可能なとき）
+# ===========================================================================
+
+@test "merge-gate: includes worker-issue-pr-alignment when WORKER_ISSUE_NUM set" {
+  run bash -c "export WORKER_ISSUE_NUM=135; echo '' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-issue-pr-alignment"
+}
+
+@test "phase-review: includes worker-issue-pr-alignment when WORKER_ISSUE_NUM set" {
+  run bash -c "export WORKER_ISSUE_NUM=135; echo 'src/index.ts' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode phase-review"
+  assert_success
+  assert_output --partial "worker-issue-pr-alignment"
+}
+
+@test "merge-gate: skips worker-issue-pr-alignment when issue number unresolvable" {
+  # Empty AUTOPILOT_DIR + non-issue branch + no WORKER_ISSUE_NUM
+  run bash -c "unset WORKER_ISSUE_NUM AUTOPILOT_DIR; cd '$SANDBOX' && (git checkout -b plain-branch 2>/dev/null || true); echo '' | bash scripts/pr-review-manifest.sh --mode merge-gate 2>/dev/null"
+  assert_success
+  refute_output --partial "worker-issue-pr-alignment"
+}
+
+@test "post-fix-verify: does not include worker-issue-pr-alignment" {
+  run bash -c "export WORKER_ISSUE_NUM=135; echo '' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode post-fix-verify"
+  assert_success
+  refute_output --partial "worker-issue-pr-alignment"
+}
+
+@test "merge-gate: skip warning logged to stderr when issue unresolvable" {
+  run bash -c "unset WORKER_ISSUE_NUM AUTOPILOT_DIR; cd '$SANDBOX' && (git checkout -b plain-branch 2>/dev/null || true); echo '' | bash scripts/pr-review-manifest.sh --mode merge-gate 2>&1 1>/dev/null"
+  assert_success
+  assert_output --partial "WARNING: pr-review-manifest"
+}


### PR DESCRIPTION
## 概要

Issue body と PR diff の意味的整合性をレビューする specialist `worker-issue-pr-alignment` を新規作成し、`pr-review-manifest.sh` の phase-review / merge-gate モードに **常時必須** specialist として組み込む。

## 変更内容

### 1. Specialist 新規作成
- `agents/worker-issue-pr-alignment.md` (新規)
  - soft gate role（可視化中心、CRITICAL は明確な未達成のみ）
  - **逐語引用 MUST**: Issue body / PR diff の引用なし → parser が CRITICAL → WARNING 自動降格
  - **UNKNOWN 状態**: `category: ac-alignment-unknown` + INFO で人間レビュー要求
  - **confidence 上限 75**（原則）、CRITICAL 例外時のみ 80
  - **Issue 1 (ac-verify) との重複回避**: ac-verify checkpoint を read し既 CRITICAL 判定 AC をスキップ

### 2. pr-review-manifest.sh の必須登録
- `phase-review` / `merge-gate` モードで `resolve-issue-num.sh` 経由で Issue 番号を取得
- 解決可能時 → `worker-issue-pr-alignment` を出力に含める（変更ファイルパターンに依存しない）
- 解決不能時 → スキップ + stderr WARNING ログ

### 3. ref-specialist-output-schema.md の category enum 拡張
- `ac-alignment` / `ac-alignment-unknown` を merge-gate 共通カテゴリ enum に追加
- ac-alignment specialist の追加要件セクション追記（逐語引用 MUST、confidence 上限、override label）

### 4. ref-specialist-few-shot.md の例追加
- ac-alignment（CRITICAL with 引用）と ac-alignment-unknown（INFO）の 2 例

### 5. deps.yaml への登録
- `worker-issue-pr-alignment` specialist エントリ（`gate_role: soft` フィールド付き）
- `phase-review` / `merge-gate` composite の calls に追加
- `pr-review-manifest` script の calls に `resolve-issue-num` を追加

### 6. parser.py の後処理ロジック
- `_process_alignment_findings()`: ac-alignment finding 専用後処理
- 逐語引用なし CRITICAL → WARNING 自動降格（評価ヒューリスティック: `「」`/`""`/`> ` 引用を 2 つ以上）
- `PR_LABELS=alignment-override` ラベル付き → alignment finding を全スキップ
- 既存 specialist (vulnerability/bug/etc) は影響を受けない（fast path で early return）

### 7. テスト
- `cli/twl/tests/test_autopilot_parser.py`: 7 ケース追加
  - 逐語引用なし CRITICAL → 降格
  - 2 引用ありで CRITICAL 維持
  - blockquote 引用での CRITICAL 維持
  - alignment-override label でドロップ + 他 finding 保持
  - 未知 category 素通し（後方互換）
  - WARNING 降格対象外
  - 既存 specialist 後方互換
- `plugins/twl/tests/bats/scripts/pr-review-manifest.bats`: 5 ケース追加
  - merge-gate / phase-review で Issue 番号設定時に含まれる
  - Issue 番号解決不能時はスキップ + WARNING ログ
  - post-fix-verify では含まれない

## 検証

- `twl --check` PASS (193 OK / 0 missing)
- `twl --validate` PASS (1902 OK / 0 violations)
- `twl --audit` PASS (CRITICAL 0)
- `pytest tests/test_autopilot_parser.py` 25/25 PASS

## 受け入れ基準

- [x] `agents/worker-issue-pr-alignment.md` が存在し、ref-specialist-output-schema + ref-specialist-few-shot + ref-prompt-guide skills が注入されている
- [x] specialist プロンプトが「逐語引用必須」「UNKNOWN 状態許容」「confidence 上限 75（CRITICAL 例外を除く）」を明示している
- [x] `deps.yaml` に worker-issue-pr-alignment が specialist として登録されており、`gate_role: soft` フィールドを持つ
- [x] `pr-review-manifest.sh` の phase-review / merge-gate モードで Issue 番号解決可能時のみ常時追加される（番号解決不可時はスキップ + warning ログ）
- [x] `refs/ref-specialist-output-schema.md` の merge-gate 共通カテゴリ enum に `ac-alignment` および `ac-alignment-unknown` が追加されている
- [x] few-shot 例に ac-alignment（CRITICAL with 引用）と ac-alignment-unknown（INFO）の 2 例が含まれている
- [x] specialist の出力に Issue / diff の逐語引用が無い場合、parser が自動的に CRITICAL→WARNING に降格するロジックが実装されている
- [x] PR ラベル `alignment-override` が付いている場合、alignment specialist の Finding がスキップされる
- [x] Issue 1 (ac-verify) との重複回避: alignment specialist が ac-verify checkpoint を read し、既に CRITICAL 判定済みの AC をスキップする（プロンプトに明記）
- [x] bats テスト 5 シナリオ + 既存 17 シナリオ
- [x] 既存 parser の category enum 後方互換テスト PASS（未知 category 素通し）
- [x] `deps.yaml` の `refined_by`/`refined_at` フィールドに `<hash>`/`<date>` プレースホルダ文字列が残っていない
- [x] `cd plugins/twl && twl --check && twl --validate` PASS

## 関連

- 設計意図: `plugins/twl/architecture/domain/contexts/pr-cycle.md` Component Mapping
- 関連 Issue: #1 (ac-verify chain 接続), #3 (Closes #N), #4 (mergegate.py close verify)

Closes #135