### PR TITLE
docs(adr): ADR-014 Accept + ADR-013 Supersede (#349)

### DIFF
--- a/deltaspec/changes/issue-349/.deltaspec.yaml
+++ b/deltaspec/changes/issue-349/.deltaspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/deltaspec/changes/issue-349/design.md
+++ b/deltaspec/changes/issue-349/design.md
@@ -1,0 +1,23 @@
+## Context
+
+ADR（Architecture Decision Record）は Markdown ファイルで管理されており、ステータスフィールドとヘッダー注記によって有効/廃止状態を表現する。ADR-013 が ADR-014 に置き換えられたため、両ファイルの更新が必要。
+
+## Goals / Non-Goals
+
+**Goals:**
+- ADR-014 の Status フィールドを `Proposed` → `Accepted` に変更する
+- ADR-013 の Status フィールドを `Accepted` → `Superseded by ADR-014` に変更する
+- ADR-013 冒頭に Superseded 注記ブロックを追加する
+
+**Non-Goals:**
+- ADR のリナンバー（ADR-014 番号重複の解消は別 Issue）
+- ADR の内容（本文）の変更
+
+## Decisions
+
+1. **Superseded 注記の形式**: `> **[SUPERSEDED]** This ADR has been superseded by [ADR-014](ADR-014-supervisor-redesign.md).` をドキュメント先頭に追加する
+2. **Status フィールドの場所**: 各 ADR の YAML フロントマター（またはテーブル形式）の Status 行を直接編集する
+
+## Risks / Trade-offs
+
+- ADR-014 番号重複（`ADR-014-pilot-driven-workflow-loop.md` が別途存在）は本 Issue のスコープ外。変更対象ファイルのパスで明確に区別する

--- a/deltaspec/changes/issue-349/proposal.md
+++ b/deltaspec/changes/issue-349/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+ADR-014 (Supervisor 再定義) の設計が完成し実装が進んだため、ステータスを Proposed から Accepted に昇格させる。同時に、ADR-014 が ADR-013 (Observer First-Class) を置き換える関係を明示するため、ADR-013 を Superseded に更新する。
+
+## What Changes
+
+- `plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md`: Status を `Proposed` → `Accepted` に変更
+- `plugins/twl/architecture/decisions/ADR-013-observer-first-class.md`: Status を `Accepted` → `Superseded by ADR-014` に変更
+- ADR-013 冒頭に Superseded 注記を追加
+
+## Capabilities
+
+### New Capabilities
+
+なし（ドキュメント更新のみ）
+
+### Modified Capabilities
+
+- ADR ステータス管理: ADR-014 が Accepted となり、公式アーキテクチャ決定として有効化される
+- ADR ステータス管理: ADR-013 が Superseded となり、ADR-014 への参照が明記される
+
+## Impact
+
+- 影響コード: なし（Markdown ファイルのみ）
+- 影響 API: なし
+- 影響依存: なし

--- a/deltaspec/changes/issue-349/specs/adr-status-update/spec.md
+++ b/deltaspec/changes/issue-349/specs/adr-status-update/spec.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: ADR-014 ステータス更新
+
+ADR-014-supervisor-redesign.md の Status フィールドを Accepted に更新しなければならない（SHALL）。
+
+#### Scenario: ADR-014 が Accepted に変更されている
+- **WHEN** `plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md` を参照する
+- **THEN** Status フィールドが `Accepted` であること
+
+### Requirement: ADR-013 ステータス更新
+
+ADR-013-observer-first-class.md の Status フィールドを Superseded by ADR-014 に更新しなければならない（SHALL）。
+
+#### Scenario: ADR-013 が Superseded に変更されている
+- **WHEN** `plugins/twl/architecture/decisions/ADR-013-observer-first-class.md` を参照する
+- **THEN** Status フィールドが `Superseded by ADR-014` であること
+
+### Requirement: ADR-013 Superseded 注記追加
+
+ADR-013 の冒頭に Superseded 注記ブロックを追加しなければならない（SHALL）。
+
+#### Scenario: ADR-013 冒頭に注記が存在する
+- **WHEN** ADR-013 の先頭を参照する
+- **THEN** `[SUPERSEDED]` を含む注記ブロックと ADR-014 へのリンクが存在すること

--- a/deltaspec/changes/issue-349/tasks.md
+++ b/deltaspec/changes/issue-349/tasks.md
@@ -1,0 +1,8 @@
+## 1. ADR-014 ステータス更新
+
+- [ ] 1.1 `plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md` の Status を `Proposed` → `Accepted` に変更
+
+## 2. ADR-013 ステータス更新
+
+- [ ] 2.1 `plugins/twl/architecture/decisions/ADR-013-observer-first-class.md` の Status を `Accepted` → `Superseded by ADR-014` に変更
+- [ ] 2.2 ADR-013 冒頭に Superseded 注記ブロックを追加

--- a/deltaspec/changes/issue-349/tasks.md
+++ b/deltaspec/changes/issue-349/tasks.md
@@ -1,8 +1,8 @@
 ## 1. ADR-014 ステータス更新
 
-- [ ] 1.1 `plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md` の Status を `Proposed` → `Accepted` に変更
+- [x] 1.1 `plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md` の Status を `Proposed` → `Accepted` に変更
 
 ## 2. ADR-013 ステータス更新
 
-- [ ] 2.1 `plugins/twl/architecture/decisions/ADR-013-observer-first-class.md` の Status を `Accepted` → `Superseded by ADR-014` に変更
-- [ ] 2.2 ADR-013 冒頭に Superseded 注記ブロックを追加
+- [x] 2.1 `plugins/twl/architecture/decisions/ADR-013-observer-first-class.md` の Status を `Accepted` → `Superseded by ADR-014` に変更
+- [x] 2.2 ADR-013 冒頭に Superseded 注記ブロックを追加

--- a/plugins/twl/architecture/decisions/ADR-013-observer-first-class.md
+++ b/plugins/twl/architecture/decisions/ADR-013-observer-first-class.md
@@ -1,7 +1,9 @@
 # ADR-013: Observer の First-Class 昇格 — メタ認知レイヤーの独立型化
 
+> **[SUPERSEDED]** This ADR has been superseded by [ADR-014](ADR-014-supervisor-redesign.md). ADR-013 で定義した observer 型は ADR-014 の supervisor 型に完全置換された。
+
 ## Status
-Accepted
+Superseded by ADR-014
 
 ## Context
 

--- a/plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md
+++ b/plugins/twl/architecture/decisions/ADR-014-supervisor-redesign.md
@@ -1,7 +1,7 @@
 # ADR-014: Observer → Supervisor 再定義 — プロジェクト常駐メタ認知レイヤー
 
 ## Status
-Proposed
+Accepted
 
 ## Supersedes
 ADR-013 (Observer の First-Class 昇格)


### PR DESCRIPTION
## 概要

ADR-014（Supervisor 再定義）を Accepted に、ADR-013（Observer First-Class）を Superseded に更新。

Closes #349

## 変更内容
- ADR-014: Status: Proposed → Accepted
- ADR-013: Status: Accepted → Superseded by ADR-014
- ADR-013 冒頭に [SUPERSEDED] 注記追加