### PR TITLE
feat(autopilot): step_init() 再設計 — deltaspec 存在チェック削除 + scope/direct ラベル対応

### DIFF
--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -224,12 +224,14 @@ class ChainRunner:
         self.record_step(issue_num, "init")
 
         branch = self._git_current_branch()
-        is_quick = self._detect_quick_label(issue_num) if issue_num else "false"
-        is_direct = self._detect_direct_label(issue_num) if issue_num else "false"
+        labels = self._fetch_labels(issue_num) if issue_num else []
+        is_quick = "true" if "quick" in labels else "false"
+        is_direct = "true" if "scope/direct" in labels else "false"
 
-        # Persist is_quick to state
+        # Persist is_quick and is_direct to state
         if issue_num and re.match(r"^\d+$", issue_num):
             self._write_state_field(issue_num, f"is_quick={is_quick}")
+            self._write_state_field(issue_num, f"is_direct={is_direct}")
 
         if branch in ("main", "master"):
             result = {
@@ -248,6 +250,7 @@ class ChainRunner:
                 "branch": branch,
                 "deltaspec": False,
                 "is_quick": is_quick == "true",
+                "is_direct": is_direct == "true",
             }
             self._ok("init", f"recommended_action=direct ({reason}, is_quick={is_quick})")
             if issue_num and re.match(r"^\d+$", issue_num):
@@ -921,37 +924,29 @@ class ChainRunner:
         except Exception:
             pass
 
-    def _detect_quick_label(self, issue_num: str) -> str:
-        """Return 'true' if issue has quick label, else 'false'."""
+    def _fetch_labels(self, issue_num: str) -> list[str]:
+        """Fetch issue label names via gh CLI. Returns empty list on failure."""
         if not issue_num or not re.match(r"^\d+$", issue_num):
-            return "false"
+            return []
         try:
             result = subprocess.run(
                 ["gh", "issue", "view", issue_num, "--json", "labels",
                  "--jq", ".labels[].name"],
                 capture_output=True, text=True, timeout=10,
             )
-            if result.returncode == 0 and "quick" in result.stdout.splitlines():
-                return "true"
+            if result.returncode == 0:
+                return result.stdout.splitlines()
         except Exception:
             pass
-        return "false"
+        return []
+
+    def _detect_quick_label(self, issue_num: str) -> str:
+        """Return 'true' if issue has quick label, else 'false'."""
+        return "true" if "quick" in self._fetch_labels(issue_num) else "false"
 
     def _detect_direct_label(self, issue_num: str) -> str:
         """Return 'true' if issue has scope/direct label, else 'false'."""
-        if not issue_num or not re.match(r"^\d+$", issue_num):
-            return "false"
-        try:
-            result = subprocess.run(
-                ["gh", "issue", "view", issue_num, "--json", "labels",
-                 "--jq", ".labels[].name"],
-                capture_output=True, text=True, timeout=10,
-            )
-            if result.returncode == 0 and "scope/direct" in result.stdout.splitlines():
-                return "true"
-        except Exception:
-            pass
-        return "false"
+        return "true" if "scope/direct" in self._fetch_labels(issue_num) else "false"
 
     def _has_command(self, cmd: str) -> bool:
         try:

--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -944,10 +944,6 @@ class ChainRunner:
         """Return 'true' if issue has quick label, else 'false'."""
         return "true" if "quick" in self._fetch_labels(issue_num) else "false"
 
-    def _detect_direct_label(self, issue_num: str) -> str:
-        """Return 'true' if issue has scope/direct label, else 'false'."""
-        return "true" if "scope/direct" in self._fetch_labels(issue_num) else "false"
-
     def _has_command(self, cmd: str) -> bool:
         try:
             subprocess.check_output(["which", cmd], stderr=subprocess.DEVNULL)

--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -225,6 +225,7 @@ class ChainRunner:
 
         branch = self._git_current_branch()
         is_quick = self._detect_quick_label(issue_num) if issue_num else "false"
+        is_direct = self._detect_direct_label(issue_num) if issue_num else "false"
 
         # Persist is_quick to state
         if issue_num and re.match(r"^\d+$", issue_num):
@@ -239,17 +240,34 @@ class ChainRunner:
             self._ok("init", f"recommended_action=worktree (branch={branch}, is_quick={is_quick})")
             return result
 
-        root = self._project_root()
-        deltaspec_dir = root / "deltaspec"
-
-        if not deltaspec_dir.is_dir():
+        # quick or scope/direct label → direct
+        if is_quick == "true" or is_direct == "true":
+            reason = "quick" if is_quick == "true" else "scope/direct label"
             result = {
                 "recommended_action": "direct",
                 "branch": branch,
                 "deltaspec": False,
                 "is_quick": is_quick == "true",
             }
