### PR TITLE
feat(plugins-twl): Worker worktree 境界 pre-edit guard を追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1715,6 +1715,11 @@ scripts:
       - script: resolve-issue-num
     description: "PostToolUse hook: Skill tool 完了後に autopilot Worker の chain 継続を stdout 注入（Layer 1 defense in depth）"
 
+  pre-tool-use-worktree-boundary:
+    type: script
+    path: scripts/hooks/pre-tool-use-worktree-boundary.sh
+    description: "PreToolUse hook: Edit/Write/NotebookEdit 対象パスを realpath -m 正規化し worktree 外なら deny（不変条件 B Worker 境界ガード, AUTOPILOT_DIR 設定時のみ）"
+
   tech-stack-detect:
     type: script
     path: scripts/tech-stack-detect.sh

--- a/plugins/twl/hooks/hooks.json
+++ b/plugins/twl/hooks/hooks.json
@@ -10,6 +10,16 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool-use-worktree-boundary.sh",
+            "timeout": 10000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugins/twl/scripts/hooks/pre-tool-use-worktree-boundary.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-worktree-boundary.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Worker worktree 境界 pre-edit guard
+#
+# Edit/Write/NotebookEdit の対象パスを realpath -m で正規化し、
+# 現在の worktree root の prefix 配下でなければ permissionDecision: deny を返す。
+# AUTOPILOT_DIR 設定時のみ発火（通常セッション無影響）。
+#
+# 不変条件 B（Worktree ライフサイクル Pilot 専任）: Worker は worktree 内で完結。
+# symlink 越えによる worktree 外編集を事前ブロックし、permission ダイアログでの
+# Worker スタックを回避する。
+#
+# TOCTOU 注記: realpath 判定後の symlink 差し替え攻撃は想定脅威外
+# （co-autopilot は信頼境界内）。本ガードの目的は誤操作・意図せぬ
+# symlink 越えの事前ブロックである。
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 → no-op（通常セッション）
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# JSON パース失敗時は no-op
+if ! echo "$payload" | jq empty 2>/dev/null; then
+  exit 0
+fi
+
+tool_name=$(echo "$payload" | jq -r '.tool_name // empty')
+case "$tool_name" in
+  Edit|Write|NotebookEdit) ;;
+  *) exit 0 ;;
+esac
+
+# Edit/Write は file_path、NotebookEdit は notebook_path
+target=$(echo "$payload" | jq -r '.tool_input.file_path // .tool_input.notebook_path // empty')
+if [[ -z "$target" ]]; then
+  exit 0
+fi
+
+# realpath -m: 未存在ファイル（新規 Write）にも対応
+resolved=$(realpath -m "$target" 2>/dev/null) || exit 0
+if [[ -z "$resolved" ]]; then
+  exit 0
+fi
+
+wt_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+if [[ -z "$wt_root" ]]; then
+  exit 0
+fi
+wt_root_resolved=$(realpath "$wt_root" 2>/dev/null) || exit 0
+if [[ -z "$wt_root_resolved" ]]; then
+  exit 0
+fi
+
+# 末尾スラッシュ付き prefix 比較で /foo と /foobar の誤マッチを回避
+if [[ "$resolved" == "$wt_root_resolved" || "$resolved" == "$wt_root_resolved/"* ]]; then
+  exit 0
+fi
+
+# worktree 外 → deny
+jq -nc \
+  --arg target "$target" \
+  --arg resolved "$resolved" \
+  --arg wt "$wt_root_resolved" \
+  '{
+    hookSpecificOutput: {
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: ("不変条件 B 違反: worktree 外編集を試行 / target=" + $target + " / resolved=" + $resolved + " / worktree=" + $wt)
+    }
+  }'
+
+exit 0

