### PR TITLE
feat(#353): vision.md に Supervisor カテゴリを追加

### DIFF
--- a/deltaspec/changes/issue-353/.deltaspec.yaml
+++ b/deltaspec/changes/issue-353/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-353
+status: pending

--- a/deltaspec/changes/issue-353/design.md
+++ b/deltaspec/changes/issue-353/design.md
@@ -1,0 +1,27 @@
+## Context
+
+vision.md は architecture spec の living document として co-issue・co-architect が直接参照する設計意図の前方参照。ADR-014 Decision 6 により su-observer が Supervisor 型として分離されたが、vision.md はまだ Meta-cognitive / co-observer 表記のままである。変更対象は `plugins/twl/architecture/vision.md` の1ファイルのみで、コード変更は伴わない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Supervisor カテゴリを Controller 操作カテゴリ表に追加する
+- Meta-cognitive カテゴリの表記を Supervisor に更新する
+- co-observer を su-observer に更新する
+- Constraints セクションの controller 一覧から co-observer を除き、controller 数の記述を整合させる
+
+**Non-Goals:**
+- CLAUDE.md（plugins/twl/CLAUDE.md）の「Controller は7つ」記述の更新（別 Issue で対応）
+- su-observer の実装変更
+- ADR の新規作成（ADR-014 が既存）
+
+## Decisions
+
+1. **controller 数の表記**: `Controller は7つ（...co-observer）` を `Controller は6つ（...）+ Supervisor は1つ（su-observer）` に変更する。co-observer は controller ではなく Supervisor 型であるため、一覧から除外する
+2. **カテゴリ表の更新**: `Meta-cognitive` 行を削除し `Supervisor` 行を追加。`該当 Controller` 列を `該当コンポーネント` に変更することも検討するが、最小変更として `co-observer` → `su-observer` の文字列置換のみ実施する
+3. **説明文の整合**: `Non-implementation controller は co-autopilot を spawn しない` の文脈で co-observer が出てくる場合は su-observer に更新する
+
+## Risks / Trade-offs
+
+- vision.md を参照している他のドキュメントや CLAUDE.md が追従していない場合、一時的に乖離が生じる（次 Wave で修正予定）
+- `Controller は6つ` という数の正確性は Issue #348 の types.yaml 変更内容に依存するため、先行 Issue の完了を確認すること

--- a/deltaspec/changes/issue-353/proposal.md
+++ b/deltaspec/changes/issue-353/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+su-observer（ADR-014 Decision 6）の導入により、controller とは異なる「Supervisor」型コンポーネントが誕生した。vision.md の Controller 操作カテゴリ表が実態と乖離しており、Meta-cognitive カテゴリが co-observer を controller として扱っているため、型の誤解を招く。
+
+## What Changes
+
+- `plugins/twl/architecture/vision.md`
+  - Constraints セクション: `co-observer` を一覧から除き、controller 数を7→6に修正（または su-observer を Supervisor 型として別記）
+  - Controller 操作カテゴリ表: `Meta-cognitive` 行を `Supervisor` に改名、`co-observer` を `su-observer` に更新
+  - `Non-implementation controller は co-autopilot を spawn しない` の説明文で co-observer → su-observer を反映
+
+## Capabilities
+
+### New Capabilities
+
+- **Supervisor カテゴリ**: controller の動作を監視・介入するメタレイヤーを独立カテゴリとして定義
+
+### Modified Capabilities
+
+- **Meta-cognitive → Supervisor**: カテゴリ名変更により su-observer の型的位置づけを明確化
+- **controller 数の整合性**: co-observer が controller ではなく Supervisor 型であることを明示
+
+## Impact
+
+- `plugins/twl/architecture/vision.md` のみ変更（コード変更なし）
+- CLAUDE.md（plugins/twl/CLAUDE.md）の「Controller は7つ」記述は別 Issue で更新予定
+- ADR-014 と整合

--- a/deltaspec/changes/issue-353/specs/supervisor-category/spec.md
+++ b/deltaspec/changes/issue-353/specs/supervisor-category/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Supervisor カテゴリ定義
+
+vision.md の Controller 操作カテゴリ表は Supervisor カテゴリを持たなければならない（SHALL）。
+Meta-cognitive カテゴリは Supervisor カテゴリに置き換えられなければならない（MUST）。
+
+#### Scenario: Supervisor カテゴリが表に存在する
+- **WHEN** `plugins/twl/architecture/vision.md` の Controller 操作カテゴリ表を参照したとき
+- **THEN** `Supervisor` 行が存在し、`su-observer` が該当コンポーネントとして記載されている
+
+#### Scenario: Meta-cognitive 行が存在しない
+- **WHEN** `plugins/twl/architecture/vision.md` の Controller 操作カテゴリ表を参照したとき
+- **THEN** `Meta-cognitive` 行が存在しない
+
+### Requirement: co-observer 表記の除去
+
+Constraints セクションの controller 一覧から `co-observer` を除去しなければならない（MUST）。
+controller 数の記述は実際の controller 数と一致しなければならない（SHALL）。
+
+#### Scenario: controller 一覧に co-observer が含まれない
+- **WHEN** `plugins/twl/architecture/vision.md` の Constraints セクションを参照したとき
+- **THEN** controller 一覧に `co-observer` が含まれず、su-observer は Supervisor 型として別途記載されている
+
+#### Scenario: controller 数の整合性
+- **WHEN** `plugins/twl/architecture/vision.md` の Constraints セクションを参照したとき
+- **THEN** controller 数の記述（例: 「Controller は6つ」）が実際の controller 数（co-observer を除いた数）と一致している
+
+### Requirement: su-observer の型的位置づけ明示
+
+su-observer は Supervisor 型であることが vision.md に明示されなければならない（SHALL）。
+
+#### Scenario: su-observer が Supervisor カテゴリに分類される
+- **WHEN** Controller 操作カテゴリ表の Supervisor カテゴリを参照したとき
+- **THEN** su-observer が該当コンポーネントとして記載されている
+
+#### Scenario: su-observer が controller 一覧に含まれない
+- **WHEN** Constraints セクションの controller 一覧を参照したとき
+- **THEN** su-observer は controller 一覧には含まれず、Supervisor カテゴリで管理されている

--- a/deltaspec/changes/issue-353/tasks.md
+++ b/deltaspec/changes/issue-353/tasks.md
@@ -1,0 +1,12 @@
+## 1. vision.md 更新
+
+- [x] 1.1 Constraints セクションの controller 一覧から `co-observer` を除去し、controller 数を6に更新する
+- [x] 1.2 Controller 操作カテゴリ表の `Meta-cognitive` 行を `Supervisor` 行に変更し、`co-observer` を `su-observer` に更新する
+- [x] 1.3 変更後の vision.md を通読し、co-observer/su-observer/controller 数に関する記述の整合性を確認する
+
+## 2. 検証
+
+- [x] 2.1 AC チェック: Supervisor カテゴリが定義されている
+- [x] 2.2 AC チェック: Meta-cognitive の記述が Supervisor に更新されている
+- [x] 2.3 AC チェック: Constraints セクションの controller 一覧が更新されている
+- [x] 2.4 AC チェック: 「Controller は7つ」の記述が実態（6つ + Supervisor 1つ）と一致している

--- a/plugins/twl/architecture/vision.md
+++ b/plugins/twl/architecture/vision.md
@@ -7,7 +7,7 @@ chain-driven + autopilot-first アーキテクチャに基づく Claude Code 開
 
 - TWiLL フレームワーク準拠（deps.yaml v3.0, types.yaml 型システム）
 - Claude Code プラグインシステム仕様に準拠
-- Controller は7つ（co-autopilot, co-issue, co-project, co-architect, co-utility, co-self-improve, co-observer）
+- Controller は6つ（co-autopilot, co-issue, co-project, co-architect, co-utility, co-self-improve）+ Supervisor は1つ（su-observer）
 - Bare repo + worktree 一律（branch モード廃止）
 - 状態管理は統一 JSON 2種（issue-{N}.json + session.json）
 - **Project Board 必須**（ADR-006）: 全プロジェクトで GitHub Projects V2 を使用。autopilot の Issue 選択元、ステータス同期先
@@ -22,7 +22,7 @@ chain-driven + autopilot-first アーキテクチャに基づく Claude Code 開
 | Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project, co-architect |
 | Utility | スタンドアロンユーティリティ操作 | co-utility |
 | Observation | ライブセッション観察・問題検出・Issue 起票 | co-self-improve |
-| Meta-cognitive | controller の動作を監視・介入するメタレイヤー | co-observer |
+| Supervisor | controller の動作を監視・介入するメタレイヤー | su-observer |
 
 Non-implementation controller は co-autopilot を spawn しない。
 co-architect が「設計 + 実装」を要求された場合: 設計完了 → Issue 起票（co-issue 経由）→ co-autopilot で実装。


### PR DESCRIPTION
feat(#353): vision.md に Supervisor カテゴリを追加

- Meta-cognitive カテゴリ → Supervisor カテゴリに変更
- co-observer → su-observer に更新
- Controller は7つ → Controller は6つ + Supervisor は1つ（su-observer）

Refs: ADR-014 Decision 6

Closes #353