### PR TITLE
feat(autopilot): Worker terminal status 検証ガード (#131)

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1756,6 +1756,7 @@ scripts:
       - script: state-write
       - script: chain-steps
       - script: resolve-issue-num
+      - script: worker-terminal-guard
     commands:
       - init
       - board-status-update
@@ -1773,6 +1774,11 @@ scripts:
       - autopilot-detect
       - quick-detect
     description: "機械的 chain ステップを実行（Python: python3 -m twl.autopilot.chain; ChainRunner クラス）"
+
+  worker-terminal-guard:
+    type: script
+    path: scripts/worker-terminal-guard.sh
+    description: "Worker chain 終端で issue-{N}.json の status が terminal 集合 {merge-ready,done,failed,conflict} に含まれるか検証。非 terminal 時は status=failed + failure.message=non_terminal_chain_end を書き込み exit 1（Issue #131）"
 
   worktree-create:
     type: script

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -650,14 +650,20 @@ step_all_pass_check() {
     local _cr_branch _cr_pr
     _cr_branch=$(git branch --show-current 2>/dev/null || echo "")
     _cr_pr=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
-    python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=merge-ready" --set "pr=$_cr_pr" --set "branch=$_cr_branch" 2>/dev/null || true
+    if ! python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=merge-ready" --set "pr=$_cr_pr" --set "branch=$_cr_branch" >&2; then
+      err "all-pass-check" "state write merge-ready 失敗"
+      return 1
+    fi
     if $is_autopilot; then
       ok "all-pass-check" "PASS — autopilot 配下: merge-ready 宣言。Pilot による merge-gate を待機"
     else
       ok "all-pass-check" "PASS — merge-ready"
     fi
   else
-    python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=failed" 2>/dev/null || true
+    if ! python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=failed" >&2; then
+      err "all-pass-check" "state write failed 失敗"
+      return 1
+    fi
     skip "all-pass-check" "FAIL — status=failed"
     return 1
   fi
@@ -765,6 +771,8 @@ main() {
   fi
   shift
 
+  local _main_rc=0
+  set +e
   case "$step" in
     init)                step_init "$@" ;;
     worktree-create)     step_worktree_create "$@" ;;
@@ -795,6 +803,22 @@ main() {
       exit 1
       ;;
   esac
+  _main_rc=$?
+  set -e
+
+  # Worker terminal status 検証ガード (Issue #131)
+  # chain main 終端（=all-pass-check ステップ完了後）で issue-{N}.json の
+  # status が terminal 集合 {merge-ready, done, failed, conflict} に含まれている
+  # ことを検証。AUTOPILOT_DIR 設定時のみ作動し、非 autopilot フローには影響しない。
+  if [[ "$step" == "all-pass-check" && -n "${AUTOPILOT_DIR:-}" ]]; then
+    local _guard_issue_num
+    _guard_issue_num="$(resolve_issue_num 2>/dev/null || echo "")"
+    if [[ -n "$_guard_issue_num" ]]; then
+      bash "${SCRIPT_DIR}/worker-terminal-guard.sh" "$_guard_issue_num" || _main_rc=$?
+    fi
+  fi
+
+  return $_main_rc
 }
 
 main "$@"

--- a/plugins/twl/scripts/worker-terminal-guard.sh
+++ b/plugins/twl/scripts/worker-terminal-guard.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# worker-terminal-guard.sh - Worker chain 終端での status terminal 検証ガード
+#
+# Issue #131: Worker terminal status 検証ガード（chain 終端での status 漏れ検出）
+#
+# terminal 集合: {"merge-ready", "done", "failed", "conflict"}
+#   - cli/twl/src/twl/autopilot/state.py の _TRANSITIONS 定義と一致
+#   - merge-ready / failed / conflict は further 遷移可能だが、Worker chain の
+#     責務としては「次フェーズに引き渡せる状態」として扱う
+#
+# 挙動:
+#   - AUTOPILOT_DIR 未設定 → no-op（非 autopilot フローには影響させない）
+#   - issue 番号なし        → no-op（保守的スキップ）
+#   - status が terminal   → no-op（exit 0）
+#   - status が非 terminal → stderr WARNING + state write status=failed
+#                             failure={message:"non_terminal_chain_end",
+#                                      step:"worker-terminal-guard"} → exit 1
+#
+# Usage: worker-terminal-guard.sh <issue_num>
+#
+# trap EXIT には登録しない（cleanup 処理との競合リスク）。chain-runner.sh の
+# main 関数終端から明示呼び出しする。
+
+set -uo pipefail
+
+# AUTOPILOT_DIR 未設定 → no-op（非 autopilot 保護）
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+issue_num="${1:-}"
+if [[ -z "$issue_num" ]]; then
+  exit 0
+fi
+
+# 数値検証（引数注入防止）
+if ! [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+  exit 0
+fi
+
+current=$(python3 -m twl.autopilot.state read \
+  --autopilot-dir "$AUTOPILOT_DIR" \
+  --type issue --issue "$issue_num" --field status 2>/dev/null || echo "")
+
+case "$current" in
+  merge-ready|done|failed|conflict)
+    # terminal — no-op
+    exit 0
+    ;;
+  *)
+    echo "[worker-terminal-guard] WARNING: issue-${issue_num}.json status=${current:-empty} (non-terminal). Force-failing." >&2
+    python3 -m twl.autopilot.state write \
+      --autopilot-dir "$AUTOPILOT_DIR" \
+      --type issue --issue "$issue_num" --role worker \
+      --set "status=failed" \
+      --set 'failure={"message":"non_terminal_chain_end","step":"worker-terminal-guard"}' >&2 || true
+    exit 1
+    ;;
+esac

