### PR TITLE
feat(plugins-twl): archive_done_issues に GitHub Issue state 二重チェック追加 (#138)

### DIFF
--- a/cli/twl/src/twl/autopilot/orchestrator.py
+++ b/cli/twl/src/twl/autopilot/orchestrator.py
@@ -180,6 +180,8 @@ class PhaseOrchestrator:
         self._nudge_counts: dict[str, int] = {}
         self._last_output_hash: dict[str, str] = {}
         self._health_check_counter: dict[str, int] = {}
+        # skipped_archives: fail-closed で archive を skip した Issue 番号（Issue #138）
+        self._skipped_archives: list[int] = []
 
     def run(self) -> dict[str, Any]:
         """Execute phase. Returns phase report dict."""
@@ -199,8 +201,9 @@ class PhaseOrchestrator:
         if not active_entries:
             print(f"[orchestrator] Phase {self.phase}: 全 Issue が skip/done", file=sys.stderr)
             all_nums = [_parse_issue_entry(e)[1] for e in all_entries]
-            report = self._generate_phase_report(all_nums)
+            # 先に archive を実行して skipped_archives を集約してからレポート生成（Issue #138）
             self._archive_done_issues(all_nums)
+            report = self._generate_phase_report(all_nums)
             return report
 
         # Step 3: Batch execution
@@ -209,10 +212,12 @@ class PhaseOrchestrator:
             batch = active_entries[batch_start:batch_start + MAX_PARALLEL]
             self._run_batch(batch)
 
-        # Step 4: Generate report
+        # Step 4: Archive (先に archive して skipped_archives を集約)
         all_nums = [_parse_issue_entry(e)[1] for e in all_entries]
-        report = self._generate_phase_report(all_nums)
         self._archive_done_issues(all_nums)
+
+        # Step 5: Generate report (skipped_archives を含む)
+        report = self._generate_phase_report(all_nums)
         return report
 
     def _filter_active(self, entries: list[str]) -> list[str]:
@@ -609,19 +614,66 @@ class PhaseOrchestrator:
                 "failed": failed,
                 "skipped": skipped,
             },
+            "skipped_archives": list(self._skipped_archives),
             "changed_files": changed_files,
         }
 
