### PR TITLE
test(plugins-twl): autopilot core 5 workflow の bats e2e scenario tests を追加 (Phase 4-A)

### DIFF
--- a/plugins/twl/scripts/dry-run-lib.sh
+++ b/plugins/twl/scripts/dry-run-lib.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dry-run-lib.sh - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-* skill 配下の dry-run.sh が共有する trace emit ヘルパー。
+# LLM ステップや破壊的副作用を持つステップ（auto-merge, worktree-create 等）は
+# chain-runner.sh の dispatch を経由できないため、本ヘルパーで TWL_CHAIN_TRACE に
+# 直接 start/end イベントを書き込む。フォーマットは chain-runner.sh の trace_event() と
+# 完全一致させ、assert_trace_order/contains が機械的・LLM 両方を区別なく扱えるようにする。
+
+# trace ファイルにイベントを 1 件書き込む（内部実装）
+# Args: <step> <phase> [exit_code]
+_dry_run_emit_event() {
+  local step="$1" phase="$2" exit_code="${3:-}"
+  [[ -z "${TWL_CHAIN_TRACE:-}" ]] && return 0
+  local trace_file="$TWL_CHAIN_TRACE"
+  case "$trace_file" in *..*) return 0 ;; esac
+  mkdir -p "$(dirname "$trace_file")" 2>/dev/null || return 0
+  local ts
+  ts=$(date -Iseconds 2>/dev/null || date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local exit_field
+  if [[ -z "$exit_code" ]]; then exit_field="null"; else exit_field="$exit_code"; fi
+  printf '{"step":"%s","phase":"%s","ts":"%s","exit_code":%s,"pid":%s}\n' \
+    "$step" "$phase" "$ts" "$exit_field" "$$" >> "$trace_file" 2>/dev/null || true
+}
+
+# LLM / 破壊的ステップ用の trace emit。chain-runner を経由せず start/end を一気に書く。
+# Args: <step> [exit_code=0]
+dry_run_emit_step() {
+  local step="$1" exit_code="${2:-0}"
+  _dry_run_emit_event "$step" "start"
+  _dry_run_emit_event "$step" "end" "$exit_code"
+}

--- a/plugins/twl/skills/workflow-pr-fix/dry-run.sh
+++ b/plugins/twl/skills/workflow-pr-fix/dry-run.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# dry-run.sh - workflow-pr-fix chain step 順序を trace に記録する dry-run スクリプト
+# Issue #144 (Phase 4-A): bats workflow-scenarios テストから呼び出される。
+#
+# 副作用は TWL_CHAIN_TRACE のみ。fix-phase / post-fix-verify / warning-fix は
+# 全て LLM ステップのため chain-runner case 未登録 → mock emit。
+#
+# Usage:
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+# shellcheck source=../../scripts/dry-run-lib.sh
+source "$PLUGIN_ROOT/scripts/dry-run-lib.sh"
+
+# Step 4: fix-phase（LLM）
+dry_run_emit_step fix-phase
+
+# Step 4.5: post-fix-verify（LLM）
+dry_run_emit_step post-fix-verify
+
+# Step 5: warning-fix（LLM）
+dry_run_emit_step warning-fix
+
+echo "[dry-run] workflow-pr-fix completed"

--- a/plugins/twl/skills/workflow-pr-merge/dry-run.sh
+++ b/plugins/twl/skills/workflow-pr-merge/dry-run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# dry-run.sh - workflow-pr-merge chain step 順序を trace に記録する dry-run スクリプト
+# Issue #144 (Phase 4-A): bats workflow-scenarios テストから呼び出される。
+#
+# 副作用は TWL_CHAIN_TRACE のみ。auto-merge / e2e-screening / pr-cycle-analysis /
+# merge-gate は破壊的・LLM のため mock emit。pr-cycle-report / all-pass-check は
+# chain-runner mechanical 経由（safe）。
+#
+# Usage:
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+# shellcheck source=../../scripts/dry-run-lib.sh
+source "$PLUGIN_ROOT/scripts/dry-run-lib.sh"
+
+CR="$PLUGIN_ROOT/scripts/chain-runner.sh"
+
+# Step 6: e2e-screening（LLM）
+dry_run_emit_step e2e-screening
+
+# Step 7: pr-cycle-report（mechanical, no PR + no stdin → skip）
+bash "$CR" pr-cycle-report "" >/dev/null 2>&1 </dev/null || true
+
+# Step 7.3: pr-cycle-analysis（LLM）
+dry_run_emit_step pr-cycle-analysis
+
+# Step 7.5: all-pass-check（mechanical, no AUTOPILOT_DIR → ok skip）
+bash "$CR" all-pass-check PASS >/dev/null 2>&1 || true
+
+# Step 8: merge-gate（LLM）
+dry_run_emit_step merge-gate
+
+# Step 8.5: auto-merge（破壊的 — mock emit のみ。実 squash merge は行わない）
+dry_run_emit_step auto-merge
+
+echo "[dry-run] workflow-pr-merge completed"

