### PR TITLE
fix(chain): Mermaid classDef の色をWCAG AA準拠に修正

### DIFF
--- a/cli/twl/src/twl/chain/viz.py
+++ b/cli/twl/src/twl/chain/viz.py
@@ -250,10 +250,10 @@ def chain_viz_all(deps: dict) -> str:
 
 
 def _append_classdefs(lines: List[str]) -> None:
-    lines.append("    classDef script fill:#c8e6c9,stroke:#4caf50")
-    lines.append("    classDef llm fill:#bbdefb,stroke:#1976d2")
-    lines.append("    classDef composite fill:#e1bee7,stroke:#7b1fa2")
-    lines.append("    classDef marker fill:#eeeeee,stroke:#9e9e9e")
+    lines.append("    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff")
+    lines.append("    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff")
+    lines.append("    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff")
+    lines.append("    classDef marker fill:#616161,stroke:#424242,color:#ffffff")
 
 
 def _generate_for_marker(deps: dict, chain_name: str) -> Optional[str]:

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -149,10 +149,10 @@ flowchart TD
     pr_verify__ac_verify --> pr_fix__fix_phase
     pr_fix__warning_fix --> pr_merge__e2e_screening
 
-    classDef script fill:#c8e6c9,stroke:#4caf50
-    classDef llm fill:#bbdefb,stroke:#1976d2
-    classDef composite fill:#e1bee7,stroke:#7b1fa2
-    classDef marker fill:#eeeeee,stroke:#9e9e9e
+    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff
+    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff
+    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff
+    classDef marker fill:#616161,stroke:#424242,color:#ffffff
 ```
 <!-- CHAIN-FLOW:all END -->
 

--- a/plugins/twl/architecture/domain/contexts/pr-cycle.md
+++ b/plugins/twl/architecture/domain/contexts/pr-cycle.md
@@ -74,10 +74,10 @@ flowchart TD
     pr_verify__scope_judge --> pr_verify__pr_test
     pr_verify__pr_test --> pr_verify__ac_verify
 
-    classDef script fill:#c8e6c9,stroke:#4caf50
-    classDef llm fill:#bbdefb,stroke:#1976d2
-    classDef composite fill:#e1bee7,stroke:#7b1fa2
-    classDef marker fill:#eeeeee,stroke:#9e9e9e
+    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff
+    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff
+    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff
+    classDef marker fill:#616161,stroke:#424242,color:#ffffff
 ```
 <!-- CHAIN-FLOW:pr-verify END -->
 
@@ -96,10 +96,10 @@ flowchart TD
     pr_fix__fix_phase --> pr_fix__post_fix_verify
     pr_fix__post_fix_verify --> pr_fix__warning_fix
 
-    classDef script fill:#c8e6c9,stroke:#4caf50
-    classDef llm fill:#bbdefb,stroke:#1976d2
-    classDef composite fill:#e1bee7,stroke:#7b1fa2
-    classDef marker fill:#eeeeee,stroke:#9e9e9e
+    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff
+    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff
+    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff
+    classDef marker fill:#616161,stroke:#424242,color:#ffffff
 ```
 <!-- CHAIN-FLOW:pr-fix END -->
 
@@ -124,10 +124,10 @@ flowchart TD
     pr_merge__all_pass_check --> pr_merge__merge_gate
     pr_merge__merge_gate --> pr_merge__auto_merge
 
-    classDef script fill:#c8e6c9,stroke:#4caf50
-    classDef llm fill:#bbdefb,stroke:#1976d2
-    classDef composite fill:#e1bee7,stroke:#7b1fa2
-    classDef marker fill:#eeeeee,stroke:#9e9e9e
+    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff
+    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff
+    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff
+    classDef marker fill:#616161,stroke:#424242,color:#ffffff
 ```
 <!-- CHAIN-FLOW:pr-merge END -->
 

--- a/plugins/twl/architecture/domain/model.md
+++ b/plugins/twl/architecture/domain/model.md
@@ -295,10 +295,10 @@ flowchart TD
     pr_verify__ac_verify --> pr_fix__fix_phase
     pr_fix__warning_fix --> pr_merge__e2e_screening
 
-    classDef script fill:#c8e6c9,stroke:#4caf50
-    classDef llm fill:#bbdefb,stroke:#1976d2
-    classDef composite fill:#e1bee7,stroke:#7b1fa2
-    classDef marker fill:#eeeeee,stroke:#9e9e9e
+    classDef script fill:#2e7d32,stroke:#1b5e20,color:#ffffff
+    classDef llm fill:#1565c0,stroke:#0d47a1,color:#ffffff
+    classDef composite fill:#7b1fa2,stroke:#4a148c,color:#ffffff
+    classDef marker fill:#616161,stroke:#424242,color:#ffffff
 ```
 <!-- CHAIN-FLOW:all END -->
 


### PR DESCRIPTION
## 変更内容

`twl chain viz` で生成される Mermaid フロー図の classDef 色定義を修正。

### 問題
- 薄い背景色に黒文字でコントラスト不足
- script / llm の色相が近く識別困難

### 修正
| classDef | Before (fill) | After (fill + color) |
|----------|--------------|---------------------|
| script | #c8e6c9 (薄緑) | #2e7d32 (濃緑) + 白文字 |
| llm | #bbdefb (薄青) | #1565c0 (濃青) + 白文字 |
| composite | #e1bee7 (薄紫) | #7b1fa2 (濃紫) + 白文字 |
| marker | #eeeeee (薄灰) | #616161 (濃灰) + 白文字 |

WCAG AA基準（コントラスト比 4.5:1 以上）を満たす配色。
architecture spec の CHAIN-FLOW マーカーも `--update-arch` で同期更新済み。