### PR TITLE
feat(model): Observer → Supervisor クラス更新 (#351)

### DIFF
--- a/deltaspec/changes/issue-351/.deltaspec.yaml
+++ b/deltaspec/changes/issue-351/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-351
+status: pending

--- a/deltaspec/changes/issue-351/design.md
+++ b/deltaspec/changes/issue-351/design.md
@@ -1,0 +1,36 @@
+## Context
+
+ADR-014 Decision 1 が Observer → Supervisor の改名を決定した。対象は `plugins/twl/architecture/domain/model.md` のみ。コード実装（Python/Shell）への変更は含まない。本 Issue は Phase 5（ドメインモデル + Context 更新）の一部であり、後続 C1 が依存する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- model.md 内のすべての `Observer` クラス定義を `Supervisor` に更新
+- `InterventionRecord.observer` フィールドを `supervisor` に更新
+- Mermaid クラス図・関係図の `co-observer` ノードを `su-observer` に更新
+- `intervention-{N}.json` スキーマの `observer` フィールドを `supervisor` に更新
+- Spawning ルール説明文の `co-observer` 参照を `su-observer` に更新
+
+**Non-Goals:**
+
+- Python/Shell コードの変更（別 Issue）
+- ADR ドキュメントの編集
+- co-observer 以外のコントローラー名の変更
+
+## Decisions
+
+**D1: テキスト置換のみ、構造変更なし**
+クラス図・関係図の構造（関係線・依存方向）は変更しない。名前のみを更新する。
+
+**D2: `co-*` prefix から `su-*` prefix への変更**
+ADR-014 の su- prefix 規則に従い、Observer クラスの `name: co-*` を `name: su-*` に変更する。Mermaid ノード ID も `CO` → `SO` に更新する。
+
+**D3: フィールド名の一貫した置換**
+`InterventionRecord.observer` と `intervention-{N}.json` の `observer` フィールドを同時に `supervisor` に変更し、スキーマの整合性を保つ。
+
+## Risks / Trade-offs
+
+- **リスク**: Spawning ルール説明文に `co-observer` の文字列参照が複数箇所ある。見落としがあると不整合が残る。
+  - **対策**: Grep で model.md 全体の `observer`（大文字小文字含む）を確認してから変更する。
+- **トレードオフ**: なし（純粋なリネーム）

--- a/deltaspec/changes/issue-351/proposal.md
+++ b/deltaspec/changes/issue-351/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+ADR-014 Decision 1 により、Observer クラスを Supervisor クラスに改名する設計決定が下された。ドメインモデル（model.md）がこの決定を反映していないため、型定義・スキーマ・図表との乖離が生じている。
+
+## What Changes
+
+- `Observer` クラスを `Supervisor` クラスに改名（`name: co-*` → `name: su-*`）
+- `InterventionRecord` クラスの `observer` フィールドを `supervisor` に改名
+- Controller Spawning 関係図のノード `CO["co-observer"]` を `SO["su-observer"]` に更新
+- クラス図の `Observer ..> Controller` 関係を `Supervisor ..> Controller` に更新
+- `intervention-{N}.json` スキーマの `observer` フィールドを `supervisor` に更新
+- Spawning ルール説明文の `co-observer` 参照を `su-observer` に更新
+
+## Capabilities
+
+### New Capabilities
+
+なし（既存機能の改名のみ）
+
+### Modified Capabilities
+
+- **Supervisor（旧 Observer）**: ドメインクラスのプレフィックスが `su-*` となり、ADR-014 の su- prefix 規則に準拠
+- **InterventionRecord**: `supervisor` フィールドで介入記録の記録者を識別
+- **intervention-{N}.json**: `supervisor` フィールドを持つスキーマとして更新
+
+## Impact
+
+- `plugins/twl/architecture/domain/model.md` のみ変更
+- コード実装への影響なし（ドキュメント更新のみ）
+- 後続 Issue（C1）が本変更に依存

--- a/deltaspec/changes/issue-351/specs/supervisor-rename/spec.md
+++ b/deltaspec/changes/issue-351/specs/supervisor-rename/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: Supervisor クラス定義
+
+model.md の Observer クラスは Supervisor クラスに更新されなければならない（SHALL）。クラス名を `Observer` → `Supervisor` に変更し、`name: co-*` を `name: su-*` に変更する。
+
+#### Scenario: クラス図の Supervisor 定義
+- **WHEN** model.md のクラス図を参照する
+- **THEN** `class Supervisor` が存在し、`name: su-*` と `type: observer` を持つ
+
+#### Scenario: クラス図の関係線更新
+- **WHEN** model.md のクラス図を参照する
+- **THEN** `Supervisor ..> Controller : supervises` および `Supervisor *-- InterventionRecord : records` が存在する
+
+### Requirement: InterventionRecord の supervisor フィールド
+
+InterventionRecord クラスの `observer` フィールドは `supervisor` に更新されなければならない（SHALL）。
+
+#### Scenario: InterventionRecord.supervisor フィールド
+- **WHEN** model.md の InterventionRecord クラス定義を参照する
+- **THEN** `supervisor: string` フィールドが存在し、`observer: string` は存在しない
+
+### Requirement: Controller Spawning 関係図の su-observer 更新
+
+関係図のノード `CO["co-observer"]` は `SO["su-observer"]` に更新されなければならない（SHALL）。
+
+#### Scenario: Mermaid ノードの更新
+- **WHEN** model.md の Controller Spawning 関係図を参照する
+- **THEN** `SO["su-observer<br/>(Meta-cognitive)"]` ノードが存在し、`CO["co-observer"]` は存在しない
+
+#### Scenario: Spawning ルール説明文の更新
+- **WHEN** model.md の Spawning ルール説明文を参照する
+- **THEN** `su-observer` が全 `co-observer` 参照箇所を置換している
+
+### Requirement: intervention-{N}.json スキーマの supervisor フィールド
+
+`intervention-{N}.json` スキーマの `observer` フィールドは `supervisor` に更新されなければならない（SHALL）。
+
+#### Scenario: スキーマテーブルの supervisor フィールド
+- **WHEN** model.md の intervention-{N}.json スキーマテーブルを参照する
+- **THEN** `supervisor` 行が存在し、`observer` 行は存在しない

--- a/deltaspec/changes/issue-351/tasks.md
+++ b/deltaspec/changes/issue-351/tasks.md
@@ -1,0 +1,20 @@
+## 1. クラス図の Supervisor クラス更新
+
+- [x] 1.1 `class Observer` を `class Supervisor` に変更（name: co-* → su-*）
+- [x] 1.2 `Observer ..> Controller : supervises` を `Supervisor ..> Controller : supervises` に変更
+- [x] 1.3 `Observer *-- InterventionRecord : records` を `Supervisor *-- InterventionRecord : records` に変更
+
+## 2. InterventionRecord の supervisor フィールド更新
+
+- [x] 2.1 `InterventionRecord` クラスの `observer: string` を `supervisor: string` に変更
+
+## 3. Controller Spawning 関係図の更新
+
+- [x] 3.1 Mermaid ノード `CO["co-observer<br/>(Meta-cognitive)"]` を `SO["su-observer<br/>(Meta-cognitive)"]` に変更
+- [x] 3.2 `CO -.->|supervises| CA` 等の全 CO 参照を SO に変更
+- [x] 3.3 Spawning ルール説明文の `co-observer` を `su-observer` に変更
+
+## 4. intervention-{N}.json スキーマの更新
+
+- [x] 4.1 スキーマテーブルの `observer` 行を `supervisor` に変更
+- [x] 4.2 アクセスルール説明文の `Observer = write` を `Supervisor = write` に変更

--- a/plugins/twl/architecture/domain/model.md
+++ b/plugins/twl/architecture/domain/model.md
@@ -70,14 +70,14 @@ classDiagram
         nudge_timeout: number
         health_check: HealthCheck
     }
