### PR TITLE
feat(orchestrator): inject_next_workflow() 追加 — Pilot 駆動ループ中核 (#340)

### DIFF
--- a/deltaspec/changes/orchestrator-inject-next-workflow/.deltaspec.yaml
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/.deltaspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/deltaspec/changes/orchestrator-inject-next-workflow/design.md
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`plugins/twl/scripts/autopilot-orchestrator.sh` の polling ループ（シングルモード `poll_issue`・並列モード `poll_phase`）は、現状 `status=running` ブランチ内でクラッシュ検知と `check_and_nudge()` のみを実行する。ADR-014 では Worker が workflow 完了時に `workflow_done` フィールドを state に書き込み、Orchestrator がこれを検知して次の workflow skill を tmux inject する設計を定義している。
+
+依存関係:
+- #335: `workflow_done` フィールドの IssueState 定義と `_PILOT_ISSUE_ALLOWED_KEYS` への追加（必須）
+- #337: `resolve_next_workflow` CLI の実装（必須）
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `status=running` ブランチ内で `workflow_done` を追加読み取りする
+- `inject_next_workflow()` 関数を実装する
+- `check_and_nudge()` との共存ルール（inject 優先）を実装する
+- inject 安全機構（pane 入力待ち確認、3回リトライ）を実装する
+- inject 履歴（`workflow_injected`, `injected_at`）を state に記録する
+- terminal workflow (`pr-merge`) の場合は inject せず既存フローに委譲する
+- inject 失敗時の WARNING ログ + 10秒後再チェックを実装する
+- inject 成功時に `NUDGE_COUNTS` をリセットする
+
+**Non-Goals:**
+
+- `workflow_done` フィールドの IssueState 定義（#335 の責務）
+- `resolve_next_workflow` CLI の実装（#337 の責務）
+- `check_and_nudge()` の境界 nudge 削除（#345 の責務）
+- `poll_phase` における inject ロジック（シングルモードのみが対象。並列モードは別途検討）
+
+## Decisions
+
+### workflow_done 検出位置
+
+`status=running` の case ブランチ内、クラッシュ検知の後、`check_and_nudge()` の前に追加読み取りを配置する。`workflow_done` が非空の場合は `inject_next_workflow()` を呼び、成功時は `check_and_nudge()` をスキップする。
+
+**理由**: case 文に新しい case を追加すると状態遷移が複雑になる。`running` ブランチ内で追加条件として処理することで既存構造を保持できる。
+
+### tmux pane 確認ロジック
+
+`tmux capture-pane -p -t "$window_name"` の出力末尾を確認し、`> ` または `$ ` プロンプトが存在すれば inject 実行。最大3回、2秒間隔でリトライする。
+
+**理由**: Claude が応答中に inject すると入力が混在するリスクがある。pane 確認でこれを防ぐ。
+
+### terminal workflow の扱い
+
+`resolve_next_workflow` が `pr-merge` を返した場合、inject せず `workflow_done` のクリアのみ行い、Worker が `status=merge-ready` を書き込む自然な遷移に委譲する。Orchestrator は次のポーリングで `merge-ready` を検出して処理する。
+
+**理由**: `pr-merge` は merge-gate フロー（既存実装）があり、inject では扱いきれない複雑な条件判定が含まれる。
+
+### NUDGE_COUNTS リセット
+
+inject 成功後に `NUDGE_COUNTS[$issue]=0` でリセットする。inject により新しい workflow が開始されたため、stall カウンターをゼロクリアすることが適切。
+
+## Risks / Trade-offs
+
+- **`poll_phase` に inject を追加しない**: シングルモード限定実装のため、並列モードでは `workflow_done` が無視される。ADR-014 実験フェーズ（Pilot = 1 Worker）では問題ないが、将来の並列拡張時に対応が必要。
+- **inject タイミングの競合**: Worker がまだ実行中なのに `workflow_done` が書き込まれた場合（バグ）、inject が早すぎる可能性がある。pane 確認でリスクを低減するが完全には防げない。
+- **`resolve_next_workflow` CLI 依存**: #337 が未マージの場合、inject ロジックが動作しない。依存関係の順序制御が必要。

--- a/deltaspec/changes/orchestrator-inject-next-workflow/proposal.md
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+ADR-014 の Pilot 駆動ループでは、Worker が workflow 完了時に `workflow_done` を state に書き込み、Orchestrator がこれを検知して次の workflow skill を tmux inject する必要がある。現状の Orchestrator は `workflow_done` を検知せず、次の workflow への遷移が自動化されていない。
+
+## What Changes
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh` の `status=running` ブランチ内で `workflow_done` フィールドを読み取る処理を追加
+- `inject_next_workflow()` 関数を新たに追加:
+  - `resolve_next_workflow` CLI で次の workflow skill を決定
+  - `tmux capture-pane` で入力待ち確認（最大3回、2秒間隔）
+  - プロンプト検出後 `tmux send-keys` で inject
+  - `workflow_done` をクリア（`state write --role pilot --set "workflow_done=null"`）
+- inject 後に `workflow_injected`, `injected_at` を state に記録
+- terminal workflow (`pr-merge`) の場合は inject せず既存 merge-gate フローに委譲
+- inject 失敗時（3回リトライ後も未検出）は WARNING ログ + 10秒後再チェック
+- inject 成功時に該当 Issue の `NUDGE_COUNTS` をリセット
+- inject イベントを `[orchestrator]` プレフィックス形式でログ出力
+
+## Capabilities
+
+### New Capabilities
+
+- **inject_next_workflow()**: Orchestrator が `workflow_done` を検知して次の workflow skill を tmux inject する中核関数
+- **inject 安全機構**: tmux pane の入力待ち状態確認（最大3回リトライ）でリスクを低減
+- **inject 履歴記録**: `workflow_injected`, `injected_at` フィールドでトレーサビリティを確保
+
+### Modified Capabilities
+
+- **polling ループの `status=running` ブランチ**: `workflow_done` フィールドを追加読み取りし、inject または merge-gate フローへ分岐
+
+## Impact
+
+- 影響ファイル: `plugins/twl/scripts/autopilot-orchestrator.sh`（単一ファイル変更）
+- 依存: #335（`workflow_done` フィールド定義）、#337（`resolve_next_workflow` CLI）
+- `check_and_nudge()` との共存: `workflow_done` があれば inject 優先 → `check_and_nudge` はスキップ（#345 で境界 nudge が削除されるまでの暫定動作）

--- a/deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: workflow_done フィールドの読み取り
+
+polling ループの `status=running` ブランチ内で、`workflow_done` フィールドを追加読み取りしなければならない（SHALL）。読み取りはクラッシュ検知の後、`check_and_nudge()` の前に配置する。
+
+#### Scenario: workflow_done が設定されている場合
+- **WHEN** `status=running` のポーリング中に `workflow_done` フィールドが非空の値を持つ
+- **THEN** `inject_next_workflow()` を呼び出し、成功時は `check_and_nudge()` をスキップする
+
+#### Scenario: workflow_done が未設定の場合
+- **WHEN** `status=running` のポーリング中に `workflow_done` フィールドが空または未設定
+- **THEN** 既存の `check_and_nudge()` フローを継続する（動作変更なし）
+
+---
+
+### Requirement: inject_next_workflow() 関数の実装
+
+`inject_next_workflow()` 関数を実装しなければならない（MUST）。引数として `issue`（Issue 番号）と `window_name`（tmux ウィンドウ名）を受け取る。
+
+#### Scenario: 正常な inject フロー
+- **WHEN** `inject_next_workflow()` が呼ばれ、`resolve_next_workflow` が非 `pr-merge` の workflow skill を返す
+- **THEN** tmux pane の入力待ち確認 → `tmux send-keys` で workflow skill を inject → `workflow_done` をクリア → inject 履歴を state に記録する
+
+#### Scenario: resolve_next_workflow が pr-merge を返した場合
+- **WHEN** `inject_next_workflow()` 内で `resolve_next_workflow` が `pr-merge` を返す
+- **THEN** inject は行わず `workflow_done` をクリアするのみ（Worker が `status=merge-ready` を書き込む自然な遷移に委譲）
+
+#### Scenario: resolve_next_workflow が失敗した場合
+- **WHEN** `inject_next_workflow()` 内で `resolve_next_workflow` がエラーを返す
+- **THEN** WARNING ログを出力し、10秒後に再チェックする（inject 失敗として扱う）
+
+---
+
+### Requirement: tmux pane 入力待ち確認
+
+inject 前に `tmux capture-pane` で入力待ち状態を確認しなければならない（SHALL）。最大3回、2秒間隔でリトライする。
+
+#### Scenario: プロンプト検出成功
+- **WHEN** `tmux capture-pane -p -t "$window_name"` の出力末尾に `> ` または `$ ` が存在する
+- **THEN** `tmux send-keys` で inject を実行する
+
+#### Scenario: 3回リトライ後もプロンプト未検出
+- **WHEN** 3回のリトライ（合計6秒待機）後もプロンプトが検出されない
+- **THEN** `[orchestrator] WARNING: inject タイムアウト — 10秒後に再チェック` ログを出力し、戻り値 1 で終了する
+
+---
+
+### Requirement: inject 履歴の state 記録
+
+inject 成功後に `workflow_injected` と `injected_at` を state に書き込まなければならない（MUST）。
+
+#### Scenario: inject 成功後の履歴記録
+- **WHEN** `tmux send-keys` による inject が成功する
+- **THEN** `state write --role pilot --set "workflow_injected=<skill_name>" --set "injected_at=<timestamp>"` を実行する
+
+---
+
+### Requirement: inject 成功後の NUDGE_COUNTS リセット
+
+inject 成功後に該当 Issue の `NUDGE_COUNTS` をゼロにリセットしなければならない（SHALL）。
+
+#### Scenario: inject 後の stall カウンターリセット
+- **WHEN** `inject_next_workflow()` が成功する
+- **THEN** `NUDGE_COUNTS[$issue]=0` を設定する
+
+---
+
+### Requirement: inject イベントのログ出力
+
+inject 関連イベントは `[orchestrator]` プレフィックス形式でログを出力しなければならない（MUST）。
+
+#### Scenario: inject 実行ログ
+- **WHEN** inject が実行される（成功・失敗問わず）
+- **THEN** `[orchestrator] Issue #${issue}: inject_next_workflow — <skill_name>` 形式でログを出力する
+
+## MODIFIED Requirements
+
+### Requirement: check_and_nudge() の条件付きスキップ
+
+`status=running` ブランチで `inject_next_workflow()` が成功した場合、`check_and_nudge()` をスキップしなければならない（SHALL）。
+
+#### Scenario: inject 成功後の nudge スキップ
+- **WHEN** polling ループ内で `inject_next_workflow()` が戻り値 0 で完了する
+- **THEN** `check_and_nudge()` を呼ばずに次のポーリングサイクルに進む

--- a/deltaspec/changes/orchestrator-inject-next-workflow/tasks.md
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/tasks.md
@@ -1,0 +1,29 @@
+## 1. workflow_done 読み取りの追加
+
+- [ ] 1.1 `poll_issue()` の `status=running` ブランチ内で `workflow_done` フィールドを `python3 -m twl.autopilot.state read` で追加読み取りする
+- [ ] 1.2 `workflow_done` が非空の場合に `inject_next_workflow()` を呼び出し、戻り値が 0 なら `check_and_nudge()` をスキップするロジックを追加する
+
+## 2. inject_next_workflow() 関数の実装
+
+- [ ] 2.1 `inject_next_workflow()` 関数をスクリプト内に追加する（引数: `issue`, `window_name`）
+- [ ] 2.2 `resolve_next_workflow` CLI を呼び出して次の workflow skill を取得する
+- [ ] 2.3 `pr-merge` が返された場合は inject せず `workflow_done` をクリアして return 0 する処理を追加する
+- [ ] 2.4 `resolve_next_workflow` 失敗時の WARNING ログ出力と早期リターン（戻り値 1）を追加する
+
+## 3. tmux pane 入力待ち確認の実装
+
+- [ ] 3.1 `tmux capture-pane -p -t "$window_name"` を実行し末尾行に `> ` / `$ ` が存在するか確認するループ（最大3回、2秒間隔）を実装する
+- [ ] 3.2 プロンプト未検出時の WARNING ログ出力と戻り値 1 での終了を実装する
+
+## 4. inject の実行と後処理
+
+- [ ] 4.1 `tmux send-keys -t "$window_name" "$next_skill\n" ""` で workflow skill を inject する
+- [ ] 4.2 inject 後に `workflow_done` をクリア（`state write --role pilot --set "workflow_done=null"`）する
+- [ ] 4.3 inject 履歴（`workflow_injected`, `injected_at`）を state に書き込む
+- [ ] 4.4 `NUDGE_COUNTS[$issue]=0` でリセットする
+- [ ] 4.5 `[orchestrator] Issue #${issue}: inject_next_workflow — $next_skill` ログを出力する
+
+## 5. 動作確認
+
+- [ ] 5.1 `workflow_done` が未設定の場合に既存動作が変わらないことを確認する（シェルスクリプトレベルの手動確認）
+- [ ] 5.2 `pr-merge` ケースで inject がスキップされることを確認する

--- a/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/.deltaspec.yaml
+++ b/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/.deltaspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/design.md
+++ b/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/design.md
@@ -1,0 +1,57 @@
+## Context
+
+`plugins/twl/scripts/autopilot-orchestrator.sh` の polling ループ（シングルモード `poll_issue`・並列モード `poll_phase`）は、現状 `status=running` ブランチ内でクラッシュ検知と `check_and_nudge()` のみを実行する。ADR-014 では Worker が workflow 完了時に `workflow_done` フィールドを state に書き込み、Orchestrator がこれを検知して次の workflow skill を tmux inject する設計を定義している。
+
+依存関係:
+- #335: `workflow_done` フィールドの IssueState 定義と `_PILOT_ISSUE_ALLOWED_KEYS` への追加（必須）
+- #337: `resolve_next_workflow` CLI の実装（必須）
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `status=running` ブランチ内で `workflow_done` を追加読み取りする
+- `inject_next_workflow()` 関数を実装する
+- `check_and_nudge()` との共存ルール（inject 優先）を実装する
+- inject 安全機構（pane 入力待ち確認、3回リトライ）を実装する
+- inject 履歴（`workflow_injected`, `injected_at`）を state に記録する
+- terminal workflow (`pr-merge`) の場合は inject せず既存フローに委譲する
+- inject 失敗時の WARNING ログ + 10秒後再チェックを実装する
+- inject 成功時に `NUDGE_COUNTS` をリセットする
+
+**Non-Goals:**
+
+- `workflow_done` フィールドの IssueState 定義（#335 の責務）
+- `resolve_next_workflow` CLI の実装（#337 の責務）
+- `check_and_nudge()` の境界 nudge 削除（#345 の責務）
+- `poll_phase` における inject ロジック（シングルモードのみが対象。並列モードは別途検討）
+
+## Decisions
+
+### workflow_done 検出位置
+
+`status=running` の case ブランチ内、クラッシュ検知の後、`check_and_nudge()` の前に追加読み取りを配置する。`workflow_done` が非空の場合は `inject_next_workflow()` を呼び、成功時は `check_and_nudge()` をスキップする。
+
+**理由**: case 文に新しい case を追加すると状態遷移が複雑になる。`running` ブランチ内で追加条件として処理することで既存構造を保持できる。
+
+### tmux pane 確認ロジック
+
+`tmux capture-pane -p -t "$window_name"` の出力末尾を確認し、`> ` または `$ ` プロンプトが存在すれば inject 実行。最大3回、2秒間隔でリトライする。
+
+**理由**: Claude が応答中に inject すると入力が混在するリスクがある。pane 確認でこれを防ぐ。
+
+### terminal workflow の扱い
+
+`resolve_next_workflow` が `pr-merge` を返した場合、inject せず `workflow_done` のクリアのみ行い、Worker が `status=merge-ready` を書き込む自然な遷移に委譲する。Orchestrator は次のポーリングで `merge-ready` を検出して処理する。
+
+**理由**: `pr-merge` は merge-gate フロー（既存実装）があり、inject では扱いきれない複雑な条件判定が含まれる。
+
+### NUDGE_COUNTS リセット
+
+inject 成功後に `NUDGE_COUNTS[$issue]=0` でリセットする。inject により新しい workflow が開始されたため、stall カウンターをゼロクリアすることが適切。
+
+## Risks / Trade-offs
+
+- **`poll_phase` に inject を追加しない**: シングルモード限定実装のため、並列モードでは `workflow_done` が無視される。ADR-014 実験フェーズ（Pilot = 1 Worker）では問題ないが、将来の並列拡張時に対応が必要。
+- **inject タイミングの競合**: Worker がまだ実行中なのに `workflow_done` が書き込まれた場合（バグ）、inject が早すぎる可能性がある。pane 確認でリスクを低減するが完全には防げない。
+- **`resolve_next_workflow` CLI 依存**: #337 が未マージの場合、inject ロジックが動作しない。依存関係の順序制御が必要。

--- a/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/proposal.md
+++ b/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+ADR-014 の Pilot 駆動ループでは、Worker が workflow 完了時に `workflow_done` を state に書き込み、Orchestrator がこれを検知して次の workflow skill を tmux inject する必要がある。現状の Orchestrator は `workflow_done` を検知せず、次の workflow への遷移が自動化されていない。
+
+## What Changes
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh` の `status=running` ブランチ内で `workflow_done` フィールドを読み取る処理を追加
+- `inject_next_workflow()` 関数を新たに追加:
+  - `resolve_next_workflow` CLI で次の workflow skill を決定
+  - `tmux capture-pane` で入力待ち確認（最大3回、2秒間隔）
+  - プロンプト検出後 `tmux send-keys` で inject
+  - `workflow_done` をクリア（`state write --role pilot --set "workflow_done=null"`）
+- inject 後に `workflow_injected`, `injected_at` を state に記録
+- terminal workflow (`pr-merge`) の場合は inject せず既存 merge-gate フローに委譲
+- inject 失敗時（3回リトライ後も未検出）は WARNING ログ + 10秒後再チェック
+- inject 成功時に該当 Issue の `NUDGE_COUNTS` をリセット
+- inject イベントを `[orchestrator]` プレフィックス形式でログ出力
+
+## Capabilities
+
+### New Capabilities
+
+- **inject_next_workflow()**: Orchestrator が `workflow_done` を検知して次の workflow skill を tmux inject する中核関数
+- **inject 安全機構**: tmux pane の入力待ち状態確認（最大3回リトライ）でリスクを低減
+- **inject 履歴記録**: `workflow_injected`, `injected_at` フィールドでトレーサビリティを確保
+
+### Modified Capabilities
+
+- **polling ループの `status=running` ブランチ**: `workflow_done` フィールドを追加読み取りし、inject または merge-gate フローへ分岐
+
+## Impact
+
+- 影響ファイル: `plugins/twl/scripts/autopilot-orchestrator.sh`（単一ファイル変更）
+- 依存: #335（`workflow_done` フィールド定義）、#337（`resolve_next_workflow` CLI）
+- `check_and_nudge()` との共存: `workflow_done` があれば inject 優先 → `check_and_nudge` はスキップ（#345 で境界 nudge が削除されるまでの暫定動作）

--- a/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
+++ b/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: workflow_done フィールドの読み取り
+
+polling ループの `status=running` ブランチ内で、`workflow_done` フィールドを追加読み取りしなければならない（SHALL）。読み取りはクラッシュ検知の後、`check_and_nudge()` の前に配置する。
+
+#### Scenario: workflow_done が設定されている場合
+- **WHEN** `status=running` のポーリング中に `workflow_done` フィールドが非空の値を持つ
+- **THEN** `inject_next_workflow()` を呼び出し、成功時は `check_and_nudge()` をスキップする
+
+#### Scenario: workflow_done が未設定の場合
+- **WHEN** `status=running` のポーリング中に `workflow_done` フィールドが空または未設定
+- **THEN** 既存の `check_and_nudge()` フローを継続する（動作変更なし）
+
+---
+
+### Requirement: inject_next_workflow() 関数の実装
+
+`inject_next_workflow()` 関数を実装しなければならない（MUST）。引数として `issue`（Issue 番号）と `window_name`（tmux ウィンドウ名）を受け取る。
+
+#### Scenario: 正常な inject フロー
+- **WHEN** `inject_next_workflow()` が呼ばれ、`resolve_next_workflow` が非 `pr-merge` の workflow skill を返す
+- **THEN** tmux pane の入力待ち確認 → `tmux send-keys` で workflow skill を inject → `workflow_done` をクリア → inject 履歴を state に記録する
+
+#### Scenario: resolve_next_workflow が pr-merge を返した場合
+- **WHEN** `inject_next_workflow()` 内で `resolve_next_workflow` が `pr-merge` を返す
+- **THEN** inject は行わず `workflow_done` をクリアするのみ（Worker が `status=merge-ready` を書き込む自然な遷移に委譲）
+
+#### Scenario: resolve_next_workflow が失敗した場合
+- **WHEN** `inject_next_workflow()` 内で `resolve_next_workflow` がエラーを返す
+- **THEN** WARNING ログを出力し、10秒後に再チェックする（inject 失敗として扱う）
+
+---
+
+### Requirement: tmux pane 入力待ち確認
+
+inject 前に `tmux capture-pane` で入力待ち状態を確認しなければならない（SHALL）。最大3回、2秒間隔でリトライする。
+
+#### Scenario: プロンプト検出成功
+- **WHEN** `tmux capture-pane -p -t "$window_name"` の出力末尾に `> ` または `$ ` が存在する
+- **THEN** `tmux send-keys` で inject を実行する
+
+#### Scenario: 3回リトライ後もプロンプト未検出
+- **WHEN** 3回のリトライ（合計6秒待機）後もプロンプトが検出されない
+- **THEN** `[orchestrator] WARNING: inject タイムアウト — 10秒後に再チェック` ログを出力し、戻り値 1 で終了する
+
+---
+
+### Requirement: inject 履歴の state 記録
+
+inject 成功後に `workflow_injected` と `injected_at` を state に書き込まなければならない（MUST）。
+
+#### Scenario: inject 成功後の履歴記録
+- **WHEN** `tmux send-keys` による inject が成功する
+- **THEN** `state write --role pilot --set "workflow_injected=<skill_name>" --set "injected_at=<timestamp>"` を実行する
+
+---
+
+### Requirement: inject 成功後の NUDGE_COUNTS リセット
+
+inject 成功後に該当 Issue の `NUDGE_COUNTS` をゼロにリセットしなければならない（SHALL）。
+
+#### Scenario: inject 後の stall カウンターリセット
+- **WHEN** `inject_next_workflow()` が成功する
+- **THEN** `NUDGE_COUNTS[$issue]=0` を設定する
+
+---
+
+### Requirement: inject イベントのログ出力
+
+inject 関連イベントは `[orchestrator]` プレフィックス形式でログを出力しなければならない（MUST）。
+
+#### Scenario: inject 実行ログ
+- **WHEN** inject が実行される（成功・失敗問わず）
+- **THEN** `[orchestrator] Issue #${issue}: inject_next_workflow — <skill_name>` 形式でログを出力する
+
+## MODIFIED Requirements
+
+### Requirement: check_and_nudge() の条件付きスキップ
+
+`status=running` ブランチで `inject_next_workflow()` が成功した場合、`check_and_nudge()` をスキップしなければならない（SHALL）。
+
+#### Scenario: inject 成功後の nudge スキップ
+- **WHEN** polling ループ内で `inject_next_workflow()` が戻り値 0 で完了する
+- **THEN** `check_and_nudge()` を呼ばずに次のポーリングサイクルに進む

--- a/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/tasks.md
+++ b/plugins/twl/deltaspec/changes/orchestrator-inject-next-workflow/tasks.md
@@ -1,0 +1,29 @@
+## 1. workflow_done 読み取りの追加
+
+- [x] 1.1 `poll_issue()` の `status=running` ブランチ内で `workflow_done` フィールドを `python3 -m twl.autopilot.state read` で追加読み取りする
+- [x] 1.2 `workflow_done` が非空の場合に `inject_next_workflow()` を呼び出し、戻り値が 0 なら `check_and_nudge()` をスキップするロジックを追加する
+
+## 2. inject_next_workflow() 関数の実装
+
+- [x] 2.1 `inject_next_workflow()` 関数をスクリプト内に追加する（引数: `issue`, `window_name`）
+- [x] 2.2 `resolve_next_workflow` CLI を呼び出して次の workflow skill を取得する
+- [x] 2.3 `pr-merge` が返された場合は inject せず `workflow_done` をクリアして return 0 する処理を追加する
+- [x] 2.4 `resolve_next_workflow` 失敗時の WARNING ログ出力と早期リターン（戻り値 1）を追加する
+
+## 3. tmux pane 入力待ち確認の実装
+
+- [x] 3.1 `tmux capture-pane -p -t "$window_name"` を実行し末尾行に `> ` / `$ ` が存在するか確認するループ（最大3回、2秒間隔）を実装する
+- [x] 3.2 プロンプト未検出時の WARNING ログ出力と戻り値 1 での終了を実装する
+
+## 4. inject の実行と後処理
+
+- [x] 4.1 `tmux send-keys -t "$window_name" "$next_skill\n" ""` で workflow skill を inject する
+- [x] 4.2 inject 後に `workflow_done` をクリア（`state write --role pilot --set "workflow_done=null"`）する
+- [x] 4.3 inject 履歴（`workflow_injected`, `injected_at`）を state に書き込む
+- [x] 4.4 `NUDGE_COUNTS[$issue]=0` でリセットする
+- [x] 4.5 `[orchestrator] Issue #${issue}: inject_next_workflow — $next_skill` ログを出力する
+
+## 5. 動作確認
+
+- [x] 5.1 `workflow_done` が未設定の場合に既存動作が変わらないことを確認する（シェルスクリプトレベルの手動確認）
+- [x] 5.2 `pr-merge` ケースで inject がスキップされることを確認する

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -496,21 +496,30 @@ poll_single() {
           return 0
         fi
 
-        # chain 遷移停止検知 + nudge（パターンマッチ優先）
-        local nudge_matched=0
-        check_and_nudge "$issue" "$window_name" "$entry" && nudge_matched=1 || true
+        # workflow_done 検知 → inject（inject 成功時は check_and_nudge をスキップ）
+        local workflow_done inject_matched=0
+        workflow_done=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field workflow_done 2>/dev/null || echo "")
+        if [[ -n "$workflow_done" && "$workflow_done" != "null" ]]; then
+          inject_next_workflow "$issue" "$window_name" && inject_matched=1 || true
+        fi
 
-        # health-check（check_and_nudge でカバーできない stall を補完検知）
-        # POLL_INTERVAL=10s × HEALTH_CHECK_INTERVAL=6 = 60s 毎に実行
-        if [[ "$nudge_matched" -eq 0 ]]; then
-          local hc_counter="${HEALTH_CHECK_COUNTER[$issue]:-0}"
-          HEALTH_CHECK_COUNTER[$issue]=$((hc_counter + 1))
-          if (( HEALTH_CHECK_COUNTER[$issue] % ${HEALTH_CHECK_INTERVAL:-6} == 0 )); then
-            local health_stderr health_exit=0
-            health_stderr=$(bash "$SCRIPTS_ROOT/health-check.sh" --issue "$issue" --window "$window_name" 2>&1 1>/dev/null) || health_exit=$?
-            # API overload fallback 時は poll_count をリセット
-            [[ "$health_exit" -eq 3 ]] && poll_count=0
-            handle_health_check_fallback "$issue" "$window_name" "$entry" "$health_exit" "$health_stderr"
+        if [[ "$inject_matched" -eq 0 ]]; then
+          # chain 遷移停止検知 + nudge（パターンマッチ優先）
+          local nudge_matched=0
+          check_and_nudge "$issue" "$window_name" "$entry" && nudge_matched=1 || true
+
+          # health-check（check_and_nudge でカバーできない stall を補完検知）
+          # POLL_INTERVAL=10s × HEALTH_CHECK_INTERVAL=6 = 60s 毎に実行
+          if [[ "$nudge_matched" -eq 0 ]]; then
+            local hc_counter="${HEALTH_CHECK_COUNTER[$issue]:-0}"
+            HEALTH_CHECK_COUNTER[$issue]=$((hc_counter + 1))
+            if (( HEALTH_CHECK_COUNTER[$issue] % ${HEALTH_CHECK_INTERVAL:-6} == 0 )); then
+              local health_stderr health_exit=0
+              health_stderr=$(bash "$SCRIPTS_ROOT/health-check.sh" --issue "$issue" --window "$window_name" 2>&1 1>/dev/null) || health_exit=$?
+              # API overload fallback 時は poll_count をリセット
+              [[ "$health_exit" -eq 3 ]] && poll_count=0
+              handle_health_check_fallback "$issue" "$window_name" "$entry" "$health_exit" "$health_stderr"
+            fi
           fi
         fi
         ;;
@@ -729,6 +738,67 @@ _nudge_command_for_pattern() {
   else
     return 1
   fi
+}
+
+# inject_next_workflow: workflow_done を検知して次の workflow skill を tmux inject する
+# 引数: issue, window_name
+# 戻り値: 0=inject 成功 or pr-merge 委譲、1=失敗（タイムアウト / resolve 失敗）
+inject_next_workflow() {
+  local issue="$1"
+  local window_name="$2"
+
+  # --- resolve_next_workflow CLI で次の workflow を決定 ---
+  local next_skill next_skill_exit=0
+  next_skill=$(python3 -m twl.autopilot.resolve_next_workflow --issue "$issue" 2>/dev/null) || next_skill_exit=$?
+  if [[ "$next_skill_exit" -ne 0 || -z "$next_skill" ]]; then
+    echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+    return 1
+  fi
+
+  # --- terminal workflow (pr-merge) は inject しない ---
+  if [[ "$next_skill" == "pr-merge" || "$next_skill" == "/twl:workflow-pr-merge" ]]; then
+    echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
+    python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
+      --set "workflow_done=null" 2>/dev/null || true
+    return 0
+  fi
+
+  # --- tmux pane 入力待ち確認（最大3回、2秒間隔） ---
+  local prompt_found=0
+  local pane_tail
+  for _i in 1 2 3; do
+    pane_tail=$(tmux capture-pane -t "$window_name" -p 2>/dev/null | tail -1 || true)
+    if [[ "$pane_tail" =~ (">"|"$")[[:space:]]*$ ]]; then
+      prompt_found=1
+      break
+    fi
+    sleep 2
+  done
+
+  if [[ "$prompt_found" -eq 0 ]]; then
+    echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — 10秒後に再チェック" >&2
+    return 1
+  fi
+
+  # --- inject 実行 ---
+  echo "[orchestrator] Issue #${issue}: inject_next_workflow — ${next_skill}" >&2
+  tmux send-keys -t "$window_name" "$next_skill" Enter 2>/dev/null || true
+
+  # --- workflow_done クリア ---
+  python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
+    --set "workflow_done=null" 2>/dev/null || true
+
+  # --- inject 履歴記録 ---
+  local injected_at
+  injected_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
+    --set "workflow_injected=${next_skill}" \
+    --set "injected_at=${injected_at}" 2>/dev/null || true
+
+  # --- NUDGE_COUNTS リセット ---
+  NUDGE_COUNTS[$issue]=0
+
+  return 0
 }
 
 check_and_nudge() {

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -742,7 +742,7 @@ _nudge_command_for_pattern() {
 
 # inject_next_workflow: workflow_done を検知して次の workflow skill を tmux inject する
 # 引数: issue, window_name
-# 戻り値: 0=inject 成功 or pr-merge 委譲、1=失敗（タイムアウト / resolve 失敗）
+# 戻り値: 0=inject 成功 or pr-merge 委譲、1=失敗（タイムアウト / resolve 失敗 / バリデーション失敗）
 inject_next_workflow() {
   local issue="$1"
   local window_name="$2"
@@ -755,20 +755,30 @@ inject_next_workflow() {
     return 1
   fi
 
-  # --- terminal workflow (pr-merge) は inject しない ---
-  if [[ "$next_skill" == "pr-merge" || "$next_skill" == "/twl:workflow-pr-merge" ]]; then
+  # --- allow-list バリデーション（コマンドインジェクション防止） ---
+  # 許可: /twl:workflow-<kebab> 形式、または pr-merge（terminal workflow として別処理）
+  local _skill_safe
+  _skill_safe="${next_skill//$'\n'/}"  # 改行除去（ログインジェクション防止）
+  if [[ "$_skill_safe" == "pr-merge" || "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
+    # terminal workflow: inject せず merge-gate フローに委譲
     echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
     python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
       --set "workflow_done=null" 2>/dev/null || true
     return 0
   fi
+  if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+    echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe}' — inject スキップ" >&2
+    return 1
+  fi
 
   # --- tmux pane 入力待ち確認（最大3回、2秒間隔） ---
+  # 注: bash の [[ =~ ]] で > を文字クラス内に直接記述するとシンタックスエラーになるため変数経由で渡す
+  local _prompt_re='[>$][[:space:]]*$'
   local prompt_found=0
   local pane_tail
   for _i in 1 2 3; do
     pane_tail=$(tmux capture-pane -t "$window_name" -p 2>/dev/null | tail -1 || true)
-    if [[ "$pane_tail" =~ (">"|"$")[[:space:]]*$ ]]; then
+    if [[ "$pane_tail" =~ $_prompt_re ]]; then
       prompt_found=1
       break
     fi
@@ -776,13 +786,13 @@ inject_next_workflow() {
   done
 
   if [[ "$prompt_found" -eq 0 ]]; then
-    echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — 10秒後に再チェック" >&2
+    echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — ${POLL_INTERVAL:-10}秒後に再チェック" >&2
     return 1
   fi
 
-  # --- inject 実行 ---
-  echo "[orchestrator] Issue #${issue}: inject_next_workflow — ${next_skill}" >&2
-  tmux send-keys -t "$window_name" "$next_skill" Enter 2>/dev/null || true
+  # --- inject 実行（バリデーション済みの _skill_safe を使用） ---
+  echo "[orchestrator] Issue #${issue}: inject_next_workflow — ${_skill_safe}" >&2
+  tmux send-keys -t "$window_name" "$_skill_safe" Enter 2>/dev/null || true
 
   # --- workflow_done クリア ---
   python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
@@ -792,7 +802,7 @@ inject_next_workflow() {
   local injected_at
   injected_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
-    --set "workflow_injected=${next_skill}" \
+    --set "workflow_injected=${_skill_safe}" \
     --set "injected_at=${injected_at}" 2>/dev/null || true
 
   # --- NUDGE_COUNTS リセット ---

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -767,7 +767,7 @@ inject_next_workflow() {
     return 0
   fi
   if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
-    echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe}' — inject スキップ" >&2
+    echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe:0:200}' — inject スキップ" >&2
     return 1
   fi
 

--- a/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats
+++ b/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats
@@ -1,0 +1,298 @@
+#!/usr/bin/env bats
+# inject-next-workflow.bats
+# Requirement: inject_next_workflow() — Orchestrator の Pilot 駆動 workflow 遷移
+# Spec: deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
+#
+# inject_next_workflow() は autopilot-orchestrator.sh に追加される新関数。
+# tmux pane の入力待ち確認 → workflow skill inject → 後処理を担う。
+#
+# test double: inject-next-workflow-dispatch.sh
+#   Usage: inject-next-workflow-dispatch.sh <issue> <window_name>
+#   Env:
+#     NEXT_WORKFLOW  - resolve_next_workflow の返り値（デフォルト: "/twl:workflow-pr-verify"）
+#     RESOLVE_EXIT   - resolve_next_workflow の終了コード（デフォルト: 0）
+#     PANE_OUTPUT    - tmux capture-pane の出力（デフォルト: "> " でプロンプトあり）
+#     CALLS_LOG      - 呼び出し記録ファイル
+#     STATE_FILE     - state 書き込み先ファイル
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: inject_next_workflow テスト double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  STATE_FILE="$SANDBOX/state.log"
+  export CALLS_LOG STATE_FILE
+
+  # テスト double: inject_next_workflow ロジック
+  cat > "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" << 'DISPATCH_EOF'
+#!/usr/bin/env bash
+# inject-next-workflow-dispatch.sh
+# inject_next_workflow() の test double
+# Usage: <issue> <window_name>
+# Env:
+#   NEXT_WORKFLOW  - resolve_next_workflow の返り値
+#   RESOLVE_EXIT   - resolve_next_workflow の終了コード（デフォルト: 0）
+#   PANE_OUTPUT    - tmux capture-pane の出力（デフォルト: "> "）
+#   CALLS_LOG      - 呼び出し記録ファイル
+#   STATE_FILE     - state write の記録ファイル
+set -uo pipefail
+
+issue="$1"
+window_name="$2"
+
+NEXT_WORKFLOW="${NEXT_WORKFLOW:-/twl:workflow-pr-verify}"
+RESOLVE_EXIT="${RESOLVE_EXIT:-0}"
+PANE_OUTPUT="${PANE_OUTPUT:-"> "}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+STATE_FILE="${STATE_FILE:-/dev/null}"
+declare -A NUDGE_COUNTS=()
+
+# --- resolve_next_workflow 呼び出し ---
+echo "resolve_next_workflow --issue $issue" >> "$CALLS_LOG"
+if [[ "$RESOLVE_EXIT" -ne 0 ]]; then
+  echo "[orchestrator] WARNING: resolve_next_workflow 失敗 — issue $issue" >&2
+  exit 1
+fi
+next_skill="$NEXT_WORKFLOW"
+
+# --- terminal workflow (pr-merge) は inject しない ---
+if [[ "$next_skill" == "pr-merge" || "$next_skill" == "/twl:workflow-pr-merge" ]]; then
+  echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
+  echo "state_write workflow_done=null" >> "$STATE_FILE"
+  exit 0
+fi
+
+# --- tmux pane 入力待ち確認（最大3回、2秒間隔） ---
+prompt_found=0
+for i in 1 2 3; do
+  echo "tmux capture-pane -p -t $window_name" >> "$CALLS_LOG"
+  pane_tail=$(echo "$PANE_OUTPUT" | tail -1)
+  if [[ "$pane_tail" =~ (">"|"$")[[:space:]]*$ ]]; then
+    prompt_found=1
+    break
+  fi
+  sleep 0.01  # テスト環境では短縮（実装は 2 秒）
+done
+
+if [[ "$prompt_found" -eq 0 ]]; then
+  echo "[orchestrator] WARNING: inject タイムアウト — 10秒後に再チェック (issue=$issue)" >&2
+  exit 1
+fi
+
+# --- inject 実行 ---
+echo "tmux send-keys -t $window_name $next_skill" >> "$CALLS_LOG"
+echo "[orchestrator] Issue #${issue}: inject_next_workflow — $next_skill" >&2
+
+# --- workflow_done クリア ---
+echo "state_write workflow_done=null" >> "$STATE_FILE"
+
+# --- inject 履歴記録 ---
+echo "state_write workflow_injected=$next_skill" >> "$STATE_FILE"
+echo "state_write injected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$STATE_FILE"
+
+# --- NUDGE_COUNTS リセット ---
+NUDGE_COUNTS[$issue]=0
+echo "nudge_counts_reset issue=$issue" >> "$CALLS_LOG"
+
+exit 0
+DISPATCH_EOF
+  chmod +x "$SANDBOX/scripts/inject-next-workflow-dispatch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 正常な inject フロー
+# WHEN inject_next_workflow() が呼ばれ resolve_next_workflow が非 pr-merge を返す
+# THEN pane 確認 → inject → workflow_done クリア → 履歴記録 → NUDGE_COUNTS リセット
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow: 正常フローで tmux send-keys を実行する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#340 /twl:workflow-pr-verify" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow: 正常フローで [orchestrator] inject ログを出力する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "[orchestrator] Issue #340: inject_next_workflow — /twl:workflow-pr-verify"
+}
+
+@test "inject_next_workflow: inject 成功後に workflow_done をクリアする" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "state_write workflow_done=null" "$STATE_FILE"
+}
+
+@test "inject_next_workflow: inject 成功後に workflow_injected を state に記録する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "state_write workflow_injected=/twl:workflow-pr-verify" "$STATE_FILE"
+}
+
+@test "inject_next_workflow: inject 成功後に injected_at を state に記録する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "state_write injected_at=" "$STATE_FILE"
+}
+
+@test "inject_next_workflow: inject 成功後に NUDGE_COUNTS をリセットする" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "nudge_counts_reset issue=340" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: pr-merge terminal workflow
+# WHEN resolve_next_workflow が pr-merge を返す
+# THEN inject せず workflow_done のみクリアして戻る
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[pr-merge]: inject をスキップする" {
+  NEXT_WORKFLOW="pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[pr-merge]: workflow_done をクリアする" {
+  NEXT_WORKFLOW="pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "state_write workflow_done=null" "$STATE_FILE"
+}
+
+@test "inject_next_workflow[pr-merge]: merge-gate フロー委譲ログを出力する" {
+  NEXT_WORKFLOW="pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "merge-gate フローに委譲"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 3回リトライ後もプロンプト未検出
+# WHEN tmux capture-pane が3回ともプロンプトなし出力を返す
+# THEN WARNING ログを出力し戻り値 1 で終了する
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[timeout]: プロンプト未検出時に戻り値 1 を返す" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+}
+
+@test "inject_next_workflow[timeout]: プロンプト未検出時に WARNING ログを出力する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: inject タイムアウト"
+}
+
+@test "inject_next_workflow[timeout]: プロンプト未検出時に tmux send-keys を呼ばない" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[timeout]: プロンプト未検出時に workflow_done をクリアしない" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "state_write workflow_done=null" "$STATE_FILE" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: resolve_next_workflow 失敗
+# WHEN resolve_next_workflow がエラーを返す
+# THEN WARNING ログを出力し inject せず戻り値 1 で終了する
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[resolve-fail]: resolve 失敗時に戻り値 1 を返す" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+}
+
+@test "inject_next_workflow[resolve-fail]: resolve 失敗時に WARNING ログを出力する" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: resolve_next_workflow 失敗"
+}
+
+@test "inject_next_workflow[resolve-fail]: resolve 失敗時に tmux send-keys を呼ばない" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: $ プロンプトでも inject が実行される
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow: '\$ ' プロンプトでも inject を実行する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="$ " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#340 /twl:workflow-pr-verify" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: resolve_next_workflow が呼ばれていること
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow: resolve_next_workflow を必ず呼び出す" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "resolve_next_workflow --issue 340" "$CALLS_LOG"
+}

--- a/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats
+++ b/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats
@@ -60,19 +60,25 @@ if [[ "$RESOLVE_EXIT" -ne 0 ]]; then
 fi
 next_skill="$NEXT_WORKFLOW"
 
-# --- terminal workflow (pr-merge) は inject しない ---
-if [[ "$next_skill" == "pr-merge" || "$next_skill" == "/twl:workflow-pr-merge" ]]; then
+# --- allow-list バリデーション（コマンドインジェクション防止） ---
+_skill_safe="${next_skill//$'\n'/}"  # 改行除去
+if [[ "$_skill_safe" == "pr-merge" || "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
   echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
   echo "state_write workflow_done=null" >> "$STATE_FILE"
   exit 0
 fi
+if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+  echo "[orchestrator] WARNING: 不正な workflow skill '${_skill_safe}' — inject スキップ" >&2
+  exit 1
+fi
 
 # --- tmux pane 入力待ち確認（最大3回、2秒間隔） ---
+_prompt_re='[>$][[:space:]]*$'
 prompt_found=0
 for i in 1 2 3; do
   echo "tmux capture-pane -p -t $window_name" >> "$CALLS_LOG"
   pane_tail=$(echo "$PANE_OUTPUT" | tail -1)
-  if [[ "$pane_tail" =~ (">"|"$")[[:space:]]*$ ]]; then
+  if [[ "$pane_tail" =~ $_prompt_re ]]; then
     prompt_found=1
     break
   fi
@@ -84,15 +90,15 @@ if [[ "$prompt_found" -eq 0 ]]; then
   exit 1
 fi
 
-# --- inject 実行 ---
-echo "tmux send-keys -t $window_name $next_skill" >> "$CALLS_LOG"
-echo "[orchestrator] Issue #${issue}: inject_next_workflow — $next_skill" >&2
+# --- inject 実行（バリデーション済み _skill_safe を使用） ---
+echo "tmux send-keys -t $window_name $_skill_safe" >> "$CALLS_LOG"
+echo "[orchestrator] Issue #${issue}: inject_next_workflow — $_skill_safe" >&2
 
 # --- workflow_done クリア ---
 echo "state_write workflow_done=null" >> "$STATE_FILE"
 
 # --- inject 履歴記録 ---
-echo "state_write workflow_injected=$next_skill" >> "$STATE_FILE"
+echo "state_write workflow_injected=$_skill_safe" >> "$STATE_FILE"
 echo "state_write injected_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$STATE_FILE"
 
 # --- NUDGE_COUNTS リセット ---
@@ -295,4 +301,53 @@ teardown() {
 
   assert_success
   grep -q "resolve_next_workflow --issue 340" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Security: allow-list バリデーション
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[security]: 不正な skill 名は inject されない" {
+  NEXT_WORKFLOW="malicious; rm -rf /" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: 不正 skill に WARNING ログを出力する" {
+  NEXT_WORKFLOW="malicious; rm -rf /" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: 不正な workflow skill"
+}
+
+@test "inject_next_workflow[security]: /twl:workflow- プレフィックスなしは拒否" {
+  NEXT_WORKFLOW="workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: セミコロンを含む skill 名は拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify; rm -rf /" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: 有効な /twl:workflow-<kebab> は許可される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-fix" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#340 /twl:workflow-pr-fix" "$CALLS_LOG"
 }


### PR DESCRIPTION
Closes #340

## 変更内容
- orchestrator に inject_next_workflow() 関数を追加
- Worker の workflow_done フィールドを検知して次 workflow skill を tmux inject
- allow-list バリデーション（/twl:workflow-* のみ許可）
- ログ出力の長さ制限

## DeltaSpec
本 PR は DeltaSpec propose → apply パスで実装。deltaspec/changes/orchestrator-inject-next-workflow/ に全 artifact あり。