--- a/plugins/twl/tests/scenarios/worker-terminal-guard.test.sh
+++ b/plugins/twl/tests/scenarios/worker-terminal-guard.test.sh
@@ -1,0 +1,369 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Unit Tests: Worker terminal status 検証ガード (Issue #131)
+#
+# Coverage:
+#   1. Document-level: worker-terminal-guard.sh の構造検証
+#   2. chain-runner.sh 修正: 2>/dev/null || true 削除 + err 関数経由出力
+#   3. deps.yaml に worker-terminal-guard 登録
+#   4. Runtime behavior: ガードの実行時挙動（terminal / non-terminal / no-op）
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+REPO_GIT_ROOT="$(cd "${PROJECT_ROOT}" && git rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result=0
+  "$func" || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "${PROJECT_ROOT}/${file}" ]]
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  ! grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"
+}
+
+# =============================================================================
+# Document verification
+# =============================================================================
+echo ""
+echo "--- Document: worker-terminal-guard.sh の構造検証 ---"
+
+test_guard_script_exists() {
+  assert_file_exists "scripts/worker-terminal-guard.sh" || return 1
+}
+run_test "scripts/worker-terminal-guard.sh が存在する" test_guard_script_exists
+
+test_guard_terminal_set_definition() {
+  # terminal 集合 {merge-ready, done, failed, conflict} がコメントで明記されている
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'merge-ready.*done.*failed.*conflict' || return 1
+}
+run_test "worker-terminal-guard.sh コメントに terminal 集合が明記されている" test_guard_terminal_set_definition
+
+test_guard_autopilot_dir_noop() {
+  # AUTOPILOT_DIR 未設定 → no-op（exit 0）
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'AUTOPILOT_DIR' || return 1
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'exit 0' || return 1
+}
+run_test "AUTOPILOT_DIR 未設定時 no-op 分岐が存在する" test_guard_autopilot_dir_noop
+
+test_guard_terminal_case() {
+  # case 文で terminal 集合を網羅
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'merge-ready\|done\|failed\|conflict' || return 1
+}
+run_test "case 文で terminal 集合を網羅している" test_guard_terminal_case
+
+test_guard_force_fail_writes_failure() {
+  # 非 terminal 時に failure.message=non_terminal_chain_end を書き込む
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'non_terminal_chain_end' || return 1
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'worker-terminal-guard' || return 1
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'status=failed' || return 1
+}
+run_test "非 terminal 時に status=failed + failure.message を書き込む" test_guard_force_fail_writes_failure
+
+test_guard_stderr_warning() {
+  assert_file_contains "scripts/worker-terminal-guard.sh" 'WARNING.*>&2|echo.*>&2' || return 1
+}
+run_test "非 terminal 時に stderr WARNING を出力する" test_guard_stderr_warning
+
+test_guard_numeric_validation() {
+  # 引数注入防止: 数値検証
+  assert_file_contains "scripts/worker-terminal-guard.sh" '\^\[0-9\]' || return 1
+}
+run_test "issue_num 数値検証（引数注入防止）" test_guard_numeric_validation
+
+# =============================================================================
+# chain-runner.sh の修正検証
+# =============================================================================
+echo ""
+echo "--- chain-runner.sh: 2>/dev/null || true 削除 + err 関数経由 ---"
+
+test_chain_runner_no_dev_null_in_all_pass() {
+  assert_file_exists "scripts/chain-runner.sh" || return 1
+  # step_all_pass_check 周辺に `2>/dev/null || true` が残っていないこと
+  # （他のステップでは残っていてよいので、all-pass-check 周辺をピンポイントで）
+  local line_pass line_fail
+  line_pass=$(grep -n 'status=merge-ready' "${PROJECT_ROOT}/scripts/chain-runner.sh" | head -1 | cut -d: -f1)
+  line_fail=$(grep -n '"status=failed"' "${PROJECT_ROOT}/scripts/chain-runner.sh" | head -1 | cut -d: -f1)
+  [[ -z "$line_pass" || -z "$line_fail" ]] && return 1
+
+  # 当該行に `2>/dev/null || true` が含まれないこと
+  local pass_line fail_line
+  pass_line=$(sed -n "${line_pass}p" "${PROJECT_ROOT}/scripts/chain-runner.sh")
+  fail_line=$(sed -n "${line_fail}p" "${PROJECT_ROOT}/scripts/chain-runner.sh")
+
+  if echo "$pass_line" | grep -q '2>/dev/null || true'; then
+    return 1
+  fi
+  if echo "$fail_line" | grep -q '2>/dev/null || true'; then
+    return 1
+  fi
+  return 0
+}
+run_test "all-pass-check の state write から 2>/dev/null || true が削除されている" test_chain_runner_no_dev_null_in_all_pass
+
+test_chain_runner_uses_err_on_failure() {
+  assert_file_exists "scripts/chain-runner.sh" || return 1
+  assert_file_contains "scripts/chain-runner.sh" 'err "all-pass-check" "state write merge-ready' || return 1
+  assert_file_contains "scripts/chain-runner.sh" 'err "all-pass-check" "state write failed' || return 1
+}
+run_test "all-pass-check 失敗時に err 関数で stderr 出力する" test_chain_runner_uses_err_on_failure
+
+test_chain_runner_invokes_guard() {
+  assert_file_exists "scripts/chain-runner.sh" || return 1
+  assert_file_contains "scripts/chain-runner.sh" 'worker-terminal-guard\.sh' || return 1
+  # all-pass-check 限定で呼び出される
+  assert_file_contains "scripts/chain-runner.sh" 'all-pass-check.*AUTOPILOT_DIR|AUTOPILOT_DIR.*all-pass-check' || return 1
+}
+run_test "chain-runner.sh main 終端で worker-terminal-guard.sh を呼び出す" test_chain_runner_invokes_guard
+
+# =============================================================================
+# deps.yaml 検証
+# =============================================================================
+echo ""
+echo "--- deps.yaml: worker-terminal-guard 登録 ---"
+
+test_deps_yaml_has_worker_terminal_guard() {
+  assert_file_exists "deps.yaml" || return 1
+  assert_file_contains "deps.yaml" 'worker-terminal-guard:' || return 1
+  assert_file_contains "deps.yaml" 'scripts/worker-terminal-guard\.sh' || return 1
+}
+run_test "deps.yaml に worker-terminal-guard コンポーネントが登録されている" test_deps_yaml_has_worker_terminal_guard
+
+test_deps_yaml_chain_runner_calls_guard() {
+  assert_file_exists "deps.yaml" || return 1
+  # chain-runner の calls リストに worker-terminal-guard が含まれる
+  grep -q 'worker-terminal-guard' "${PROJECT_ROOT}/deps.yaml" || return 1
+}
+run_test "deps.yaml の chain-runner.calls に worker-terminal-guard が含まれる" test_deps_yaml_chain_runner_calls_guard
+
+# =============================================================================
+# Runtime behavior tests
+# =============================================================================
+echo ""
+echo "--- Runtime: worker-terminal-guard.sh の実行時挙動 ---"
+
+_make_sandbox() {
+  local sandbox
+  sandbox="$(mktemp -d)"
+  mkdir -p "$sandbox/.autopilot/issues"
+  echo "$sandbox"
+}
+
+_write_issue_status() {
+  local sandbox="$1"
+  local num="$2"
+  local status="$3"
+  local file="${sandbox}/.autopilot/issues/issue-${num}.json"
+  python3 -c "
+import json, sys
+data = {
+    'issue': int('$num'),
+    'status': '$status',
+    'branch': 'feat/${num}-test',
+    'pr': None,
+    'window': '',
+    'started_at': '2026-04-07T00:00:00Z',
+    'current_step': 'all-pass-check',
+    'retry_count': 0,
+    'fix_instructions': None,
+    'merged_at': None,
+    'files_changed': [],
+    'failure': None,
+}
+with open('$file', 'w') as f:
+    json.dump(data, f)
+"
+}
+
+GUARD="${PROJECT_ROOT}/scripts/worker-terminal-guard.sh"
+
+# PYTHONPATH for twl.autopilot.state
+if [[ -n "$REPO_GIT_ROOT" && -d "$REPO_GIT_ROOT/cli/twl/src" ]]; then
+  export PYTHONPATH="${REPO_GIT_ROOT}/cli/twl/src${PYTHONPATH:+:${PYTHONPATH}}"
+fi
+
+test_runtime_no_autopilot_dir_noop() {
+  (
+    unset AUTOPILOT_DIR
+    bash "$GUARD" "131" >/dev/null 2>&1
+  )
+}
+run_test "runtime: AUTOPILOT_DIR 未設定時は no-op (exit 0)" test_runtime_no_autopilot_dir_noop
+
+test_runtime_empty_issue_noop() {
+  (
+    export AUTOPILOT_DIR="/tmp"
+    bash "$GUARD" "" >/dev/null 2>&1
+  )
+}
+run_test "runtime: issue_num 空は no-op (exit 0)" test_runtime_empty_issue_noop
+
+test_runtime_non_numeric_issue_noop() {
+  (
+    export AUTOPILOT_DIR="/tmp"
+    bash "$GUARD" "abc" >/dev/null 2>&1
+  )
+}
+run_test "runtime: issue_num 非数値は no-op (exit 0)" test_runtime_non_numeric_issue_noop
+
+test_runtime_terminal_merge_ready_noop() {
+  local sbx
+  sbx="$(_make_sandbox)"
+  _write_issue_status "$sbx" 131 "merge-ready"
+  (
+    export AUTOPILOT_DIR="${sbx}/.autopilot"
+    bash "$GUARD" "131" >/dev/null 2>&1
+  )
+  local rc=$?
+  rm -rf "$sbx"
+  return $rc
+}
+run_test "runtime: status=merge-ready は no-op (exit 0)" test_runtime_terminal_merge_ready_noop
+
+test_runtime_terminal_done_noop() {
+  local sbx
+  sbx="$(_make_sandbox)"
+  _write_issue_status "$sbx" 131 "done"
+  (
+    export AUTOPILOT_DIR="${sbx}/.autopilot"
+    bash "$GUARD" "131" >/dev/null 2>&1
+  )
+  local rc=$?
+  rm -rf "$sbx"
+  return $rc
+}
+run_test "runtime: status=done は no-op (exit 0)" test_runtime_terminal_done_noop
+
+test_runtime_terminal_failed_noop() {
+  local sbx
+  sbx="$(_make_sandbox)"
+  _write_issue_status "$sbx" 131 "failed"
+  (
+    export AUTOPILOT_DIR="${sbx}/.autopilot"
+    bash "$GUARD" "131" >/dev/null 2>&1
+  )
+  local rc=$?
+  rm -rf "$sbx"
+  return $rc
+}
+run_test "runtime: status=failed は no-op (exit 0)" test_runtime_terminal_failed_noop
+
+test_runtime_terminal_conflict_noop() {
+  local sbx
+  sbx="$(_make_sandbox)"
+  _write_issue_status "$sbx" 131 "conflict"
+  (
+    export AUTOPILOT_DIR="${sbx}/.autopilot"
+    bash "$GUARD" "131" >/dev/null 2>&1
+  )
+  local rc=$?
+  rm -rf "$sbx"
+  return $rc
+}
+run_test "runtime: status=conflict は no-op (exit 0)" test_runtime_terminal_conflict_noop
+
+test_runtime_non_terminal_running_force_fail() {
+  local sbx
+  sbx="$(_make_sandbox)"
+  _write_issue_status "$sbx" 131 "running"
+
+  local stderr_output rc
+  stderr_output=$(
+    export AUTOPILOT_DIR="${sbx}/.autopilot"
+    bash "$GUARD" "131" 2>&1 >/dev/null
+  )
+  rc=$?
+
+  # exit 1 が返ること
+  if [[ $rc -ne 1 ]]; then
+    rm -rf "$sbx"
+    return 1
+  fi
+
+  # stderr に WARNING が含まれること
+  if ! echo "$stderr_output" | grep -q "worker-terminal-guard"; then
+    rm -rf "$sbx"
+    return 1
+  fi
+  if ! echo "$stderr_output" | grep -qi "non-terminal\|WARNING"; then
+    rm -rf "$sbx"
+    return 1
+  fi
+
+  # state が failed + failure.message=non_terminal_chain_end に更新されること
+  local new_status new_message new_step
+  new_status=$(python3 -c "import json; print(json.load(open('${sbx}/.autopilot/issues/issue-131.json'))['status'])")
+  new_message=$(python3 -c "import json; print(json.load(open('${sbx}/.autopilot/issues/issue-131.json'))['failure']['message'])")
+  new_step=$(python3 -c "import json; print(json.load(open('${sbx}/.autopilot/issues/issue-131.json'))['failure']['step'])")
+  rm -rf "$sbx"
+
+  [[ "$new_status" == "failed" ]] || return 1
+  [[ "$new_message" == "non_terminal_chain_end" ]] || return 1
+  [[ "$new_step" == "worker-terminal-guard" ]] || return 1
+  return 0
+}
+
+if python3 -c "import twl.autopilot.state" 2>/dev/null; then
+  run_test "runtime: status=running は force-fail (exit 1 + state write)" test_runtime_non_terminal_running_force_fail
+else
+  run_test_skip "runtime: status=running は force-fail (exit 1 + state write)" "twl.autopilot.state 未インポート可能"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
## 概要

