### PR TITLE
feat(plugins-twl): PR 本文に Closes #N を機械的に挿入 + 既存 PR 修復ヘルパー (#136)

### DIFF
--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -244,6 +244,10 @@ class MergeGate:
             f"PR #{self.pr_number} のマージを実行... (REPO_MODE={repo_mode})"
         )
 
+        # Pre-merge fail-safe: ensure PR body contains Closes #N so GitHub
+        # auto-close fires on merge. Issue #136.
+        self._ensure_closes_link(gh_repo_flag)
+
         merge_ok = self._run_merge(gh_repo_flag)
         if not merge_ok:
             sys.exit(1)
@@ -376,6 +380,49 @@ class MergeGate:
         # 再確認
         state_after = self._gh_issue_state(gh_repo_flag)
         return state_after == "CLOSED"
+
+    def _ensure_closes_link(self, gh_repo_flag: list[str]) -> None:
+        """Ensure PR body contains Closes #N before merge.
+
+        Issue #136 — GitHub の auto-close は PR 本文 (body) に
+        ``Closes|Fixes|Resolves #N`` がある場合のみ発火する。
+        merge 直前に PR 本文を確認し、無ければ ``gh pr edit --body`` で
+        機械的に追記する pre-merge fail-safe。
+
+        本文取得失敗時は既存挙動を維持するためスキップ（warning も出さない）。
+        """
+        result = subprocess.run(
+            ["gh", "pr", "view", self.pr_number, *gh_repo_flag,
+             "--json", "body", "-q", ".body"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            return  # 取得失敗時は既存挙動維持
+        body = result.stdout.rstrip("\n")
+        closes_pattern = re.compile(
+            rf"\b(Closes|Fixes|Resolves)\s+#{re.escape(self.issue)}\b",
+            re.IGNORECASE,
+        )
+        if closes_pattern.search(body):
+            return  # 既に存在
+        new_body = f"{body}\n\nCloses #{self.issue}\n"
+        edit_result = subprocess.run(
+            ["gh", "pr", "edit", self.pr_number, *gh_repo_flag,
+             "--body", new_body],
+            capture_output=True, text=True,
+        )
+        if edit_result.returncode == 0:
+            print(
+                f"[merge-gate] Issue #{self.issue}: "
+                f"PR #{self.pr_number} 本文に Closes #{self.issue} を機械的に追記"
+            )
+        else:
+            print(
+                f"[merge-gate] Issue #{self.issue}: "
+                f"⚠️ PR 本文への Closes 追記失敗（merge は継続）: "
+                f"{edit_result.stderr.strip()}",
+                file=sys.stderr,
+            )
 
     def _run_merge(self, gh_repo_flag: list[str]) -> bool:
         """Execute gh pr merge --squash. Returns True on success."""

--- a/cli/twl/tests/test_autopilot_mergegate.py
+++ b/cli/twl/tests/test_autopilot_mergegate.py
@@ -408,6 +408,145 @@ class TestExecuteWithIssueVerify:
             mock_verify.assert_called_once()
 
 
+# ---------------------------------------------------------------------------
+# _ensure_closes_link (Issue #136)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureClosesLink:
+    """Pre-merge fail-safe: PR 本文に Closes #N が無ければ機械的に追記する。"""
+
+    def test_skip_when_pr_view_fails(self, gate):
+        """gh pr view が失敗した場合は何もしない（既存挙動維持）。"""
+        with patch("subprocess.run",
+                   return_value=MagicMock(returncode=1, stdout="", stderr="boom")) as mock_run:
+            gate._ensure_closes_link([])
+            # Only pr view called, no pr edit
+            assert mock_run.call_count == 1
+            assert "view" in mock_run.call_args.args[0]
+
+    def test_skip_when_closes_already_present(self, gate):
+        """PR 本文に Closes #N が既にあれば追記しない。"""
+        body = "Some description\n\nCloses #42\n"
+        with patch("subprocess.run",
+                   return_value=MagicMock(returncode=0, stdout=body)) as mock_run:
+            gate._ensure_closes_link([])
+            # Only pr view called, no pr edit
+            assert mock_run.call_count == 1
+
+    def test_skip_when_fixes_present(self, gate):
+        """PR 本文に Fixes #N があっても追記しない（auto-close 同等扱い）。"""
+        body = "fix bug\n\nFixes #42"
+        with patch("subprocess.run",
+                   return_value=MagicMock(returncode=0, stdout=body)) as mock_run:
+            gate._ensure_closes_link([])
+            assert mock_run.call_count == 1
+
+    def test_skip_when_resolves_present_case_insensitive(self, gate):
+        body = "stuff\n\nresolves #42"
+        with patch("subprocess.run",
+                   return_value=MagicMock(returncode=0, stdout=body)) as mock_run:
+            gate._ensure_closes_link([])
+            assert mock_run.call_count == 1
+
+    def test_appends_closes_when_absent(self, gate):
+        """PR 本文に Closes #N が無ければ gh pr edit で追記する。"""
+        body = "Some description without close link"
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "view" in cmd:
+                return MagicMock(returncode=0, stdout=body, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._ensure_closes_link([])
+
+        # 2 calls: view + edit
+        assert len(calls) == 2
+        edit_cmd = calls[1]
+        assert "edit" in edit_cmd
+        # body argument の中に Closes #42 が含まれる
+        body_idx = edit_cmd.index("--body") + 1
+        assert "Closes #42" in edit_cmd[body_idx]
+        # 元の本文も保持
+        assert "Some description without close link" in edit_cmd[body_idx]
+
+    def test_does_not_match_other_issue_number(self, gate):
+        """Closes #420 は #42 のマッチに使えない（word boundary）。"""
+        body = "fix\n\nCloses #420"
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "view" in cmd:
+                return MagicMock(returncode=0, stdout=body, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._ensure_closes_link([])
+
+        # edit が呼ばれているはず（#42 は #420 と別物）
+        assert len(calls) == 2
+        assert "edit" in calls[1]
+
+    def test_passes_repo_flag_through(self, gate):
+        body = "no close link"
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(list(cmd))
+            if "view" in cmd:
+                return MagicMock(returncode=0, stdout=body, stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._ensure_closes_link(["-R", "owner/repo"])
+
+        # Both view and edit must include the repo flag
+        for c in calls:
+            assert "-R" in c
+            assert "owner/repo" in c
+
+    def test_edit_failure_does_not_raise(self, gate):
+        """gh pr edit 失敗時も例外を出さない（merge は継続）。"""
+        body = "no link"
+
+        def fake_run(cmd, **kwargs):
+            if "view" in cmd:
+                return MagicMock(returncode=0, stdout=body, stderr="")
+            return MagicMock(returncode=1, stdout="", stderr="edit failed")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._ensure_closes_link([])  # should not raise
+
+    def test_called_before_run_merge_in_execute(self, gate):
+        """execute() フローの中で _ensure_closes_link が _run_merge より先に呼ばれる。"""
+        order: list[str] = []
+
+        def fake_ensure(self, _flag):
+            order.append("ensure")
+
+        def fake_merge(self, _flag):
+            order.append("merge")
+            return True
+
+        with patch("os.getcwd", return_value="/home/u/repo/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch.object(MergeGate, "_verify_and_close_issue", return_value=True), \
+             patch.object(MergeGate, "_ensure_closes_link", new=fake_ensure), \
+             patch.object(MergeGate, "_run_merge", new=fake_merge), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            gate.execute()
+
+        assert order == ["ensure", "merge"]
+
+
 class TestGhRepoFlag:
     def test_no_repo_args_no_flag(self, autopilot_dir, scripts_root):
         gate = MergeGate(

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1871,6 +1871,16 @@ scripts:
     path: scripts/escape-issue-body.sh
     description: "Issue body の HTML エスケープ（& → &amp;、< → &lt;、> → &gt;）"
 
+  pr-create-helper:
+    type: script
+    path: scripts/lib/pr-create-helper.sh
+    description: "PR 作成共通ヘルパー（pr_create_with_closes 関数: PR 本文に Closes #N を機械的に挿入）"
+
+  pr-link-issue:
+    type: script
+    path: scripts/pr-link-issue.sh
+    description: "既存 PR の本文に Closes #N を追記する修復ヘルパー（--close-issue で gh issue close 直接実行）"
+
   spec-review-manifest:
     type: script
     path: scripts/spec-review-manifest.sh

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -217,7 +217,7 @@ fi
 
 # --- quick 指示をシステムプロンプトとして CONTEXT に追記 ---
 if [[ "$IS_QUICK_LAUNCH" == "true" ]]; then
-  QUICK_INSTRUCTION="[quick Issue] このIssueにはquickラベルが付いています。workflow-test-readyは実行してはいけません。直接実装→commit→push→gh pr create --fill --label quick→merge-gateのみを実行してください。"
+  QUICK_INSTRUCTION="[quick Issue] このIssueにはquickラベルが付いています。workflow-test-readyは実行してはいけません。直接実装→commit→push→PR作成（'source \"\${CLAUDE_PLUGIN_ROOT}/scripts/lib/pr-create-helper.sh\" && pr_create_with_closes \"${ISSUE}\" quick' を実行し、PR 本文に必ず 'Closes #${ISSUE}' を機械的に挿入する）→merge-gateのみを実行してください。"
   if [[ -n "$CONTEXT" ]]; then
     CONTEXT="${CONTEXT}
 

--- a/plugins/twl/scripts/lib/pr-create-helper.sh
+++ b/plugins/twl/scripts/lib/pr-create-helper.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# pr-create-helper.sh - 共通ヘルパー関数: PR 作成時に Closes #N を機械的に挿入
+# 使用方法: source "${SCRIPT_DIR}/lib/pr-create-helper.sh"
+#
+# 提供関数:
+#   pr_create_with_closes <issue_num> [label] [extra_args...]
+#     - latest commit message を PR body にコピー
+#     - body に Closes #${issue_num} が無ければ機械的に追記
+#     - gh pr create を実行（title は latest commit subject）
+#
+# 背景: gh pr create --fill は commit message をそのまま PR body にコピーするが、
+# commit message に Closes #N が含まれない場合 GitHub auto-close が発火しない。
+# このヘルパーは PR 作成時点で確実に Closes #N を本文に含める。
+
+pr_create_with_closes() {
+  local issue_num="$1"
+  shift || true
+
+  if [[ -z "$issue_num" ]]; then
+    echo "[pr-create-helper] Error: ISSUE_NUM 必須" >&2
+    return 1
+  fi
+  if ! [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+    echo "[pr-create-helper] Error: 不正な ISSUE_NUM: ${issue_num}" >&2
+    return 1
+  fi
+
+  local label=""
+  if [[ $# -gt 0 ]]; then
+    label="$1"
+    shift || true
+  fi
+
+  local commit_subject commit_body
+  commit_subject="$(git log -1 --format=%s)"
+  commit_body="$(git log -1 --format=%B)"
+
+  local body
+  if echo "$commit_body" | grep -Eq "(Closes|Fixes|Resolves)[[:space:]]+#${issue_num}\b"; then
+    body="$commit_body"
+  else
+    body="${commit_body}
+
+Closes #${issue_num}"
+  fi
+
+  local cmd=(gh pr create --title "$commit_subject" --body "$body")
+  if [[ -n "$label" ]]; then
+    cmd+=(--label "$label")
+  fi
+  if [[ $# -gt 0 ]]; then
+    cmd+=("$@")
+  fi
+
+  "${cmd[@]}"
+}

--- a/plugins/twl/scripts/pr-link-issue.sh
+++ b/plugins/twl/scripts/pr-link-issue.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# pr-link-issue.sh - 既存 PR の本文に Closes #N を追記する修復ヘルパー
+#
+# Usage:
+#   bash plugins/twl/scripts/pr-link-issue.sh <issue_num> <pr_num> [--close-issue] [--repo OWNER/REPO]
+#
+# 機能:
+#   - gh pr view で現在の PR 本文を取得
+#   - Closes #${issue_num} が既に含まれていれば no-op
+#   - 含まれていなければ追記して gh pr edit
+#   - --close-issue 指定時は gh issue close を**直接**呼ぶ
+#
+# 注意: GitHub は PR merge 後の本文編集を auto-close 再評価しない。
+# 既に merge 済みの PR で Issue を CLOSED にしたい場合は、--close-issue
+# フラグを必ず付けること。本フラグは「auto-close を期待せず gh issue close
+# を直接実行する」操作である。
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bash pr-link-issue.sh <issue_num> <pr_num> [OPTIONS]
+
+Arguments:
+  issue_num      対象 Issue 番号 (例: 136)
+  pr_num         対象 PR 番号 (例: 200)
+
+Options:
+  --close-issue       gh issue close を直接実行する（merge 済み PR 用）
+                      注意: GitHub は merge 後の本文編集を auto-close 再評価
+                      しないため、merged PR で Issue を閉じたい場合は本
+                      フラグを必ず付けること。
+  --repo OWNER/REPO   クロスリポ指定（省略時は CWD のリポを使用）
+  -h, --help          このヘルプを表示
+EOF
+}
+
+ISSUE_NUM=""
+PR_NUM=""
+CLOSE_ISSUE=false
+REPO_FLAG=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --close-issue)
+      CLOSE_ISSUE=true
+      shift
+      ;;
+    --repo)
+      REPO_FLAG=(--repo "$2")
+      shift 2
+      ;;
+    --repo=*)
+      REPO_FLAG=(--repo "${1#--repo=}")
+      shift
+      ;;
+    -*)
+      echo "[pr-link-issue] Error: 不明なオプション: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      if [[ -z "$ISSUE_NUM" ]]; then
+        ISSUE_NUM="$1"
+      elif [[ -z "$PR_NUM" ]]; then
+        PR_NUM="$1"
+      else
+        echo "[pr-link-issue] Error: 余分な引数: $1" >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$ISSUE_NUM" || -z "$PR_NUM" ]]; then
+  echo "[pr-link-issue] Error: issue_num と pr_num が必須" >&2
+  usage >&2
+  exit 1
+fi
+
+if ! [[ "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "[pr-link-issue] Error: 不正な issue_num: $ISSUE_NUM" >&2
+  exit 1
+fi
+if ! [[ "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  echo "[pr-link-issue] Error: 不正な pr_num: $PR_NUM" >&2
+  exit 1
+fi
+
+# --- 現在の PR body 取得 ---
+CURRENT_BODY="$(gh pr view "$PR_NUM" "${REPO_FLAG[@]}" --json body -q .body)"
+
+# --- Closes #N 既存チェック ---
+if echo "$CURRENT_BODY" | grep -Eq "(Closes|Fixes|Resolves)[[:space:]]+#${ISSUE_NUM}\b"; then
+  echo "[pr-link-issue] PR #${PR_NUM} の本文に既に Closes #${ISSUE_NUM} が含まれています (no-op)"
+else
+  NEW_BODY="${CURRENT_BODY}
+
+Closes #${ISSUE_NUM}"
+  gh pr edit "$PR_NUM" "${REPO_FLAG[@]}" --body "$NEW_BODY"
+  echo "[pr-link-issue] PR #${PR_NUM} の本文に Closes #${ISSUE_NUM} を追記しました"
+fi
+
+# --- --close-issue: gh issue close を直接実行 ---
+if [[ "$CLOSE_ISSUE" == "true" ]]; then
+  ISSUE_STATE="$(gh issue view "$ISSUE_NUM" "${REPO_FLAG[@]}" --json state -q .state 2>/dev/null || echo "")"
+  if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+    echo "[pr-link-issue] Issue #${ISSUE_NUM} は既に CLOSED です (no-op)"
+  else
+    gh issue close "$ISSUE_NUM" "${REPO_FLAG[@]}"
+    echo "[pr-link-issue] Issue #${ISSUE_NUM} を CLOSED にしました（gh issue close 直接実行）"
+  fi
+fi

--- a/plugins/twl/skills/workflow-setup/SKILL.md
+++ b/plugins/twl/skills/workflow-setup/SKILL.md
@@ -41,7 +41,7 @@ setup chain のオーケストレーター。chain 実行順序は deps.yaml に
    eval "$(bash "$CR" autopilot-detect)"
    eval "$(bash "$CR" quick-detect)"
    ```
-   - IS_QUICK=true かつ IS_AUTOPILOT=true → workflow-test-ready **呼び出し禁止**。直接実装 → commit → push → `gh pr create --fill --label quick` → `bash "$CR" ac-verify` → `commands/ac-verify.md` Read → 実行（checkpoint 永続化必須）→ `commands/merge-gate.md` Read → merge-gate 実行（merge-gate は ac-verify checkpoint を統合する）
+   - IS_QUICK=true かつ IS_AUTOPILOT=true → workflow-test-ready **呼び出し禁止**。直接実装 → commit → push → PR 作成（`source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/pr-create-helper.sh" && pr_create_with_closes "$ISSUE_NUM" quick`、PR 本文に必ず `Closes #${ISSUE_NUM}` を機械的に挿入）→ `bash "$CR" ac-verify` → `commands/ac-verify.md` Read → 実行（checkpoint 永続化必須）→ `commands/merge-gate.md` Read → merge-gate 実行（merge-gate は ac-verify checkpoint を統合する）
    - IS_QUICK=false かつ IS_AUTOPILOT=true → 即座に `/twl:workflow-test-ready` を Skill 実行（停止禁止）
    - IS_AUTOPILOT=false → 「setup chain 完了。次: `/twl:workflow-test-ready`」と案内
 

--- a/plugins/twl/tests/bats/helpers/common.bash
+++ b/plugins/twl/tests/bats/helpers/common.bash
@@ -31,6 +31,11 @@ common_setup() {
   # Copy all scripts into sandbox
   cp "$REPO_ROOT"/scripts/*.sh "$SANDBOX/scripts/" 2>/dev/null || true
   cp "$REPO_ROOT"/scripts/*.py "$SANDBOX/scripts/" 2>/dev/null || true
+  # Copy lib/ subdirectory (common shell helpers, e.g. pr-create-helper.sh)
+  if [[ -d "$REPO_ROOT/scripts/lib" ]]; then
+    mkdir -p "$SANDBOX/scripts/lib"
+    cp "$REPO_ROOT"/scripts/lib/*.sh "$SANDBOX/scripts/lib/" 2>/dev/null || true
+  fi
 
   # Copy Python autopilot modules (replaces state/session bash scripts)
   local _repo_git_root

--- a/plugins/twl/tests/bats/scripts/pr-create-helper.bats
+++ b/plugins/twl/tests/bats/scripts/pr-create-helper.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# pr-create-helper.bats - unit tests for scripts/lib/pr-create-helper.sh
+#
+# Issue #136: PR 本文に Closes #N を機械的に挿入する共通ヘルパー
+# Note: bats-support/bats-assert 非依存（環境にサブモジュール未初期化でも実行可能）
+
+setup() {
+  REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  HELPER_SH="$REPO_ROOT_REAL/scripts/lib/pr-create-helper.sh"
+
+  # Create sandbox with throwaway git repo
+  SANDBOX="$(mktemp -d)"
+  cd "$SANDBOX" || exit 1
+  git init -q
+  git config user.email t@t
+  git config user.name t
+  echo a > a.txt
+  git add a.txt
+  git commit -q -m "feat: initial commit"
+
+  # gh stub: capture all args verbatim
+  STUB_BIN="$SANDBOX/.stub-bin"
+  mkdir -p "$STUB_BIN"
+  cat > "$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+: > "${GH_CAPTURE:-/dev/null}"
+for a in "$@"; do
+  printf '%s\n' "$a" >> "${GH_CAPTURE:-/dev/null}"
+done
+echo "https://github.com/o/r/pull/1"
+EOF
+  chmod +x "$STUB_BIN/gh"
+  export PATH="$STUB_BIN:$PATH"
+  export GH_CAPTURE="$SANDBOX/gh-args.txt"
+}
+
+teardown() {
+  cd /
+  rm -rf "$SANDBOX"
+}
+
+@test "pr_create_with_closes appends Closes #N when missing from commit body" {
+  source "$HELPER_SH"
+  pr_create_with_closes 136 quick
+
+  grep -F -- "--body" "$GH_CAPTURE"
+  grep -F "Closes #136" "$GH_CAPTURE"
+  grep -F -- "--label" "$GH_CAPTURE"
+  grep -F "quick" "$GH_CAPTURE"
+}
+
+@test "pr_create_with_closes does not duplicate Closes #N when already in commit" {
+  echo b > b.txt
+  git add b.txt
+  git commit -q -m "feat: add b
+
+Closes #99"
+
+  source "$HELPER_SH"
+  pr_create_with_closes 99
+
+  local count
+  count=$(grep -c "Closes #99" "$GH_CAPTURE" || true)
+  [ "$count" -eq 1 ]
+}
+
+@test "pr_create_with_closes treats Fixes #N in commit as already-linked" {
+  echo c > c.txt
+  git add c.txt
+  git commit -q -m "fix: bug
+
+Fixes #50"
+
+  source "$HELPER_SH"
+  pr_create_with_closes 50
+
+  ! grep -q "Closes #50" "$GH_CAPTURE"
+  grep -q "Fixes #50" "$GH_CAPTURE"
+}
+
+@test "pr_create_with_closes errors when issue_num is empty" {
+  source "$HELPER_SH"
+  run pr_create_with_closes ''
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ISSUE_NUM 必須"* ]]
+}
+
+@test "pr_create_with_closes errors when issue_num is non-numeric" {
+  source "$HELPER_SH"
+  run pr_create_with_closes 'abc'
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"不正な ISSUE_NUM"* ]]
+}
+
+@test "pr_create_with_closes passes commit subject as title" {
+  source "$HELPER_SH"
+  pr_create_with_closes 7
+  grep -q "feat: initial commit" "$GH_CAPTURE"
+}
+
+@test "pr_create_with_closes omits --label when label arg empty" {
+  source "$HELPER_SH"
+  pr_create_with_closes 8
+  ! grep -qx -- "--label" "$GH_CAPTURE"
+}

--- a/plugins/twl/tests/bats/scripts/pr-link-issue.bats
+++ b/plugins/twl/tests/bats/scripts/pr-link-issue.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# pr-link-issue.bats - unit tests for scripts/pr-link-issue.sh
+#
+# Issue #136: 既存 PR 本文に Closes #N を追記する修復ヘルパー
+# Note: bats-support/bats-assert 非依存
+
+setup() {
+  REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SCRIPT_SH="$REPO_ROOT_REAL/scripts/pr-link-issue.sh"
+
+  SANDBOX="$(mktemp -d)"
+  STUB_BIN="$SANDBOX/.stub-bin"
+  mkdir -p "$STUB_BIN"
+
+  cat > "$STUB_BIN/gh" <<'EOF'
+#!/usr/bin/env bash
+: > "${GH_CAPTURE:-/dev/null}"
+for a in "$@"; do
+  printf '%s\n' "$a" >> "${GH_CAPTURE:-/dev/null}"
+done
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  cat "${GH_PR_BODY_FILE:-/dev/null}" 2>/dev/null || echo ""
+  exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "edit" ]]; then
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+  echo "${GH_ISSUE_STATE:-OPEN}"
+  exit 0
+fi
+if [[ "$1" == "issue" && "$2" == "close" ]]; then
+  echo "closed" > "${GH_ISSUE_CLOSED_MARK:-/dev/null}"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$STUB_BIN/gh"
+  export PATH="$STUB_BIN:$PATH"
+  export GH_CAPTURE="$SANDBOX/gh-args.txt"
+  export GH_PR_BODY_FILE="$SANDBOX/pr-body.txt"
+  export GH_ISSUE_CLOSED_MARK="$SANDBOX/issue-closed.mark"
+}
+
+teardown() {
+  rm -rf "$SANDBOX"
+}
+
+@test "pr-link-issue appends Closes #N when missing" {
+  echo "Original body without close link" > "$GH_PR_BODY_FILE"
+
+  run bash "$SCRIPT_SH" 136 200
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"追記しました"* ]]
+
+  grep -q "edit" "$GH_CAPTURE"
+  grep -q "Closes #136" "$GH_CAPTURE"
+}
+
+@test "pr-link-issue is no-op when Closes #N already present" {
+  printf 'Body\n\nCloses #136\n' > "$GH_PR_BODY_FILE"
+
+  run bash "$SCRIPT_SH" 136 200
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に Closes #136"* ]]
+  ! grep -qx "edit" "$GH_CAPTURE"
+}
+
+@test "pr-link-issue treats Fixes #N as already-linked" {
+  printf 'Body\n\nFixes #136\n' > "$GH_PR_BODY_FILE"
+
+  run bash "$SCRIPT_SH" 136 200
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に Closes #136"* ]]
+  ! grep -qx "edit" "$GH_CAPTURE"
+}
+
+@test "pr-link-issue --close-issue calls gh issue close directly" {
+  echo "body" > "$GH_PR_BODY_FILE"
+  export GH_ISSUE_STATE="OPEN"
+
+  run bash "$SCRIPT_SH" 136 200 --close-issue
+  [ "$status" -eq 0 ]
+  [ -f "$GH_ISSUE_CLOSED_MARK" ]
+  [[ "$output" == *"CLOSED にしました"* ]]
+}
+
+@test "pr-link-issue --close-issue is no-op when issue already CLOSED" {
+  echo "body" > "$GH_PR_BODY_FILE"
+  export GH_ISSUE_STATE="CLOSED"
+
+  run bash "$SCRIPT_SH" 136 200 --close-issue
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に CLOSED"* ]]
+  [ ! -f "$GH_ISSUE_CLOSED_MARK" ]
+}
+
+@test "pr-link-issue without --close-issue does NOT call gh issue close" {
+  echo "body" > "$GH_PR_BODY_FILE"
+
+  run bash "$SCRIPT_SH" 136 200
+  [ "$status" -eq 0 ]
+  [ ! -f "$GH_ISSUE_CLOSED_MARK" ]
+}
+
+@test "pr-link-issue errors when issue_num missing" {
+  run bash "$SCRIPT_SH"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"必須"* ]]
+}
+
+@test "pr-link-issue errors when pr_num missing" {
+  run bash "$SCRIPT_SH" 136
+  [ "$status" -ne 0 ]
+}
+
+@test "pr-link-issue errors on non-numeric issue_num" {
+  run bash "$SCRIPT_SH" abc 200
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"不正な"* ]]
+}
+
+@test "pr-link-issue errors on non-numeric pr_num" {
+  run bash "$SCRIPT_SH" 136 abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"不正な"* ]]
+}
+
+@test "pr-link-issue --help shows usage" {
+  run bash "$SCRIPT_SH" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+  [[ "$output" == *"--close-issue"* ]]
+}

--- a/plugins/twl/tests/bats/structure/quick-path-closes-link.bats
+++ b/plugins/twl/tests/bats/structure/quick-path-closes-link.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# quick-path-closes-link.bats - static checks for Issue #136
+#
+# Issue #136 受け入れ基準:
+# - workflow-setup quick path セクション内に Closes # の記載があること
+# - autopilot-launch.sh の QUICK_INSTRUCTION 文字列に Closes #${ISSUE} が含まれること
+#
+# Note: 本ファイルは bats-support/bats-assert 非依存。
+# 環境にサブモジュール未初期化でも実行可能。
+
+setup() {
+  REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: workflow-setup SKILL.md quick path に Closes # 記載
+# ---------------------------------------------------------------------------
+
+@test "workflow-setup SKILL.md quick path mentions Closes #" {
+  local skill_md="$REPO_ROOT_REAL/skills/workflow-setup/SKILL.md"
+  [ -f "$skill_md" ]
+  grep -E "IS_QUICK=true.*IS_AUTOPILOT=true" "$skill_md"
+  grep -F "Closes #" "$skill_md"
+}
+
+@test "workflow-setup SKILL.md quick path references pr_create_with_closes helper" {
+  local skill_md="$REPO_ROOT_REAL/skills/workflow-setup/SKILL.md"
+  grep -F "pr_create_with_closes" "$skill_md"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: autopilot-launch.sh QUICK_INSTRUCTION に Closes #${ISSUE}
+# ---------------------------------------------------------------------------
+
+@test "autopilot-launch.sh QUICK_INSTRUCTION contains Closes #\${ISSUE}" {
+  local launch_sh="$REPO_ROOT_REAL/scripts/autopilot-launch.sh"
+  [ -f "$launch_sh" ]
+  local line
+  line=$(grep -E '^\s*QUICK_INSTRUCTION=' "$launch_sh")
+  [ -n "$line" ]
+  [[ "$line" == *'Closes #${ISSUE}'* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 共通ヘルパー存在確認
+# ---------------------------------------------------------------------------
+
+@test "scripts/lib/pr-create-helper.sh exists and defines pr_create_with_closes" {
+  local helper="$REPO_ROOT_REAL/scripts/lib/pr-create-helper.sh"
+  [ -f "$helper" ]
+  grep -E "^pr_create_with_closes\(\)" "$helper"
+}
+
+@test "scripts/pr-link-issue.sh exists and is executable" {
+  local script="$REPO_ROOT_REAL/scripts/pr-link-issue.sh"
+  [ -f "$script" ]
+  [ -x "$script" ]
+}
+
+@test "scripts/pr-link-issue.sh --help mentions auto-close caveat" {
+  local script="$REPO_ROOT_REAL/scripts/pr-link-issue.sh"
+  local out
+  out=$(bash "$script" --help 2>&1)
+  [[ "$out" == *"--close-issue"* ]]
+  [[ "$out" == *"再評価"* ]] || [[ "$out" == *"merge 後"* ]] || [[ "$out" == *"再評価しない"* ]]
+}


### PR DESCRIPTION
## Summary

Issue #136 の実装。autopilot Worker の `gh pr create --fill` が PR body に `Closes #N` を含めず、GitHub auto-close が発火しないため、PR merge 後も Issue が OPEN のまま残る不整合を機械的に解消する。

## 変更内容

### 新規ヘルパー
- **`plugins/twl/scripts/lib/pr-create-helper.sh`** — 共通関数 `pr_create_with_closes <issue_num> [label]`
  - 最新 commit の subject/body から PR を作成
  - body に `Closes|Fixes|Resolves #N` が無ければ機械的に追記（既存時は no-op）
- **`plugins/twl/scripts/pr-link-issue.sh`** — 既存 PR 本文修復ヘルパー
  - `bash pr-link-issue.sh <issue> <pr> [--close-issue] [--repo OWNER/REPO]`
  - `--close-issue` は `gh issue close` を**直接**実行（GitHub は merge 後の本文編集を auto-close 再評価しないため、help に明記）

### 既存ファイル修正
- **`plugins/twl/skills/workflow-setup/SKILL.md`** quick path → `pr_create_with_closes` を使用
- **`plugins/twl/scripts/autopilot-launch.sh`** `QUICK_INSTRUCTION` → 指示文字列内に `Closes #${ISSUE}` を含む形に更新
- **`cli/twl/src/twl/autopilot/mergegate.py`** `_ensure_closes_link` を追加。`execute()` の `_run_merge` 直前に呼び出し、PR 本文に `Closes #N` が無ければ `gh pr edit --body` で機械的に追記（pre-merge fail-safe、edit 失敗時も merge 継続）
- **`plugins/twl/deps.yaml`** に `pr-create-helper` / `pr-link-issue` を `script` 型として登録

### テスト
- **pytest** (`cli/twl/tests/test_autopilot_mergegate.py`) — `_ensure_closes_link` の 8 ケース
  - skip on view failure / Closes・Fixes・Resolves 既存検出 / word boundary / repo flag 透過 / edit 失敗時 raise しない / `_run_merge` より先に呼ばれる順序
- **bats** (`tests/bats/scripts/pr-create-helper.bats`) — 7 ケース
- **bats** (`tests/bats/scripts/pr-link-issue.bats`) — 11 ケース
- **bats** (`tests/bats/structure/quick-path-closes-link.bats`) — 6 ケース（SKILL.md / autopilot-launch.sh の grep 静的検証 + ヘルパー存在確認）

## 検証

```
cd cli/twl && pytest tests/test_autopilot_mergegate.py
=> 39 passed (新規 8 ケース含む)

cd plugins/twl && bats tests/bats/scripts/pr-create-helper.bats \
  tests/bats/scripts/pr-link-issue.bats \
  tests/bats/structure/quick-path-closes-link.bats
=> 24 ok

cd plugins/twl && twl --check && twl --validate
=> OK: 195/195, OK: 1921/1921, Violations: 0
```

`pytest tests/` 全体で 916 passed / 4 failed の baseline と同じ（4 件は本 PR 無関係の既存失敗、stash で確認済み）。`twl --audit` も baseline と同じ CRITICAL=14 / WARNING=53 で、新規スクリプトに対する警告は無し。

## follow-up（本 PR スコープ外）

archived 5 件 (#103, #106, #107, #110, #112) の手動修復は本 PR マージ後に運用 task として実行:

```bash
for n in 103 106 107 110 112; do
  pr=$(gh pr list --search "#${n}" --state merged --json number -q '.[0].number')
  bash plugins/twl/scripts/pr-link-issue.sh "$n" "$pr" --close-issue
done
```

Closes #136