### PR TITLE
fix(mergegate): base drift による silent file deletion を検知して merge を停止 (#166)

### DIFF
--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -248,6 +248,9 @@ class MergeGate:
         # auto-close fires on merge. Issue #136.
         self._ensure_closes_link(gh_repo_flag)
 
+        # Pre-merge check: detect silent file deletions from base staleness. Issue #166.
+        self._check_base_drift()
+
         merge_ok = self._run_merge(gh_repo_flag)
         if not merge_ok:
             sys.exit(1)
@@ -422,6 +425,66 @@ class MergeGate:
                 f"⚠️ PR 本文への Closes 追記失敗（merge は継続）: "
                 f"{edit_result.stderr.strip()}",
                 file=sys.stderr,
+            )
+
+    def _check_base_drift(self) -> None:
+        """Detect silent file deletions caused by worker base staleness."""
+        if os.environ.get("MERGE_GATE_SKIP_DRIFT_CHECK") == "1":
+            print(
+                f"[merge-gate] Issue #{self.issue}: ⚠️ "
+                f"MERGE_GATE_SKIP_DRIFT_CHECK=1 で base drift 検知をスキップ",
+                file=sys.stderr,
+            )
+            return
+        fetch_result = subprocess.run(
+            ["git", "fetch", "origin", "main"],
+            check=False,
+            capture_output=True,
+        )
+        if fetch_result.returncode != 0:
+            return  # fail-open: ネットワーク断で merge が止まらないようにする
+        diff_result = subprocess.run(
+            ["git", "diff", "--name-only", "--diff-filter=D", "origin/main...HEAD"],
+            capture_output=True,
+            text=True,
+        )
+        if diff_result.returncode != 0:
+            return
+        deleted_files = [line for line in diff_result.stdout.splitlines() if line.strip()]
+        if not deleted_files:
+            return
+
+        mb_result = subprocess.run(
+            ["git", "merge-base", "HEAD", "origin/main"],
+            capture_output=True,
+            text=True,
+        )
+        if mb_result.returncode != 0:
+            return
+        merge_base = mb_result.stdout.strip()
+
+        silent_deletions = []
+        for path in deleted_files:
+            # MUST: レンジを {merge_base}..HEAD に限定する。
+            # 限定しないとリポジトリ全履歴の削除 commit を拾い、silent deletion を取りこぼす。
+            log_result = subprocess.run(
+                ["git", "log", "--format=%H", "--diff-filter=D",
+                 f"{merge_base}..HEAD", "--", path],
+                capture_output=True,
+                text=True,
+            )
+            if not log_result.stdout.strip():
+                silent_deletions.append(path)
+
+        if silent_deletions:
+            paths_str = "\n  - " + "\n  - ".join(silent_deletions[:10])
+            if len(silent_deletions) > 10:
+                paths_str += f"\n  - ... and {len(silent_deletions) - 10} more"
+            raise MergeGateError(
+                f"base drift 検出: PR 内に削除 commit の無いファイルが "
+                f"{len(silent_deletions)} 件含まれています。"
+                f"`git rebase origin/main` → `git push --force-with-lease` を実行してください。"
+                f"{paths_str}"
             )
 
     def _run_merge(self, gh_repo_flag: list[str]) -> bool:

--- a/cli/twl/tests/test_autopilot_mergegate.py
+++ b/cli/twl/tests/test_autopilot_mergegate.py
@@ -547,6 +547,151 @@ class TestEnsureClosesLink:
         assert order == ["ensure", "merge"]
 
 