--- a/plugins/twl/skills/workflow-pr-verify/dry-run.sh
+++ b/plugins/twl/skills/workflow-pr-verify/dry-run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# dry-run.sh - workflow-pr-verify chain step 順序を trace に記録する dry-run スクリプト
+# Issue #144 (Phase 4-A): bats workflow-scenarios テストから呼び出される。
+#
+# 副作用は TWL_CHAIN_TRACE のみ。
+# **回帰テスト**: ac-verify は Issue #134 で step 3.5 (pr-test の後) に確定。
+#
+# Usage:
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+# shellcheck source=../../scripts/dry-run-lib.sh
+source "$PLUGIN_ROOT/scripts/dry-run-lib.sh"
+
+CR="$PLUGIN_ROOT/scripts/chain-runner.sh"
+
+# Step 1: ts-preflight（mechanical, no tsconfig → skip）
+bash "$CR" ts-preflight >/dev/null 2>&1 || true
+
+# Step 2: phase-review（LLM, 並列 specialist レビュー）
+dry_run_emit_step phase-review
+
+# Step 2.5: scope-judge（LLM）
+dry_run_emit_step scope-judge
+
+# Step 3: pr-test（mechanical, no tests → warn skip）
+bash "$CR" pr-test >/dev/null 2>&1 || true
+
+# Step 3.5: ac-verify（chain-runner marker — Issue #134 で pr-test の後に確定）
+bash "$CR" ac-verify >/dev/null 2>&1 || true
+
+echo "[dry-run] workflow-pr-verify completed"

--- a/plugins/twl/skills/workflow-setup/dry-run.sh
+++ b/plugins/twl/skills/workflow-setup/dry-run.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# dry-run.sh - workflow-setup chain step 順序を trace に記録する dry-run スクリプト
+# Issue #144 (Phase 4-A): bats workflow-scenarios テストから呼び出される。
+#
+# 副作用は TWL_CHAIN_TRACE のみ。実 gh / git push / worktree 操作は行わない。
+#
+# 前提:
+#   - CLAUDE_PLUGIN_ROOT: plugin ルート（未設定なら本スクリプト位置から解決）
+#   - TWL_CHAIN_TRACE:    trace 出力先（必須）
+#   - CWD:                テスト sandbox（branch != main、AUTOPILOT_DIR 未設定）
+#
+# Usage:
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh           # normal path
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh --quick   # quick path
+#
+# 各 chain step は SKILL.md の chain 実行指示（必須順）に対応する。順序が
+# 変わった場合は対応する bats シナリオが落ちるよう設計（回帰テスト凍結）。
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+# shellcheck source=../../scripts/dry-run-lib.sh
+source "$PLUGIN_ROOT/scripts/dry-run-lib.sh"
+
+CR="$PLUGIN_ROOT/scripts/chain-runner.sh"
+
+QUICK=false
+[[ "${1:-}" == "--quick" ]] && QUICK=true
+
+# Step 1: init（mechanical）
+bash "$CR" init "" >/dev/null 2>&1 || true
+
+# Step 2: worktree-create（autopilot 経由では Pilot が事前作成済みのためスキップ）
+# dry-run では trace marker のみ emit（python 呼び出しを避ける）
+dry_run_emit_step worktree-create
+
+# Step 2.3: board-status-update（mechanical, 引数なし→早期 return）
+bash "$CR" board-status-update "" >/dev/null 2>&1 || true
+
+# Step 2.4: crg-auto-build（LLM ステップ — chain-runner case 未登録）
+dry_run_emit_step crg-auto-build
+
+# Step 2.5: arch-ref（mechanical, 引数なし→skip）
+bash "$CR" arch-ref "" >/dev/null 2>&1 || true
+
+# Step 3: change-propose（chain-runner marker）
+bash "$CR" change-propose >/dev/null 2>&1 || true
+
+# Step 3.5: ac-extract（mechanical, issue 番号なし→skip）
+bash "$CR" ac-extract >/dev/null 2>&1 || true
+
+# 完了後の遷移
+if $QUICK; then
+  # Quick path (Issue #134): workflow-test-ready をスキップし、直接実装→
+  # ac-verify→merge-gate を実行する。ac-verify は chain-runner marker、
+  # merge-gate は LLM ステップ。
+  bash "$CR" ac-verify >/dev/null 2>&1 || true
+  dry_run_emit_step merge-gate
+fi
+
+echo "[dry-run] workflow-setup completed (quick=$QUICK)"

