### PR TITLE
docs(deltaspec): Issue #350 DeltaSpec artifacts + test-mapping 追加

### DIFF
--- a/deltaspec/changes/issue-350/.deltaspec.yaml
+++ b/deltaspec/changes/issue-350/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-350
+status: pending

--- a/deltaspec/changes/issue-350/design.md
+++ b/deltaspec/changes/issue-350/design.md
@@ -1,0 +1,29 @@
+## Context
+
+ADR-014 で `observer` 型を `supervisor` 型に再定義。Issue #348 で types.yaml・Python ソースコードの置換は完了済み。本 Issue (#350) はテストコードの残存 `observer` 参照を修正する。
+
+対象ファイルは `cli/twl/tests/test_observer_type.py` の 1 ファイルのみ（grep 確認済み）。
+
+## Goals / Non-Goals
+
+**Goals**
+- `test_observer_type.py` を `test_supervisor_type.py` にリネーム
+- テストクラス名・docstring の observer → supervisor 置換
+- `spawnable_by` assertion から `launcher` を除去（ADR-014 準拠: `spawnable_by: [user]` のみ）
+- `pytest tests/` が全件 PASS すること
+
+**Non-Goals**
+- types.yaml・Python ソースの変更（Issue #348 で完了済み）
+- 新機能追加
+
+## Decisions
+
+| 決定 | 理由 |
+|------|------|
+| ファイルリネーム（rename ではなく新規作成 + 削除） | git mv で履歴を保持 |
+| `test_supervisor_type.py` に `test_observer_type.py` の全テストを移植 | 型名 supervisor に合わせた完全置換 |
+| `spawnable_by` assertion から `launcher` を除去 | ADR-014: supervisor の spawnable_by は `[user]` のみ |
+
+## Risks / Trade-offs
+
+- リスクなし（テストファイルのみの変更、実装コードへの影響なし）

--- a/deltaspec/changes/issue-350/proposal.md
+++ b/deltaspec/changes/issue-350/proposal.md
@@ -1,0 +1,21 @@
+## Why
+
+ADR-014 で `observer` 型を `supervisor` 型に再定義し、`cli/twl/types.yaml` および Python ソースコードは既に置換済み（Issue #348）だが、`cli/twl/tests/` 内のテストファイルに `observer` 参照が残存している。型システムの一貫性を保つため、テストコードも `supervisor` に完全置換する必要がある。
+
+## What Changes
+
+- `cli/twl/tests/test_observer_type.py`: ファイルを `test_supervisor_type.py` にリネーム
+- テストクラス名・docstring の `observer` → `supervisor` 置換
+- `spawnable_by` assertion から `launcher` を除去し、`[user]` のみに変更（ADR-014 準拠）
+- 型名参照 (`observer`) を `supervisor` に置換
+
+## Capabilities
+
+### Modified Capabilities
+
+- テストスイートが `supervisor` 型を正しく検証する
+- `pytest tests/` が全件 PASS する（`observer` 未定義エラーなし）
+
+## Impact
+
+- `cli/twl/tests/test_observer_type.py`（リネーム → `test_supervisor_type.py`、型名・assertion 更新）

--- a/deltaspec/changes/issue-350/specs/test-supervisor-rename/spec.md
+++ b/deltaspec/changes/issue-350/specs/test-supervisor-rename/spec.md
@@ -1,0 +1,23 @@
+## RENAMED Requirements
+
+### Requirement: テストファイル名を supervisor に更新
+
+`cli/twl/tests/test_observer_type.py` は `test_supervisor_type.py` にリネームされなければならない（SHALL）。
+
+#### Scenario: テストファイルのリネーム
+- **WHEN** `cli/twl/tests/` ディレクトリを確認する
+- **THEN** `test_supervisor_type.py` が存在し、`test_observer_type.py` は存在しない
+
+## MODIFIED Requirements
+
+### Requirement: テスト内 observer 参照を supervisor に更新
+
+テストクラス名・docstring・アサーション内の `observer` 参照はすべて `supervisor` に更新されなければならない（SHALL）。
+
+#### Scenario: spawnable_by アサーション（launcher 除去）
+- **WHEN** `supervisor` 型の `spawnable_by` をチェックするテストが実行される
+- **THEN** `'launcher' not in spawnable_by` アサーションが PASS する（ADR-014 準拠）
+
+#### Scenario: pytest 全件 PASS
+- **WHEN** `pytest tests/test_supervisor_type.py` を実行する
+- **THEN** 全テストが PASS し、FAIL が 0 件である

