### PR TITLE
refactor(cli-twl): deep.py の TOKEN_THRESHOLDS 定数を削除し動的ロード化

### DIFF
--- a/cli/twl/src/twl/validation/deep.py
+++ b/cli/twl/src/twl/validation/deep.py
@@ -10,10 +10,6 @@ from twl.validation.audit import (
     _check_output_schema_keywords
 )
 
-# Token bloat thresholds: loaded from types.yaml (SSOT), fallback to hardcoded values.
-# reference and script types are intentionally excluded (no token_target in types.yaml).
-TOKEN_THRESHOLDS: Dict[str, Tuple[int, int]] = load_token_thresholds()
-
 
 def deep_validate(deps: dict, plugin_root: Path) -> Tuple[List[str], List[str], List[str]]:
     """深層検証: controller bloat, ref配置, tools整合性
@@ -64,10 +60,12 @@ def deep_validate(deps: dict, plugin_root: Path) -> Tuple[List[str], List[str], 
                 add_warning(f"[controller-bloat] {name}: {body_lines} lines (>120)")
 
     # (A2) Token bloat チェック（全型対応）
+    # types.yaml から token_target を毎回ロード（テストで値を差し替え可能にするため）
+    token_thresholds = load_token_thresholds()
     for section in ('skills', 'commands', 'agents'):
         for name, spec in deps.get(section, {}).items():
             comp_type = resolve_type(spec.get('type', ''))
-            if comp_type not in TOKEN_THRESHOLDS:
+            if comp_type not in token_thresholds:
                 continue
             path_str = spec.get('path', '')
             if not path_str:
@@ -80,7 +78,7 @@ def deep_validate(deps: dict, plugin_root: Path) -> Tuple[List[str], List[str], 
             tok = count_tokens(path)
             if tok == 0:
                 continue
-            warn_threshold, crit_threshold = TOKEN_THRESHOLDS[comp_type]
+            warn_threshold, crit_threshold = token_thresholds[comp_type]
             if tok > crit_threshold:
                 add_critical(f"[token-bloat] {name} ({comp_type}): {tok} tok (>{crit_threshold})")
             elif tok > warn_threshold:

--- a/cli/twl/tests/test_token_target.py
+++ b/cli/twl/tests/test_token_target.py
@@ -186,6 +186,41 @@ class TestSyncCheckTokenTable:
         assert result.returncode != 0
         assert "token-invalid" in result.stdout
 
+    def test_deep_validate_reads_thresholds_dynamically(self, tmp_path, monkeypatch):
+        """WHEN types.yaml token_target is updated
+        THEN deep_validate uses the new thresholds without reimport.
+
+        AC #3: types.yaml の token_target を変更 → twl --deep-validate 再実行で反映。
+        deep.py に module-level TOKEN_THRESHOLDS 定数を残すと in-process では反映されない。
+        """
+        # 小さな warning 値を持つ types.yaml を準備
+        types_yaml = tmp_path / "types.yaml"
+        types_yaml.write_text(
+            "types:\n"
+            "  controller:\n"
+            "    section: skills\n"
+            "    can_spawn: [reference]\n"
+            "    spawnable_by: [user]\n"
+            "    token_target:\n"
+            "      warning: 1\n"
+            "      critical: 2\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("TWL_LOOM_ROOT", str(tmp_path))
+
+        # deep.py の module-level 定数キャッシュが残っていないことを確認するため、
+        # deep_validate を呼んだときに新しい types.yaml が反映される
+        from twl.validation import deep as deep_mod
+        # TOKEN_THRESHOLDS という名前の module-level 定数は存在しないこと
+        assert not hasattr(deep_mod, "TOKEN_THRESHOLDS"), (
+            "deep.py must not retain a module-level TOKEN_THRESHOLDS constant; "
+            "thresholds must be loaded inside deep_validate() to support dynamic updates."
+        )
+
+        # 実際に load_token_thresholds が更新値を読むことも確認
+        result = load_token_thresholds(tmp_path)
+        assert result["controller"] == (1, 2)
+
     def test_missing_type_in_token_table_fails(self, tmp_path):
         """WHEN a token_target type from types.yaml is missing in ref table
         THEN sync_check reports token-missing-in-ref."""


### PR DESCRIPTION
## 概要

Issue #103 の受け入れ基準「`deep.py` に `TOKEN_THRESHOLDS` ハードコード定数なし」を strict 解釈で完全達成するための後追い改修。

PR #117 で types.yaml 駆動化は完了済みだが、`deep.py` には module-level の
`TOKEN_THRESHOLDS = load_token_thresholds()` というキャッシュ定数が残っており、
in-process で types.yaml を変更しても反映されない構造だった。

## 変更内容

- `cli/twl/src/twl/validation/deep.py`
  - module-level `TOKEN_THRESHOLDS` 定数を削除
  - `deep_validate()` 内で `load_token_thresholds()` を毎回呼び出すように変更
  - `audit.py` は既に同様のローカル変数パターンで実装済み（変更不要）
- `cli/twl/tests/test_token_target.py`
  - `test_deep_validate_reads_thresholds_dynamically` を追加
  - `deep` モジュールに `TOKEN_THRESHOLDS` 属性が存在しないことを assert（回帰防止）
  - types.yaml 更新が `load_token_thresholds()` で読み取れることを確認

## 検証

- `pytest tests/test_token_target.py` → 10 passed
- `pytest tests/` → 936 passed（既存 4 failures は無関係の pre-existing）
- `plugins/twl` で `twl --check` / `--validate` / `--audit` 全 PASS
- `cli/twl` で `twl --sync-check docs/ref-practices.md` PASS

## 受け入れ基準（Issue #103）達成状況

- [x] types.yaml に controller/workflow/atomic/composite/specialist の token_target 定義（PR #117）
- [x] `twl --deep-validate` が types.yaml 閾値で判定（**本 PR で TOKEN_THRESHOLDS 定数削除完了**）
- [x] types.yaml の token_target 変更 → in-process でも反映（**本 PR で達成**）
- [x] `twl --sync-check` でトークン閾値テーブル整合性検証（PR #117）
- [x] `twl --audit` の token_bloat が types.yaml 駆動（PR #117）
- [x] 既存 + 新規テスト PASS

Closes #103