--- a/plugins/twl/skills/workflow-test-ready/dry-run.sh
+++ b/plugins/twl/skills/workflow-test-ready/dry-run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# dry-run.sh - workflow-test-ready chain step 順序を trace に記録する dry-run スクリプト
+# Issue #144 (Phase 4-A): bats workflow-scenarios テストから呼び出される。
+#
+# 副作用は TWL_CHAIN_TRACE のみ。前提は workflow-setup/dry-run.sh と同じ。
+# sandbox には deltaspec/changes/<id>/ を 1 件以上配置しておくこと
+# （change-id-resolve が成功するため）。
+#
+# Usage:
+#   TWL_CHAIN_TRACE=/tmp/trace.jsonl bash dry-run.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+# shellcheck source=../../scripts/dry-run-lib.sh
+source "$PLUGIN_ROOT/scripts/dry-run-lib.sh"
+
+CR="$PLUGIN_ROOT/scripts/chain-runner.sh"
+
+# Quick guard: 非 quick 想定（quick の場合 SKILL.md は workflow-test-ready 自体を
+# スキップするため、本 dry-run は非 quick path のみカバー）
+# Step 1: change-id-resolve（mechanical, deltaspec/changes/ が必要）
+bash "$CR" change-id-resolve >/dev/null 2>&1 || true
+
+# Step 2: test-scaffold（chain-runner marker）
+bash "$CR" test-scaffold >/dev/null 2>&1 || true
+
+# Step 3: check（mechanical — 失敗してもトレースは emit）
+bash "$CR" check >/dev/null 2>&1 || true
+
+# Step 4: change-apply（chain-runner marker）→ post-change-apply（marker）
+bash "$CR" change-apply >/dev/null 2>&1 || true
+bash "$CR" post-change-apply >/dev/null 2>&1 || true
+
+echo "[dry-run] workflow-test-ready completed"

--- a/plugins/twl/tests/bats/helpers/mock-specialists.bash
+++ b/plugins/twl/tests/bats/helpers/mock-specialists.bash
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# mock-specialists.bash - Issue #144 / Phase 4-A Layer 2
+#
+# bats workflow-scenarios で specialist 出力を mock するヘルパー。
+# 実 specialist (LLM) を呼ばずに checkpoint ファイルを書き出す。
+# 現状の workflow-scenarios の trace 順序検証では LLM 出力の中身は使わないが、
+# 将来 fix-phase エスカレーションや merge-gate REJECT の分岐 verify を追加する際
+# に備え、共通生成関数を集約しておく。
+
+# mock_specialist_pass <step> [path]
+# 指定 step の checkpoint を PASS で書き出す。
+mock_specialist_pass() {
+  local step="$1"
+  local path="${2:-${WORKFLOW_SANDBOX:-$BATS_TEST_TMPDIR}/.autopilot/checkpoints/${step}.json}"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+{"step":"${step}","status":"PASS","findings":[],"confidence":100}
+EOF
+}
+
+# mock_specialist_critical <step> [path]
+# CRITICAL findings 付き checkpoint を書き出す（fix ループ分岐検証用）。
+mock_specialist_critical() {
+  local step="$1"
+  local path="${2:-${WORKFLOW_SANDBOX:-$BATS_TEST_TMPDIR}/.autopilot/checkpoints/${step}.json}"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+{"step":"${step}","status":"FAIL","findings":[{"severity":"CRITICAL","confidence":90,"message":"mock critical finding"}],"confidence":90}
+EOF
+}
+
+# mock_specialist_warning <step> [path]
+mock_specialist_warning() {
+  local step="$1"
+  local path="${2:-${WORKFLOW_SANDBOX:-$BATS_TEST_TMPDIR}/.autopilot/checkpoints/${step}.json}"
+  mkdir -p "$(dirname "$path")"
+  cat > "$path" <<EOF
+{"step":"${step}","status":"WARN","findings":[{"severity":"WARNING","confidence":50,"message":"mock warning"}],"confidence":50}
+EOF
+}

