### PR TITLE
feat(arch): observation.md の OBS-* → SU-* 制約移行 (#354)

### DIFF
--- a/deltaspec/changes/issue-354/.deltaspec.yaml
+++ b/deltaspec/changes/issue-354/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-354
+status: pending

--- a/deltaspec/changes/issue-354/design.md
+++ b/deltaspec/changes/issue-354/design.md
@@ -1,0 +1,36 @@
+## Context
+
+ADR-014 Decision 5 で co-observer が su-observer に昇格。OBS-1〜OBS-5 は SU-1〜SU-7 に統合済み（supervision.md に記述）。
+observation.md は旧 Observer Context（ADR-013）の定義を残したままであり、現行アーキテクチャとの乖離がある。
+
+対象ファイル: `plugins/twl/architecture/domain/contexts/observation.md`
+
+## Goals / Non-Goals
+
+**Goals:**
+- observation.md の OBS-* Constraints セクションに deprecation 注記を追加し、supervision.md の SU-* への移行を明示する
+- Component Mapping から co-observer 行を削除（supervision.md 側に移動済みのため重複排除）
+- OB-3 適用範囲注記を ADR-014 / SU-* の参照に更新し、co-observer → su-observer の変更を反映
+
+**Non-Goals:**
+- supervision.md の変更（SU-1〜SU-7 は確認済みで変更不要）
+- コードや CLI の変更
+- OBS-* セクション自体の完全削除（deprecation 注記として残す方針）
+
+## Decisions
+
+1. **OBS-* セクションは削除せず非推奨化する**
+   - 理由: 突然削除すると既存ドキュメント参照が壊れるリスクがある。`> **Superseded**: OBS-1〜OBS-5 は supervision.md の SU-1〜SU-7 に統合されました（ADR-014）。` の blockquote 注記を追加する。
+
+2. **co-observer Component Mapping 行は削除する**
+   - 理由: supervision.md の Component Mapping にすでに su-observer が定義されており、observation.md に co-observer を残すと「observation の責務コンポーネント」として誤解される。
+
+3. **OB-3 注記は SU-7 参照に更新する**
+   - 現行: 「co-observer は介入権限を持つメタ認知レイヤー（ADR-013）のため OB-3 適用外。介入ルールは OBS-1〜OBS-5 で定義。」
+   - 更新後: 「su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。」
+
+## Risks / Trade-offs
+
+- **リスク**: OBS-* セクションを残すことで「まだ有効な制約」と誤認される可能性がある。
+  - 緩和: blockquote の Superseded 注記を先頭に目立つ形で追加する。
+- **トレードオフ**: セクション削除 vs 注記残存。削除はシンプルだが検索可能性・移行経緯の追跡性が失われる。今回は注記残存を選択。

--- a/deltaspec/changes/issue-354/proposal.md
+++ b/deltaspec/changes/issue-354/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+ADR-014 Decision 5 に基づき co-observer が su-observer に昇格し、OBS-* 制約は supervision.md の SU-* に統合された。しかし observation.md はまだ OBS-* を定義したまま残っており、supervision.md との整合が取れていない。この不整合を解消する。
+
+## What Changes
+
+- `plugins/twl/architecture/domain/contexts/observation.md`
+  - OBS-* Constraints セクション（L138-146）に「Superseded by SU-* in supervision.md（ADR-014）」deprecation 注記を追加
+  - Component Mapping の co-observer 行（L160）を削除（supervision.md に移動済みのため）
+  - OB-3 適用範囲注記（L135）の「co-observer は介入権限を持つメタ認知レイヤー（ADR-013）のため OB-3 適用外。介入ルールは OBS-1〜OBS-5 で定義。」を SU-* 参照に更新
+
+## Capabilities
+
+### New Capabilities
+
+なし（ドキュメント整合のみ）
+
+### Modified Capabilities
+
+- observation.md の OBS-* Constraints セクション: deprecation 注記付きで残存（削除ではなく非推奨化）
+- observation.md の OB-3 注記: ADR-013 (Observer) → ADR-014 (Supervisor) の参照に更新
+
+## Impact
+
+- 変更ファイル: `plugins/twl/architecture/domain/contexts/observation.md`（1ファイルのみ）
+- supervision.md の SU-* は変更不要（既に7件全て定義済み、整合確認のみ）
+- コード変更なし（アーキテクチャドキュメントのみ）

--- a/deltaspec/changes/issue-354/specs/observation-deprecation/spec.md
+++ b/deltaspec/changes/issue-354/specs/observation-deprecation/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: OBS-* セクションの deprecation 注記追加
+
+observation.md の Observer Constraints (OBS-*) セクションの先頭に、SU-* への移行を示す deprecation 注記を追加しなければならない（SHALL）。
+注記は blockquote 形式で「Superseded: OBS-1〜OBS-5 は supervision.md の SU-1〜SU-7 に統合されました（ADR-014）。」を含まなければならない（SHALL）。
+
+#### Scenario: OBS-* セクションの deprecation 表示
+
+- **WHEN** observation.md の OBS-* Constraints セクションを参照したとき
+- **THEN** セクション先頭に `> **Superseded**: OBS-1〜OBS-5 は supervision.md の SU-1〜SU-7 に統合されました（ADR-014）。` の blockquote が表示される
+
+### Requirement: OB-3 注記の ADR-014 参照更新
+
+observation.md の OB-3 適用範囲注記を更新しなければならない（SHALL）。
+旧 ADR-013 / co-observer / OBS-* の参照を ADR-014 / su-observer / SU-7 に差し替えなければならない（SHALL）。
+
+#### Scenario: OB-3 注記の正確な参照
+
+- **WHEN** observation.md の OB-3 適用範囲注記を参照したとき
+- **THEN** 「su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。」と記述されている
+
+## REMOVED Requirements
+
+### Requirement: Component Mapping から co-observer 行を削除
+
+observation.md の Component Mapping テーブルから co-observer 行を削除しなければならない（SHALL）。
+supervision.md に su-observer として移動済みであるため、observation.md への重複記載は許容されない（MUST NOT）。
+
+#### Scenario: Component Mapping に co-observer が含まれない
+
+- **WHEN** observation.md の Component Mapping テーブルを参照したとき
+- **THEN** co-observer の行が存在しない

--- a/deltaspec/changes/issue-354/tasks.md
+++ b/deltaspec/changes/issue-354/tasks.md
@@ -1,13 +1,13 @@
 ## 1. observation.md の OBS-* セクション更新
 
-- [ ] 1.1 OB-3 適用範囲注記（L135付近）を「su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。」に更新
-- [ ] 1.2 OBS-* Constraints セクション（L138付近）の先頭に deprecation blockquote 注記を追加
+- [x] 1.1 OB-3 適用範囲注記（L135付近）を「su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。」に更新
+- [x] 1.2 OBS-* Constraints セクション（L138付近）の先頭に deprecation blockquote 注記を追加
 
 ## 2. observation.md の Component Mapping 更新
 
-- [ ] 2.1 Component Mapping テーブルから co-observer 行（L160付近）を削除
+- [x] 2.1 Component Mapping テーブルから co-observer 行（L160付近）を削除
 
 ## 3. 検証
 
-- [ ] 3.1 supervision.md の SU-1〜SU-7 が observation.md の変更と整合していることを確認（読み取りのみ）
-- [ ] 3.2 observation.md の全 OB-3/OBS-* 参照が更新されていることを確認
+- [x] 3.1 supervision.md の SU-1〜SU-7 が observation.md の変更と整合していることを確認（読み取りのみ）
+- [x] 3.2 observation.md の全 OB-3/OBS-* 参照が更新されていることを確認

--- a/deltaspec/changes/issue-354/tasks.md
+++ b/deltaspec/changes/issue-354/tasks.md
@@ -1,0 +1,13 @@
+## 1. observation.md の OBS-* セクション更新
+
+- [ ] 1.1 OB-3 適用範囲注記（L135付近）を「su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。」に更新
+- [ ] 1.2 OBS-* Constraints セクション（L138付近）の先頭に deprecation blockquote 注記を追加
+
+## 2. observation.md の Component Mapping 更新
+
+- [ ] 2.1 Component Mapping テーブルから co-observer 行（L160付近）を削除
+
+## 3. 検証
+
+- [ ] 3.1 supervision.md の SU-1〜SU-7 が observation.md の変更と整合していることを確認（読み取りのみ）
+- [ ] 3.2 observation.md の全 OB-3/OBS-* 参照が更新されていることを確認

--- a/plugins/twl/architecture/domain/contexts/observation.md
+++ b/plugins/twl/architecture/domain/contexts/observation.md
@@ -122,7 +122,7 @@ flowchart TD
 - test target は実 twill main の git 履歴を**絶対に汚染しない**。隔離 worktree + 独立ブランチで管理
 - observation Issue は本物の Issue とラベルで明確に区別する（`label: from-observation`）
 
-### OB-* Constraints（co-self-improve / co-observer 共通ベース）
+### OB-* Constraints（co-self-improve ベース）
 
 | 制約 ID | 内容 | 適用範囲 |
 |---------|------|----------|
@@ -132,10 +132,12 @@ flowchart TD
 | OB-4 | 検出結果をユーザー確認なしで自動起票してはならない（SHALL）。Issue draft はユーザー確認必須 | both |
 | OB-5 | 同時 3 observed session を超えて観察してはならない（SHALL）。context budget 維持 | **co-self-improve only** |
 
-> **OB-3 適用範囲注記**: co-observer は介入権限を持つメタ認知レイヤー（ADR-013）のため OB-3 適用外。介入ルールは OBS-1〜OBS-5 で定義。  
-> **OB-5 適用範囲注記**: co-self-improve の observed session 上限。co-observer の supervised controller 上限は OBS-4 で別定義（対象エンティティが異なる別概念）。
+> **OB-3 適用範囲注記**: su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。  
+> **OB-5 適用範囲注記**: co-self-improve の observed session 上限。su-observer の supervised controller 上限は SU-4 で定義（supervision.md）（対象エンティティが異なる別概念）。
 
 ### Observer Constraints (OBS-*)（co-observer 専用）
+
+> **Superseded**: OBS-1〜OBS-5 は supervision.md の SU-1〜SU-7 に統合されました（ADR-014）。
 
 | 制約 ID | 内容 | 適用範囲 |
 |---------|------|----------|
@@ -157,7 +159,6 @@ flowchart TD
 | 種別 | コンポーネント | 役割 |
 |------|--------------|------|
 | **controller** | co-self-improve | Live Observation 統括。テストプロジェクト管理も担う。OB-3 適用（observed session への inject 禁止） |
-| **controller** | co-observer | Observer 介入制御。OBS-1〜OBS-5 に従い 3 層プロトコルで controller session を supervise |
 | **workflow** | workflow-observe-loop | observe ループ + 問題検出 + Issue draft |
 | **atomic** | test-project-init | 隔離 worktree 作成 |
 | **atomic** | test-project-reset | テストプロジェクト クリーンアップ |

--- a/plugins/twl/architecture/domain/contexts/observation.md
+++ b/plugins/twl/architecture/domain/contexts/observation.md
@@ -135,9 +135,9 @@ flowchart TD
 > **OB-3 適用範囲注記**: su-observer は介入権限を持つ Supervisor レイヤー（ADR-014）のため OB-3 適用外。介入ルールは SU-7 で定義（supervision.md）。  
 > **OB-5 適用範囲注記**: co-self-improve の observed session 上限。su-observer の supervised controller 上限は SU-4 で定義（supervision.md）（対象エンティティが異なる別概念）。
 
-### Observer Constraints (OBS-*)（co-observer 専用）
+### Observer Constraints (OBS-*)（廃止 / Superseded by SU-*）
 
-> **Superseded**: OBS-1〜OBS-5 は supervision.md の SU-1〜SU-7 に統合されました（ADR-014）。
+> **Superseded**: OBS-1〜OBS-5 は supervision.md の SU-* に置き換えられました（ADR-014）。OBS-1〜OBS-4 は SU-1〜SU-4 に対応し、OBS-5 は SU-7 に対応。SU-5・SU-6 は新規追加。
 
 | 制約 ID | 内容 | 適用範囲 |
 |---------|------|----------|


### PR DESCRIPTION
## 概要

observation.md の OBS-* 制約（co-observer 専用）を supervision.md の SU-* 制約に移行する。

## 変更内容

- OB-3 注記: co-observer（ADR-013）→ su-observer（ADR-014）、OBS-* → SU-7 参照に更新
- OB-5 注記: co-observer/OBS-4 → su-observer/SU-4（supervision.md）参照に更新
- OB-* セクションヘッダー: co-observer 除去（co-self-improve ベースのみ）
- OBS-* セクション見出し: 「廃止 / Superseded by SU-*」に変更
- OBS-* セクション先頭: Superseded blockquote 追加（OBS↔SU 対応関係明記）
- Component Mapping: co-observer 行を削除（supervision.md に移動済み）

## AC

- [x] observation.md の OBS-* が deprecation 注記付きで残っている
- [x] supervision.md の SU-* が OBS-* を正しく継承・拡張している（確認済み）
- [x] OB-3 が co-self-improve only であることが明確に記述されている

Closes #354