### PR TITLE
feat(plugins-twl): worker-workflow-integrity specialist 新規作成 (Phase 4-B Layer 3)

### DIFF
--- a/plugins/twl/agents/worker-workflow-integrity.md
+++ b/plugins/twl/agents/worker-workflow-integrity.md
@@ -1,0 +1,142 @@
+---
+name: twl:worker-workflow-integrity
+description: |
+  architecture spec と実装 (deps.yaml, chain-runner.sh, SKILL.md) の意味的整合性をレビューする specialist。
+  workflow chain の設計意図と実装の乖離を検出 (F5: 仕様外の処理 / F3 の意味的版)。
+type: specialist
+model: sonnet
+effort: high
+maxTurns: 20
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+skills:
+  - ref-specialist-output-schema
+  - ref-specialist-few-shot
+  - ref-prompt-guide
+---
+
+# worker-workflow-integrity: chain 整合性レビュー
+
+あなたは architecture spec と実装 (deps.yaml / chain-runner.sh / skills/*/SKILL.md) の **意味的整合性** をレビューする specialist です。
+workflow chain の設計意図と実装の乖離 (failure mode F5: 仕様外の処理 / F3 の意味的版) を検出します。
+
+**役割**: 純 soft gate (可視化中心)。**CRITICAL は出力しません**。WARNING / INFO のみを出力し、merge を block することはありません。
+
+## worker-architecture との役割分担 (MUST)
+
+本 specialist は `worker-architecture` と並列実行されるため、出力 category で明確に区別すること:
+
+| specialist | 出力 category | 担当範囲 |
+|---|---|---|
+| `worker-architecture` (既存) | `architecture-drift` | architecture spec の Component Mapping / Constraints / Workflow 説明と実装の全般的整合性 |
+| `worker-workflow-integrity` (本 specialist) | `chain-integrity-drift` | **chain の宣言 (deps.yaml) / dispatch (chain-runner.sh) / SKILL.md text の三者間意味的乖離に特化** |
+
+- 本 specialist は **`category: chain-integrity-drift` のみ** を出力すること
+- `architecture-drift` は worker-architecture の担当。**本 specialist は絶対に出力しない**
+- `architecture/*.md` 単独変更は worker-architecture が担当するため、本 specialist は chain 関連ファイル (deps.yaml / SKILL.md / chain-runner.sh) の変更時のみ起動する
+
+## 入力
+
+1. **PR diff**: `git diff origin/main` および `git diff --stat origin/main`
+2. **変更ファイルリスト**: `git diff --name-only origin/main`
+3. **architecture spec 全件**: `architecture/domain/contexts/*.md` (存在すれば)
+4. **deps.yaml** 全体
+5. **関連 SKILL.md**: PR で変更された `skills/<workflow>/SKILL.md`、および対応する `architecture/domain/contexts/*.md`
+6. **chain-runner.sh** / `cli/twl/src/twl/autopilot/chain.py` (chain dispatch 実装)
+
+## 実行ロジック
+
+1. `git diff --name-only origin/main` で変更ファイルを特定
+2. 変更ファイルに chain 関連 (deps.yaml / SKILL.md / chain-runner.sh) が含まれない場合は `{"status": "PASS", "findings": []}` を出力して終了
+3. `architecture/domain/contexts/*.md` 全件を Read
+4. PR で変更された workflow について、以下三者の宣言を抽出:
+   - **architecture spec**: Component Mapping / Workflow 説明 / Constraints セクションの chain step 順序・呼び出し関係
+   - **deps.yaml**: 該当 workflow の `calls:` / `dispatch_mode:` / specialist/atomic リスト
+   - **SKILL.md text**: skill 本文に記述された実行手順
+5. 三者を照合し、以下の乖離を検出:
+   - **step 順序乖離**: architecture が宣言する順序と deps.yaml の `calls:` 順序 / SKILL.md 手順が食い違う
+   - **欠落 step**: architecture に書かれているが deps.yaml または SKILL.md に存在しない step
+   - **余剰 step (F5: 仕様外処理)**: 実装 (deps.yaml / SKILL.md) にあるが architecture に説明がない step
+   - **命名不一致**: architecture と deps.yaml で異なる名前 (リネーム漏れ)
+   - **不変条件違反**: architecture の Constraints / 不変条件 (例: 「auto-merge は squash + delete-branch」) に違反する変更
+6. ref-specialist-output-schema 準拠の JSON を出力
+
+## 必須項目 (MUST)
+
+### 1. 逐語引用 (必須)
+
+各 Finding の `message` フィールドには以下を **逐語引用** として含めること:
+
+- architecture spec の該当行 (形式: `[architecture 引用 architecture/domain/contexts/<file>.md line N]: '...'`)
+- 実装側の該当 hunk (形式: `[実装引用 <file> line N]: '...'`)
+
+**両方の引用がない Finding は parser が INFO に降格する**（LLM hallucination 対策）。
+
+### 2. confidence 上限 75 (例外なし)
+
+本 specialist は **純 soft gate** であるため:
+
+- confidence の上限は **75** (例外なし)
+- severity は **WARNING** または **INFO** のみ
+- **CRITICAL は絶対に出力してはならない**
+
+理由:
+- LLM 単独の意味解釈で merge を block するのは false positive リスクが高い
+- chain integrity の機械的検証は Layer 0 (Phase 1) の `twl --audit` Section 9 が担う (静的解析なので CRITICAL 判定可)
+- 本 specialist は Layer 3 の補助的レビュー可視化レイヤー
+
+### 3. confidence マトリクス
+
+| 状態 | severity | confidence | category |
+|---|---|---|---|
+| step 順序乖離 (架空構造的要素が明確に対応) | WARNING | 75 | chain-integrity-drift |
+| 欠落 step (architecture に記載あり・実装に存在せず) | WARNING | 75 | chain-integrity-drift |
+| 余剰 step / 仕様外処理 (実装にあり・architecture に記載なし) | WARNING | 70 | chain-integrity-drift |
+| 命名不一致 (リネーム漏れ疑い) | WARNING | 70 | chain-integrity-drift |
+| 不変条件違反 (Constraints 逐語引用可) | WARNING | 75 | chain-integrity-drift |
+| 設計意図への影響が不明確 | INFO | 50 | chain-integrity-drift |
+
+### 4. category
+
+本 specialist は **`category: chain-integrity-drift` のみ** を出力する。
+`architecture-drift` / `ac-alignment` / `vulnerability` などは出力してはならない。
+
+## 出力形式 (MUST)
+
+ref-specialist-output-schema に従い、以下のサマリー行と JSON ブロックを出力すること:
+
+```
+worker-workflow-integrity 完了
+
+status: WARN
+```
+
+```json
+{
+  "status": "WARN",
+  "findings": [
+    {
+      "severity": "WARNING",
+      "confidence": 75,
+      "file": "skills/workflow-pr-verify/SKILL.md",
+      "line": 42,
+      "message": "chain step 順序乖離: architecture は workflow-pr-verify を ts-preflight → phase-review → scope-judge → pr-test の順序と規定していますが、SKILL.md 実装は scope-judge を pr-test の後に置いています。\n\n[architecture 引用 architecture/domain/contexts/pr-cycle.md line 56]: 'workflow-pr-verify は ts-preflight → phase-review → scope-judge → pr-test の順で実行する'\n[実装引用 skills/workflow-pr-verify/SKILL.md line 42]: '1. ts-preflight\\n2. phase-review\\n3. pr-test\\n4. scope-judge'",
+      "category": "chain-integrity-drift"
+    }
+  ]
+}
+```
+
+- `findings` が空の場合: `{"status": "PASS", "findings": []}`
+- status は findings から自動導出 (WARNING あり → WARN、それ以外 → PASS)
+
+## 制約
+
+- **Read-only**: ファイル変更禁止 (Write, Edit 不可)
+- **Task tool 禁止**: 全チェックを自身で実行
+- **Bash は読み取り系のみ**: `git diff`, `git log`, `cat` 等の参照系コマンドのみ
+- **CRITICAL 出力禁止**: severity は WARNING / INFO のみ
+- **推測禁止**: 逐語引用できない finding は出力しない (INFO に降格して出力するか、出力しない)

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1939,7 +1939,7 @@ scripts:
     calls:
       - script: tech-stack-detect
       - script: resolve-issue-num
-    description: "PR review 系 specialist 選択の動的マニフェスト（phase-review / merge-gate / post-fix-verify）。phase-review/merge-gate モードで Issue 番号が解決可能な場合 worker-issue-pr-alignment を出力に含める"
+    description: "PR review 系 specialist 選択の動的マニフェスト（phase-review / merge-gate / post-fix-verify）。phase-review/merge-gate モードで Issue 番号が解決可能な場合 worker-issue-pr-alignment を出力に含める。merge-gate モードで chain 関連ファイル (deps.yaml/SKILL.md/chain-runner.sh) 変更時は worker-workflow-integrity を追加"
 
   checkpoint-write:
     type: script
@@ -2188,6 +2188,20 @@ agents:
     can_spawn: []
     skills: [ref-specialist-output-schema, ref-specialist-few-shot]
     description: "Issue body と PR diff の意味的整合性レビュー (soft gate、ac-alignment 専用 specialist)"
+
+  worker-workflow-integrity:
+    type: specialist
+    refined_by: "ref-prompt-guide@de6a54f5"
+    refined_at: "2026-04-08"
+    path: agents/worker-workflow-integrity.md
+    model: sonnet
+    effort: high
+    gate_role: soft
+    dispatch_mode: trigger
+    spawnable_by: [workflow, composite, controller]
+    can_spawn: []
+    skills: [ref-specialist-output-schema, ref-specialist-few-shot, ref-prompt-guide]
+    description: "architecture spec と実装 (deps.yaml, chain-runner.sh, SKILL.md) の意味的整合性レビュー (soft gate、chain-integrity-drift 専用 specialist)"
 
   worker-llm-output-reviewer:
     type: specialist

--- a/plugins/twl/refs/ref-specialist-few-shot.md
+++ b/plugins/twl/refs/ref-specialist-few-shot.md
@@ -81,3 +81,51 @@ findings:
 - CRITICAL は「diff にゼロ言及」かつ「ac-verify 未検出」かつ「Issue body の AC が明示的」の 3 条件を満たすときのみ
 - 部分達成 / 軽量解釈 / 拡大解釈はすべて WARNING（confidence 70-75）
 - 逐語引用が無い Finding は parser が CRITICAL → WARNING に自動降格する
+
+## chain-integrity-drift 用 few-shot（worker-workflow-integrity 専用）
+
+`category: chain-integrity-drift` を出力する specialist (worker-workflow-integrity) は、以下の 2 例を参考にすること。
+**純 soft gate** であり、**CRITICAL は出力禁止**。severity は WARNING / INFO のみ、confidence 上限 75（例外なし）。
+**逐語引用は MUST**（両方の引用がない Finding は parser が INFO に降格する）。
+
+### 例 1: chain step 順序の宣言と実装の乖離
+
+```json
+{
+  "status": "WARN",
+  "findings": [
+    {
+      "severity": "WARNING",
+      "confidence": 75,
+      "file": "skills/workflow-pr-verify/SKILL.md",
+      "line": 42,
+      "message": "chain step 順序乖離: architecture spec は workflow-pr-verify を ts-preflight → phase-review → scope-judge → pr-test の順と規定していますが、SKILL.md 実装は scope-judge を pr-test の後に置いています。deps.yaml の calls: 順序も SKILL.md に一致しており、architecture 側が逸脱しています（あるいは実装 2 箇所が誤っています）。\n\n[architecture 引用 architecture/domain/contexts/pr-cycle.md line 56]: 'workflow-pr-verify は ts-preflight → phase-review → scope-judge → pr-test の順で実行する'\n[実装引用 skills/workflow-pr-verify/SKILL.md line 42]: '1. ts-preflight\\n2. phase-review\\n3. pr-test\\n4. scope-judge'",
+      "category": "chain-integrity-drift"
+    }
+  ]
+}
+```
+
+### 例 2: 不変条件違反の検出
+
+```json
+{
+  "status": "WARN",
+  "findings": [
+    {
+      "severity": "WARNING",
+      "confidence": 75,
+      "file": "scripts/auto-merge.sh",
+      "line": 88,
+      "message": "不変条件違反: architecture spec の Constraints は auto-merge が squash + delete-branch で実行されることを規定していますが、auto-merge.sh は rebase を試行しています。不変条件 F (auto-merge は squash only) 違反の疑いがあります。\n\n[architecture 引用 architecture/domain/contexts/pr-cycle.md line 142]: 'auto-merge は必ず --squash --delete-branch で実行する。rebase / merge commit は禁止 (不変条件 F)'\n[実装引用 scripts/auto-merge.sh line 88]: 'gh pr merge --rebase --delete-branch \"$PR_NUM\"'",
+      "category": "chain-integrity-drift"
+    }
+  ]
+}
+```
+
+**chain-integrity-drift ルール**:
+- **CRITICAL 禁止** (純 soft gate、merge を block しない)
+- confidence 上限 **75** (例外なし)
+- 両方の引用 (`[architecture 引用 ...]` と `[実装引用 ...]`) を含まない Finding は parser が INFO に降格
+- `worker-architecture` と役割分担: 本 specialist は chain 三者整合性のみ、architecture-drift 全般は worker-architecture の担当

--- a/plugins/twl/refs/ref-specialist-output-schema.md
+++ b/plugins/twl/refs/ref-specialist-output-schema.md
@@ -48,7 +48,7 @@ merge-gate / phase-review が機械的に消費可能な構造化出力を定義
           },
           "category": {
             "type": "string",
-            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles", "ac-alignment", "ac-alignment-unknown"],
+            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles", "ac-alignment", "ac-alignment-unknown", "architecture-drift", "chain-integrity-drift"],
             "description": "finding の分類（merge-gate 共通）。co-issue specialist は co-issue 拡張 category を使用すること"
           },
           "finding_target": {
@@ -133,6 +133,8 @@ merge-gate specialist が使用する共通 category。
 | `principles` | worker-principles |
 | `ac-alignment` | worker-issue-pr-alignment（Issue body と PR diff の意味的整合性 finding） |
 | `ac-alignment-unknown` | worker-issue-pr-alignment（達成度判断不能の AC、INFO のみ） |
+| `architecture-drift` | worker-architecture（architecture spec と実装の全般的整合性 drift） |
+| `chain-integrity-drift` | worker-workflow-integrity（chain の宣言/dispatch/SKILL.md 三者間意味的乖離に特化） |
 
 ### ac-alignment specialist の追加要件（MUST）
 

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -123,6 +123,24 @@ if [[ "$MODE" == "merge-gate" ]]; then
   fi
 fi
 
+# merge-gate モードのみ: chain 関連ファイル (deps.yaml / SKILL.md / chain-runner.sh) 変更
+# → worker-workflow-integrity を追加 (Layer 3: chain-integrity-drift 検出)
+# architecture/*.md 単独変更は worker-architecture が担当するため、ここでは起動しない
+if [[ "$MODE" == "merge-gate" ]]; then
+  chain_related=false
+  for f in "${FILES[@]}"; do
+    case "$f" in
+      *deps.yaml|*SKILL.md|*chain-runner.sh|*autopilot/chain.py)
+        chain_related=true
+        break
+        ;;
+    esac
+  done
+  if $chain_related; then
+    SPECIALISTS["worker-workflow-integrity"]=1
+  fi
+fi
+
 # --- 常時追加: AC alignment specialist (Issue 番号が解決可能な場合のみ) ---
 # phase-review / merge-gate モードで Issue 番号が解決可能な場合に worker-issue-pr-alignment を必須化。
 # 変更ファイルパターンに依存しない（コード変更ゼロでも Issue 内容と乖離している可能性があるため）。

--- a/plugins/twl/tests/bats/scripts/pr-review-manifest.bats
+++ b/plugins/twl/tests/bats/scripts/pr-review-manifest.bats
@@ -207,3 +207,58 @@ EOF
   assert_success
   assert_output --partial "WARNING: pr-review-manifest"
 }
+
+# ===========================================================================
+# Requirement: worker-workflow-integrity トリガー (Issue #145, Phase 4-B)
+# chain 関連ファイル (deps.yaml / SKILL.md / chain-runner.sh) 変更時のみ追加。
+# architecture/*.md 単独変更では起動しない (worker-architecture が担当)。
+# ===========================================================================
+
+@test "merge-gate: chain file (deps.yaml) change adds worker-workflow-integrity" {
+  run bash -c "echo 'plugins/twl/deps.yaml' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-workflow-integrity"
+}
+
+@test "merge-gate: chain file (SKILL.md) change adds worker-workflow-integrity" {
+  run bash -c "echo 'plugins/twl/skills/workflow-pr-verify/SKILL.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-workflow-integrity"
+}
+
+@test "merge-gate: chain file (chain-runner.sh) change adds worker-workflow-integrity" {
+  run bash -c "echo 'plugins/twl/scripts/chain-runner.sh' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-workflow-integrity"
+}
+
+@test "merge-gate: architecture-only change does NOT add worker-workflow-integrity" {
+  mkdir -p "$SANDBOX/architecture"
+
+  run bash -c "echo 'architecture/domain/contexts/pr-cycle.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  refute_output --partial "worker-workflow-integrity"
+  # worker-architecture は追加されるはず (architecture/ が存在するため)
+  assert_output --partial "worker-architecture"
+}
+
+@test "merge-gate: unrelated code change does NOT add worker-workflow-integrity" {
+  run bash -c "echo 'src/index.ts' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  refute_output --partial "worker-workflow-integrity"
+}
+
+@test "merge-gate: chain file + architecture simultaneous change adds BOTH specialists" {
+  mkdir -p "$SANDBOX/architecture"
+
+  run bash -c "printf 'plugins/twl/deps.yaml\narchitecture/domain/contexts/pr-cycle.md\n' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-workflow-integrity"
+  assert_output --partial "worker-architecture"
+}
+
+@test "phase-review: chain file change does NOT add worker-workflow-integrity (merge-gate only)" {
+  run bash -c "echo 'plugins/twl/deps.yaml' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode phase-review"
+  assert_success
+  refute_output --partial "worker-workflow-integrity"
+}


### PR DESCRIPTION
## 概要

Issue #145 (Phase 4-B Layer 3) を実装。architecture spec と実装 (deps.yaml, chain-runner.sh, SKILL.md) の **意味的整合性** をレビューする specialist `worker-workflow-integrity` を新規作成し、merge-gate の動的レビュアー manifest に組み込んだ。

## 変更内容

### 1. `agents/worker-workflow-integrity.md` 新規作成
- ref-specialist-output-schema + ref-specialist-few-shot + ref-prompt-guide skills 注入
- worker-architecture との役割分担明示（`chain-integrity-drift` のみ出力）
- 純 soft gate: CRITICAL 禁止、confidence 上限 75 (例外なし)
- 逐語引用必須（両方なければ INFO 降格）

### 2. `deps.yaml` に specialist 登録
- `dispatch_mode: trigger`, `gate_role: soft`, `effort: high`
- `refined_by: ref-prompt-guide@de6a54f5` / `refined_at: 2026-04-08`

### 3. `refs/ref-specialist-output-schema.md`
- category enum に `chain-integrity-drift` と `architecture-drift` を追加
- worker-architecture との役割分担を表で記載

### 4. `refs/ref-specialist-few-shot.md`
- chain-integrity-drift 用 few-shot を 2 例追加
  - 例 1: chain step 順序の宣言と実装の乖離
  - 例 2: 不変条件違反 (auto-merge の squash-only 違反)

### 5. `scripts/pr-review-manifest.sh`
- merge-gate モードのみ、chain 関連ファイル変更時に自動追加
- 対象: `*deps.yaml`, `*SKILL.md`, `*chain-runner.sh`, `*autopilot/chain.py`
- `architecture/*.md` 単独変更では起動しない（worker-architecture が担当）

### 6. `tests/bats/scripts/pr-review-manifest.bats`
- 7 scenarios を既存ファイルに追記:
  - chain file (deps.yaml) 変更 → worker-workflow-integrity 含む
  - chain file (SKILL.md) 変更 → 含む
  - chain file (chain-runner.sh) 変更 → 含む
  - architecture 単独変更 → 含まない (worker-architecture のみ)
  - 無関係 code 変更 → 含まない
  - chain file + architecture 同時 → **両方** 含む
  - phase-review モードでは chain file 変更でも起動しない (merge-gate only)

## テスト結果

- `bats tests/bats/scripts/pr-review-manifest.bats`: 新規 7 scenarios 全 PASS
- `twl --check`: OK 199, Missing 0
- `twl --validate`: OK 1959, Violations 0
- `twl --audit --section 9` (Chain Integrity): CRITICAL 0, WARNING 0, OK 52

## 受け入れ基準チェック

- [x] `worker-workflow-integrity.md` 新規作成 (ref-* skills 注入)
- [x] 逐語引用必須 / confidence 上限 75 / CRITICAL 禁止 / worker-architecture 役割分担 明示
- [x] `deps.yaml` に specialist 登録 (dispatch_mode: trigger)
- [x] `dispatch_mode: trigger` が validate.py の valid_dispatch_modes に含まれる (Phase 1 完了前提の確認: `cli/twl/src/twl/validation/validate.py:255`)
- [x] `pr-review-manifest.sh` chain 関連ファイルトリガー (architecture 単独除外)
- [x] category enum に `chain-integrity-drift` 追加
- [x] few-shot 例 2 件追加
- [x] bats 既存ファイルへの追記で 4+ シナリオ全 PASS
- [x] `refined_by`/`refined_at` にプレースホルダなし
- [x] `twl --check && twl --validate && twl --audit` 全 PASS (Section 9 = 0 findings)

Closes #145