--- a/plugins/twl/tests/bats/helpers/trace-assertions.bash
+++ b/plugins/twl/tests/bats/helpers/trace-assertions.bash
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# trace-assertions.bash - Issue #144 / Phase 4-A Layer 2
+#
+# bats workflow-scenarios 用の trace 検証ヘルパー。
+# TWL_CHAIN_TRACE が指す JSON Lines ファイルから step の出現順序を検証する。
+#
+# 想定 trace 形式（chain-runner.sh trace_event() / dry-run-lib.sh と一致）:
+#   {"step":"<name>","phase":"start|end","ts":"...","exit_code":...,"pid":...}
+#
+# 備考: bats 内では `run` でラップして status を assert することを推奨。
+# stderr に詳細を出すので失敗時は ${output} で内容確認できる。
+
+# assert_trace_order <step1> <step2> ... <stepN>
+# 与えられた step が trace に「この順序で」現れることを確認する（start phase で判定）。
+# 失敗時は exit 1 + stderr に詳細を出力。
+assert_trace_order() {
+  local trace_file="${TWL_CHAIN_TRACE:-}"
+  if [[ -z "$trace_file" || ! -f "$trace_file" ]]; then
+    echo "FAIL: trace file not found: ${trace_file:-<unset>}" >&2
+    return 1
+  fi
+  local prev_idx=0 step idx
+  for step in "$@"; do
+    # start phase の最初の出現行番号を取得
+    idx=$(grep -nE "\"step\":\"${step}\",\"phase\":\"start\"" "$trace_file" 2>/dev/null \
+      | head -1 | cut -d: -f1)
+    if [[ -z "$idx" ]]; then
+      echo "FAIL: step '$step' not found in trace ($trace_file)" >&2
+      echo "--- trace contents ---" >&2
+      cat "$trace_file" >&2
+      return 1
+    fi
+    if (( idx <= prev_idx )); then
+      echo "FAIL: step '$step' (line $idx) is at or before previous step (line $prev_idx)" >&2
+      echo "--- trace contents ---" >&2
+      cat "$trace_file" >&2
+      return 1
+    fi
+    prev_idx=$idx
+  done
+  return 0
+}
+
+# assert_trace_contains <step1> <step2> ... <stepN>
+# 与えられた step が trace に（順序問わず）全て出現することを確認する。
+assert_trace_contains() {
+  local trace_file="${TWL_CHAIN_TRACE:-}"
+  if [[ -z "$trace_file" || ! -f "$trace_file" ]]; then
+    echo "FAIL: trace file not found: ${trace_file:-<unset>}" >&2
+    return 1
+  fi
+  local step
+  for step in "$@"; do
+    if ! grep -qE "\"step\":\"${step}\"" "$trace_file"; then
+      echo "FAIL: step '$step' not found in trace ($trace_file)" >&2
+      echo "--- trace contents ---" >&2
+      cat "$trace_file" >&2
+      return 1
+    fi
+  done
+  return 0
+}
+
+# assert_trace_not_contains <step1> ...
+# 与えられた step が trace に出現しないことを確認する。
+assert_trace_not_contains() {
+  local trace_file="${TWL_CHAIN_TRACE:-}"
+  if [[ -z "$trace_file" || ! -f "$trace_file" ]]; then
+    # ファイルが無い = 何も含まない → 成功
+    return 0
+  fi
+  local step
+  for step in "$@"; do
+    if grep -qE "\"step\":\"${step}\"" "$trace_file"; then
+      echo "FAIL: step '$step' should NOT be in trace but was found" >&2
+      echo "--- trace contents ---" >&2
+      cat "$trace_file" >&2
+      return 1
+    fi
+  done
+  return 0
+}

