### PR TITLE
feat(autopilot): chain-runner --trace + twl audit-history (Phase 3 / Layer 1)

### DIFF
--- a/cli/twl/src/twl/autopilot/audit_history.py
+++ b/cli/twl/src/twl/autopilot/audit_history.py
@@ -1,0 +1,362 @@
+"""twl audit-history - Layer 1 経験的監査.
+
+過去の autopilot session trace ファイル
+(``${AUTOPILOT_DIR}/trace/<session>/issue-*.jsonl``) を mining し、
+実際に呼ばれた step 群を集計する。``--compare-deps`` モードでは
+``deps.yaml`` の宣言された chain-runner commands と突き合わせ、
+F4 (No-op 化) や F1/F2 と相補的な dead code 候補を検出する。
+
+CLI usage:
+    python3 -m twl.autopilot.audit_history [--days 30] [--compare-deps] [...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Trace file parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_trace_file(path: Path) -> list[dict[str, Any]]:
+    """Parse a JSON Lines trace file. Skip malformed lines silently."""
+    events: list[dict[str, Any]] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for raw in fh:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    events.append(json.loads(raw))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return []
+    return events
+
+
+def file_age_days(path: Path) -> float:
+    """Return age of *path* in days based on mtime, or +inf on error."""
+    try:
+        mtime = datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+    except OSError:
+        return float("inf")
+    return (datetime.now(tz=timezone.utc) - mtime).total_seconds() / 86400.0
+
+
+def parse_session(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate per-session step statistics from raw events.
+
+    Returns a dict with::
+
+        steps_called: {step: count}        # number of "start" events per step
+        steps_failed: {step: count}        # number of non-zero "end" events
+        event_count: int
+    """
+    steps_called: Counter[str] = Counter()
+    steps_failed: Counter[str] = Counter()
+    for ev in events:
+        step = ev.get("step")
+        phase = ev.get("phase")
+        if not step or not isinstance(step, str):
+            continue
+        if phase == "start":
+            steps_called[step] += 1
+        elif phase == "end":
+            ec = ev.get("exit_code")
+            if isinstance(ec, int) and ec != 0:
+                steps_failed[step] += 1
+    return {
+        "steps_called": dict(steps_called),
+        "steps_failed": dict(steps_failed),
+        "event_count": len(events),
+    }
+
+
+# ---------------------------------------------------------------------------
+# History mining
+# ---------------------------------------------------------------------------
+
+
+def mine_history(autopilot_dir: Path, days: int = 30) -> dict[str, Any]:
+    """Mine all trace files under ``<autopilot_dir>/trace/`` younger than *days*."""
+    sessions: list[dict[str, Any]] = []
+    trace_root = autopilot_dir / "trace"
+    if trace_root.is_dir():
+        for trace_file in sorted(trace_root.glob("*/issue-*.jsonl")):
+            if file_age_days(trace_file) > days:
+                continue
+            events = parse_trace_file(trace_file)
+            if not events:
+                continue
+            session = parse_session(events)
+            session["file"] = str(trace_file)
+            session["session_id"] = trace_file.parent.name
+            issue_stem = trace_file.stem  # e.g. "issue-123"
+            session["issue"] = (
+                issue_stem[len("issue-"):] if issue_stem.startswith("issue-") else issue_stem
+            )
+            sessions.append(session)
+
+    empirical: Counter[str] = Counter()
+    failures: Counter[str] = Counter()
+    for s in sessions:
+        for step, count in s.get("steps_called", {}).items():
+            empirical[step] += count
+        for step, count in s.get("steps_failed", {}).items():
+            failures[step] += count
+
+    return {
+        "sessions": sessions,
+        "session_count": len(sessions),
+        "empirical_steps": dict(empirical),
+        "failed_steps": dict(failures),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reconstructing trace from past Claude Code session jsonl
+# ---------------------------------------------------------------------------
+
+
+_CHAIN_RUNNER_PATTERN = re.compile(
+    r"""chain-runner\.sh        # script name
+        ["']?                    # optional closing quote
+        \s+                      # whitespace
+        (?:--trace(?:=\S+|\s+\S+)\s+)?   # optional --trace flag
+        ([a-z][a-z0-9-]*)        # step name
+    """,
+    re.VERBOSE,
+)
+
+
+def reconstruct_trace_from_session_jsonl(jsonl_path: Path) -> list[dict[str, Any]]:
+    """Reconstruct trace events from a Claude Code session jsonl.
+
+    Walks ``assistant`` messages, picks up Bash ``tool_use`` calls invoking
+    ``chain-runner.sh <step>`` and produces synthetic ``start`` events.
+    Used for retroactive analysis of sessions recorded before the trace
+    mechanism was introduced.
+    """
+    events: list[dict[str, Any]] = []
+    try:
+        with open(jsonl_path, encoding="utf-8") as fh:
+            for raw in fh:
+                try:
+                    msg = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if msg.get("type") != "assistant":
+                    continue
+                content = msg.get("message", {}).get("content", [])
+                if not isinstance(content, list):
+                    continue
+                for item in content:
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("type") != "tool_use" or item.get("name") != "Bash":
+                        continue
+                    cmd = item.get("input", {}).get("command", "") or ""
+                    m = _CHAIN_RUNNER_PATTERN.search(cmd)
+                    if m:
+                        events.append(
+                            {
+                                "step": m.group(1),
+                                "phase": "start",
+                                "ts": msg.get("timestamp"),
+                                "source": "reconstructed",
+                            }
+                        )
+    except OSError:
+        return []
+    return events
+
+
+def reconstruct_from_directory(directory: Path, days: int | None = None) -> dict[str, Any]:
+    """Walk a directory of Claude Code session jsonl files and aggregate."""
+    sessions: list[dict[str, Any]] = []
+    if directory.is_dir():
+        for jsonl_path in sorted(directory.glob("*.jsonl")):
+            if days is not None and file_age_days(jsonl_path) > days:
+                continue
+            events = reconstruct_trace_from_session_jsonl(jsonl_path)
+            if not events:
+                continue
+            session = parse_session(events)
+            session["file"] = str(jsonl_path)
+            session["source"] = "reconstructed"
+            sessions.append(session)
+
+    empirical: Counter[str] = Counter()
+    for s in sessions:
+        for step, count in s.get("steps_called", {}).items():
+            empirical[step] += count
+    return {
+        "sessions": sessions,
+        "session_count": len(sessions),
+        "empirical_steps": dict(empirical),
+        "failed_steps": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# deps.yaml comparison
+# ---------------------------------------------------------------------------
+
+
+def load_declared_steps(plugin_root: Path) -> set[str]:
+    """Return the set of declared chain-runner commands from deps.yaml."""
+    deps_path = plugin_root / "deps.yaml"
+    if not deps_path.is_file():
+        return set()
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        return set()
+    try:
+        deps = yaml.safe_load(deps_path.read_text(encoding="utf-8")) or {}
+    except Exception:
+        return set()
+    scripts = deps.get("scripts") or {}
+    cr = scripts.get("chain-runner") or {}
+    cmds = cr.get("commands") or []
+    return {c for c in cmds if isinstance(c, str)}
+
+
+def compare_with_deps(
+    empirical_steps: dict[str, int], declared: set[str]
+) -> dict[str, Any]:
+    """Compute set difference between empirical and declared call graphs."""
+    empirical_set = set(empirical_steps)
+    return {
+        "declared_total": len(declared),
+        "empirical_total": len(empirical_set),
+        "declared_but_never_called": sorted(declared - empirical_set),
+        "called_but_not_declared": sorted(empirical_set - declared),
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _format_text_report(
+    result: dict[str, Any], compare: dict[str, Any] | None
+) -> list[str]:
+    lines: list[str] = []
+    lines.append("=== Audit History (Layer 1 Empirical) ===")
+    lines.append(f"Sessions analyzed: {result['session_count']}")
+    lines.append("")
+    lines.append(f"Empirical steps ({len(result['empirical_steps'])}):")
+    for step, count in sorted(result["empirical_steps"].items(), key=lambda x: (-x[1], x[0])):
+        lines.append(f"  {step}: {count}")
+    if result.get("failed_steps"):
+        lines.append("")
+        lines.append("Failed steps (non-zero exit_code):")
+        for step, count in sorted(result["failed_steps"].items(), key=lambda x: (-x[1], x[0])):
+            lines.append(f"  {step}: {count}")
+    if compare is not None:
+        lines.append("")
+        lines.append("=== Empirical vs Declared ===")
+        lines.append(
+            f"Declared but never called (potential dead code) "
+            f"[{len(compare['declared_but_never_called'])}]:"
+        )
+        if compare["declared_but_never_called"]:
+            for s in compare["declared_but_never_called"]:
+                lines.append(f"  - {s}")
+        else:
+            lines.append("  (none)")
+        lines.append("")
+        lines.append(
+            f"Called but not declared (orphan executions) "
+            f"[{len(compare['called_but_not_declared'])}]:"
+        )
+        if compare["called_but_not_declared"]:
+            for s in compare["called_but_not_declared"]:
+                lines.append(f"  - {s}")
+        else:
+            lines.append("  (none)")
+    return lines
+
+
+def cli_audit_history(args: argparse.Namespace) -> int:
+    if args.reconstruct_from:
+        directory = Path(args.reconstruct_from).expanduser()
+        result = reconstruct_from_directory(directory, days=args.days)
+    else:
+        autopilot_dir = Path(args.autopilot_dir).expanduser()
+        result = mine_history(autopilot_dir, days=args.days)
+
+    compare: dict[str, Any] | None = None
+    if args.compare_deps:
+        plugin_root = (
+            Path(args.plugin_root).expanduser() if args.plugin_root else Path.cwd()
+        )
+        declared = load_declared_steps(plugin_root)
+        compare = compare_with_deps(result["empirical_steps"], declared)
+        result["compare"] = compare
+
+    if args.format == "json":
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    for line in _format_text_report(result, compare):
+        print(line)
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="twl audit-history",
+        description="Layer 1 empirical audit (mine trace files; compare with deps.yaml)",
+    )
+    p.add_argument(
+        "--autopilot-dir",
+        default=".autopilot",
+        help="Autopilot directory containing trace/ subdir (default: .autopilot)",
+    )
+    p.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        help="Only consider trace files modified within N days (default: 30)",
+    )
+    p.add_argument(
+        "--compare-deps",
+        action="store_true",
+        help="Compare empirical call graph with deps.yaml declared chain-runner commands",
+    )
+    p.add_argument(
+        "--plugin-root",
+        default=None,
+        help="Plugin root for deps.yaml (default: cwd)",
+    )
+    p.add_argument(
+        "--reconstruct-from",
+        default=None,
+        help="Reconstruct trace from a directory of Claude Code session jsonl files",
+    )
+    p.add_argument("--format", choices=["text", "json"], default="text")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return cli_audit_history(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -416,6 +416,11 @@ def handle_viz(args, graph, deps, plugin_root, plugin_name, show_tokens):
 
 
 def main():
+    # audit-history サブコマンドの前処理（Phase 3 / Layer 1 経験的監査）
+    if len(sys.argv) >= 2 and sys.argv[1] == 'audit-history':
+        from twl.autopilot.audit_history import main as audit_history_main
+        sys.exit(audit_history_main(sys.argv[2:]))
+
     # chain サブコマンドの前処理（sys.argv を先に検査）
     if len(sys.argv) >= 2 and sys.argv[1] == 'chain':
         if len(sys.argv) >= 3 and sys.argv[2] == 'generate':

--- a/cli/twl/tests/test_audit_history.py
+++ b/cli/twl/tests/test_audit_history.py
@@ -1,0 +1,382 @@
+"""Tests for twl.autopilot.audit_history (Phase 3 / Layer 1 経験的監査)."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from twl.autopilot import audit_history as ah
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autopilot_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".autopilot"
+    (d / "trace" / "session-001").mkdir(parents=True)
+    return d
+
+
+def _write_trace(
+    autopilot_dir: Path, session: str, issue: str, events: list[dict]
+) -> Path:
+    sdir = autopilot_dir / "trace" / session
+    sdir.mkdir(parents=True, exist_ok=True)
+    p = sdir / f"issue-{issue}.jsonl"
+    with open(p, "w", encoding="utf-8") as fh:
+        for ev in events:
+            fh.write(json.dumps(ev) + "\n")
+    return p
+
+
+def _start_end(step: str, exit_code: int = 0) -> list[dict]:
+    return [
+        {"step": step, "phase": "start", "ts": "2026-04-07T00:00:00Z", "pid": 1},
+        {
+            "step": step,
+            "phase": "end",
+            "ts": "2026-04-07T00:00:01Z",
+            "pid": 1,
+            "exit_code": exit_code,
+        },
+    ]
+
+
+# ---------------------------------------------------------------------------
+# parse_trace_file / parse_session
+# ---------------------------------------------------------------------------
+
+
+def test_parse_trace_file_skips_malformed(tmp_path: Path) -> None:
+    p = tmp_path / "t.jsonl"
+    p.write_text(
+        '{"step":"init","phase":"start"}\n'
+        "not-json\n"
+        '\n'
+        '{"step":"check","phase":"end","exit_code":0}\n',
+        encoding="utf-8",
+    )
+    events = ah.parse_trace_file(p)
+    assert len(events) == 2
+    assert events[0]["step"] == "init"
+    assert events[1]["step"] == "check"
+
+
+def test_parse_trace_file_missing_returns_empty(tmp_path: Path) -> None:
+    assert ah.parse_trace_file(tmp_path / "missing.jsonl") == []
+
+
+def test_parse_session_counts_starts_and_failures() -> None:
+    events = (
+        _start_end("init")
+        + _start_end("ts-preflight", exit_code=1)
+        + _start_end("ts-preflight")
+    )
+    s = ah.parse_session(events)
+    assert s["steps_called"] == {"init": 1, "ts-preflight": 2}
+    assert s["steps_failed"] == {"ts-preflight": 1}
+    assert s["event_count"] == 6
+
+
+# ---------------------------------------------------------------------------
+# mine_history
+# ---------------------------------------------------------------------------
+
+
+def test_mine_history_zero_sessions(tmp_path: Path) -> None:
+    result = ah.mine_history(tmp_path / ".autopilot")
+    assert result["session_count"] == 0
+    assert result["sessions"] == []
+    assert result["empirical_steps"] == {}
+
+
+def test_mine_history_aggregates_multiple_sessions(autopilot_dir: Path) -> None:
+    _write_trace(autopilot_dir, "s1", "10", _start_end("init") + _start_end("check"))
+    _write_trace(
+        autopilot_dir,
+        "s2",
+        "11",
+        _start_end("init") + _start_end("ts-preflight", exit_code=1),
+    )
+    result = ah.mine_history(autopilot_dir)
+    assert result["session_count"] == 2
+    assert result["empirical_steps"] == {"init": 2, "check": 1, "ts-preflight": 1}
+    assert result["failed_steps"] == {"ts-preflight": 1}
+    issues = sorted(s["issue"] for s in result["sessions"])
+    assert issues == ["10", "11"]
+
+
+def test_mine_history_skips_old_files(autopilot_dir: Path) -> None:
+    p = _write_trace(autopilot_dir, "old", "1", _start_end("init"))
+    # backdate file mtime by 60 days
+    old_ts = time.time() - 60 * 86400
+    os.utime(p, (old_ts, old_ts))
+    result = ah.mine_history(autopilot_dir, days=30)
+    assert result["session_count"] == 0
+
+
+def test_mine_history_includes_recent_files(autopilot_dir: Path) -> None:
+    _write_trace(autopilot_dir, "fresh", "1", _start_end("init"))
+    result = ah.mine_history(autopilot_dir, days=30)
+    assert result["session_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# compare_with_deps
+# ---------------------------------------------------------------------------
+
+
+def test_compare_with_deps_detects_never_called() -> None:
+    empirical = {"init": 5, "check": 2}
+    declared = {"init", "check", "board-archive", "ac-verify"}
+    cmp = ah.compare_with_deps(empirical, declared)
+    assert cmp["declared_but_never_called"] == ["ac-verify", "board-archive"]
+    assert cmp["called_but_not_declared"] == []
+    assert cmp["declared_total"] == 4
+    assert cmp["empirical_total"] == 2
+
+
+def test_compare_with_deps_detects_orphan_executions() -> None:
+    empirical = {"init": 1, "rogue-step": 1}
+    declared = {"init", "check"}
+    cmp = ah.compare_with_deps(empirical, declared)
+    assert cmp["declared_but_never_called"] == ["check"]
+    assert cmp["called_but_not_declared"] == ["rogue-step"]
+
+
+def test_load_declared_steps(tmp_path: Path) -> None:
+    pytest.importorskip("yaml")
+    (tmp_path / "deps.yaml").write_text(
+        "scripts:\n"
+        "  chain-runner:\n"
+        "    type: script\n"
+        "    commands:\n"
+        "      - init\n"
+        "      - check\n"
+        "      - board-archive\n",
+        encoding="utf-8",
+    )
+    declared = ah.load_declared_steps(tmp_path)
+    assert declared == {"init", "check", "board-archive"}
+
+
+def test_load_declared_steps_missing_yaml(tmp_path: Path) -> None:
+    assert ah.load_declared_steps(tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# reconstruct_trace_from_session_jsonl
+# ---------------------------------------------------------------------------
+
+
+def test_reconstruct_trace_extracts_chain_runner_calls(tmp_path: Path) -> None:
+    p = tmp_path / "session.jsonl"
+    msgs = [
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-07T01:00:00Z",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {
+                            "command": 'bash "$CR/chain-runner.sh" init 42'
+                        },
+                    }
+                ]
+            },
+        },
+        {
+            "type": "user",
+            "message": {"content": []},
+        },
+        {
+            "type": "assistant",
+            "timestamp": "2026-04-07T01:01:00Z",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {
+                            "command": "bash chain-runner.sh ts-preflight"
+                        },
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Bash",
+                        "input": {
+                            "command": "bash chain-runner.sh --trace /tmp/x.jsonl pr-test"
+                        },
+                    },
+                    {
+                        "type": "tool_use",
+                        "name": "Read",
+                        "input": {"file_path": "/etc/hosts"},
+                    },
+                ]
+            },
+        },
+    ]
+    with open(p, "w", encoding="utf-8") as fh:
+        for m in msgs:
+            fh.write(json.dumps(m) + "\n")
+
+    events = ah.reconstruct_trace_from_session_jsonl(p)
+    steps = [e["step"] for e in events]
+    assert steps == ["init", "ts-preflight", "pr-test"]
+    assert all(e["phase"] == "start" for e in events)
+    assert all(e["source"] == "reconstructed" for e in events)
+
+
+def test_reconstruct_from_directory_aggregates(tmp_path: Path) -> None:
+    d = tmp_path / "sessions"
+    d.mkdir()
+    (d / "a.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "input": {"command": "bash chain-runner.sh init 1"},
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    result = ah.reconstruct_from_directory(d)
+    assert result["session_count"] == 1
+    assert result["empirical_steps"] == {"init": 1}
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_text_output(autopilot_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_trace(autopilot_dir, "s1", "10", _start_end("init") + _start_end("check"))
+    rc = ah.main(["--autopilot-dir", str(autopilot_dir), "--days", "30"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Sessions analyzed: 1" in out
+    assert "init: 1" in out
+    assert "check: 1" in out
+
+
+def test_cli_json_output(autopilot_dir: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    _write_trace(autopilot_dir, "s1", "10", _start_end("init"))
+    rc = ah.main(
+        ["--autopilot-dir", str(autopilot_dir), "--format", "json"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out)
+    assert payload["session_count"] == 1
+    assert payload["empirical_steps"] == {"init": 1}
+
+
+def test_cli_compare_deps(
+    autopilot_dir: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pytest.importorskip("yaml")
+    _write_trace(autopilot_dir, "s1", "10", _start_end("init"))
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    (plugin_root / "deps.yaml").write_text(
+        "scripts:\n"
+        "  chain-runner:\n"
+        "    commands:\n"
+        "      - init\n"
+        "      - dead-step\n",
+        encoding="utf-8",
+    )
+    rc = ah.main(
+        [
+            "--autopilot-dir",
+            str(autopilot_dir),
+            "--compare-deps",
+            "--plugin-root",
+            str(plugin_root),
+            "--format",
+            "json",
+        ]
+    )
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["compare"]["declared_but_never_called"] == ["dead-step"]
+    assert payload["compare"]["called_but_not_declared"] == []
+
+
+def test_cli_compare_deps_text_format(
+    autopilot_dir: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    pytest.importorskip("yaml")
+    _write_trace(autopilot_dir, "s1", "10", _start_end("init"))
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir()
+    (plugin_root / "deps.yaml").write_text(
+        "scripts:\n"
+        "  chain-runner:\n"
+        "    commands:\n"
+        "      - init\n"
+        "      - dead-step\n",
+        encoding="utf-8",
+    )
+    rc = ah.main(
+        [
+            "--autopilot-dir",
+            str(autopilot_dir),
+            "--compare-deps",
+            "--plugin-root",
+            str(plugin_root),
+        ]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Empirical vs Declared" in out
+    assert "dead-step" in out
+
+
+def test_cli_reconstruct_from(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    d = tmp_path / "sessions"
+    d.mkdir()
+    (d / "s.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "name": "Bash",
+                            "input": {
+                                "command": "bash chain-runner.sh ac-extract"
+                            },
+                        }
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rc = ah.main(["--reconstruct-from", str(d), "--format", "json"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["session_count"] == 1
+    assert payload["empirical_steps"] == {"ac-extract": 1}

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -265,9 +265,25 @@ else
   LAUNCH_DIR="$EFFECTIVE_PROJECT_DIR"
 fi
 
+# --- Trace path 計算 (Phase 3 / Layer 1 経験的監査) ---
+# session.json から session_id を取得し、Worker に TWL_CHAIN_TRACE を渡す。
+# session_id が取得できない場合はタイムスタンプベースの ID を使用する。
+TRACE_SESSION_ID=""
+if [[ -f "$AUTOPILOT_DIR/session.json" ]]; then
+  TRACE_SESSION_ID=$(jq -r '.session_id // ""' "$AUTOPILOT_DIR/session.json" 2>/dev/null || echo "")
+fi
+if [[ -z "$TRACE_SESSION_ID" ]]; then
+  TRACE_SESSION_ID=$(date -u +"%Y%m%d-%H%M%S")
+fi
+TRACE_PATH="${AUTOPILOT_DIR}/trace/${TRACE_SESSION_ID}/issue-${ISSUE}.jsonl"
+mkdir -p "$(dirname "$TRACE_PATH")" 2>/dev/null || true
+
 # --- AUTOPILOT_DIR / REPO_ENV 環境変数構築 (Task 1.8) ---
 QUOTED_AUTOPILOT_DIR=$(printf '%q' "$AUTOPILOT_DIR")
 AUTOPILOT_ENV="AUTOPILOT_DIR=${QUOTED_AUTOPILOT_DIR}"
+
+QUOTED_TRACE_PATH=$(printf '%q' "$TRACE_PATH")
+TRACE_ENV="TWL_CHAIN_TRACE=${QUOTED_TRACE_PATH}"
 
 REPO_ENV=""
 if [[ -n "$REPO_OWNER" && -n "$REPO_NAME" ]]; then
@@ -293,7 +309,7 @@ QUOTED_CLD=$(printf '%q' "$CLD_PATH")
 QUOTED_PROMPT=$(printf '%q' "$PROMPT")
 # プロンプトは positional arg で渡す。-p/--print は禁止（非対話モードで即終了する）
 tmux new-window -d -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
-  "env ${AUTOPILOT_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
+  "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
 
 # --- クラッシュ検知フック設定 (Task 1.10) ---
 tmux set-option -t "$WINDOW_NAME" remain-on-exit on

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -55,6 +55,40 @@ resolve_autopilot_dir() {
   echo "${main_wt:-.}/.autopilot"
 }
 
+# =====================================================================
+# Trace Event (Phase 3 / Layer 1 経験的監査)
+# =====================================================================
+# TWL_CHAIN_TRACE 環境変数が設定されている場合、step の start/end を
+# JSON Lines 形式で append する。設定がなければノーオペ（後方互換）。
+trace_event() {
+  local step="$1" phase="$2" exit_code="${3:-}"
+  [[ -z "${TWL_CHAIN_TRACE:-}" ]] && return 0
+  local trace_file="$TWL_CHAIN_TRACE"
+  # パストラバーサル拒否
+  case "$trace_file" in
+    *..*) return 0 ;;
+  esac
+  # 親ディレクトリ作成（失敗してもサイレント）
+  mkdir -p "$(dirname "$trace_file")" 2>/dev/null || return 0
+  local ts
+  ts=$(date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc \
+      --arg step "$step" \
+      --arg phase "$phase" \
+      --arg ts "$ts" \
+      --arg exit_code "$exit_code" \
+      --arg pid "$$" \
+      '{step: $step, phase: $phase, ts: $ts, exit_code: (if $exit_code == "" then null else ($exit_code | tonumber? // null) end), pid: ($pid | tonumber)}' \
+      >> "$trace_file" 2>/dev/null || true
+  else
+    local exit_field
+    if [[ -z "$exit_code" ]]; then exit_field="null"; else exit_field="$exit_code"; fi
+    printf '{"step":"%s","phase":"%s","ts":"%s","exit_code":%s,"pid":%s}\n' \
+      "$step" "$phase" "$ts" "$exit_field" "$$" >> "$trace_file" 2>/dev/null || true
+  fi
+}
+
 # 成功出力
 ok() {
   local step="$1"; shift
@@ -793,15 +827,34 @@ step_check() {
 # =====================================================================
 
 main() {
+  # --trace <path> フラグ前処理（Phase 3 / Layer 1 経験的監査）
+  # 環境変数 TWL_CHAIN_TRACE と等価。フラグは複数回指定不可。
+  while [[ "${1:-}" == --trace || "${1:-}" == --trace=* ]]; do
+    if [[ "$1" == --trace=* ]]; then
+      TWL_CHAIN_TRACE="${1#--trace=}"
+      shift
+    else
+      if [[ -z "${2:-}" ]]; then
+        echo "ERROR: --trace にはパスを指定してください" >&2
+        exit 1
+      fi
+      TWL_CHAIN_TRACE="$2"
+      shift 2
+    fi
+    export TWL_CHAIN_TRACE
+  done
+
   local step="${1:-}"
   if [[ -z "$step" ]]; then
-    echo "Usage: chain-runner.sh <step-name> [args...]" >&2
+    echo "Usage: chain-runner.sh [--trace <path>] <step-name> [args...]" >&2
     echo "Steps: init, worktree-create, board-status-update, project-board-status-update, board-archive," >&2
     echo "       ac-extract, arch-ref, change-id-resolve, next-step, ts-preflight, pr-test, ac-verify," >&2
     echo "       all-pass-check, pr-cycle-report, auto-merge, check" >&2
     exit 1
   fi
   shift
+
+  trace_event "$step" "start"
 
   local _main_rc=0
   set +e
@@ -840,6 +893,8 @@ main() {
   esac
   _main_rc=$?
   set -e
+
+  trace_event "$step" "end" "$_main_rc"
 
   # Worker terminal status 検証ガード (Issue #131)
   # chain main 終端（=all-pass-check ステップ完了後）で issue-{N}.json の

--- a/plugins/twl/tests/scenarios/chain-runner-trace.test.sh
+++ b/plugins/twl/tests/scenarios/chain-runner-trace.test.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Scenario: chain-runner.sh --trace + TWL_CHAIN_TRACE
+# Verifies Phase 3 / Layer 1 trace event recording.
+# =============================================================================
+set -uo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CHAIN_RUNNER="$PLUGIN_ROOT/scripts/chain-runner.sh"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+run_test() {
+  local name="$1"; shift
+  if "$@"; then
+    PASS=$((PASS + 1))
+    echo "  PASS: $name"
+  else
+    FAIL=$((FAIL + 1))
+    ERRORS+=("$name")
+    echo "  FAIL: $name"
+  fi
+}
+
+# Use a per-test temp dir to avoid leaking state.
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# Invoking init without an issue number runs the no-op-style branch and exits 0.
+# We use the env-var form (no flag) for the first test.
+test_trace_via_env_var_records_start_and_end() {
+  local trace_file="$TMP_DIR/env.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    TWL_CHAIN_TRACE="$trace_file" bash "$CHAIN_RUNNER" check >/dev/null 2>&1 ) || true
+  [[ -s "$trace_file" ]] || return 1
+  grep -q '"step":"check"' "$trace_file" || return 1
+  grep -q '"phase":"start"' "$trace_file" || return 1
+  grep -q '"phase":"end"' "$trace_file" || return 1
+}
+
+# --trace <path> flag form
+test_trace_via_flag_records_event() {
+  local trace_file="$TMP_DIR/flag.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    bash "$CHAIN_RUNNER" --trace "$trace_file" check >/dev/null 2>&1 ) || true
+  [[ -s "$trace_file" ]] || return 1
+  grep -q '"step":"check"' "$trace_file" || return 1
+}
+
+# --trace=<path> form (single argument)
+test_trace_via_equals_form() {
+  local trace_file="$TMP_DIR/equals.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    bash "$CHAIN_RUNNER" --trace="$trace_file" check >/dev/null 2>&1 ) || true
+  [[ -s "$trace_file" ]] || return 1
+  grep -q '"step":"check"' "$trace_file" || return 1
+}
+
+# Without the env var or flag, no trace file is created and behaviour is unchanged.
+test_no_trace_no_file() {
+  local trace_file="$TMP_DIR/should-not-exist.jsonl"
+  unset TWL_CHAIN_TRACE
+  ( cd "$PLUGIN_ROOT" && \
+    bash "$CHAIN_RUNNER" check >/dev/null 2>&1 ) || true
+  [[ ! -e "$trace_file" ]] || return 1
+}
+
+# Each invocation appends events; multiple runs accumulate lines.
+test_trace_appends_events() {
+  local trace_file="$TMP_DIR/append.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    TWL_CHAIN_TRACE="$trace_file" bash "$CHAIN_RUNNER" check >/dev/null 2>&1 ) || true
+  ( cd "$PLUGIN_ROOT" && \
+    TWL_CHAIN_TRACE="$trace_file" bash "$CHAIN_RUNNER" check >/dev/null 2>&1 ) || true
+  local line_count
+  line_count=$(wc -l < "$trace_file")
+  [[ "$line_count" -ge 4 ]] || return 1
+}
+
+# Trace events are valid JSON Lines (each line parses).
+test_trace_lines_are_valid_json() {
+  local trace_file="$TMP_DIR/json.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    TWL_CHAIN_TRACE="$trace_file" bash "$CHAIN_RUNNER" check >/dev/null 2>&1 ) || true
+  [[ -s "$trace_file" ]] || return 1
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    echo "$line" | python3 -c 'import json,sys; json.loads(sys.stdin.read())' || return 1
+  done < "$trace_file"
+}
+
+# Path traversal is rejected (no file should be created when path contains ..).
+test_path_traversal_rejected() {
+  local trace_file="$TMP_DIR/../etc-evil.jsonl"
+  ( cd "$PLUGIN_ROOT" && \
+    bash "$CHAIN_RUNNER" --trace "$trace_file" check >/dev/null 2>&1 ) || true
+  [[ ! -e "$trace_file" ]] || return 1
+}
+
+run_test "trace_via_env_var_records_start_and_end" test_trace_via_env_var_records_start_and_end
+run_test "trace_via_flag_records_event"            test_trace_via_flag_records_event
+run_test "trace_via_equals_form"                   test_trace_via_equals_form
+run_test "no_trace_no_file"                        test_no_trace_no_file
+run_test "trace_appends_events"                    test_trace_appends_events
+run_test "trace_lines_are_valid_json"              test_trace_lines_are_valid_json
+run_test "path_traversal_rejected"                 test_path_traversal_rejected
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+  echo "Failures: ${ERRORS[*]}"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## 概要

Phase 3 (Layer 1 経験的監査) の実装。

- `chain-runner.sh` に `--trace <path>` フラグと `TWL_CHAIN_TRACE` 環境変数を追加
- `autopilot-launch.sh` が session_id ベースの trace パスを Worker tmux window に自動 export
- `twl audit-history` サブコマンド新規追加（mining + compare-deps + reconstruct）

## 主な変更

### chain-runner.sh
- `trace_event()` ヘルパー（jq 優先、なければ printf フォールバック）
- `main()` 冒頭で `--trace <path>` / `--trace=<path>` を解釈し `TWL_CHAIN_TRACE` を export
- dispatch case の前後で `trace_event "$step" "start"` / `"end" "$rc"` を発火
- `TWL_CHAIN_TRACE` 未設定時はノーオペ（既存 bats 全 PASS、後方互換）
- パストラバーサル `..` を含むパスは拒否

### autopilot-launch.sh
- `session.json` から `session_id` を取得（失敗時は UTC タイムスタンプにフォールバック）
- `${AUTOPILOT_DIR}/trace/${SESSION_ID}/issue-${ISSUE}.jsonl` を `mkdir -p`
- `tmux new-window` の env に `TWL_CHAIN_TRACE` を追加

### cli/twl/src/twl/autopilot/audit_history.py（新規）
- `parse_trace_file` / `parse_session`: JSON Lines パース＋ステップ集計
- `mine_history`: `<autopilot_dir>/trace/*/issue-*.jsonl` を `--days` で期間フィルタしながら集計
- `compare_with_deps`: `deps.yaml` の `scripts.chain-runner.commands` と突き合わせ、`declared_but_never_called`（F4 dead code 候補）と orphan executions を検出
- `reconstruct_trace_from_session_jsonl` / `reconstruct_from_directory`: trace 機構導入前の Claude Code session jsonl から `chain-runner.sh <step>` 呼び出しを抽出し疑似 trace を生成
- `cli_audit_history`: text/json 出力
- `cli.py` の `main()` 前処理で `audit-history` を直接ディスパッチ

## 使い方

```bash
# トレース有効化（autopilot 経由なら自動）
TWL_CHAIN_TRACE=/tmp/trace.jsonl bash chain-runner.sh init 42
bash chain-runner.sh --trace /tmp/trace.jsonl ts-preflight

# 過去 30 日の trace を mining
twl audit-history --autopilot-dir .autopilot --days 30

# 経験的 vs 宣言の突き合わせ
twl audit-history --compare-deps --plugin-root plugins/twl

# 過去 Claude Code session jsonl からの遡及解析
twl audit-history --reconstruct-from ~/.claude/projects/.../ --format json
```

## テスト

- `cli/twl/tests/test_audit_history.py`: 18 ケース（parse / mine / age filter / compare / reconstruct / CLI text & json / compare-deps）— **全 PASS**
- `plugins/twl/tests/scenarios/chain-runner-trace.test.sh`: 7 ケース（env-var / flag / `--trace=` / 後方互換 / append / JSON 妥当性 / path traversal 拒否）— **全 PASS**
- `cd plugins/twl && twl --check && twl --validate && twl --audit` — **全 PASS**
- `cd cli/twl && pytest tests/` — 既存の 4 件失敗は本 PR と無関係（main でも再現）

## 受け入れ基準

- [x] `chain-runner.sh` の `trace_event` 関数 + `TWL_CHAIN_TRACE`/`--trace`
- [x] `autopilot-launch.sh` が `TWL_CHAIN_TRACE` を Worker に自動 export
- [x] `cli/twl/src/twl/autopilot/audit_history.py` を新規作成、`mine_history` / `cli_audit_history`
- [x] `twl audit-history --days N` で過去 trace を mining
- [x] `twl audit-history --compare-deps` で empirical vs declared 比較
- [x] `twl audit-history --reconstruct-from <path>` で遡及解析
- [x] pytest テスト全 PASS
- [x] bats シナリオテスト PASS
- [x] trace 無効時の後方互換性
- [x] `twl --check && --validate && --audit` 全 PASS

Closes #143