-            self._ok("init", f"recommended_action=direct (no deltaspec, is_quick={is_quick})")
+            self._ok("init", f"recommended_action=direct ({reason}, is_quick={is_quick})")
+            if issue_num and re.match(r"^\d+$", issue_num):
+                self._write_state_field(issue_num, "mode=direct")
+            return result
+
+        root = self._project_root()
+        deltaspec_dir = root / "deltaspec"
+
+        if not deltaspec_dir.is_dir():
+            result = {
+                "recommended_action": "propose",
+                "branch": branch,
+                "deltaspec": False,
+                "auto_init": True,
+                "is_quick": is_quick == "true",
+            }
+            self._ok("init", f"recommended_action=propose (no deltaspec, auto_init=true, is_quick={is_quick})")
+            if issue_num and re.match(r"^\d+$", issue_num):
+                self._write_state_field(issue_num, "mode=propose")
             return result
 
         changes_dir = deltaspec_dir / "changes"
@@ -262,6 +280,8 @@ class ChainRunner:
                 "is_quick": is_quick == "true",
             }
             self._ok("init", f"recommended_action=propose (no changes, is_quick={is_quick})")
+            if issue_num and re.match(r"^\d+$", issue_num):
+                self._write_state_field(issue_num, "mode=propose")
             return result
 
         latest_dirs = sorted(
@@ -278,6 +298,8 @@ class ChainRunner:
                 "is_quick": is_quick == "true",
             }
             self._ok("init", f"recommended_action=propose (no proposal, is_quick={is_quick})")
+            if issue_num and re.match(r"^\d+$", issue_num):
+                self._write_state_field(issue_num, "mode=propose")
             return result
 
         latest = latest_dirs[0]
@@ -295,6 +317,8 @@ class ChainRunner:
                     "is_quick": is_quick == "true",
                 }
                 self._ok("init", f"recommended_action=apply (change={latest.name}, approved, is_quick={is_quick})")
+                if issue_num and re.match(r"^\d+$", issue_num):
+                    self._write_state_field(issue_num, "mode=apply")
             else:
                 result = {
                     "recommended_action": "propose",
@@ -305,6 +329,8 @@ class ChainRunner:
                     "is_quick": is_quick == "true",
                 }
                 self._ok("init", f"recommended_action=propose (change={latest.name}, pending, is_quick={is_quick})")
+                if issue_num and re.match(r"^\d+$", issue_num):
+                    self._write_state_field(issue_num, "mode=propose")
         else:
             result = {
                 "recommended_action": "propose",
@@ -314,6 +340,8 @@ class ChainRunner:
                 "is_quick": is_quick == "true",
             }
             self._ok("init", f"recommended_action=propose (no proposal, is_quick={is_quick})")
+            if issue_num and re.match(r"^\d+$", issue_num):
+                self._write_state_field(issue_num, "mode=propose")
 
         return result
 
@@ -904,6 +932,22 @@ class ChainRunner:
                 capture_output=True, text=True, timeout=10,
             )
             if result.returncode == 0 and "quick" in result.stdout.splitlines():
+                return "true"
+        except Exception:
+            pass
+        return "false"
+
+    def _detect_direct_label(self, issue_num: str) -> str:
+        """Return 'true' if issue has scope/direct label, else 'false'."""
+        if not issue_num or not re.match(r"^\d+$", issue_num):
+            return "false"
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", issue_num, "--json", "labels",
+                 "--jq", ".labels[].name"],
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode == 0 and "scope/direct" in result.stdout.splitlines():
                 return "true"
         except Exception:
             pass

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -365,3 +365,50 @@ class TestChainCLI:
             capture_output=True, text=True,
         )
         assert result.returncode != 0
+
+
+# ===========================================================================
+# step_init
+# ===========================================================================
+
+
+class TestStepInit:
+    """Tests for ChainRunner.step_init() AC (#338)."""
+
+    def _make_runner(self, tmp_path: Path, autopilot_dir: Path) -> ChainRunner:
+        scripts_root = tmp_path / "scripts"
+        scripts_root.mkdir(exist_ok=True)
+        return ChainRunner(scripts_root=scripts_root, autopilot_dir=autopilot_dir)
+
+    def test_no_deltaspec_non_quick_non_direct_returns_propose_auto_init(
+        self, tmp_path: Path, autopilot_dir: Path
+    ) -> None:
+        """deltaspec/ なし + quick なし + direct なし → propose (auto_init=true)."""
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with (
+            patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
+            patch.object(runner, "_project_root", return_value=tmp_path),
+            patch.object(runner, "_detect_quick_label", return_value="false"),
+            patch.object(runner, "_detect_direct_label", return_value="false"),
+            patch.object(runner, "_write_state_field"),
+        ):
+            result = runner.step_init("")
+        assert result["recommended_action"] == "propose"
+        assert result.get("auto_init") is True
+        assert result.get("deltaspec") is False
+
+    def test_scope_direct_label_returns_direct(
+        self, tmp_path: Path, autopilot_dir: Path
+    ) -> None:
+        """scope/direct ラベルあり → direct."""
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with (
+            patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
+            patch.object(runner, "_project_root", return_value=tmp_path),
+            patch.object(runner, "_detect_quick_label", return_value="false"),
+            patch.object(runner, "_detect_direct_label", return_value="true"),
+            patch.object(runner, "_write_state_field"),
+        ):
+            result = runner.step_init("338")
+        assert result["recommended_action"] == "direct"
+        assert result.get("deltaspec") is False

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -388,8 +388,7 @@ class TestStepInit:
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
             patch.object(runner, "_project_root", return_value=tmp_path),