--- a/plugins/twl/tests/bats/helpers/workflow-scenario-env.bash
+++ b/plugins/twl/tests/bats/helpers/workflow-scenario-env.bash
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# workflow-scenario-env.bash - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-scenarios bats 共通の sandbox 構築ヘルパー。
+# 各テストは setup() で setup_workflow_scenario_env を呼ぶ。teardown() は
+# teardown_workflow_scenario_env を呼ぶ。実環境の AUTOPILOT_DIR / git config /
+# gh CLI 等が混入しないよう全てを isolate する。
+
+# 1 度だけ解決される plugin ルート（symlink 解決済み）
+# trace-assertions.bash と mock-specialists.bash も自動 source する。
+setup_workflow_scenario_env() {
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  PLUGIN_ROOT="$(cd "$helpers_dir/../../.." && pwd)"
+  export PLUGIN_ROOT
+  export CLAUDE_PLUGIN_ROOT="$PLUGIN_ROOT"
+
+  # PYTHONPATH: chain-runner.sh が source する python-env.sh は自身の位置から
+  # git toplevel を解決するが、念のため明示しておく
+  local repo_root
+  repo_root="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+  if [[ -d "$repo_root/cli/twl/src" ]]; then
+    export PYTHONPATH="$repo_root/cli/twl/src${PYTHONPATH:+:${PYTHONPATH}}"
+  fi
+
+  # Sandbox: 各テストごとに独立した tmpdir を bats 提供のものから派生させる
+  WORKFLOW_SANDBOX="$(mktemp -d "${BATS_TEST_TMPDIR:-/tmp}/twl-wfscenario.XXXXXX")"
+  export WORKFLOW_SANDBOX
+  TWL_CHAIN_TRACE="$WORKFLOW_SANDBOX/trace.jsonl"
+  export TWL_CHAIN_TRACE
+  : > "$TWL_CHAIN_TRACE"
+
+  # 環境分離: 実環境の AUTOPILOT_DIR / WORKER_ISSUE_NUM を必ず unset
+  # （chain-runner の guard 群と resolve_issue_num が誤発火しないように）
+  unset AUTOPILOT_DIR WORKER_ISSUE_NUM
+
+  # gh CLI を no-op 化（実 API 叩かないように）
+  WORKFLOW_STUB_BIN="$WORKFLOW_SANDBOX/.stub-bin"
+  mkdir -p "$WORKFLOW_STUB_BIN"
+  cat > "$WORKFLOW_STUB_BIN/gh" <<'STUB_EOF'
+#!/usr/bin/env bash
+# stub gh: 全コマンドを成功扱い・空出力
+exit 0
+STUB_EOF
+  chmod +x "$WORKFLOW_STUB_BIN/gh"
+  _WFSC_ORIG_PATH="$PATH"
+  export PATH="$WORKFLOW_STUB_BIN:$PATH"
+
+  # Sandbox 内に git repo を構築し、worktree-create が早期 return する非 main
+  # ブランチに切り替える
+  pushd "$WORKFLOW_SANDBOX" >/dev/null
+  git init -q -b feat/9999-dry-run 2>/dev/null \
+    || { git init -q && git checkout -q -b feat/9999-dry-run; }
+  git config user.email "test@example.com"
+  git config user.name "test"
+  git commit -q --allow-empty -m "init" 2>/dev/null || true
+
+  # workflow-test-ready dry-run の change-id-resolve が成功するように
+  # deltaspec/changes/<id>/ を 1 件配置
+  mkdir -p deltaspec/changes/test-change
+  : > deltaspec/changes/test-change/proposal.md
+  cat > deltaspec/changes/test-change/.deltaspec.yaml <<'YAML_EOF'
+status: pending
+YAML_EOF
+  popd >/dev/null
+
+  # CWD を sandbox に固定（chain-runner の resolve_project_root が git toplevel を返す）
+  _WFSC_ORIG_CWD="$PWD"
+  cd "$WORKFLOW_SANDBOX"
+}
+
+teardown_workflow_scenario_env() {
+  if [[ -n "${_WFSC_ORIG_CWD:-}" ]]; then
+    cd "$_WFSC_ORIG_CWD" 2>/dev/null || cd /
+  fi
+  if [[ -n "${_WFSC_ORIG_PATH:-}" ]]; then
+    export PATH="$_WFSC_ORIG_PATH"
+  fi
+  if [[ -n "${WORKFLOW_SANDBOX:-}" && -d "$WORKFLOW_SANDBOX" ]]; then
+    rm -rf "$WORKFLOW_SANDBOX"
+  fi
+  unset WORKFLOW_SANDBOX TWL_CHAIN_TRACE WORKFLOW_STUB_BIN
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/_template.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/_template.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# _template.bats - Issue #144 / Phase 4-A Layer 2
+#
+# 将来 workflow を追加する際の bats workflow-scenarios テンプレート。
+# このファイルは bats から実行されないよう先頭に skip を入れている。
+# 新規 workflow テストを書く場合は本ファイルをコピーして workflow 名にリネームし、
+# skip を削除して dry-run.sh を実装すること。
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+load '../helpers/mock-specialists'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "TEMPLATE: workflow-<name> dry-run order regression test" {
+  skip "template only"
+
+  # 1. dry-run.sh を実行（trace.jsonl が export 済み）
+  run bash "$PLUGIN_ROOT/skills/workflow-<name>/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  # 2. trace の順序を assert
+  run assert_trace_order step1 step2 step3
+  [ "$status" -eq 0 ]
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+# workflow-pr-fix.bats - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-pr-fix の chain step 順序を回帰テストとして凍結する。
+#   fix-phase → post-fix-verify → warning-fix
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "workflow-pr-fix: fix-phase → post-fix-verify → warning-fix の順で実行" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-fix/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order \
+    fix-phase \
+    post-fix-verify \
+    warning-fix
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-fix: 全 3 step が trace に存在する" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-fix/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_contains fix-phase post-fix-verify warning-fix
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-fix: 30 秒以内に完了する" {
+  local start_ts end_ts
+  start_ts=$(date +%s)
+  bash "$PLUGIN_ROOT/skills/workflow-pr-fix/dry-run.sh" >/dev/null 2>&1
+  end_ts=$(date +%s)
+  [ $((end_ts - start_ts)) -lt 30 ]
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-merge.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-merge.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# workflow-pr-merge.bats - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-pr-merge の chain step 順序を回帰テストとして凍結する。
+#   e2e-screening → pr-cycle-report → pr-cycle-analysis → all-pass-check →
+#   merge-gate → auto-merge
+#
+# NOTE: change-archive は SKILL.md chain ライフサイクル表に未含まれるため
+#       本 Issue 時点ではテスト対象外（Phase 2 トリアージ後に追加予定）。
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "workflow-pr-merge: e2e-screening → pr-cycle-report → pr-cycle-analysis → all-pass-check → merge-gate → auto-merge の順で実行" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-merge/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order \
+    e2e-screening \
+    pr-cycle-report \
+    pr-cycle-analysis \
+    all-pass-check \
+    merge-gate \
+    auto-merge
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-merge: auto-merge は merge-gate より後に実行される（不変条件 C）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-merge/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order merge-gate auto-merge
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-merge: 全 6 step が trace に存在する" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-merge/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_contains \
+    e2e-screening \
+    pr-cycle-report \
+    pr-cycle-analysis \
+    all-pass-check \
+    merge-gate \
+    auto-merge
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-merge: 30 秒以内に完了する" {
+  local start_ts end_ts
+  start_ts=$(date +%s)
+  bash "$PLUGIN_ROOT/skills/workflow-pr-merge/dry-run.sh" >/dev/null 2>&1
+  end_ts=$(date +%s)
+  [ $((end_ts - start_ts)) -lt 30 ]
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-verify.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-verify.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# workflow-pr-verify.bats - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-pr-verify の chain step 順序を回帰テストとして凍結する。
+# 重要: ac-verify は Issue #134 で step 3.5 (pr-test の後) に確定済み。
+#       ts-preflight → phase-review → scope-judge → pr-test → ac-verify
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "workflow-pr-verify: ts-preflight → phase-review → scope-judge → pr-test → ac-verify の順で実行" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-verify/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order \
+    ts-preflight \
+    phase-review \
+    scope-judge \
+    pr-test \
+    ac-verify
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-verify: ac-verify が必ず trace に現れる（Issue #134 回帰テスト）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-verify/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_contains ac-verify
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-verify: ac-verify は pr-test より後に実行される（順序の不変条件）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-pr-verify/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order pr-test ac-verify
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-pr-verify: 30 秒以内に完了する" {
+  local start_ts end_ts
+  start_ts=$(date +%s)
+  bash "$PLUGIN_ROOT/skills/workflow-pr-verify/dry-run.sh" >/dev/null 2>&1
+  end_ts=$(date +%s)
+  [ $((end_ts - start_ts)) -lt 30 ]
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-setup.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-setup.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# workflow-setup.bats - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-setup の chain step 順序を回帰テストとして凍結する。
+# - 通常 path: init → board-status-update → crg-auto-build → arch-ref →
+#              change-propose → ac-extract
+# - quick path (Issue #134): init → board-status-update → ac-extract → ac-verify
+#   （quick の場合 SKILL.md は workflow-test-ready をスキップし
+#   ac-verify→merge-gate を必ず呼ぶよう Issue #134 で義務化された）
+#
+# trace は dry-run.sh が TWL_CHAIN_TRACE に書き出す JSON Lines。
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "workflow-setup: 通常 path で init → board-status-update → crg-auto-build → arch-ref → change-propose → ac-extract の順で実行" {
+  run bash "$PLUGIN_ROOT/skills/workflow-setup/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order \
+    init \
+    worktree-create \
+    board-status-update \
+    crg-auto-build \
+    arch-ref \
+    change-propose \
+    ac-extract
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-setup: 通常 path では ac-verify を呼ばない（次 workflow へ遷移）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-setup/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_not_contains ac-verify merge-gate
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-setup: quick path で ac-verify と merge-gate を必ず呼ぶ（Issue #134 回帰テスト）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-setup/dry-run.sh" --quick
+  [ "$status" -eq 0 ]
+
+  # 全 step（init を含む setup 系）→ ac-verify → merge-gate の順で出現
+  run assert_trace_order \
+    init \
+    board-status-update \
+    ac-extract \
+    ac-verify \
+    merge-gate
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-setup: quick path でも ac-verify が trace に必ず現れる（regression freeze）" {
+  run bash "$PLUGIN_ROOT/skills/workflow-setup/dry-run.sh" --quick
+  [ "$status" -eq 0 ]
+
+  run assert_trace_contains ac-verify
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-setup: 30 秒以内に完了する" {
+  local start_ts end_ts
+  start_ts=$(date +%s)
+  bash "$PLUGIN_ROOT/skills/workflow-setup/dry-run.sh" >/dev/null 2>&1
+  end_ts=$(date +%s)
+  [ $((end_ts - start_ts)) -lt 30 ]
+}

--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-test-ready.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-test-ready.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+# workflow-test-ready.bats - Issue #144 / Phase 4-A Layer 2
+#
+# workflow-test-ready の chain step 順序を回帰テストとして凍結する。
+#   change-id-resolve → test-scaffold → check → change-apply → post-change-apply
+
+load '../helpers/workflow-scenario-env'
+load '../helpers/trace-assertions'
+
+setup() {
+  setup_workflow_scenario_env
+}
+
+teardown() {
+  teardown_workflow_scenario_env
+}
+
+@test "workflow-test-ready: change-id-resolve → test-scaffold → check → change-apply → post-change-apply の順で実行" {
+  run bash "$PLUGIN_ROOT/skills/workflow-test-ready/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_order \
+    change-id-resolve \
+    test-scaffold \
+    check \
+    change-apply \
+    post-change-apply
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-test-ready: 全 5 step が trace に存在する" {
+  run bash "$PLUGIN_ROOT/skills/workflow-test-ready/dry-run.sh"
+  [ "$status" -eq 0 ]
+
+  run assert_trace_contains \
+    change-id-resolve \
+    test-scaffold \
+    check \
+    change-apply \
+    post-change-apply
+  [ "$status" -eq 0 ]
+}
+
+@test "workflow-test-ready: 30 秒以内に完了する" {
+  local start_ts end_ts
+  start_ts=$(date +%s)
+  bash "$PLUGIN_ROOT/skills/workflow-test-ready/dry-run.sh" >/dev/null 2>&1
+  end_ts=$(date +%s)
+  [ $((end_ts - start_ts)) -lt 30 ]
+}


### PR DESCRIPTION
## 概要

Issue #144 / Phase 4-A Layer 2: autopilot core 5 workflow について chain step 順序を bats 回帰テストとして凍結する。Phase 3 (#160) の trace 機構 (`chain-runner.sh --trace` / `TWL_CHAIN_TRACE`) を利用。

## 追加内容

### 1. dry-run スクリプト (各 skill 配下)
- `plugins/twl/skills/workflow-setup/dry-run.sh` (normal + `--quick` path 対応)
- `plugins/twl/skills/workflow-test-ready/dry-run.sh`
- `plugins/twl/skills/workflow-pr-verify/dry-run.sh`
- `plugins/twl/skills/workflow-pr-fix/dry-run.sh`
- `plugins/twl/skills/workflow-pr-merge/dry-run.sh`

設計原則: 機械的 step は `chain-runner.sh` を実際に呼び (dispatch 表の機能 verify を兼ねる)、LLM step / 破壊的 step (`auto-merge`, `worktree-create` 等) は `dry-run-lib.sh::dry_run_emit_step` で trace marker を直接 emit する。実 `gh` / `git push` / 実 squash merge は行わず、副作用は `TWL_CHAIN_TRACE` への JSONL 出力のみ。

### 2. 共通ライブラリ
- `plugins/twl/scripts/dry-run-lib.sh` — LLM/破壊的 step 用 trace emit ヘルパー (chain-runner.sh の `trace_event()` フォーマットと完全一致)
- `plugins/twl/tests/bats/helpers/trace-assertions.bash` — `assert_trace_order` / `assert_trace_contains` / `assert_trace_not_contains`
- `plugins/twl/tests/bats/helpers/mock-specialists.bash` — specialist checkpoint mock (PASS / CRITICAL / WARN)
- `plugins/twl/tests/bats/helpers/workflow-scenario-env.bash` — sandbox 構築 (独立 git repo / `gh` stub / `AUTOPILOT_DIR` unset / `TWL_CHAIN_TRACE` 設定)

### 3. bats シナリオ (新規 `tests/bats/workflow-scenarios/`)
責務分離のため既存 `scripts/` `scenarios/` とは別ディレクトリ:
- `workflow-setup.bats` (normal path / quick path / ac-verify regression / 30s gate)
- `workflow-test-ready.bats`
- `workflow-pr-verify.bats` (**ac-verify Issue #134 回帰テスト**含む)
- `workflow-pr-fix.bats`
- `workflow-pr-merge.bats` (**auto-merge は merge-gate より後**を assert)
- `_template.bats` — 将来追加用テンプレート (`skip` 入り)

合計 **20 ケース (1 skip = template) すべて PASS**。

## 凍結する不変条件 (回帰テスト)

将来 chain step の追加・削除・順序変更で **dead code 化バグの再発を機械的に防ぐ**:

- `workflow-setup` 通常 path: `init → board-status-update → crg-auto-build → arch-ref → change-propose → ac-extract`
- `workflow-setup` quick path: `ac-verify` と `merge-gate` を必ず呼ぶ (Issue #134)
- `workflow-pr-verify`: `ts-preflight → phase-review → scope-judge → pr-test → ac-verify` (**ac-verify は pr-test の後**, Issue #134 step 3.5)
- `workflow-pr-fix`: `fix-phase → post-fix-verify → warning-fix`
- `workflow-pr-merge`: `e2e-screening → pr-cycle-report → pr-cycle-analysis → all-pass-check → merge-gate → auto-merge` (不変条件 C: auto-merge は merge-gate の後にのみ)

## 検証

```bash
$ bats plugins/twl/tests/bats/workflow-scenarios/
1..20
ok 1 TEMPLATE: ... # skip template only
ok 2..20 (all 19 scenarios PASS)

$ cd plugins/twl && python3 -m twl --check && python3 -m twl --validate && python3 -m twl --audit
File Check: OK 198 / Missing 0
Type Validation: OK 1953 / Violations 0
Audit Summary: CRITICAL 0 / WARNING 43 / OK 522
```

各 workflow scenario の実行時間は 30 秒以内 (mock により高速)。

## スコープ外 (本 Issue では含まない)

- 非 autopilot workflow (`workflow-self-improve`, `workflow-plugin-create`, `workflow-plugin-diagnose`, `workflow-dead-cleanup`, `workflow-tech-debt-triage`) のテスト — 別 Issue 群で漸進的追加
- `change-archive` の追加 — SKILL.md ライフサイクル表に未含まれるため Phase 2 トリアージ後に追加予定
- 既存 4 件の pre-existing pytest 失敗 (test_add_to_project_action_version 等) — origin/main でも失敗、本 PR 無関係

Closes #144