--- a/deltaspec/changes/issue-350/tasks.md
+++ b/deltaspec/changes/issue-350/tasks.md
@@ -1,3 +1,5 @@
+<!-- Note: 全タスクは Issue #348 PR (#392) の中で実施・マージ済み（origin/main で確認済み）。本 DeltaSpec は事後記録として作成。 -->
+
 ## 1. テストファイルのリネームと更新
 
 - [x] 1.1 `cli/twl/tests/test_observer_type.py` を `test_supervisor_type.py` にリネームする

--- a/deltaspec/changes/issue-350/tasks.md
+++ b/deltaspec/changes/issue-350/tasks.md
@@ -1,0 +1,11 @@
+## 1. テストファイルのリネームと更新
+
+- [x] 1.1 `cli/twl/tests/test_observer_type.py` を `test_supervisor_type.py` にリネームする
+- [x] 1.2 テストクラス名・docstring の `observer` → `supervisor` 置換する
+- [x] 1.3 `spawnable_by` assertion から `launcher` を除去する（ADR-014 準拠: `spawnable_by: [user]` のみ）
+- [x] 1.4 型名参照 (`observer`) を `supervisor` に置換する
+
+## 2. 検証
+
+- [x] 2.1 `pytest tests/test_supervisor_type.py` を実行して全 24 テストが PASS することを確認する
+- [x] 2.2 全 AC チェックボックスを満たすことを確認する

--- a/deltaspec/changes/issue-350/test-mapping.yaml
+++ b/deltaspec/changes/issue-350/test-mapping.yaml
@@ -1,0 +1,39 @@
+change_id: issue-350
+generated_at: "2026-04-10T00:00:00Z"
+test_framework: pytest
+scenarios:
+  - id: "test-file-rename"
+    name: "テストファイルのリネーム"
+    spec_file: "specs/test-supervisor-rename/spec.md"
+    spec_line: 7
+    requirement: "テストファイル名を supervisor に更新"
+    test_file: "cli/twl/tests/test_supervisor_type.py"
+    test_name: "test_supervisor_type.py が存在し test_observer_type.py は存在しない"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "spawnable-by-assertion-launcher-exclude"
+    name: "spawnable_by アサーション（launcher 除去）"
+    spec_file: "specs/test-supervisor-rename/spec.md"
+    spec_line: 17
+    requirement: "テスト内 observer 参照を supervisor に更新"
+    test_file: "cli/twl/tests/test_supervisor_type.py"
+    test_name: "test_supervisor_spawnable_by_excludes_launcher (or equivalent)"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "pytest-all-pass"
+    name: "pytest 全件 PASS"
+    spec_file: "specs/test-supervisor-rename/spec.md"
+    spec_line: 21
+    requirement: "テスト内 observer 参照を supervisor に更新"
+    test_file: "cli/twl/tests/test_supervisor_type.py"
+    test_name: "pytest tests/test_supervisor_type.py (全件 PASS)"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null


### PR DESCRIPTION
## 概要

Issue #350「CLI テスト: observer → supervisor 参照修正」のDeltaSpecドキュメントを追加する。

実装（test_supervisor_type.py の作成、observer→supervisor置換、launcher除去）は Issue #348 の PR #392 でマージ済み。本PRはDeltaSpecドキュメントとして事後記録を追加する。

## 変更内容

- `deltaspec/changes/issue-350/proposal.md`: 変更の Why/What/Impact
- `deltaspec/changes/issue-350/design.md`: 技術設計（Context/Goals/Decisions）
- `deltaspec/changes/issue-350/specs/test-supervisor-rename/spec.md`: RENAMED/MODIFIED 要件定義
- `deltaspec/changes/issue-350/tasks.md`: 実装タスクチェックリスト（全完了済み）
- `deltaspec/changes/issue-350/test-mapping.yaml`: Scenario → テストファイルマッピング

## AC

- [x] テスト内の observer 参照が全て supervisor に更新されている（origin/main で確認済み）
- [x] `pytest tests/test_supervisor_type.py` 全24件 PASS（このセッションで確認済み）

Closes #350