### PR TITLE
feat(workflow): context.md 書き出し・復元 — ワークフロー間コンテキスト引き継ぎ (#342)

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1133,12 +1133,13 @@ main() {
     quick-guard)         step_quick_guard "$@" ;;
     autopilot-detect)    step_autopilot_detect "$@" ;;
     quick-detect)        step_quick_detect "$@" ;;
+    resolve-issue-num)   resolve_issue_num ;;
     *)
       echo "ERROR: 未知のステップ: $step" >&2
       echo "利用可能: init, worktree-create, board-status-update, project-board-status-update," >&2
       echo "         board-archive, ac-extract, arch-ref, change-id-resolve, next-step, prompt-compliance, ts-preflight," >&2
       echo "         pr-test, ac-verify, all-pass-check, pr-cycle-report, auto-merge, check," >&2
-      echo "         quick-guard, autopilot-detect, quick-detect," >&2
+      echo "         quick-guard, autopilot-detect, quick-detect, resolve-issue-num," >&2
       echo "         dispatch-info, llm-delegate, llm-complete, chain-status" >&2
       exit 1
       ;;

--- a/plugins/twl/skills/workflow-pr-fix/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-fix/SKILL.md
@@ -49,6 +49,16 @@ ELSE
 
 **重要**: 以下の全ステップを上から順に実行すること。各ステップ完了後、**即座に**次のステップに進むこと。プロンプトで停止してはならない。
 
+### 前提: 前 workflow コンテキスト復元
+
+```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
+[[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
+```
+
 ### Step 4: fix-phase（自動修正ループ）【LLM 判断】
 review に CRITICAL findings がある場合のみ。`commands/fix-phase.md` を Read → 実行。
 fix 後は post-fix-verify（Step 4.5）→ pr-test 再実行のループ。
@@ -67,8 +77,42 @@ ISSUE_NUM=$(resolve_issue_num 2>/dev/null || echo "")
 eval "$(bash "$CR" autopilot-detect)"
 ```
 
-- IS_AUTOPILOT=true → `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-fix"` を実行して停止
+- IS_AUTOPILOT=true → context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-fix"` を実行して停止
 - IS_AUTOPILOT=false → 「workflow-pr-fix 完了。次のステップ: /twl:workflow-pr-merge を実行してください」と案内
+
+**context.md 書き出しスニペット（workflow_done=pr-fix 直前）:**
+```bash
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+if [[ -n "$ISSUE_NUM" ]]; then
+  AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+  mkdir -p "${AUTOPILOT_DIR}/issues"
+  CHANGE_ID_VAL=$(python3 -m twl.autopilot.state read --autopilot-dir "${AUTOPILOT_DIR}" --type issue --issue "${ISSUE_NUM}" --field change_id 2>/dev/null || echo "")
+  PR_NUMBER=$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number' 2>/dev/null || echo "")
+  TEST_RESULTS=$(python3 -m twl.autopilot.checkpoint read --step pr-test --field status 2>/dev/null || echo "")
+  REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field status 2>/dev/null || echo "")
+  cat > "${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md" <<EOF
+# Workflow Context: Issue #${ISSUE_NUM}
+workflow: pr-fix
+
+## completed_steps
+- fix-phase
+- post-fix-verify
+- warning-fix
+
+## change_id
+${CHANGE_ID_VAL}
+
+## pr_number
+${PR_NUMBER}
+
+## test_results
+${TEST_RESULTS}
+
+## review_findings
+${REVIEW_FINDINGS}
+EOF
+fi
+```
 
 ## compaction 復帰プロトコル
 