Worker chain の終端で `issue-{N}.json` の `status` が terminal 集合 `{merge-ready, done, failed, conflict}` に含まれているか検証し、未遷移なら stderr WARNING + force-fail するガードレールを追加。

## 変更内容

### 1. `chain-runner.sh` のエラー可視化

`step_all_pass_check` の PASS/FAIL パスから `2>/dev/null || true` を削除し、`state write` 失敗時は `err` 関数経由で stderr 出力 + `return 1` する。state write 失敗が隠蔽される問題を解消。

### 2. 新規 `plugins/twl/scripts/worker-terminal-guard.sh`

- **AUTOPILOT_DIR 未設定** → no-op（非 autopilot フロー保護）
- **issue_num 空 / 非数値** → no-op（保守的スキップ + 引数注入防止）
- **terminal status** → no-op（`exit 0`）
- **非 terminal status** → stderr WARNING + `state write status=failed failure={message:"non_terminal_chain_end",step:"worker-terminal-guard"}` → `exit 1`

terminal 集合はスクリプトコメントと Issue 用語定義の両方に明記。`cli/twl/src/twl/autopilot/state.py` の `_TRANSITIONS` 定義と一致。

### 3. `chain-runner.sh` main 終端フック

`step == "all-pass-check"` かつ `AUTOPILOT_DIR` 設定時のみガードを明示呼び出し。trap EXIT は使用しない（cleanup 処理との競合リスク回避、Issue 指定通り）。set +e / set -e で case 呼び出しの exit code を明示的に保持。