-            patch.object(runner, "_detect_quick_label", return_value="false"),
-            patch.object(runner, "_detect_direct_label", return_value="false"),
+            patch.object(runner, "_fetch_labels", return_value=[]),
             patch.object(runner, "_write_state_field"),
         ):
             result = runner.step_init("")
@@ -405,10 +404,10 @@ class TestStepInit:
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
             patch.object(runner, "_project_root", return_value=tmp_path),
-            patch.object(runner, "_detect_quick_label", return_value="false"),
-            patch.object(runner, "_detect_direct_label", return_value="true"),
+            patch.object(runner, "_fetch_labels", return_value=["scope/direct"]),
             patch.object(runner, "_write_state_field"),
         ):
             result = runner.step_init("338")
         assert result["recommended_action"] == "direct"
         assert result.get("deltaspec") is False
+        assert result.get("is_direct") is True

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -172,17 +172,6 @@ detect_quick_label() {
   fi
 }
 
-detect_direct_label() {
-  local issue_num="${1:-}"
-  local labels
-  labels="$(fetch_labels "$issue_num")"
-  if echo "$labels" | grep -qxF "scope/direct"; then
-    echo "true"
-  else
-    echo "false"
-  fi
-}
-
 # --- quick-guard: quick Issue 判定（exit 1 = quick, exit 0 = 非 quick）---
 # state 優先 → detect_quick_label() fallback
 # ブランチから Issue 番号が抽出できない場合は exit 0（保守的）
@@ -276,7 +265,7 @@ step_init() {
   if [[ "$is_quick" == "true" || "$is_direct" == "true" ]]; then
     local reason
     [[ "$is_quick" == "true" ]] && reason="quick" || reason="scope/direct label"
-    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"direct","branch":$branch,"deltaspec":false,"is_quick":$is_quick}'
+    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" --argjson is_direct "$is_direct" '{"recommended_action":"direct","branch":$branch,"deltaspec":false,"is_quick":$is_quick,"is_direct":$is_direct}'
     ok "init" "recommended_action=direct ($reason, is_quick=$is_quick)"
     if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
       python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=direct" 2>/dev/null || true

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -167,6 +167,18 @@ detect_quick_label() {
   fi
 }
 
+detect_direct_label() {
+  local issue_num="${1:-}"
+  [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]] || { echo "false"; return 0; }
+  local labels
+  labels=$(gh issue view "$issue_num" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+  if echo "$labels" | grep -qxF "scope/direct"; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
 # --- quick-guard: quick Issue 判定（exit 1 = quick, exit 0 = 非 quick）---
 # state 優先 → detect_quick_label() fallback
 # ブランチから Issue 番号が抽出できない場合は exit 0（保守的）
@@ -238,6 +250,8 @@ step_init() {
   branch="$(git branch --show-current 2>/dev/null || echo "detached")"
   local is_quick
   is_quick="$(detect_quick_label "$issue_num")"
+  local is_direct
+  is_direct="$(detect_direct_label "$issue_num")"
 
   # is_quick を state に永続化（state ファイルが存在する場合のみ）
   if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
@@ -251,10 +265,25 @@ step_init() {
     return 0
   fi
 
+  # quick or scope/direct ラベル → direct
+  if [[ "$is_quick" == "true" || "$is_direct" == "true" ]]; then
+    local reason
+    [[ "$is_quick" == "true" ]] && reason="quick" || reason="scope/direct label"
+    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"direct","branch":$branch,"deltaspec":false,"is_quick":$is_quick}'
+    ok "init" "recommended_action=direct ($reason, is_quick=$is_quick)"
+    if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+      python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=direct" 2>/dev/null || true
+    fi
+    return 0
+  fi
+
   # deltaspec 判定
   if [[ ! -d "$root/deltaspec" ]]; then
-    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"direct","branch":$branch,"deltaspec":false,"is_quick":$is_quick}'
-    ok "init" "recommended_action=direct (no deltaspec, is_quick=$is_quick)"
+    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"propose","branch":$branch,"deltaspec":false,"auto_init":true,"is_quick":$is_quick}'
+    ok "init" "recommended_action=propose (no deltaspec, auto_init=true, is_quick=$is_quick)"
+    if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+      python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=propose" 2>/dev/null || true
+    fi
     return 0
   fi
 