+# ---------------------------------------------------------------------------
+# _check_base_drift (Issue #166)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckBaseDrift:
+    """base drift 検知ロジックのテスト。"""
+
+    def _make_run(self, deleted_files: list[str], log_commits: dict[str, str]):
+        """subprocess.run の side_effect を生成するヘルパー。
+
+        Args:
+            deleted_files: git diff で返す削除ファイル一覧
+            log_commits: path → git log 出力（空文字 = silent deletion）
+        """
+        def fake_run(cmd, **kwargs):
+            cmd_list = list(cmd)
+            if cmd_list[:3] == ["git", "fetch", "origin"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if "--diff-filter=D" in cmd_list and "origin/main...HEAD" in cmd_list:
+                content = "\n".join(deleted_files) + "\n" if deleted_files else ""
+                return MagicMock(returncode=0, stdout=content, stderr="")
+            if cmd_list[:3] == ["git", "merge-base"]:
+                return MagicMock(returncode=0, stdout="abc123\n", stderr="")
+            if cmd_list[:2] == ["git", "log"]:
+                path = cmd_list[-1]
+                return MagicMock(returncode=0, stdout=log_commits.get(path, ""), stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+        return fake_run
+
+    def test_silent_deletion_raises_merge_gate_error(self, gate):
+        """PR 内に削除 commit のないファイルがある場合 MergeGateError を raise する。"""
+        fake_run = self._make_run(
+            deleted_files=["some/file.py"],
+            log_commits={"some/file.py": ""},  # 削除 commit なし = silent deletion
+        )
+        with patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(MergeGateError, match="base drift 検出"):
+                gate._check_base_drift()
+
+    def test_silent_deletion_does_not_call_gh_pr_merge(self, gate):
+        """base drift 検出時は gh pr merge --squash が呼ばれないこと。"""
+        merge_calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):
+            cmd_list = list(cmd)
+            if "merge" in cmd_list and "gh" in cmd_list:
+                merge_calls.append(cmd_list)
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if cmd_list[:3] == ["git", "fetch", "origin"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if "--diff-filter=D" in cmd_list and "origin/main...HEAD" in cmd_list:
+                return MagicMock(returncode=0, stdout="deleted.py\n", stderr="")
+            if cmd_list[:3] == ["git", "merge-base"]:
+                return MagicMock(returncode=0, stdout="abc123\n", stderr="")
+            if cmd_list[:2] == ["git", "log"]:
+                return MagicMock(returncode=0, stdout="", stderr="")  # silent
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("os.getcwd", return_value="/home/user/projects/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(MergeGateError, match="base drift 検出"):
+                gate.execute()
+
+        assert merge_calls == [], "gh pr merge が呼ばれてはならない"
+
+    def test_intentional_deletion_does_not_raise(self, gate):
+        """PR 内に明示的な削除 commit がある場合は raise しない（意図的削除）。"""
+        fake_run = self._make_run(
+            deleted_files=["intentionally-deleted.py"],
+            log_commits={"intentionally-deleted.py": "deadbeef\n"},  # 削除 commit あり
+        )
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._check_base_drift()  # should not raise
+
+    def test_no_deleted_files_does_not_raise(self, gate):
+        """削除ファイルがない場合は何もしない。"""
+        fake_run = self._make_run(deleted_files=[], log_commits={})
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._check_base_drift()  # should not raise
+
+    def test_bypass_env_skips_check(self, gate, monkeypatch, capsys):
+        """MERGE_GATE_SKIP_DRIFT_CHECK=1 で bypass され、stderr 警告が出力されること。"""
+        monkeypatch.setenv("MERGE_GATE_SKIP_DRIFT_CHECK", "1")
+        call_count = [0]
+
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._check_base_drift()  # should not raise
+
+        captured = capsys.readouterr()
+        assert "MERGE_GATE_SKIP_DRIFT_CHECK=1" in captured.err
+        # git fetch など subprocess が呼ばれていないこと
+        assert call_count[0] == 0
+
+    def test_fetch_failure_is_fail_open(self, gate):
+        """git fetch 失敗時は fail-open で処理を継続する（raise しない）。"""
+        def fake_run(cmd, **kwargs):
+            cmd_list = list(cmd)
+            if cmd_list[:3] == ["git", "fetch", "origin"]:
+                return MagicMock(returncode=1, stdout="", stderr="network error")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            gate._check_base_drift()  # should not raise
+
+    def test_called_after_ensure_closes_link_before_run_merge_in_execute(self, gate):
+        """execute() フローの中で _check_base_drift が _ensure_closes_link の後、
+        _run_merge の前に呼ばれること。"""
+        order: list[str] = []
+
+        def fake_ensure(self, _flag):
+            order.append("ensure")
+
+        def fake_drift(self):
+            order.append("drift")
+
+        def fake_merge(self, _flag):
+            order.append("merge")
+            return True
+
+        with patch("os.getcwd", return_value="/home/u/repo/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch.object(MergeGate, "_verify_and_close_issue", return_value=True), \
+             patch.object(MergeGate, "_ensure_closes_link", new=fake_ensure), \
+             patch.object(MergeGate, "_check_base_drift", new=fake_drift), \
+             patch.object(MergeGate, "_run_merge", new=fake_merge), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            gate.execute()
+
+        assert order == ["ensure", "drift", "merge"]
+
+
 class TestGhRepoFlag:
     def test_no_repo_args_no_flag(self, autopilot_dir, scripts_root):
         gate = MergeGate(

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -117,7 +117,7 @@ stateDiagram-v2
 
 ## Constraints
 
-### 不変条件（9件）
+### 不変条件（10件）
 
 | ID | 不変条件 | 概要 |
 |----|----------|------|
@@ -130,6 +130,7 @@ stateDiagram-v2
 | **G** | クラッシュ検知保証 | Worker の crash/timeout は必ず検知される |
 | **H** | deps.yaml 変更排他性 | 同一 Phase 内で deps.yaml を変更する複数 Issue は separate Phase |
 | **I** | 循環依存拒否 | plan.yaml 生成時に循環依存を検出した場合、拒否 |
+| **J** | merge 前 base drift 検知 | merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止する |
 
 ### 並行性の制約
 


### PR DESCRIPTION
## 概要

並列 Worker の base staleness による silent file deletion を merge-gate で検知する機能を追加。

## 変更内容

- `mergegate.py`: `_check_base_drift()` メソッドを新規追加
  - `git fetch origin main` で最新 main を取得（失敗時は fail-open）
  - `git diff --name-only --diff-filter=D origin/main...HEAD` で削除ファイル一覧取得
  - 各削除ファイルの PR 内削除 commit を `git log {merge_base}..HEAD` で確認
  - 削除 commit なし → base drift と判定し `MergeGateError` を raise
  - `MERGE_GATE_SKIP_DRIFT_CHECK=1` で bypass 可能（stderr に警告出力）
- `execute()`: `_ensure_closes_link()` 直後・`_run_merge()` 直前で `_check_base_drift()` を呼び出す
- `test_autopilot_mergegate.py`: `TestCheckBaseDrift` クラスに 7 ケースを追加（46 tests PASS）
- `autopilot.md`: 不変条件 J（merge 前 base drift 検知）を追加し 9件→10件 に更新

## テスト結果

```
46 passed in 0.07s
```

Closes #166