### PR TITLE
feat(plugins-twl): co-autopilot Phase 完了 Issue close サニティチェック追加 (#139)

### DIFF
--- a/plugins/twl/commands/autopilot-phase-sanity.md
+++ b/plugins/twl/commands/autopilot-phase-sanity.md
@@ -1,0 +1,144 @@
+# Phase 完了サニティチェック (atomic)
+
+PHASE_COMPLETE 受信後、各 done Issue の GitHub Issue close 状態を Pilot 側で軽量 verify する。
+co-autopilot Step 4 から呼び出される layered defense の最終層（Issue #4/#5 の安全網）。
+
+PR diff・Issue body・テスト結果は **読まない**（Pilot context budget 維持）。
+Issue close 状態のみを `gh issue view`/`gh issue close` で確認する。
+
+## 入力
+
+| 変数 | 説明 |
+|------|------|
+| `$PHASE_RESULTS_JSON` | orchestrator から返された PHASE_COMPLETE JSON のパス |
+| `$P` | 現在の Phase 番号 |
+| `$SESSION_STATE_FILE` | session.json のパス |
+
+`$PHASE_RESULTS_JSON` のスキーマ:
+
+```json
+{
+  "phase": <int>,
+  "done": [<issue_number>, ...],
+  "failed": [<issue_number>, ...],
+  "skipped": [<issue_number>, ...]
+}
+```
+
+## 処理ロジック (MUST)
+
+各 done Issue について以下を順に実行する。
+
+### Step 1: 入力読込
+
+```bash
+DONE_LIST=$(jq -r '.done[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+FAILED_LIST=$(jq -r '.failed[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+SKIPPED_LIST=$(jq -r '.skipped[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+
+declare -a NEW_DONE=()
+declare -a NEW_FAILED=()
+declare -a AUTO_CLOSE_FALLBACK=()
+declare -a SANITY_WARNINGS=()
+
+# 既存 failed をそのまま継承
+while IFS= read -r f; do [ -n "$f" ] && NEW_FAILED+=("$f"); done <<< "$FAILED_LIST"
+```
+
+### Step 2: 各 done Issue を verify
+
+```bash
+while IFS= read -r issue; do
+  [ -z "$issue" ] && continue
+
+  # 1. GitHub 状態取得
+  state=$(gh issue view "$issue" --json state -q .state 2>/dev/null || echo "")
+
+  case "$state" in
+    CLOSED)
+      # 2a. 正常: そのまま done
+      NEW_DONE+=("$issue")
+      ;;
+    OPEN)
+      # 2b. 警告 → close 試行 → 再確認
+      echo "WARN: Issue #${issue} is OPEN after PHASE_COMPLETE; attempting auto-close" >&2
+      gh issue close "$issue" --comment "auto-close-fallback by autopilot-phase-sanity (Phase ${P})" >/dev/null 2>&1 || true
+      recheck=$(gh issue view "$issue" --json state -q .state 2>/dev/null || echo "")
+      if [ "$recheck" = "CLOSED" ]; then
+        NEW_DONE+=("$issue")
+        AUTO_CLOSE_FALLBACK+=("$issue")
+        echo "INFO: Issue #${issue} auto-closed successfully" >&2
+      else
+        NEW_FAILED+=("$issue")
+        echo "CRITICAL: Issue #${issue} could not be closed; moved from done to failed" >&2
+      fi
+      ;;
+    "")
+      # 2c. 取得失敗: warning + done 維持
+      SANITY_WARNINGS+=("issue=${issue} reason=state-fetch-failed")
+      NEW_DONE+=("$issue")
+      echo "WARN: Issue #${issue} state fetch failed; keeping in done" >&2
+      ;;
+    *)
+      SANITY_WARNINGS+=("issue=${issue} reason=unknown-state:${state}")
+      NEW_DONE+=("$issue")
+      ;;
+  esac
+done <<< "$DONE_LIST"
+```
+
+### Step 3: 修正済み results JSON を出力
+
+`$PHASE_RESULTS_JSON` を以下のスキーマで上書きする:
+
+```bash
+jq -n \
+  --argjson phase "$P" \
+  --argjson done "$(printf '%s\n' "${NEW_DONE[@]}" | jq -R . | jq -s 'map(tonumber)')" \
+  --argjson failed "$(printf '%s\n' "${NEW_FAILED[@]}" | jq -R . | jq -s 'map(select(length>0) | tonumber)')" \
+  --argjson skipped "$(printf '%s\n' "$SKIPPED_LIST" | jq -R . | jq -s 'map(select(length>0) | tonumber)')" \
+  --argjson fallback "$(printf '%s\n' "${AUTO_CLOSE_FALLBACK[@]}" | jq -R . | jq -s 'map(select(length>0) | tonumber)')" \
+  --argjson warnings "$(printf '%s\n' "${SANITY_WARNINGS[@]}" | jq -R . | jq -s 'map(select(length>0))')" \
+  '{phase:$phase, done:$done, failed:$failed, skipped:$skipped, auto_close_fallback:$fallback, sanity_warnings:$warnings}' \
+  > "${PHASE_RESULTS_JSON}.tmp" && mv "${PHASE_RESULTS_JSON}.tmp" "$PHASE_RESULTS_JSON"
+```
+
+### Step 4: session.json への記録（任意）
+
+`auto_close_fallback` または `sanity_warnings` が非空の場合、session.json の `.sanity_log` 配列に Phase エントリを追加する:
+
+```bash
+if [ "${#AUTO_CLOSE_FALLBACK[@]}" -gt 0 ] || [ "${#SANITY_WARNINGS[@]}" -gt 0 ]; then
+  jq --argjson phase "$P" \
+     --argjson fb "$(printf '%s\n' "${AUTO_CLOSE_FALLBACK[@]}" | jq -R . | jq -s 'map(select(length>0) | tonumber)')" \
+     --argjson wn "$(printf '%s\n' "${SANITY_WARNINGS[@]}" | jq -R . | jq -s 'map(select(length>0))')" \
+     '.sanity_log = ((.sanity_log // []) + [{phase:$phase, auto_close_fallback:$fb, sanity_warnings:$wn}])' \
+     "$SESSION_STATE_FILE" > "${SESSION_STATE_FILE}.tmp" \
+     && mv "${SESSION_STATE_FILE}.tmp" "$SESSION_STATE_FILE"
+fi
+```
+
+## 出力
+
+修正済み `$PHASE_RESULTS_JSON`:
+
+```json
+{
+  "phase": <int>,
+  "done": [<verified closed issues>],
+  "failed": [<...originally failed... + close失敗 issues>],
+  "skipped": [...],
+  "auto_close_fallback": [<auto-close で救済された issue リスト>],
+  "sanity_warnings": [<取得失敗等のリスト>]
+}
+```
+
+呼び出し元（co-autopilot SKILL.md Step 4）はこの修正済み results を後続の autopilot-phase-postprocess.md へ引き渡す。
+
+## 禁止事項 (MUST NOT)
+
+- PR diff を読んではならない（Pilot context budget 維持）
+- Issue body を読んではならない
+- テスト結果を再実行してはならない
+- `gh issue view <issue>` で `state` 以外のフィールドを取得してはならない
+- skipped リストを変更してはならない（done と failed のみ操作対象）

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -71,6 +71,8 @@ skills:
       - atomic: autopilot-launch
       - atomic: autopilot-poll
       - atomic: autopilot-phase-execute
+      - atomic: autopilot-phase-sanity
+        step: "4"
       - atomic: autopilot-phase-postprocess
       - atomic: autopilot-collect
       - atomic: autopilot-retrospective
@@ -1545,6 +1547,18 @@ commands:
       - script: session:session-state
       - reference: ref-dci
     description: "Phase Issue ループ実行（launch → poll → merge-gate → health-check）"
+
+  autopilot-phase-sanity:
+    type: atomic
+    refined_by: "ref-prompt-guide@2c7a62f2"
+    refined_at: "2026-04-07"
+    path: commands/autopilot-phase-sanity.md
+    spawnable_by: [controller]
+    can_spawn: []
+    step_in:
+      parent: co-autopilot
+      step: "4"
+    description: "Phase 完了後の Issue close 状態サニティチェック (Pilot 側 layered defense)"
 
   autopilot-phase-postprocess:
     type: atomic

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -51,7 +51,16 @@ TaskCreate で全体タスク「Autopilot: N Phases, M Issues」を登録。
 
 ## Step 4: Phase ループ（orchestrator 委譲）
 
-`autopilot-orchestrator.sh --plan --phase --session --project-dir --autopilot-dir [$REPOS_ARG]` で Phase 実行を委譲。orchestrator は JSON レポート（PHASE_COMPLETE）を返す。Pilot は `commands/autopilot-phase-postprocess.md` を Read → 実行（retrospective / cross-issue のみ）。TaskUpdate Phase P → completed。
+`autopilot-orchestrator.sh --plan --phase --session --project-dir --autopilot-dir [$REPOS_ARG]` で Phase 実行を委譲。orchestrator は JSON レポート（PHASE_COMPLETE）を返す。
+
+### Step 4.5: Phase 完了サニティチェック（MUST）
+
+PHASE_COMPLETE 受信後、`commands/autopilot-phase-sanity.md` を Read → 実行する。
+**処理ロジックの詳細は autopilot-phase-sanity.md を正典とする**（SKILL.md 側では責務範囲のみ記述）。
+
+役割: 各 done Issue の GitHub Issue close 状態を verify し、必要に応じて修正後の results JSON（auto_close_fallback / sanity_warnings 付き）を返す。Pilot LLM は PR diff・Issue body を読まず、Issue state のみを参照する（context budget 維持）。
+
+Pilot は次に `commands/autopilot-phase-postprocess.md` を Read → 実行（retrospective / cross-issue のみ）。TaskUpdate Phase P → completed。
 
 orchestrator が一括処理する内容:
 - batch 分割・Worker 起動・ポーリング・chain 遷移停止検知 + 自動 nudge

--- a/plugins/twl/tests/bats/scenarios/autopilot-phase-sanity-logic.bats
+++ b/plugins/twl/tests/bats/scenarios/autopilot-phase-sanity-logic.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# autopilot-phase-sanity-logic.bats — behavior tests for Issue #139
+#
+# autopilot-phase-sanity.md の処理ロジックを bash で再現し、4 シナリオを検証する。
+# 実 gh コマンドを呼ばず、PATH 先頭にモック gh を挿入する。
+#
+# シナリオ:
+#  1. 全 done Issue が CLOSED         → results 不変
+#  2. 1 Issue OPEN → close 成功         → auto_close_fallback に追加
+#  3. 1 Issue OPEN → close 失敗         → done から failed に移動
+#  4. state 取得失敗（空文字）          → sanity_warnings に追加 + done 維持
+
+setup() {
+  REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+  PHASE_RESULTS_JSON="$TEST_TMP/phase-results.json"
+  SESSION_STATE_FILE="$TEST_TMP/session.json"
+  GH_MOCK_DIR="$TEST_TMP/bin"
+  GH_STATE_DIR="$TEST_TMP/gh-state"
+  mkdir -p "$GH_MOCK_DIR" "$GH_STATE_DIR"
+
+  # mock gh
+  cat > "$GH_MOCK_DIR/gh" <<'MOCK_EOF'
+#!/usr/bin/env bash
+# usage:
+#  gh issue view <N> --json state -q .state
+#  gh issue close <N> [--comment ...]
+set -uo pipefail
+case "${1:-}" in
+  issue)
+    sub="${2:-}"
+    issue="${3:-}"
+    state_file="$GH_STATE_DIR/${issue}.state"
+    case "$sub" in
+      view)
+        if [ -f "$state_file" ]; then
+          cat "$state_file"
+        else
+          echo ""  # state-fetch-failed simulation
+        fi
+        ;;
+      close)
+        # close-allowed marker
+        allow="$GH_STATE_DIR/${issue}.close-allowed"
+        if [ -f "$allow" ]; then
+          echo "CLOSED" > "$state_file"
+          exit 0
+        else
+          exit 1
+        fi
+        ;;
+    esac
+    ;;
+esac
+MOCK_EOF
+  chmod +x "$GH_MOCK_DIR/gh"
+
+  export GH_STATE_DIR
+  export PATH="$GH_MOCK_DIR:$PATH"
+  export P=1
+  export PHASE_RESULTS_JSON
+  export SESSION_STATE_FILE
+
+  echo '{}' > "$SESSION_STATE_FILE"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: run sanity logic (extracted from commands/autopilot-phase-sanity.md)
+# ---------------------------------------------------------------------------
+run_sanity() {
+  DONE_LIST=$(jq -r '.done[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+  FAILED_LIST=$(jq -r '.failed[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+  SKIPPED_LIST=$(jq -r '.skipped[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
+
+  declare -a NEW_DONE=()
+  declare -a NEW_FAILED=()
+  declare -a AUTO_CLOSE_FALLBACK=()
+  declare -a SANITY_WARNINGS=()
+
+  while IFS= read -r f; do [ -n "$f" ] && NEW_FAILED+=("$f"); done <<< "$FAILED_LIST"
+
+  while IFS= read -r issue; do
+    [ -z "$issue" ] && continue
+    state=$(gh issue view "$issue" --json state -q .state 2>/dev/null || echo "")
+    case "$state" in
+      CLOSED)
+        NEW_DONE+=("$issue")
+        ;;
+      OPEN)
+        gh issue close "$issue" --comment "auto-close-fallback" >/dev/null 2>&1 || true
+        recheck=$(gh issue view "$issue" --json state -q .state 2>/dev/null || echo "")
+        if [ "$recheck" = "CLOSED" ]; then
+          NEW_DONE+=("$issue")
+          AUTO_CLOSE_FALLBACK+=("$issue")
+        else
+          NEW_FAILED+=("$issue")
+        fi
+        ;;
+      "")
+        SANITY_WARNINGS+=("issue=${issue} reason=state-fetch-failed")
+        NEW_DONE+=("$issue")
+        ;;
+      *)
+        SANITY_WARNINGS+=("issue=${issue} reason=unknown-state:${state}")
+        NEW_DONE+=("$issue")
+        ;;
+    esac
+  done <<< "$DONE_LIST"
+
+  to_json_int_array() {
+    if [ "$#" -eq 0 ]; then
+      echo "[]"
+    else
+      printf '%s\n' "$@" | jq -R . | jq -s 'map(select(length>0) | tonumber)'
+    fi
+  }
+  to_json_str_array() {
+    if [ "$#" -eq 0 ]; then
+      echo "[]"
+    else
+      printf '%s\n' "$@" | jq -R . | jq -s 'map(select(length>0))'
+    fi
+  }
+
+  done_arr=$(to_json_int_array "${NEW_DONE[@]+"${NEW_DONE[@]}"}")
+  failed_arr=$(to_json_int_array "${NEW_FAILED[@]+"${NEW_FAILED[@]}"}")
+  skipped_arr=$(printf '%s\n' "$SKIPPED_LIST" | jq -R . | jq -s 'map(select(length>0) | tonumber)')
+  fallback_arr=$(to_json_int_array "${AUTO_CLOSE_FALLBACK[@]+"${AUTO_CLOSE_FALLBACK[@]}"}")
+  warnings_arr=$(to_json_str_array "${SANITY_WARNINGS[@]+"${SANITY_WARNINGS[@]}"}")
+
+  jq -n \
+    --argjson phase "$P" \
+    --argjson done "$done_arr" \
+    --argjson failed "$failed_arr" \
+    --argjson skipped "$skipped_arr" \
+    --argjson fallback "$fallback_arr" \
+    --argjson warnings "$warnings_arr" \
+    '{phase:$phase, done:$done, failed:$failed, skipped:$skipped, auto_close_fallback:$fallback, sanity_warnings:$warnings}' \
+    > "${PHASE_RESULTS_JSON}.tmp" && mv "${PHASE_RESULTS_JSON}.tmp" "$PHASE_RESULTS_JSON"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: 全 Issue CLOSED → results 不変
+# ---------------------------------------------------------------------------
+@test "scenario 1: all done issues CLOSED → results unchanged" {
+  echo "CLOSED" > "$GH_STATE_DIR/100.state"
+  echo "CLOSED" > "$GH_STATE_DIR/101.state"
+  echo '{"phase":1,"done":[100,101],"failed":[],"skipped":[]}' > "$PHASE_RESULTS_JSON"
+
+  run_sanity
+
+  [ "$(jq -c '.done | sort' "$PHASE_RESULTS_JSON")" = "[100,101]" ]
+  [ "$(jq -c '.failed' "$PHASE_RESULTS_JSON")" = "[]" ]
+  [ "$(jq -c '.auto_close_fallback' "$PHASE_RESULTS_JSON")" = "[]" ]
+  [ "$(jq -c '.sanity_warnings' "$PHASE_RESULTS_JSON")" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: OPEN → close 成功 → auto_close_fallback
+# ---------------------------------------------------------------------------
+@test "scenario 2: OPEN issue auto-closed → moved to auto_close_fallback" {
+  echo "CLOSED" > "$GH_STATE_DIR/200.state"
+  echo "OPEN"   > "$GH_STATE_DIR/201.state"
+  touch "$GH_STATE_DIR/201.close-allowed"
+  echo '{"phase":1,"done":[200,201],"failed":[],"skipped":[]}' > "$PHASE_RESULTS_JSON"
+
+  run_sanity
+
+  [ "$(jq -c '.done | sort' "$PHASE_RESULTS_JSON")" = "[200,201]" ]
+  [ "$(jq -c '.failed' "$PHASE_RESULTS_JSON")" = "[]" ]
+  [ "$(jq -c '.auto_close_fallback' "$PHASE_RESULTS_JSON")" = "[201]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: OPEN → close 失敗 → done から failed へ移動
+# ---------------------------------------------------------------------------
+@test "scenario 3: OPEN issue close failed → moved from done to failed" {
+  echo "CLOSED" > "$GH_STATE_DIR/300.state"
+  echo "OPEN"   > "$GH_STATE_DIR/301.state"
+  # 301.close-allowed を作らない → close 失敗
+  echo '{"phase":1,"done":[300,301],"failed":[],"skipped":[]}' > "$PHASE_RESULTS_JSON"
+
+  run_sanity
+
+  [ "$(jq -c '.done | sort' "$PHASE_RESULTS_JSON")" = "[300]" ]
+  [ "$(jq -c '.failed' "$PHASE_RESULTS_JSON")" = "[301]" ]
+  [ "$(jq -c '.auto_close_fallback' "$PHASE_RESULTS_JSON")" = "[]" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: state 取得失敗 → sanity_warnings + done 維持
+# ---------------------------------------------------------------------------
+@test "scenario 4: state fetch failed → sanity_warnings + done preserved" {
+  echo "CLOSED" > "$GH_STATE_DIR/400.state"
+  # 401.state を作らない → 空文字返却
+  echo '{"phase":1,"done":[400,401],"failed":[],"skipped":[]}' > "$PHASE_RESULTS_JSON"
+
+  run_sanity
+
+  [ "$(jq -c '.done | sort' "$PHASE_RESULTS_JSON")" = "[400,401]" ]
+  [ "$(jq -c '.failed' "$PHASE_RESULTS_JSON")" = "[]" ]
+  warnings=$(jq -c '.sanity_warnings' "$PHASE_RESULTS_JSON")
+  [[ "$warnings" == *"401"* ]]
+  [[ "$warnings" == *"state-fetch-failed"* ]]
+}

--- a/plugins/twl/tests/bats/structure/autopilot-phase-sanity.bats
+++ b/plugins/twl/tests/bats/structure/autopilot-phase-sanity.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# autopilot-phase-sanity.bats — static structure checks for Issue #139
+#
+# 受け入れ基準:
+# - commands/autopilot-phase-sanity.md が存在する
+# - 必須セクション（## 入力 / ## 処理ロジック (MUST) / ## 出力）を含む
+# - gh issue view と gh issue close を呼び出す
+# - skills/co-autopilot/SKILL.md Step 4 にサニティチェック呼び出しが追加されている
+# - SKILL.md には処理詳細を記載せず、autopilot-phase-sanity.md を正典とする旨が明記されている
+# - deps.yaml に atomic として登録されている (spawnable_by: [controller], can_spawn: [])
+# - deps.yaml にプレースホルダ <実装時に解決> が残っていない
+#
+# Note: bats-support/bats-assert 非依存（環境にサブモジュール未初期化でも実行可能）。
+
+setup() {
+  REPO_ROOT_REAL="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+  SANITY_MD="$REPO_ROOT_REAL/commands/autopilot-phase-sanity.md"
+  SKILL_MD="$REPO_ROOT_REAL/skills/co-autopilot/SKILL.md"
+  DEPS_YAML="$REPO_ROOT_REAL/deps.yaml"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: autopilot-phase-sanity.md prompt structure
+# ---------------------------------------------------------------------------
+
+@test "autopilot-phase-sanity.md exists" {
+  [ -f "$SANITY_MD" ]
+}
+
+@test "autopilot-phase-sanity.md contains '## 入力' section" {
+  grep -F "## 入力" "$SANITY_MD"
+}
+
+@test "autopilot-phase-sanity.md contains '## 処理ロジック (MUST)' section" {
+  grep -F "## 処理ロジック (MUST)" "$SANITY_MD"
+}
+
+@test "autopilot-phase-sanity.md contains '## 出力' section" {
+  grep -F "## 出力" "$SANITY_MD"
+}
+
+@test "autopilot-phase-sanity.md references 'gh issue view'" {
+  grep -F "gh issue view" "$SANITY_MD"
+}
+
+@test "autopilot-phase-sanity.md references 'gh issue close'" {
+  grep -F "gh issue close" "$SANITY_MD"
+}
+
+@test "autopilot-phase-sanity.md MUST NOT read PR diff or Issue body" {
+  # 禁止事項セクションに PR diff/Issue body を読まない旨が明記されているか
+  grep -F "PR diff" "$SANITY_MD"
+  grep -F "Issue body" "$SANITY_MD"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: SKILL.md Step 4 integration
+# ---------------------------------------------------------------------------
+
+@test "co-autopilot SKILL.md references autopilot-phase-sanity.md" {
+  grep -F "commands/autopilot-phase-sanity.md" "$SKILL_MD"
+}
+
+@test "co-autopilot SKILL.md Step 4.5 exists" {
+  grep -E "^### Step 4\.5" "$SKILL_MD"
+}
+
+@test "co-autopilot SKILL.md delegates sanity logic to atomic (single source of truth)" {
+  # 「正典とする」記述があり、SKILL.md 側に詳細処理（gh issue close）を書いていない
+  grep -F "正典" "$SKILL_MD"
+  ! grep -F "gh issue close" "$SKILL_MD"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: deps.yaml registration
+# ---------------------------------------------------------------------------
+
+@test "deps.yaml registers autopilot-phase-sanity as atomic" {
+  grep -E "^  autopilot-phase-sanity:" "$DEPS_YAML"
+}
+
+@test "deps.yaml autopilot-phase-sanity has spawnable_by: [controller]" {
+  awk '/^  autopilot-phase-sanity:/{flag=1; next} /^  autopilot-phase-postprocess:/{flag=0} flag' "$DEPS_YAML" | grep -F "spawnable_by: [controller]"
+}
+
+@test "deps.yaml autopilot-phase-sanity has can_spawn: []" {
+  awk '/^  autopilot-phase-sanity:/{flag=1; next} /^  autopilot-phase-postprocess:/{flag=0} flag' "$DEPS_YAML" | grep -F "can_spawn: []"
+}
+
+@test "deps.yaml co-autopilot calls includes autopilot-phase-sanity" {
+  awk '/^  co-autopilot:/,/^  co-issue:/' "$DEPS_YAML" | grep -F "atomic: autopilot-phase-sanity"
+}
+
+@test "deps.yaml has no <実装時に解決> placeholder" {
+  ! grep -F "<実装時に解決>" "$DEPS_YAML"
+}


### PR DESCRIPTION
## 概要

co-autopilot Pilot 側の layered defense 最終層として、PHASE_COMPLETE 受信後に各 done Issue の GitHub Issue close 状態を軽量 verify する仕組みを追加。Issue #4/#5 の安全網。

## 変更内容

### 1. `commands/autopilot-phase-sanity.md` (新規 atomic)

- 各 done Issue について `gh issue view <N> --json state -q .state` を呼び出し
- **CLOSED**: そのまま done 維持
- **OPEN**: 警告 → `gh issue close` 試行 → 再確認
  - 再確認 CLOSED: `auto_close_fallback` リストへ追加
  - 再確認 OPEN: done から `failed` へ移動
- **state 取得失敗** (空文字): `sanity_warnings` に記録 + done 維持
- 修正済み results JSON を `$PHASE_RESULTS_JSON` に書き戻し
- session.json `.sanity_log` 配列にも記録
- **PR diff・Issue body・テスト結果は読まない** (Pilot context budget 維持)

### 2. `skills/co-autopilot/SKILL.md` Step 4.5 統合

- PHASE_COMPLETE 受信後、postprocess の前にサニティチェックを実行
- **処理詳細は autopilot-phase-sanity.md を正典とする** (責務単一化 / 二重定義回避)
- SKILL.md 側には責務範囲（"何をやるか"）のみ記述

### 3. `deps.yaml` 登録

- `autopilot-phase-sanity` を atomic として登録
- `spawnable_by: [controller]`, `can_spawn: []`
- `step_in: { parent: co-autopilot, step: "4" }`
- `co-autopilot.calls` に追加
- プレースホルダ `<実装時に解決>` 不使用

### 4. テスト

- **構造検証** (`tests/bats/structure/autopilot-phase-sanity.bats`): 15 ケース
  - 必須セクション (## 入力 / ## 処理ロジック (MUST) / ## 出力)
  - `gh issue view` / `gh issue close` の参照確認
  - 「PR diff/Issue body を読まない」明記の確認
  - SKILL.md Step 4.5 の存在と「正典とする」記述
  - SKILL.md に `gh issue close` 詳細が混入していないこと
  - deps.yaml 登録 / プレースホルダ不在
- **シナリオ動作検証** (`tests/bats/scenarios/autopilot-phase-sanity-logic.bats`): 4 ケース
  - モック `gh` を PATH 注入し処理ロジックを bash で再現
  1. 全 done CLOSED → results 不変
  2. OPEN → close 成功 → `auto_close_fallback` に追加
  3. OPEN → close 失敗 → done から `failed` に移動
  4. state 取得失敗 → `sanity_warnings` に追加 + done 維持

## 検証結果

- `bats tests/bats/structure/autopilot-phase-sanity.bats tests/bats/scenarios/autopilot-phase-sanity-logic.bats` → **19/19 PASS**
- `twl --check` → File OK 197/197, Chain Validation OK
- `twl --validate` → 1950/1950, Violations: 0
- `twl --audit` → CRITICAL: 0 / WARNING: 43 (pre-existing) / OK: 522, exit=0
- `cd cli/twl && pytest tests/` → 921 passed, 4 failed (全て pre-existing、本変更と無関係)

## 受け入れ基準

- [x] `commands/autopilot-phase-sanity.md` 新規作成
- [x] `deps.yaml` に atomic 登録 (`spawnable_by:[controller]`, `can_spawn:[]`)
- [x] `skills/co-autopilot/SKILL.md` Step 4 にサニティチェック呼び出し追加
- [x] SKILL.md には処理詳細を記載せず autopilot-phase-sanity.md を正典化
- [x] サニティチェックは Issue close 状態のみを verify (PR diff/body は読まない)
- [x] bats prompt 構造検証 全 PASS
- [x] 4 シナリオ bats 動作検証 全 PASS
- [x] deps.yaml にプレースホルダなし
- [x] `twl --check && twl --validate` PASS

Closes #139