### PR TITLE
feat(autopilot): IssueState に workflow_done フィールド追加

### DIFF
--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -31,7 +31,7 @@ _TRANSITIONS: dict[str, set[str]] = {
     "conflict": {"merge-ready", "failed"},
 }
 
-_PILOT_ISSUE_ALLOWED_KEYS = {"status", "merged_at", "failure", "manual_override"}
+_PILOT_ISSUE_ALLOWED_KEYS = {"status", "merged_at", "failure", "manual_override", "workflow_done"}
 
 
 def _autopilot_dir() -> Path:
@@ -242,6 +242,7 @@ class StateManager:
             "merged_at": None,
             "files_changed": [],
             "failure": None,
+            "workflow_done": None,
         }
         self._atomic_write(file, data)
         return f"OK: issue-{issue}.json を作成しました (status=running)"

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -38,6 +38,7 @@ per-issue の状態ファイル。
 | merged_at | null \| string (ISO 8601) | マージ完了時刻 |
 | files_changed | string[] | 変更されたファイルパス配列 |
 | failure | null \| { message, step, timestamp } | 失敗情報 |
+| workflow_done | null \| string | 完了したワークフロー名（例: `setup`, `test-ready`）。Orchestrator が次 workflow inject 検知に使用 |
 
 ### AutopilotPlan (plan.yaml)
 autopilot セッションの実行計画。


### PR DESCRIPTION
feat(autopilot): IssueState に workflow_done フィールド追加

- _init_issue() のデフォルトスキーマに "workflow_done": null を追加
- _PILOT_ISSUE_ALLOWED_KEYS に workflow_done を追加（Pilot が inject 後にクリア可能）
- autopilot.md の IssueState テーブルに workflow_done フィールドを追加

Closes #335

Co-Authored-By: Claude <noreply@anthropic.com>