-    class Observer {
-        name: co-*
+    class Supervisor {
+        name: su-*
         type: observer
         supervised: Controller[]
     }
     class InterventionRecord {
         intervention_id: string
-        observer: string
+        supervisor: string
         target_controller: string
         layer: string
         status: detected|intervening|resolved
@@ -97,8 +97,8 @@ classDiagram
     Controller ..> ProjectBoard : queries (Issue 選択)
     Orchestrator --> IssueState : polls
     Orchestrator --> Script : executes (health-check, crash-detect)
-    Observer ..> Controller : supervises
-    Observer *-- InterventionRecord : records
+    Supervisor ..> Controller : supervises
+    Supervisor *-- InterventionRecord : records
 ```
 
 ### Controller Spawning 関係図
@@ -112,7 +112,7 @@ graph TD
         CR["co-architect<br/>(Non-implementation)"]
         CU["co-utility<br/>(Utility)"]
         CS["co-self-improve<br/>(Observation)"]
-        CO["co-observer<br/>(Meta-cognitive)"]
+        SO["su-observer<br/>(Meta-cognitive)"]
     end
 
     subgraph "Spawnable Types"
@@ -146,17 +146,17 @@ graph TD
     CS -->|spawns| SP
     CS -.->|orchestrates| WF
 
-    CO -.->|supervises| CA
-    CO -.->|supervises| CI
-    CO -.->|supervises| CP
-    CO -.->|supervises| CR
-    CO -.->|supervises| CU
-    CO -.->|supervises| CS
-    CO -->|spawns| WF
-    CO -->|spawns| AT
-    CO -->|spawns| CM
-    CO -->|spawns| SP
-    CO -->|spawns| RF
+    SO -.->|supervises| CA
+    SO -.->|supervises| CI
+    SO -.->|supervises| CP
+    SO -.->|supervises| CR
+    SO -.->|supervises| CU
+    SO -.->|supervises| CS
+    SO -->|spawns| WF
+    SO -->|spawns| AT
+    SO -->|spawns| CM
+    SO -->|spawns| SP
+    SO -->|spawns| RF
 
     CA -.->|orchestrates| WF
     WF -->|chain steps| AT
@@ -172,8 +172,8 @@ graph TD
 - co-issue は specialist を spawn できる（issue-critic, issue-feasibility, worker-codex-reviewer）
 - co-project は composite + atomic（構成変更の最小単位で操作）
 - co-architect は atomic + reference のみ（設計情報の参照・評価）
-- co-observer は全 controller を supervise できる（ADR-013: Observer 型）。spawn 関係は controller と同等（workflow, atomic, composite, specialist, reference）
-- co-self-improve と co-observer の共存: co-self-improve は Observation workflow を orchestrate し内部状態を改善する。co-observer は全 controller を meta-cognitive レイヤーで supervise し介入記録（InterventionRecord）を管理する
+- su-observer は全 controller を supervise できる（ADR-013: Observer 型）。spawn 関係は controller と同等（workflow, atomic, composite, specialist, reference）
+- co-self-improve と su-observer の共存: co-self-improve は Observation workflow を orchestrate し内部状態を改善する。su-observer は全 controller を meta-cognitive レイヤーで supervise し介入記録（InterventionRecord）を管理する
 
 ### Issue 状態遷移図
 
@@ -245,7 +245,7 @@ stateDiagram-v2
 | フィールド | 型 | 必須 | 説明 |
 |---|---|---|---|
 | intervention_id | string | Yes | 介入一意識別子 |
-| observer | string | Yes | Observer 名（例: `co-observer`） |
+| supervisor | string | Yes | Supervisor 名（例: `su-observer`） |
 | target_controller | string | Yes | 対象 controller 名（例: `co-autopilot`） |
 | layer | string | Yes | 介入レイヤー（例: `meta-cognitive`, `observation`） |
 | status | `detected` \| `intervening` \| `resolved` | Yes | 介入状態 |
@@ -253,7 +253,7 @@ stateDiagram-v2
 | resolved_at | null \| string (ISO 8601) | Yes | 解決時刻（未解決時は null） |
 | reason | string | Yes | 介入理由の説明 |
 
-**アクセスルール**: Observer = write, Pilot = read only。介入ごとに独立ファイルを生成する（per-intervention ファイル）。
+**アクセスルール**: Supervisor = write, Pilot = read only。介入ごとに独立ファイルを生成する（per-intervention ファイル）。
 
 ### Orchestrator パターン
 


### PR DESCRIPTION
## 概要

model.md の Observer クラスを Supervisor クラスに更新する（ADR-014 Decision 1 / Phase 5）。

## 変更内容

- `class Observer` → `class Supervisor`（`name: co-*` → `name: su-*`）
- `InterventionRecord.observer` → `supervisor` フィールド
- 関係図ノード `CO["co-observer"]` → `SO["su-observer"]` 全箇所更新
- `intervention-{N}.json` スキーマの `observer` → `supervisor`
- Spawning ルール説明文の `co-observer` → `su-observer`

Closes #351