+    def _gh_issue_state(self, issue: str) -> str:
+        """Return GitHub Issue state ('OPEN' / 'CLOSED' / '' on failure).
+
+        fail-closed helper: 呼び出し側は空文字 (取得失敗) を "CLOSED でない" として扱う。
+        Issue #138: archive_done_issues の二重チェックで使用。
+        """
+        try:
+            r = subprocess.run(
+                ["gh", "issue", "view", issue, "--json", "state", "-q", ".state"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if r.returncode != 0:
+                return ""
+            return r.stdout.strip()
+        except Exception:
+            return ""
+
     def _archive_done_issues(self, issue_nums: list[str]) -> None:
+        """Fail-closed archive: local status=done かつ GitHub state=CLOSED のみ archive.
+
+        Issue #138: 空文字 (取得失敗) / OPEN は skip し、_skipped_archives に追加する。
+        """
         for issue in issue_nums:
             status = _read_state(issue, "status", self.autopilot_dir)
-            if status == "done":
-                subprocess.run(
-                    ["bash", str(self.scripts_root / "chain-runner.sh"),
-                     "board-archive", issue],
-                    capture_output=True,
+            if status != "done":
+                continue
+
+            # NEW: GitHub Issue state 二重チェック (fail-closed)
+            gh_state = self._gh_issue_state(issue)
+            if gh_state != "CLOSED":
+                if not gh_state:
+                    print(
+                        f"[orchestrator] Issue #{issue}: ⚠️ GitHub state 取得失敗 — fail-closed で archive をスキップ",
+                        file=sys.stderr,
+                    )
+                else:
+                    print(
+                        f"[orchestrator] Issue #{issue}: ⚠️ ローカル state=done だが GitHub state={gh_state} — archive をスキップ",
+                        file=sys.stderr,
+                    )
+                print(
+                    f"[orchestrator] Issue #{issue}: 手動 close または autopilot state 修正が必要です",
+                    file=sys.stderr,
                 )
-                self._archive_deltaspec_changes(issue)
+                try:
+                    self._skipped_archives.append(int(issue))
+                except ValueError:
+                    pass
+                continue
+
+            subprocess.run(
+                ["bash", str(self.scripts_root / "chain-runner.sh"),
+                 "board-archive", issue],
+                capture_output=True,
+            )
+            self._archive_deltaspec_changes(issue)
 
     def _archive_deltaspec_changes(self, issue: str) -> None:
         try:

--- a/cli/twl/tests/test_autopilot_orchestrator.py
+++ b/cli/twl/tests/test_autopilot_orchestrator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -325,3 +326,106 @@ class TestNudgeCommandForPattern:
         orch = self._make_orchestrator(autopilot_dir, tmp_path)
         cmd = orch._nudge_command_for_pattern("PR マージ完了", "1", "_default:1")
         assert cmd == ""
+
+
+# ===========================================================================
+# Fail-closed archive guard (Issue #138)
+# ===========================================================================
+
+
+class TestArchiveDoneIssuesFailClosed:
+    """PhaseOrchestrator._archive_done_issues must fail-closed:
+    only archive when local status=done AND GitHub state=CLOSED.
+    """
+
+    def _make_orchestrator(self, autopilot_dir: Path, tmp_path: Path) -> PhaseOrchestrator:
+        return PhaseOrchestrator(
+            plan_file=str(tmp_path / "plan.yaml"),
+            phase=1,
+            session_file=str(tmp_path / "session.json"),
+            project_dir=str(tmp_path),
+            autopilot_dir=str(autopilot_dir),
+            scripts_root=tmp_path / "scripts",
+        )
+
+    def test_closed_issue_is_archived(self, autopilot_dir: Path, tmp_path: Path) -> None:
+        """GitHub state=CLOSED → archive 実行、skipped_archives 空"""
+        _write_issue(autopilot_dir, "10", "done")
+        orch = self._make_orchestrator(autopilot_dir, tmp_path)
+
+        with patch("twl.autopilot.orchestrator._read_state", return_value="done"), \
+             patch.object(orch, "_gh_issue_state", return_value="CLOSED"), \
+             patch.object(orch, "_archive_deltaspec_changes"), \
+             patch("twl.autopilot.orchestrator.subprocess.run") as mock_run:
+            orch._archive_done_issues(["10"])
+
+        # board-archive 呼び出しが発生
+        assert any(
+            "board-archive" in " ".join(str(a) for a in call.args[0])
+            for call in mock_run.call_args_list
+        )
+        assert orch._skipped_archives == []
+
+    def test_open_issue_is_skipped(self, autopilot_dir: Path, tmp_path: Path) -> None:
+        """GitHub state=OPEN → archive skip、skipped_archives に追加"""
+        _write_issue(autopilot_dir, "11", "done")
+        orch = self._make_orchestrator(autopilot_dir, tmp_path)
+
+        with patch("twl.autopilot.orchestrator._read_state", return_value="done"), \
+             patch.object(orch, "_gh_issue_state", return_value="OPEN"), \
+             patch("twl.autopilot.orchestrator.subprocess.run") as mock_run:
+            orch._archive_done_issues(["11"])
+
+        # board-archive 呼び出しは発生しない
+        assert not any(
+            "board-archive" in " ".join(str(a) for a in call.args[0])
+            for call in mock_run.call_args_list
+        )
+        assert 11 in orch._skipped_archives
+
+    def test_empty_state_is_skipped(self, autopilot_dir: Path, tmp_path: Path) -> None:
+        """GitHub state 取得失敗 (空文字) → fail-closed で skip"""
+        _write_issue(autopilot_dir, "12", "done")
+        orch = self._make_orchestrator(autopilot_dir, tmp_path)
+
+        with patch("twl.autopilot.orchestrator._read_state", return_value="done"), \
+             patch.object(orch, "_gh_issue_state", return_value=""), \
+             patch("twl.autopilot.orchestrator.subprocess.run") as mock_run:
+            orch._archive_done_issues(["12"])
+
+        assert not any(
+            "board-archive" in " ".join(str(a) for a in call.args[0])
+            for call in mock_run.call_args_list
+        )
+        assert 12 in orch._skipped_archives
+
+    def test_non_done_status_is_ignored(self, autopilot_dir: Path, tmp_path: Path) -> None:
+        """status != done → gh issue view 呼び出しなし、archive なし"""
+        _write_issue(autopilot_dir, "13", "running")
+        orch = self._make_orchestrator(autopilot_dir, tmp_path)
+
+        with patch("twl.autopilot.orchestrator._read_state", return_value="running"), \
+             patch.object(orch, "_gh_issue_state") as mock_gh, \
+             patch("twl.autopilot.orchestrator.subprocess.run"):
+            orch._archive_done_issues(["13"])
+
+        # status != done なので gh issue view も呼ばれない
+        assert mock_gh.call_count == 0
+        assert orch._skipped_archives == []
+
+    def test_generate_phase_report_includes_skipped_archives(
+        self, autopilot_dir: Path, tmp_path: Path
+    ) -> None:
+        """_generate_phase_report の出力に skipped_archives が含まれる"""
+        _write_issue(autopilot_dir, "14", "done")
+        orch = self._make_orchestrator(autopilot_dir, tmp_path)
+
+        # fail-closed で skip させる
+        with patch("twl.autopilot.orchestrator._read_state", return_value="done"), \
+             patch.object(orch, "_gh_issue_state", return_value="OPEN"), \
+             patch("twl.autopilot.orchestrator.subprocess.run"):
+            orch._archive_done_issues(["14"])
+
+        report = orch._generate_phase_report(["14"])
+        assert "skipped_archives" in report
+        assert 14 in report["skipped_archives"]

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -724,12 +724,14 @@ generate_phase_report() {
   done
 
   # JSON レポート出力
+  # skipped_archives: archive_done_issues が fail-closed で skip した Issue 番号（滞留検知用、Issue #138）
   jq -n \
     --arg signal "PHASE_COMPLETE" \
     --argjson phase "$phase" \
     --argjson done "$(printf '%s\n' "${done_issues[@]+"${done_issues[@]}"}" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')" \
     --argjson failed "$(printf '%s\n' "${failed_issues[@]+"${failed_issues[@]}"}" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')" \
     --argjson skipped "$(printf '%s\n' "${skipped_issues[@]+"${skipped_issues[@]}"}" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')" \
+    --argjson skipped_archives "$(printf '%s\n' "${SKIPPED_ARCHIVES[@]+"${SKIPPED_ARCHIVES[@]}"}" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)')" \
     --argjson changed_files "$(printf '%s\n' "${changed_files[@]+"${changed_files[@]}"}" | jq -R -s 'split("\n") | map(select(length > 0))')" \
     '{
       signal: $signal,
@@ -739,6 +741,7 @@ generate_phase_report() {
         failed: $failed,
         skipped: $skipped
       },
+      skipped_archives: $skipped_archives,
       changed_files: $changed_files
     }'
 }
@@ -796,18 +799,39 @@ generate_summary() {
 # Phase 内の Done Issue のみを選択的にアーカイブする
 # 他 Phase・手動 Issue はアーカイブ対象外（仕様: specs/phase-selective-archive）
 # 引数: issue 番号リスト（スペース区切り）
+#
+# fail-closed: ローカル status=done かつ GitHub Issue state=CLOSED の両方を満たす場合のみ archive
+# 空文字 (取得失敗) も "CLOSED でない" として skip 扱い（Issue #138）
+# skip された Issue は SKIPPED_ARCHIVES グローバル配列に追加される（滞留検知用）
+SKIPPED_ARCHIVES=()
 archive_done_issues() {
   local issue
   for issue in "$@"; do
     local status
     status=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field status 2>/dev/null || echo "")
-    if [[ "$status" == "done" ]]; then
-      if ! bash "$SCRIPTS_ROOT/chain-runner.sh" board-archive "$issue" 2>/dev/null; then
-        echo "[orchestrator] Issue #${issue}: ⚠️ Board アーカイブに失敗しました（Phase 完了は続行）" >&2
-      fi
-      # OpenSpec change archive
-      _archive_openspec_changes_for_issue "$issue"
+    if [[ "$status" != "done" ]]; then
+      continue
     fi
+
+    # NEW: GitHub Issue state 二重チェック (fail-closed)
+    local gh_state
+    gh_state=$(gh issue view "$issue" --json state -q .state 2>/dev/null || echo "")
+    if [[ "$gh_state" != "CLOSED" ]]; then
+      if [[ -z "$gh_state" ]]; then
+        echo "[orchestrator] Issue #${issue}: ⚠️ GitHub state 取得失敗 — fail-closed で archive をスキップ" >&2
+      else
+        echo "[orchestrator] Issue #${issue}: ⚠️ ローカル state=done だが GitHub state=${gh_state} — archive をスキップ" >&2
+      fi
+      echo "[orchestrator] Issue #${issue}: 手動 close または autopilot state 修正が必要です" >&2
+      SKIPPED_ARCHIVES+=("$issue")
+      continue
+    fi
+
+    if ! bash "$SCRIPTS_ROOT/chain-runner.sh" board-archive "$issue" 2>/dev/null; then
+      echo "[orchestrator] Issue #${issue}: ⚠️ Board アーカイブに失敗しました（Phase 完了は続行）" >&2
+    fi
+    # OpenSpec change archive
+    _archive_openspec_changes_for_issue "$issue"
   done
 }
 
@@ -877,9 +901,9 @@ if [[ ${#ACTIVE_ISSUES[@]} -eq 0 ]]; then
   for entry in "${ISSUES_WITH_REPO[@]}"; do
     ALL_ISSUE_NUMS+=("${entry#*:}")
   done
-  generate_phase_report "$PHASE" "${ALL_ISSUE_NUMS[@]}"
-  # 当該 Phase の Done アイテムのみを選択的にアーカイブ
+  # 先に archive を実行（SKIPPED_ARCHIVES をレポートに含めるため）
   archive_done_issues "${ALL_ISSUE_NUMS[@]}"
+  generate_phase_report "$PHASE" "${ALL_ISSUE_NUMS[@]}"
   exit 0
 fi
 
@@ -954,14 +978,15 @@ for ((BATCH_START=0; BATCH_START < TOTAL; BATCH_START += MAX_PARALLEL)); do
   unset _batch_issue_to_entry
 done
 
-# Step 4: Phase 完了レポート
+# Step 4: 当該 Phase の Done アイテムのみを選択的にアーカイブ
+# fail-closed で skip された Issue は SKIPPED_ARCHIVES に集約される
 ALL_ISSUE_NUMS=()
 for entry in "${ISSUES_WITH_REPO[@]}"; do
   ALL_ISSUE_NUMS+=("${entry#*:}")
 done
-generate_phase_report "$PHASE" "${ALL_ISSUE_NUMS[@]}"
-
-# Step 5: 当該 Phase の Done アイテムのみを選択的にアーカイブ
 archive_done_issues "${ALL_ISSUE_NUMS[@]}"
+
+# Step 5: Phase 完了レポート（skipped_archives を含む）
+generate_phase_report "$PHASE" "${ALL_ISSUE_NUMS[@]}"
 
 echo "[orchestrator] Phase ${PHASE} 完了" >&2

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -323,6 +323,19 @@ step_board_archive() {
     return 0
   fi
 
+  # NEW: GitHub state 二重チェック (fail-closed, Issue #138)
+  # 空文字 (取得失敗) も "CLOSED でない" として skip 扱いにする
+  local gh_state
+  gh_state=$(gh issue view "$issue_num" --json state -q .state 2>/dev/null || echo "")
+  if [[ "$gh_state" != "CLOSED" ]]; then
+    if [[ -z "$gh_state" ]]; then
+      skip "board-archive" "Issue #${issue_num} の GitHub state 取得失敗 — fail-closed で archive をスキップ"
+    else
+      skip "board-archive" "Issue #${issue_num} が GitHub 上で ${gh_state} — archive をスキップ"
+    fi
+    return 0
+  fi
+
   # project スコープ確認
   if ! gh project list --owner @me --limit 1 >/dev/null 2>&1; then
     skip "board-archive" "gh auth refresh -s project が必要"

--- a/plugins/twl/scripts/project-board-archive.sh
+++ b/plugins/twl/scripts/project-board-archive.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 # project-board-archive.sh - Project Board の Done アイテムを一括アーカイブ
 #
-# Usage: bash scripts/project-board-archive.sh [--dry-run]
-#   --dry-run: 実際のアーカイブなしに対象一覧を表示
+# Usage: bash scripts/project-board-archive.sh [--dry-run] [--no-verify]
+#   --dry-run:   実際のアーカイブなしに対象一覧を表示
+#   --no-verify: GitHub Issue state 二重チェックをスキップ（従来挙動）
+#
+# デフォルトは fail-closed: Project Board status=Done かつ
+# GitHub Issue state=CLOSED の両方を満たす場合のみ archive する（Issue #138）
 #
 # Example:
 #   bash scripts/project-board-archive.sh --dry-run
 #   bash scripts/project-board-archive.sh
+#   bash scripts/project-board-archive.sh --no-verify  # 従来挙動
 
 set -euo pipefail
 
@@ -16,9 +21,11 @@ source "${SCRIPT_DIR}/lib/python-env.sh"
 
 # ── 引数解析 ───────────────────────────────────────────────────
 DRY_RUN=false
+NO_VERIFY=false
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
+    --no-verify) NO_VERIFY=true ;;
     *) echo "Unknown option: $arg" >&2; exit 1 ;;
   esac
 done
@@ -70,9 +77,26 @@ if $DRY_RUN; then
 fi
 
 ARCHIVED_COUNT=0
+SKIPPED_COUNT=0
 while IFS= read -r ITEM; do
   ITEM_ID=$(echo "$ITEM" | jq -r '.id')
   ISSUE_NUM=$(echo "$ITEM" | jq -r '.content.number // "N/A"')
+
+  # NEW: GitHub Issue state 二重チェック (fail-closed, Issue #138)
+  # --no-verify 時はスキップ（従来挙動）
+  if ! $NO_VERIFY && [[ "$ISSUE_NUM" != "N/A" ]]; then
+    GH_STATE=$(gh issue view "$ISSUE_NUM" --json state -q .state 2>/dev/null || echo "")
+    if [[ "$GH_STATE" != "CLOSED" ]]; then
+      if [[ -z "$GH_STATE" ]]; then
+        echo "  ⚠️ #${ISSUE_NUM}: GitHub state 取得失敗 — fail-closed で archive をスキップ"
+      else
+        echo "  ⚠️ #${ISSUE_NUM}: GitHub state=${GH_STATE} — archive をスキップ"
+      fi
+      SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+      sleep 0.5
+      continue
+    fi
+  fi
 
   if gh project item-archive "$PROJECT_NUM" --owner "$OWNER" --id "$ITEM_ID" >/dev/null 2>&1; then
     ARCHIVED_COUNT=$((ARCHIVED_COUNT + 1))
@@ -86,3 +110,6 @@ done < <(echo "$DONE_ITEMS" | jq -c '.[]')
 
 echo ""
 echo "✓ ${ARCHIVED_COUNT} 件をアーカイブしました"
+if [[ "$SKIPPED_COUNT" -gt 0 ]]; then
+  echo "⚠️ ${SKIPPED_COUNT} 件を fail-closed により skip しました（GitHub state が CLOSED でない）"
+fi

--- a/plugins/twl/tests/bats/helpers/common.bash
+++ b/plugins/twl/tests/bats/helpers/common.bash
@@ -31,10 +31,10 @@ common_setup() {
   # Copy all scripts into sandbox
   cp "$REPO_ROOT"/scripts/*.sh "$SANDBOX/scripts/" 2>/dev/null || true
   cp "$REPO_ROOT"/scripts/*.py "$SANDBOX/scripts/" 2>/dev/null || true
-  # Copy lib/ subdirectory (common shell helpers, e.g. pr-create-helper.sh)
+  # Copy scripts/lib/* (sourced by chain-runner.sh, project-board-archive.sh, pr-create-helper.sh, etc.)
   if [[ -d "$REPO_ROOT/scripts/lib" ]]; then
     mkdir -p "$SANDBOX/scripts/lib"
-    cp "$REPO_ROOT"/scripts/lib/*.sh "$SANDBOX/scripts/lib/" 2>/dev/null || true
+    cp -r "$REPO_ROOT/scripts/lib/." "$SANDBOX/scripts/lib/" 2>/dev/null || true
   fi
 
   # Copy Python autopilot modules (replaces state/session bash scripts)

--- a/plugins/twl/tests/bats/scripts/archive-fail-closed.bats
+++ b/plugins/twl/tests/bats/scripts/archive-fail-closed.bats
@@ -1,0 +1,300 @@
+#!/usr/bin/env bats
+# archive-fail-closed.bats — Issue #138
+#
+# archive_done_issues / step_board_archive / project-board-archive.sh の
+# fail-closed ガード（ローカル status=done かつ GitHub state=CLOSED の両方を満たす場合のみ archive）を検証する。
+#
+# Scenarios:
+#   step_board_archive:
+#     1. GitHub CLOSED → archive 実行 (成功メッセージ)
+#     2. GitHub OPEN → skip (OPEN メッセージ)
+#     3. GitHub state 取得失敗 (空文字) → skip (取得失敗メッセージ)
+#   project-board-archive.sh:
+#     4. 全 CLOSED → 全 archive
+#     5. 一部 OPEN → OPEN の Issue を skip + warning
+#     6. state 取得失敗 → skip + warning
+#     7. --no-verify → 取得失敗を無視して archive 実行 (従来挙動)
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*) echo "feat/131-test" ;;
+      *"rev-parse --show-toplevel"*) echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*) echo ".git" ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  stub_command "tmux" 'exit 0'
+  stub_command "sleep" 'exit 0'
+
+  # chain-steps.sh placeholder
+  if [[ ! -f "$SANDBOX/scripts/chain-steps.sh" ]]; then
+    echo '#!/usr/bin/env bash' > "$SANDBOX/scripts/chain-steps.sh"
+  fi
+
+  stub_command "state-write.sh" 'exit 0'
+  cat > "$SANDBOX/scripts/state-write.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SANDBOX/scripts/state-write.sh"
+
+  cat > "$SANDBOX/scripts/state-read.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$SANDBOX/scripts/state-read.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Helper: gh stub builders
+# ---------------------------------------------------------------------------
+
+# _stub_gh_issue_state_closed: gh issue view → CLOSED
+_stub_gh_issue_state_closed() {
+  local log_path="$SANDBOX/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "${log_path}"
+case "\$*" in
+  *"issue view"*"--json state"*)
+    echo "CLOSED" ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-list"*)
+    echo '{"items": [{"id": "PVTI_1", "content": {"number": 131, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 131"}]}' ;;
+  *"project item-archive"*)
+    echo "archived" ;;
+  *)
+    echo "{}" ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+}
+
+# _stub_gh_issue_state_open: gh issue view → OPEN
+_stub_gh_issue_state_open() {
+  local log_path="$SANDBOX/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "${log_path}"
+case "\$*" in
+  *"issue view"*"--json state"*)
+    echo "OPEN" ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-list"*)
+    echo '{"items": [{"id": "PVTI_1", "content": {"number": 131, "type": "Issue"}, "status": "Done", "title": "Issue 131"}]}' ;;
+  *"project item-archive"*)
+    echo "archived" ;;
+  *)
+    echo "{}" ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+}
+
+# _stub_gh_issue_state_fail: gh issue view → 非ゼロ exit (state 取得失敗)
+_stub_gh_issue_state_fail() {
+  local log_path="$SANDBOX/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "${log_path}"
+case "\$*" in
+  *"issue view"*"--json state"*)
+    echo "network error" >&2
+    exit 1 ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-list"*)
+    echo '{"items": [{"id": "PVTI_1", "content": {"number": 131, "type": "Issue"}, "status": "Done", "title": "Issue 131"}]}' ;;
+  *"project item-archive"*)
+    echo "archived" ;;
+  *)
+    echo "{}" ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+}
+
+# ---------------------------------------------------------------------------
+# step_board_archive (chain-runner.sh)
+# ---------------------------------------------------------------------------
+
+@test "step_board_archive: GitHub CLOSED → archive を実行（fail-closed 成立）" {
+  _stub_gh_issue_state_closed
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" board-archive "131"
+
+  assert_success
+  assert_output --partial "✓ board-archive"
+  # gh project item-archive が呼ばれる
+  grep -q "project item-archive" "$SANDBOX/gh-calls.log"
+}
+
+@test "step_board_archive: GitHub OPEN → archive を skip (fail-closed)" {
+  _stub_gh_issue_state_open
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" board-archive "131"
+
+  assert_success
+  assert_output --partial "⚠️ board-archive"
+  assert_output --partial "OPEN"
+  assert_output --partial "スキップ"
+  # gh project item-archive は呼ばれない
+  run grep "project item-archive" "$SANDBOX/gh-calls.log"
+  assert_failure
+}
+
+@test "step_board_archive: GitHub state 取得失敗 → archive を skip (fail-closed)" {
+  _stub_gh_issue_state_fail
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" board-archive "131"
+
+  assert_success
+  assert_output --partial "⚠️ board-archive"
+  assert_output --partial "取得失敗"
+  assert_output --partial "スキップ"
+  run grep "project item-archive" "$SANDBOX/gh-calls.log"
+  assert_failure
+}
+
+@test "step_board_archive: Issue 番号なし → 番号検証で早期 return（gh issue view 呼ばれない）" {
+  _stub_gh_issue_state_fail
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" board-archive ""
+
+  assert_success
+  # 空引数では gh issue view も呼ばれない
+  if [[ -f "$SANDBOX/gh-calls.log" ]]; then
+    run grep "issue view" "$SANDBOX/gh-calls.log"
+    assert_failure
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# project-board-archive.sh
+# ---------------------------------------------------------------------------
+
+# _stub_gh_project_board_mixed: Issue 131 (CLOSED) と 132 (OPEN) が Done ステータス
+_stub_gh_project_board_mixed() {
+  local log_path="$SANDBOX/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "${log_path}"
+case "\$*" in
+  *"issue view 131"*)
+    echo "CLOSED" ;;
+  *"issue view 132"*)
+    echo "OPEN" ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-list"*)
+    echo '{"items": [
+      {"id": "PVTI_131", "content": {"number": 131, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 131"},
+      {"id": "PVTI_132", "content": {"number": 132, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 132"}
+    ]}' ;;
+  *"project item-archive"*)
+    echo "archived" ;;
+  *)
+    echo "{}" ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "project-board-archive.sh: 一部 OPEN → OPEN の Issue は skip + warning" {
+  _stub_gh_project_board_mixed
+
+  run bash "$SANDBOX/scripts/project-board-archive.sh"
+
+  assert_success
+  # #132 (OPEN) は skip warning
+  assert_output --partial "#132"
+  assert_output --partial "OPEN"
+  assert_output --partial "スキップ"
+  # #131 (CLOSED) は archive
+  assert_output --partial "archived: #131"
+  # skip サマリー
+  assert_output --partial "fail-closed"
+}
+
+# _stub_gh_project_board_fetch_fail: 131 は state 取得失敗
+_stub_gh_project_board_fetch_fail() {
+  local log_path="$SANDBOX/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+echo "\$*" >> "${log_path}"
+case "\$*" in
+  *"issue view"*)
+    echo "network error" >&2
+    exit 1 ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-list"*)
+    echo '{"items": [
+      {"id": "PVTI_131", "content": {"number": 131, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 131"}
+    ]}' ;;
+  *"project item-archive"*)
+    echo "archived" ;;
+  *)
+    echo "{}" ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+}
+
+@test "project-board-archive.sh: state 取得失敗 → fail-closed で skip" {
+  _stub_gh_project_board_fetch_fail
+
+  run bash "$SANDBOX/scripts/project-board-archive.sh"
+
+  assert_success
+  assert_output --partial "取得失敗"
+  assert_output --partial "スキップ"
+  # item-archive は呼ばれない
+  run grep "project item-archive" "$SANDBOX/gh-calls.log"
+  assert_failure
+}
+
+@test "project-board-archive.sh: --no-verify → state 取得失敗でも archive 実行 (従来挙動)" {
+  _stub_gh_project_board_fetch_fail
+
+  run bash "$SANDBOX/scripts/project-board-archive.sh" --no-verify
+
+  assert_success
+  # --no-verify では fail-closed skip メッセージは出ない
+  refute_output --partial "fail-closed で archive をスキップ"
+  # item-archive は呼ばれる
+  grep -q "project item-archive" "$SANDBOX/gh-calls.log"
+  assert_output --partial "archived: #131"
+}

--- a/plugins/twl/tests/bats/scripts/board-archive.bats
+++ b/plugins/twl/tests/bats/scripts/board-archive.bats
@@ -73,10 +73,12 @@ _stub_gh_with_item_archive() {
   cat > "$STUB_BIN/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -97,10 +99,12 @@ _stub_gh_no_item() {
   cat > "$STUB_BIN/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -119,10 +123,12 @@ _stub_gh_archive_fails() {
   cat > "$STUB_BIN/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -146,10 +152,12 @@ _stub_gh_merge_with_archive() {
 case "$*" in
   *"pr merge"*)
     echo "merged" ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -175,10 +183,12 @@ GHSTUB_LOG_HEAD
   printf 'echo "$*" >> "%s"\n' "$log_path" >> "$STUB_BIN/gh"
   cat >> "$STUB_BIN/gh" <<'GHSTUB_LOG_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -235,10 +245,12 @@ GHSTUB_LOG_BODY
 #!/usr/bin/env bash
 COUNTER_FILE="$counter_file"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -350,10 +362,12 @@ GHSTUB
   cat > "$STUB_BIN/gh" <<'GHSTUB'
 #!/usr/bin/env bash
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": []}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": null}}}' ;;
   *)
@@ -382,10 +396,12 @@ GHSTUB_MERGE_LOG_HEAD
 case "$*" in
   *"pr merge"*)
     exit 0 ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -442,10 +458,12 @@ GHSTUB_MERGE_LOG_BODY
 case "$*" in
   *"pr merge"*)
     exit 0 ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -479,10 +497,12 @@ GHSTUB
 case "$*" in
   *"pr merge"*)
     exit 0 ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)

--- a/plugins/twl/tests/bats/scripts/board-merge-done-transition.bats
+++ b/plugins/twl/tests/bats/scripts/board-merge-done-transition.bats
@@ -131,10 +131,12 @@ GHSTUB_HEAD
 case "$*" in
   *"pr merge"*)
     exit 0 ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-add"*)

--- a/plugins/twl/tests/bats/scripts/board-phase-selective-archive.bats
+++ b/plugins/twl/tests/bats/scripts/board-phase-selective-archive.bats
@@ -152,10 +152,12 @@ echo "\$*" >> "${log_path}"
 GHSTUB_HEAD
   cat >> "$STUB_BIN/gh" <<'GHSTUB_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -371,10 +373,12 @@ echo "\$*" >> "${log_path}"
 GHSTUB_AVAIL_HEAD
   cat >> "$STUB_BIN/gh" <<'GHSTUB_AVAIL_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -408,10 +412,12 @@ echo "\$*" >> "${log_path}"
 GHSTUB_OK_HEAD
   cat >> "$STUB_BIN/gh" <<'GHSTUB_OK_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
   *"project item-list"*)
@@ -449,6 +455,8 @@ echo "\$*" >> "${log_path}"
 GHSTUB_RECOG_HEAD
   cat >> "$STUB_BIN/gh" <<'GHSTUB_RECOG_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*) echo '{"projects": []}' ;;
   *) echo '{}' ;;
 esac
@@ -478,10 +486,12 @@ echo "\$*" >> "${log_path}"
 GHSTUB_NOPROJ_HEAD
   cat >> "$STUB_BIN/gh" <<'GHSTUB_NOPROJ_BODY'
 case "$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project list"*)
     echo '{"projects": []}' ;;
   *"repo view"*"--json nameWithOwner"*)
-    echo 'shuu5/loom-plugin-dev' ;;
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
   *"api graphql"*)
     echo '{"data": {"user": {"projectV2": null}}}' ;;
   *)

--- a/plugins/twl/tests/bats/scripts/project-board-archive.bats
+++ b/plugins/twl/tests/bats/scripts/project-board-archive.bats
@@ -61,7 +61,7 @@ _stub_gh_with_done_items() {
   )
 
   # Write stub using printf to allow variable expansion for items_json
-  printf '#!/usr/bin/env bash\necho "$*" >> "%s"\ncase "$*" in\n  *"project item-list"*)\n    echo '"'"'{"items": %s}'"'"' ;;\n  *"project item-archive"*)\n    echo "archived" ;;\n  *)\n    echo "{}" ;;\nesac\n' \
+  printf '#!/usr/bin/env bash\necho "$*" >> "%s"\ncase "$*" in\n  *"issue view"*)\n    echo "CLOSED" ;;\n  *"project item-list"*)\n    echo '"'"'{"items": %s}'"'"' ;;\n  *"project item-archive"*)\n    echo "archived" ;;\n  *)\n    echo "{}" ;;\nesac\n' \
     "$log_path" "$items_json" > "$STUB_BIN/gh"
   chmod +x "$STUB_BIN/gh"
 }
@@ -73,6 +73,8 @@ _stub_gh_no_done_items() {
 #!/usr/bin/env bash
 echo "\$*" >> "${log_path}"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project item-list"*)
     echo '{"items": []}' ;;
   *"project item-archive"*)
@@ -91,6 +93,8 @@ _stub_gh_with_one_done_item() {
 #!/usr/bin/env bash
 echo "\$*" >> "${log_path}"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project item-list"*)
     echo '{"items": [{"id": "PVTI_item101", "content": {"number": 101, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 101"}]}' ;;
   *"project item-archive"*)
@@ -109,6 +113,8 @@ _stub_gh_with_two_done_items() {
 #!/usr/bin/env bash
 echo "\$*" >> "${log_path}"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project item-list"*)
     echo '{"items": [
       {"id": "PVTI_item101", "content": {"number": 101, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 101"},
@@ -130,6 +136,8 @@ _stub_gh_archive_fails() {
 #!/usr/bin/env bash
 echo "\$*" >> "${log_path}"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project item-list"*)
     echo '{"items": [{"id": "PVTI_item101", "content": {"number": 101, "repository": "shuu5/loom-plugin-dev", "type": "Issue"}, "status": "Done", "title": "Issue 101"}]}' ;;
   *"project item-archive"*)
@@ -149,6 +157,8 @@ _stub_gh_project_not_found() {
 #!/usr/bin/env bash
 echo "\$*" >> "${log_path}"
 case "\$*" in
+  *"issue view"*)
+    echo "CLOSED" ;;
   *"project item-list"*)
     echo "Could not find project" >&2
     exit 1 ;;


### PR DESCRIPTION
## Summary

`autopilot-orchestrator.sh:archive_done_issues` 等の Project Board archive 経路に GitHub Issue state 二重チェックを追加し、fail-closed で「ローカル `status == done` かつ GitHub state == `CLOSED`」を満たす場合のみ archive を実行するように変更。

これにより 2026-04-06 セッションで発生した「open の Issue 5 件 (#103, #106, #107, #110, #112) が誤って board archive される」事象を二重に防止する layered defense を実現する。

## 変更内容

### コア実装

| 経路 | 変更 |
|---|---|
| `plugins/twl/scripts/autopilot-orchestrator.sh` | `archive_done_issues` に `gh issue view --json state` 二重チェック + `SKIPPED_ARCHIVES` グローバル集約 |
| `plugins/twl/scripts/chain-runner.sh` | `step_board_archive` にも fail-closed ガード（直接呼び出し対応） |
| `plugins/twl/scripts/project-board-archive.sh` | per-item 二重チェック + `--no-verify` フラグで従来挙動を提供 |
| `cli/twl/src/twl/autopilot/orchestrator.py` | `_gh_issue_state` ヘルパー追加 + `_archive_done_issues` に fail-closed + `_skipped_archives` を report に含める |

### 滞留検知 (PHASE_COMPLETE JSON)

`generate_phase_report` 出力 JSON に `skipped_archives: number[]` フィールドを追加（additive 変更、後方互換あり）。Pilot retrospective 等で滞留した Issue を即時認識可能。

### テスト

#### 新規 bats: `plugins/twl/tests/bats/scripts/archive-fail-closed.bats` (7 scenarios, 全 PASS)

- `step_board_archive`:
  - GitHub CLOSED → archive 実行 ✓
  - GitHub OPEN → skip + warning ✓
  - GitHub state 取得失敗 → fail-closed で skip ✓
  - Issue 番号なし → 早期 return ✓
- `project-board-archive.sh`:
  - 一部 OPEN → 該当を skip + warning ✓
  - state 取得失敗 → skip ✓
  - `--no-verify` → state 取得失敗でも archive 実行 ✓

#### 新規 pytest: `cli/twl/tests/test_autopilot_orchestrator.py::TestArchiveDoneIssuesFailClosed` (5 scenarios, 全 PASS)

- CLOSED → archive 実行
- OPEN → skip + skipped_archives 追加
- 取得失敗 → skip + skipped_archives 追加
- status != done → gh 呼び出しなし
- `_generate_phase_report` 出力に `skipped_archives` 含まれる

### 既存テスト互換性

- 全 gh stub に `*"issue view"*) echo "CLOSED"` ケース追加
- `gh repo view --json nameWithOwner` の戻り値を proper JSON 形式に修正（`shuu5/loom-plugin-dev` → `{"nameWithOwner":...,"owner":{"login":...}}`）
- `tests/bats/helpers/common.bash`: `scripts/lib/` を sandbox にコピーする処理を追加（`chain-runner.sh` が source する `python-env.sh` 欠落のため既存テストが起動失敗していた問題の修正）

## 受け入れ基準

- [x] `archive_done_issues` が fail-closed (`[[ "$gh_state" != "CLOSED" ]]` 統一)
- [x] `step_board_archive` も同等の fail-closed ガード
- [x] 条件式統一 (空文字を通過させない)
- [x] Python 側 `orchestrator.py` archive 経路にも同等のガード
- [x] `project-board-archive.sh` にも同等のガード（`--no-verify` で従来挙動）
- [x] 取得失敗 vs OPEN を区別する warning ログ
- [x] `skipped_archives` フィールド追加（滞留検知用）
- [x] bats 全 fail-closed シナリオ PASS（CLOSED / OPEN / 取得失敗 / 番号不正）
- [x] pytest Python 側 archive 経路 4+1 シナリオ PASS
- [x] `twl --check && twl --validate` PASS
- [x] `cd cli/twl && pytest tests/test_autopilot_orchestrator.py` 全 30 PASS

## Test Results

```
plugins/twl: tests/lib/bats-core/bin/bats tests/bats/scripts/archive-fail-closed.bats
1..7
ok 1 step_board_archive: GitHub CLOSED → archive を実行（fail-closed 成立）
ok 2 step_board_archive: GitHub OPEN → archive を skip (fail-closed)
ok 3 step_board_archive: GitHub state 取得失敗 → archive を skip (fail-closed)
ok 4 step_board_archive: Issue 番号なし → 番号検証で早期 return（gh issue view 呼ばれない）
ok 5 project-board-archive.sh: 一部 OPEN → OPEN の Issue は skip + warning
ok 6 project-board-archive.sh: state 取得失敗 → fail-closed で skip
ok 7 project-board-archive.sh: --no-verify → state 取得失敗でも archive 実行 (従来挙動)

cli/twl: pytest tests/test_autopilot_orchestrator.py
30 passed
```

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)