--- a/plugins/twl/tests/bats/scripts/pre-tool-use-worktree-boundary.bats
+++ b/plugins/twl/tests/bats/scripts/pre-tool-use-worktree-boundary.bats
@@ -1,0 +1,209 @@
+#!/usr/bin/env bats
+# pre-tool-use-worktree-boundary.bats
+#
+# Tests for plugins/twl/scripts/hooks/pre-tool-use-worktree-boundary.sh
+#
+# Spec: Issue #133 — Worker worktree 境界 pre-edit guard
+#
+# Scenarios:
+#   1. AUTOPILOT_DIR 未設定 → no-op (exit 0, stdout 空)
+#   2. AUTOPILOT_DIR 設定 + worktree 内 absolute path → allow (exit 0, stdout 空)
+#   3. AUTOPILOT_DIR 設定 + worktree 外 absolute path → deny JSON
+#   4. worktree 内 → 外への symlink → deny
+#   5. 未存在ファイルの Write (worktree 内, 新規) → allow (realpath -m)
+#   6. NotebookEdit (notebook_path) → 同様に判定
+#   7. worktree root と完全一致するパス → 誤 deny しない
+#   8. prefix 末尾スラッシュ誤マッチ回避 (/foo vs /foobar)
+#   9. 対象外 tool (Read など) → no-op
+#  10. JSON パース失敗 → no-op
+#  11. file_path 空 → no-op
+
+load '../helpers/common'
+
+HOOK_SRC=""
+
+setup() {
+  common_setup
+
+  # Resolve absolute path to the hook under test
+  HOOK_SRC="$(cd "$REPO_ROOT" && pwd)/scripts/hooks/pre-tool-use-worktree-boundary.sh"
+
+  # SANDBOX を仮想 worktree root として扱うため git stub を仕込む
+  # rev-parse --show-toplevel が SANDBOX を返すようにする
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$SANDBOX"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+}
+
+teardown() {
+  common_teardown
+}
+
+# Helper: invoke hook with given JSON payload
+_run_hook() {
+  local payload="$1"
+  echo "$payload" | bash "$HOOK_SRC"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: AUTOPILOT_DIR 未設定 → no-op
+# ---------------------------------------------------------------------------
+@test "no-op when AUTOPILOT_DIR is unset" {
+  unset AUTOPILOT_DIR
+  local payload
+  payload=$(jq -nc --arg p "/etc/passwd" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: worktree 内 absolute path → allow (no output)
+# ---------------------------------------------------------------------------
+@test "allow when target is inside worktree (absolute path)" {
+  local target="$SANDBOX/src/foo.txt"
+  mkdir -p "$(dirname "$target")"
+  : > "$target"
+  local payload
+  payload=$(jq -nc --arg p "$target" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: worktree 外 absolute path → deny
+# ---------------------------------------------------------------------------
+@test "deny when target is outside worktree (absolute path)" {
+  local outside
+  outside="$(mktemp -d)/outside.txt"
+  : > "$outside"
+  local payload
+  payload=$(jq -nc --arg p "$outside" '{tool_name:"Write", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"'
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("不変条件 B")'
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("target=")'
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("resolved=")'
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("worktree=")'
+  rm -f "$outside"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: symlink within worktree pointing outside → deny
+# ---------------------------------------------------------------------------
+@test "deny when symlink inside worktree resolves outside" {
+  local outside_dir
+  outside_dir="$(mktemp -d)"
+  : > "$outside_dir/secret.txt"
+  local link="$SANDBOX/link-to-secret"
+  ln -s "$outside_dir/secret.txt" "$link"
+
+  local payload
+  payload=$(jq -nc --arg p "$link" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"'
+  rm -rf "$outside_dir"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 5: 未存在ファイル (新規 Write, worktree 内) → allow
+# ---------------------------------------------------------------------------
+@test "allow new (non-existent) file inside worktree (realpath -m)" {
+  local target="$SANDBOX/new/dir/never-created.txt"
+  local payload
+  payload=$(jq -nc --arg p "$target" '{tool_name:"Write", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 6: NotebookEdit uses notebook_path
+# ---------------------------------------------------------------------------
+@test "NotebookEdit: deny when notebook_path is outside worktree" {
+  local outside
+  outside="$(mktemp -d)/nb.ipynb"
+  : > "$outside"
+  local payload
+  payload=$(jq -nc --arg p "$outside" '{tool_name:"NotebookEdit", tool_input:{notebook_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"'
+  rm -f "$outside"
+}
+
+@test "NotebookEdit: allow when notebook_path is inside worktree" {
+  local target="$SANDBOX/notebook.ipynb"
+  : > "$target"
+  local payload
+  payload=$(jq -nc --arg p "$target" '{tool_name:"NotebookEdit", tool_input:{notebook_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 7: worktree root と完全一致 (誤 deny しない)
+# ---------------------------------------------------------------------------
+@test "allow target equal to worktree root itself" {
+  local payload
+  payload=$(jq -nc --arg p "$SANDBOX" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 8: prefix 末尾スラッシュ誤マッチ回避
+# ---------------------------------------------------------------------------
+@test "deny when target shares string prefix but is sibling dir (slash boundary)" {
+  # Sibling dir whose name starts with the worktree root's basename
+  local sibling="${SANDBOX}-sibling/file.txt"
+  mkdir -p "$(dirname "$sibling")"
+  : > "$sibling"
+  local payload
+  payload=$(jq -nc --arg p "$sibling" '{tool_name:"Edit", tool_input:{file_path:$p}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"'
+  rm -rf "${SANDBOX}-sibling"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 9: 対象外 tool → no-op
+# ---------------------------------------------------------------------------
+@test "no-op for non-target tools (Read)" {
+  local payload
+  payload=$(jq -nc '{tool_name:"Read", tool_input:{file_path:"/etc/passwd"}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 10: 不正 JSON → no-op
+# ---------------------------------------------------------------------------
+@test "no-op when payload is invalid JSON" {
+  run _run_hook "not-a-json{"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 11: file_path empty → no-op
+# ---------------------------------------------------------------------------
+@test "no-op when file_path is empty" {
+  local payload
+  payload=$(jq -nc '{tool_name:"Edit", tool_input:{}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
## 概要

Worker が Edit/Write/NotebookEdit tool で worktree 外のファイルを編集しようとした場合（symlink 越えを含む）、PreToolUse hook で realpath 解決後パスが worktree root の prefix 配下か検査し、外なら deny する。permission ダイアログによる Worker スタックを回避し、不変条件 B（Worktree ライフサイクル Pilot 専任）の運用境界を強化する。

## 変更内容

- **`plugins/twl/scripts/hooks/pre-tool-use-worktree-boundary.sh`** (新規)
  - AUTOPILOT_DIR 設定時のみ発火（通常セッション無影響）
  - 対象 tool: `Edit` / `Write` / `NotebookEdit`
  - `realpath -m` で未存在ファイル（新規 Write）にも対応
  - 末尾スラッシュ付き prefix 比較で `/foo` と `/foobar` の誤マッチ回避
  - deny 時の reason に「不変条件 B 違反 / target / resolved / worktree」4 項目を含む
- **`plugins/twl/hooks/hooks.json`**: PreToolUse matcher `"Edit|Write|NotebookEdit"` 登録
- **`plugins/twl/deps.yaml`**: SSOT に新規スクリプト登録
- **`plugins/twl/tests/bats/scripts/pre-tool-use-worktree-boundary.bats`** (新規): 12 シナリオ全 PASS

## 受け入れ基準

- [x] `pre-tool-use-worktree-boundary.sh` が新規実装されている
- [x] `Edit` / `Write` / `NotebookEdit` が matcher に登録され、3 tool 全てに発火する
- [x] AUTOPILOT_DIR 未設定時は no-op であることが bats で保証される
- [x] symlink 解決後パスが worktree 外なら deny される
- [x] 未存在ファイル（新規 Write）の正常系を誤 deny しない（`realpath -m`）
- [x] worktree root の prefix 比較が末尾スラッシュ付きで誤マッチを回避する
- [x] deny 時の reason に不変条件 B 違反 / target / resolved / worktree 4 項目が含まれる
- [x] `hooks.json` の PreToolUse セクションに登録されている
- [x] bats テスト全件 PASS（12/12）
- [x] `deps.yaml` に新規スクリプトが登録され `twl --check` PASS
- [x] `twl --validate` / `twl --audit` PASS（CRITICAL=0, baseline 維持）

## テスト結果

- bats: `pre-tool-use-worktree-boundary.bats` 12/12 PASS
- `python3 -m twl --check`: OK 197 / Missing 0
- `python3 -m twl --validate`: OK 1943 / Violations 0
- `python3 -m twl --audit`: CRITICAL 0 / WARNING 41（baseline 維持）
- `cli/twl pytest tests/`: 921 passed（4 failed は pre-existing で本変更無関係）

Closes #133