@@ -263,6 +292,9 @@ step_init() {
   if [[ ! -d "$changes_dir" ]] || [[ -z "$(ls -A "$changes_dir" 2>/dev/null)" ]]; then
     jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"propose","branch":$branch,"deltaspec":true,"change_exists":false,"is_quick":$is_quick}'
     ok "init" "recommended_action=propose (no changes, is_quick=$is_quick)"
+    if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+      python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=propose" 2>/dev/null || true
+    fi
     return 0
   fi
 
@@ -277,13 +309,22 @@ step_init() {
     if [[ -f "$yaml" ]] && grep -q 'status:.*approved' "$yaml" 2>/dev/null; then
       jq -n --arg branch "$branch" --arg cid "$latest_change" --argjson is_quick "$is_quick" '{"recommended_action":"apply","branch":$branch,"deltaspec":true,"change_id":$cid,"proposal_status":"approved","is_quick":$is_quick}'
       ok "init" "recommended_action=apply (change=$latest_change, approved, is_quick=$is_quick)"
+      if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+        python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=apply" 2>/dev/null || true
+      fi
     else
       jq -n --arg branch "$branch" --arg cid "$latest_change" --argjson is_quick "$is_quick" '{"recommended_action":"propose","branch":$branch,"deltaspec":true,"change_id":$cid,"proposal_status":"pending","is_quick":$is_quick}'
       ok "init" "recommended_action=propose (change=$latest_change, pending, is_quick=$is_quick)"
+      if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+        python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=propose" 2>/dev/null || true
+      fi
     fi
   else
     jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"propose","branch":$branch,"deltaspec":true,"change_exists":true,"is_quick":$is_quick}'
     ok "init" "recommended_action=propose (no proposal, is_quick=$is_quick)"
+    if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+      python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=propose" 2>/dev/null || true
+    fi
   fi
 }
 

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -155,11 +155,16 @@ record_current_step() {
 # =====================================================================
 
 # Issue の quick ラベルを検出する（Issue 番号が正の整数の場合のみ）
+fetch_labels() {
+  local issue_num="${1:-}"
+  [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]] || { echo ""; return 0; }
+  gh issue view "$issue_num" --json labels --jq '.labels[].name' 2>/dev/null || echo ""
+}
+
 detect_quick_label() {
   local issue_num="${1:-}"
-  [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]] || { echo "false"; return 0; }
   local labels
-  labels=$(gh issue view "$issue_num" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+  labels="$(fetch_labels "$issue_num")"
   if echo "$labels" | grep -qxF "quick"; then
     echo "true"
   else
@@ -169,9 +174,8 @@ detect_quick_label() {
 
 detect_direct_label() {
   local issue_num="${1:-}"
-  [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]] || { echo "false"; return 0; }
   local labels
-  labels=$(gh issue view "$issue_num" --json labels --jq '.labels[].name' 2>/dev/null || echo "")
+  labels="$(fetch_labels "$issue_num")"
   if echo "$labels" | grep -qxF "scope/direct"; then
     echo "true"
   else
@@ -248,14 +252,17 @@ step_init() {
   root="$(resolve_project_root)"
   local branch
   branch="$(git branch --show-current 2>/dev/null || echo "detached")"
+  local _labels
+  _labels="$(fetch_labels "$issue_num")"
   local is_quick
-  is_quick="$(detect_quick_label "$issue_num")"
+  is_quick="$(echo "$_labels" | grep -qxF "quick" && echo "true" || echo "false")"
   local is_direct
-  is_direct="$(detect_direct_label "$issue_num")"
+  is_direct="$(echo "$_labels" | grep -qxF "scope/direct" && echo "true" || echo "false")"
 
-  # is_quick を state に永続化（state ファイルが存在する場合のみ）
+  # is_quick と is_direct を state に永続化（state ファイルが存在する場合のみ）
   if [[ -n "$issue_num" ]] && [[ "$issue_num" =~ ^[0-9]+$ ]]; then
     python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "is_quick=$is_quick" 2>/dev/null || true
+    python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "is_direct=$is_direct" 2>/dev/null || true
   fi
 
   # ブランチ判定


### PR DESCRIPTION
Closes #338

## 変更内容
- step_init() から deltaspec/ 存在チェックを削除
- scope/direct ラベル対応を追加
- _fetch_labels() でラベル取得を一元化
- is_direct の state 永続化を追加
- chain-runner.sh と meta_generate.py の同期

Co-Authored-By: Claude <noreply@anthropic.com>