--- a/plugins/twl/skills/workflow-pr-merge/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-merge/SKILL.md
@@ -116,6 +116,7 @@ eval "$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh" autopilot-detect)"
 
 **context.md 書き出しスニペット（workflow_done=pr-merge 直前）:**
 ```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
 ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
 if [[ -n "$ISSUE_NUM" ]]; then
   AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"

--- a/plugins/twl/skills/workflow-pr-merge/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-merge/SKILL.md
@@ -61,6 +61,16 @@ THEN
 
 **重要**: 以下の全ステップを上から順に実行すること。各ステップ完了後、**即座に**次のステップに進むこと。プロンプトで停止してはならない。
 
+### 前提: 前 workflow コンテキスト復元
+
+```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
+[[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
+```
+
 ### Step 6: e2e-screening（Visual 検証）【LLM 判断】
 `commands/e2e-screening.md` を Read → 実行。E2E なければスキップ。
 
@@ -101,8 +111,45 @@ ISSUE_NUM=$(resolve_issue_num 2>/dev/null || echo "")
 eval "$(bash "${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh" autopilot-detect)"
 ```
 
-- IS_AUTOPILOT=true → `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-merge" --set "status=merge-ready"` を実行して停止
+- IS_AUTOPILOT=true → context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-merge" --set "status=merge-ready"` を実行して停止
 - IS_AUTOPILOT=false → 「workflow-pr-merge 完了」と報告して停止
+
+**context.md 書き出しスニペット（workflow_done=pr-merge 直前）:**
+```bash
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+if [[ -n "$ISSUE_NUM" ]]; then
+  AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+  mkdir -p "${AUTOPILOT_DIR}/issues"
+  CHANGE_ID_VAL=$(python3 -m twl.autopilot.state read --autopilot-dir "${AUTOPILOT_DIR}" --type issue --issue "${ISSUE_NUM}" --field change_id 2>/dev/null || echo "")
+  PR_NUMBER=$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number' 2>/dev/null || echo "")
+  TEST_RESULTS=$(python3 -m twl.autopilot.checkpoint read --step pr-test --field status 2>/dev/null || echo "")
+  REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field status 2>/dev/null || echo "")
+  cat > "${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md" <<EOF
+# Workflow Context: Issue #${ISSUE_NUM}
+workflow: pr-merge
+
+## completed_steps
+- e2e-screening
+- pr-cycle-report
+- pr-cycle-analysis
+- all-pass-check
+- merge-gate
+- auto-merge
+
+## change_id
+${CHANGE_ID_VAL}
+
+## pr_number
+${PR_NUMBER}
+
+## test_results
+${TEST_RESULTS}
+
+## review_findings
+${REVIEW_FINDINGS}
+EOF
+fi
+```
 
 ## compaction 復帰プロトコル
 

--- a/plugins/twl/skills/workflow-pr-verify/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-verify/SKILL.md
@@ -34,6 +34,16 @@ workflow-pr-cycle を 3 分割した第1段階。TypeScript preflight、speciali
 
 **重要**: 以下の全ステップを上から順に実行すること。各ステップ完了後、**即座に**次のステップに進むこと。プロンプトで停止してはならない。
 
+### 前提: 前 workflow コンテキスト復元
+
+```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
+[[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
+```
+
 ### Step 0.5: prompt-compliance（refined_by ハッシュ整合性）【機械的 → runner】
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh" prompt-compliance
@@ -77,8 +87,45 @@ ISSUE_NUM=$(resolve_issue_num 2>/dev/null || echo "")
 eval "$(bash "$CR" autopilot-detect)"
 ```
 
-- IS_AUTOPILOT=true → `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-verify"` を実行して停止
+- IS_AUTOPILOT=true → context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=pr-verify"` を実行して停止
 - IS_AUTOPILOT=false → 「workflow-pr-verify 完了。次のステップ: /twl:workflow-pr-fix を実行してください」と案内
+
+**context.md 書き出しスニペット（workflow_done=pr-verify 直前）:**
+```bash
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+if [[ -n "$ISSUE_NUM" ]]; then
+  AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+  mkdir -p "${AUTOPILOT_DIR}/issues"
+  CHANGE_ID_VAL=$(python3 -m twl.autopilot.state read --autopilot-dir "${AUTOPILOT_DIR}" --type issue --issue "${ISSUE_NUM}" --field change_id 2>/dev/null || echo "")
+  PR_NUMBER=$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number' 2>/dev/null || echo "")
+  TEST_RESULTS=$(python3 -m twl.autopilot.checkpoint read --step pr-test --field status 2>/dev/null || echo "")
+  REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field status 2>/dev/null || echo "")
+  cat > "${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md" <<EOF
+# Workflow Context: Issue #${ISSUE_NUM}
+workflow: pr-verify
+
+## completed_steps
+- prompt-compliance
+- ts-preflight
+- phase-review
+- scope-judge
+- pr-test
+- ac-verify
+
+## change_id
+${CHANGE_ID_VAL}
+
+## pr_number
+${PR_NUMBER}
+
+## test_results
+${TEST_RESULTS}
+
+## review_findings
+${REVIEW_FINDINGS}
+EOF
+fi
+```
 
 ## compaction 復帰プロトコル
 

--- a/plugins/twl/skills/workflow-setup/SKILL.md
+++ b/plugins/twl/skills/workflow-setup/SKILL.md
@@ -29,6 +29,16 @@ setup chain のオーケストレーター。chain 実行順序は deps.yaml に
 
 ## chain 実行指示（MUST — 全ステップを順に実行。途中停止禁止）
 
+### 前提: 前 workflow コンテキスト復元
+
+```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
+[[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
+```
+
 `CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"` として以下を順に実行:
 
 1. **init** [runner]: `bash "$CR" init "$ISSUE_NUM"` → JSON の `recommended_action` を記録
@@ -43,9 +53,44 @@ setup chain のオーケストレーター。chain 実行順序は deps.yaml に
    eval "$(bash "$CR" autopilot-detect)"
    eval "$(bash "$CR" quick-detect)"
    ```
-   - IS_QUICK=true かつ IS_AUTOPILOT=true → workflow-test-ready **呼び出し禁止**。直接実装 → commit → push → PR 作成（`source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/pr-create-helper.sh" && pr_create_with_closes "$ISSUE_NUM" quick`、PR 本文に必ず `Closes #${ISSUE_NUM}` を機械的に挿入）→ `bash "$CR" llm-delegate "ac-verify" "$ISSUE_NUM"` → `commands/ac-verify.md` Read → 実行（checkpoint 永続化必須）→ `bash "$CR" llm-complete "ac-verify" "$ISSUE_NUM"` → `commands/merge-gate.md` Read → merge-gate 実行（merge-gate は ac-verify checkpoint を統合する）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=setup"` を実行して停止
-   - IS_QUICK=false かつ IS_AUTOPILOT=true → `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=setup"` を実行して停止
+   - IS_QUICK=true かつ IS_AUTOPILOT=true → workflow-test-ready **呼び出し禁止**。直接実装 → commit → push → PR 作成（`source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/pr-create-helper.sh" && pr_create_with_closes "$ISSUE_NUM" quick`、PR 本文に必ず `Closes #${ISSUE_NUM}` を機械的に挿入）→ `bash "$CR" llm-delegate "ac-verify" "$ISSUE_NUM"` → `commands/ac-verify.md` Read → 実行（checkpoint 永続化必須）→ `bash "$CR" llm-complete "ac-verify" "$ISSUE_NUM"` → `commands/merge-gate.md` Read → merge-gate 実行（merge-gate は ac-verify checkpoint を統合する）→ context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=setup"` を実行して停止
+   - IS_QUICK=false かつ IS_AUTOPILOT=true → context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=setup"` を実行して停止
    - IS_AUTOPILOT=false → 「setup chain 完了。次: `/twl:workflow-test-ready`」と案内
+
+**context.md 書き出しスニペット（workflow_done=setup 直前）:**
+```bash
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+if [[ -n "$ISSUE_NUM" ]]; then
+  AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+  mkdir -p "${AUTOPILOT_DIR}/issues"
+  CHANGE_ID_VAL=$(python3 -m twl.autopilot.state read --autopilot-dir "${AUTOPILOT_DIR}" --type issue --issue "${ISSUE_NUM}" --field change_id 2>/dev/null || echo "")
+  cat > "${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md" <<EOF
+# Workflow Context: Issue #${ISSUE_NUM}
+workflow: setup
+
+## completed_steps
+- init
+- worktree-create
+- board-status-update
+- crg-auto-build
+- arch-ref
+- change-propose
+- ac-extract
+
+## change_id
+${CHANGE_ID_VAL}
+
+## pr_number
+
+
+## test_results
+
+
+## review_findings
+
+EOF
+fi
+```
 
 ## compaction 復帰プロトコル
 

--- a/plugins/twl/skills/workflow-test-ready/SKILL.md
+++ b/plugins/twl/skills/workflow-test-ready/SKILL.md
@@ -20,6 +20,16 @@ workflow-setup の後に呼び出す。`CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-
 
 ## chain 実行指示（MUST — 全ステップ順に実行。途中停止禁止）
 
+### 前提: 前 workflow コンテキスト復元
+
+```bash
+CR="${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh"
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
+[[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
+```
+
 ### Quick Guard
 ```bash
 bash "$CR" quick-guard || { echo "quick Issue — test-ready スキップ"; exit 0; }
@@ -70,6 +80,38 @@ ISSUE_NUM=$(resolve_issue_num 2>/dev/null || echo "")
 eval "$(bash "$CR" autopilot-detect)"
 ```
 
-- IS_AUTOPILOT=true → `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=test-ready"` を実行して停止
+- IS_AUTOPILOT=true → context.md 書き出し（下記スニペット）→ `python3 -m twl.autopilot.state write --autopilot-dir "${AUTOPILOT_DIR:-}" --type issue --issue "$ISSUE_NUM" --role worker --set "workflow_done=test-ready"` を実行して停止
 - IS_AUTOPILOT=false → 「完了。次: /twl:workflow-pr-verify」と案内
+
+**context.md 書き出しスニペット（workflow_done=test-ready 直前）:**
+```bash
+ISSUE_NUM=$(bash "$CR" resolve-issue-num 2>/dev/null || echo "")
+if [[ -n "$ISSUE_NUM" ]]; then
+  AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
+  mkdir -p "${AUTOPILOT_DIR}/issues"
+  CHANGE_ID_VAL=$(python3 -m twl.autopilot.state read --autopilot-dir "${AUTOPILOT_DIR}" --type issue --issue "${ISSUE_NUM}" --field change_id 2>/dev/null || echo "")
+  cat > "${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md" <<EOF
+# Workflow Context: Issue #${ISSUE_NUM}
+workflow: test-ready
+
+## completed_steps
+- change-id-resolve
+- test-scaffold
+- check
+- change-apply
+
+## change_id
+${CHANGE_ID_VAL}
+
+## pr_number
+
+
+## test_results
+
+
+## review_findings
+
+EOF
+fi
+```
 


### PR DESCRIPTION
## 概要

Pilot 駆動ループで各 workflow が独立して実行されるため、前の workflow の結果を外部ファイルに保存し、次の workflow で復元する仕組みを追加。

## 変更内容

各 workflow SKILL.md に以下を追加:
- 先頭の「前提: 前 workflow コンテキスト復元」スニペット
- `workflow_done` 書き込み直前の `context.md` 書き出しスニペット

## context.md フィールド

- `completed_steps`: 必須（全 workflow で記録）
- `change_id`: optional（workflow-setup 以降）
- `pr_number`: optional（PR 作成後）
- `test_results`: optional（workflow-pr-verify 以降）
- `review_findings`: optional（workflow-pr-verify 以降）

## 仕様

- context.md は上書き（最新の workflow 結果のみ保持）
- ISSUE_NUM 取得は `bash "$CR" resolve-issue-num` で統一
- `.autopilot/issues/` が存在しない場合は `mkdir -p` で自動作成

Closes #342