### 4. `deps.yaml` 更新

- `worker-terminal-guard` を `script` type で新規登録
- `chain-runner.calls` に追加

### 5. テスト追加

`plugins/twl/tests/scenarios/worker-terminal-guard.test.sh` を新規追加:

**Document verification (7 tests):**
- スクリプト存在確認
- terminal 集合のコメント記載
- AUTOPILOT_DIR no-op 分岐
- case 文での terminal 集合網羅
- 非 terminal 時の state write
- stderr WARNING 出力
- issue_num 数値検証

**chain-runner.sh 修正検証 (3 tests):**
- `2>/dev/null || true` 削除
- `err` 関数経由出力
- main 終端でのガード呼び出し

**deps.yaml 検証 (2 tests):**
- `worker-terminal-guard:` エントリ
- `chain-runner.calls` 反映

**Runtime behavior (8 tests):**
- AUTOPILOT_DIR 未設定 → no-op
- issue_num 空 / 非数値 → no-op
- status=merge-ready / done / failed / conflict → no-op
- status=running → force-fail + state 更新検証

**結果: 20 passed, 0 failed, 0 skipped**

## 検証結果

- `cd plugins/twl && twl --check` → `OK: 194, Missing: 0`
- `cd plugins/twl && twl --validate` → `OK: 1921, Violations: 0`
- `cd plugins/twl && twl --audit` → `CRITICAL: 14` (main と同数、回帰なし)
- `cd cli/twl && pytest tests/` → `907 passed, 4 failed` (4 failures は main でも発生する既存失敗)
- 新規 scenario test: 20/20 PASS
- Smoke: `bash chain-runner.sh all-pass-check PASS`（非 autopilot）→ `✓ all-pass-check: PASS (non-autopilot)` 正常動作

## 受け入れ基準

- [x] terminal 集合が worker-terminal-guard.sh コメント + Issue 用語定義に明記
- [x] `chain-runner.sh` PASS/FAIL パスの `2>/dev/null || true` 削除、`err` 経由 stderr 出力
- [x] `worker-terminal-guard.sh` 新規追加、chain main 終端で呼び出し
- [x] AUTOPILOT_DIR 未設定時 no-op をテストで保証
- [x] 非 terminal 時 `status=failed` + `failure.message=non_terminal_chain_end` 書き込み
- [x] `worker-terminal-guard.test.sh` PASS
- [x] 既存 autopilot scenario test 全件 PASS（回帰なし）
- [x] `deps.yaml` 登録 + `twl check` PASS

Closes #131