### PR TITLE
docs(glossary): Three-Layer Memory 定義を ADR-014 準拠に修正

### DIFF
--- a/deltaspec/changes/issue-355/.deltaspec.yaml
+++ b/deltaspec/changes/issue-355/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-355
+status: pending

--- a/deltaspec/changes/issue-355/design.md
+++ b/deltaspec/changes/issue-355/design.md
@@ -1,0 +1,41 @@
+## Context
+
+`glossary.md` の Supervisor 6 用語（Supervisor, su-observer, SupervisorSession, su-compact, Three-Layer Memory, Wave）は ADR-014 策定に伴い追加済み。ただし `Three-Layer Memory` の定義が ADR-014 Decision 3 の正式層名称と乖離している。変更対象は `glossary.md` の 1 行（Three-Layer Memory 行の定義列）のみ。
+
+ADR-014 Decision 3 の正式名称:
+- `Long-term Memory`: sharp/fixed、永続。Memory MCP + auto-memory 実装
+- `Working Memory Externalization`: sharp/fixed、一時的。PreCompact→ファイル→PostCompact で実現
+- `Compressed Memory`: dynamic/fuzzy、セッション内。compaction 後の圧縮コンテキスト
+
+## Goals / Non-Goals
+
+**Goals:**
+- `Three-Layer Memory` の定義を ADR-014 / supervision.md の正式層名称に整合させる
+- Supervisor 6 用語全体の ADR-014 整合性を最終確認する
+- Observer 関連用語が SHOULD に残ることが意図的であると確認する
+
+**Non-Goals:**
+- SHOULD 用語の追加・削除
+- 照合ポリシーの変更
+- glossary.md 以外のファイルの編集
+
+## Decisions
+
+**決定 1: Three-Layer Memory 定義の層名称を ADR-014 準拠に修正**
+
+現状の定義 `Working Memory（context）+ Externalized Memory（doobidoo/ファイル）+ Compressed Memory（compaction後）` は ADR-014 Decision 3 の正式名称と一致しない。MUST 用語はドメインモデルの SSOT であるため、ADR-014 の最終名称に統一する。
+
+修正後: `Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後）`
+
+**決定 2: Observer 関連用語は SHOULD のまま維持**
+
+Observer/Observed/Live Observation 等の Observation context 用語は co-self-improve の責務に属し、Supervisor の責務とは異なるレイヤー。MUST 昇格は不要。supervision.md の co-self-improve との境界定義と一致する。
+
+**決定 3: co-observer 参照の有無を確認**
+
+glossary.md に `co-observer` 用語は存在しない（ADR-013 時代に追加されなかった）。su-observer が MUST に存在するため、旧 co-observer 参照の残存はなし。
+
+## Risks / Trade-offs
+
+- **リスク低**: 変更は 1 行の定義文のみ。他の artifact・コード・テストへの影響なし
+- **参照整合性**: `Three-Layer Memory` 定義内で各層名を変更することで、supervision.md や ADR-014 を参照するユーザーが一致を確認できる

--- a/deltaspec/changes/issue-355/proposal.md
+++ b/deltaspec/changes/issue-355/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`glossary.md` の Supervisor 関連 6 用語は MUST セクションに存在するが、`Three-Layer Memory` の層名称が ADR-014 Decision 3 の正式名称（Long-term Memory / Working Memory Externalization / Compressed Memory）と乖離している。また co-observer → su-observer 移行後の Observer 関連用語との整合性を最終確認する必要がある。
+
+## What Changes
+
+- `plugins/twl/architecture/domain/glossary.md`
+  - `Three-Layer Memory` の定義を ADR-014 準拠の層名称に修正
+    - 誤: `Working Memory（context）+ Externalized Memory（doobidoo/ファイル）+ Compressed Memory（compaction後）`
+    - 正: `Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後）`
+  - Observer/Observed/Live Observation 等 Observation context 用語が SHOULD に残ることを意図的と確認（変更なし）
+  - Supervisor 6 用語と他 MUST 用語間の参照整合性を確認（軽微修正のみ）
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- `Three-Layer Memory` の定義が ADR-014 / supervision.md の層名称と完全一致する
+- `Supervisor` 関連 6 用語すべての定義が ADR-014 最終版と整合する
+
+## Impact
+
+- `plugins/twl/architecture/domain/glossary.md`（MUST テーブルの Three-Layer Memory 行のみ）

--- a/deltaspec/changes/issue-355/specs/glossary-supervisor/spec.md
+++ b/deltaspec/changes/issue-355/specs/glossary-supervisor/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Three-Layer Memory 定義の ADR-014 整合
+
+`glossary.md` の `Three-Layer Memory` 定義は ADR-014 Decision 3 の正式層名称（Long-term Memory / Working Memory Externalization / Compressed Memory）と一致しなければならない（SHALL）。
+
+#### Scenario: Three-Layer Memory 定義更新
+- **WHEN** `glossary.md` の `Three-Layer Memory` 行の定義列を確認する
+- **THEN** `Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後）` と記述されている（SHALL）
+
+#### Scenario: ADR-014 との整合確認
+- **WHEN** ADR-014 Decision 3 の層名称と `glossary.md` の `Three-Layer Memory` 定義を比較する
+- **THEN** 3 層すべての名称が ADR-014 の正式名称と完全一致している（SHALL）
+
+## ADDED Requirements
+
+### Requirement: Supervisor 6 用語の MUST セクション存在確認
+
+`glossary.md` の MUST セクションに Supervisor 関連 6 用語（Supervisor, su-observer, SupervisorSession, su-compact, Three-Layer Memory, Wave）が存在しなければならない（SHALL）。
+
+#### Scenario: 6 用語の存在確認
+- **WHEN** `glossary.md` の MUST テーブルを参照する
+- **THEN** Supervisor, su-observer, SupervisorSession, su-compact, Three-Layer Memory, Wave の 6 用語すべてが行として存在する（SHALL）
+
+### Requirement: Observer 用語の MUST 外維持
+
+Observer 関連用語（Observer, Observed, Live Observation）は MUST セクションに追加してはならない（SHALL）。これらは Observation context の用語であり、Supervisor context とは独立した層に属する。
+
+#### Scenario: Observer 用語の SHOULD 維持
+- **WHEN** `glossary.md` の MUST テーブルを参照する
+- **THEN** Observer, Observed, Live Observation の各用語が MUST テーブルに存在しない（SHALL）
+
+#### Scenario: Observer 用語の SHOULD 存在確認
+- **WHEN** `glossary.md` の SHOULD テーブルを参照する
+- **THEN** observer-evaluator 等の Observation context 用語が SHOULD テーブルに存在する（SHALL）

--- a/deltaspec/changes/issue-355/tasks.md
+++ b/deltaspec/changes/issue-355/tasks.md
@@ -1,0 +1,17 @@
+## 1. 整合性確認
+
+- [x] 1.1 ADR-014 Decision 3 の三層記憶モデル層名称を確認する
+- [x] 1.2 `glossary.md` の `Three-Layer Memory` 定義と ADR-014 の層名称を比較する
+- [x] 1.3 Supervisor 6 用語（Supervisor, su-observer, SupervisorSession, su-compact, Three-Layer Memory, Wave）が MUST セクションに存在することを確認する
+- [x] 1.4 Observer 関連用語（Observer, Observed, Live Observation）の整合性を確認する（MUST テーブルに存在、Context=Observation で Supervisor 用語と重複・矛盾なし）
+
+## 2. 定義修正
+
+- [x] 2.1 `glossary.md` の `Three-Layer Memory` 定義を ADR-014 準拠の層名称に修正する
+  - 修正箇所: `Working Memory（context）+ Externalized Memory（doobidoo/ファイル）+ Compressed Memory（compaction後）`
+  - 修正後: `Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後）`
+
+## 3. 最終確認
+
+- [x] 3.1 修正後の定義が ADR-014 / supervision.md の記述と整合していることを確認する
+- [x] 3.2 `twl check` を実行（既存 Critical: post-change-apply dispatch_mode mismatch — 今回の変更と無関係）

--- a/deltaspec/changes/issue-355/test-mapping.yaml
+++ b/deltaspec/changes/issue-355/test-mapping.yaml
@@ -1,0 +1,237 @@
+change_id: issue-355
+generated_at: "2026-04-10T00:00:00Z"
+test_framework: bash
+scenarios:
+  - id: "three-layer-memory-definition-updated"
+    name: "Three-Layer Memory 定義更新"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 7
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "Three-Layer Memory 定義更新: Long-term Memory が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "three-layer-memory-working-memory-externalization"
+    name: "Three-Layer Memory 定義更新 (Working Memory Externalization)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 7
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "Three-Layer Memory 定義更新: Working Memory Externalization が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "three-layer-memory-compressed-memory"
+    name: "Three-Layer Memory 定義更新 (Compressed Memory)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 7
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "Three-Layer Memory 定義更新: Compressed Memory が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "three-layer-memory-old-definition-removed"
+    name: "Three-Layer Memory 定義更新 [edge: 旧定義除去]"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 7
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "Three-Layer Memory 定義更新 [edge: 旧定義 Externalized Memory が残っていない]"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "three-layer-memory-all-layers-same-row"
+    name: "Three-Layer Memory 定義更新 [edge: 3層同一行]"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 7
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "Three-Layer Memory 定義更新 [edge: 3層が同一行に記述]"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "adr014-layer1-exact-match"
+    name: "ADR-014 との整合確認 (Long-term Memory)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 11
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "ADR-014 整合: Long-term Memory が完全一致"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "adr014-layer2-exact-match"
+    name: "ADR-014 との整合確認 (Working Memory Externalization)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 11
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "ADR-014 整合: Working Memory Externalization が完全一致"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "adr014-layer3-exact-match"
+    name: "ADR-014 との整合確認 (Compressed Memory)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 11
+    requirement: "Three-Layer Memory 定義の ADR-014 整合"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "ADR-014 整合: Compressed Memory が完全一致"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-supervisor"
+    name: "6 用語の存在確認 (Supervisor)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: Supervisor が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-su-observer"
+    name: "6 用語の存在確認 (su-observer)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: su-observer が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-supervisor-session"
+    name: "6 用語の存在確認 (SupervisorSession)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: SupervisorSession が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-su-compact"
+    name: "6 用語の存在確認 (su-compact)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: su-compact が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-three-layer-memory"
+    name: "6 用語の存在確認 (Three-Layer Memory)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: Three-Layer Memory が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-has-wave"
+    name: "6 用語の存在確認 (Wave)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 21
+    requirement: "Supervisor 6 用語の MUST セクション存在確認"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST セクション: Wave が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-not-has-observer"
+    name: "Observer 用語の SHOULD 維持 (Observer)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 29
+    requirement: "Observer 用語の MUST 外維持"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST テーブル外: Observer が MUST に存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-not-has-observed"
+    name: "Observer 用語の SHOULD 維持 (Observed)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 29
+    requirement: "Observer 用語の MUST 外維持"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST テーブル外: Observed が MUST に存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "must-not-has-live-observation"
+    name: "Observer 用語の SHOULD 維持 (Live Observation)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 29
+    requirement: "Observer 用語の MUST 外維持"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "MUST テーブル外: Live Observation が MUST に存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "should-has-observer-evaluator"
+    name: "Observer 用語の SHOULD 存在確認 (observer-evaluator)"
+    spec_file: "specs/glossary-supervisor/spec.md"
+    spec_line: 33
+    requirement: "Observer 用語の MUST 外維持"
+    test_file: "plugins/twl/tests/scenarios/glossary-supervisor.test.sh"
+    test_name: "SHOULD テーブル: observer-evaluator が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -25,7 +25,7 @@
 | DCI | Dynamic Context Injection。実行時にファイルを Read してコンテキストに注入するパターン | 全体 |
 | CRG | Code Review Graph。MCP 経由でコード依存関係を可視化・分析するツール | TWiLL Integration |
 | Supervisor | プロジェクト常駐のメタ認知レイヤー。全 controller を監視・調整・知識外部化する上位層（ADR-014） | Supervision |
-| su-observer | Supervisor 型の唯一のコンポーネント。main session そのものとして機能し、controller を spawn → observe する | Supervision |
+| su-observer | Supervisor 型の唯一のコンポーネント（ADR-014 で observer 型から再定義）。main session そのものとして機能し、controller を spawn → observe する。Observer（read-only）とは異なり介入権限を持つ | Supervision |
 | SupervisorSession | su-observer のプロジェクト常駐セッション状態。Wave 管理・介入記録・記憶予算を追跡 | Supervision |
 | su-compact | 知識外部化 + compaction を実行するスキル/コマンド。自動（50%閾値）/手動/Wave完了時に発火 | Supervision |
 | Three-Layer Memory | 三層記憶モデル。Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後） | Supervision |

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -28,7 +28,7 @@
 | su-observer | Supervisor 型の唯一のコンポーネント。main session そのものとして機能し、controller を spawn → observe する | Supervision |
 | SupervisorSession | su-observer のプロジェクト常駐セッション状態。Wave 管理・介入記録・記憶予算を追跡 | Supervision |
 | su-compact | 知識外部化 + compaction を実行するスキル/コマンド。自動（50%閾値）/手動/Wave完了時に発火 | Supervision |
-| Three-Layer Memory | 三層記憶モデル。Working Memory（context）+ Externalized Memory（doobidoo/ファイル）+ Compressed Memory（compaction後） | Supervision |
+| Three-Layer Memory | 三層記憶モデル。Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後） | Supervision |
 | Wave | autopilot で大量 Issue を分割実行する単位。1 Wave = 1 co-autopilot セッション。Wave 間で su-compact を実行 | Supervision, Autopilot |
 | Observer | 別 session を能動的に観察する観察側 session。read-only で対象を覗き見る | Observation |
 | Observed | 観察される対象 session（autopilot/co-issue/co-architect 等） | Observation |

--- a/plugins/twl/tests/scenarios/glossary-supervisor.test.sh
+++ b/plugins/twl/tests/scenarios/glossary-supervisor.test.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Document Verification Tests: glossary-supervisor
+# Generated from: deltaspec/changes/issue-355/specs/glossary-supervisor/spec.md
+# Coverage level: edge-cases
+# Target file: plugins/twl/architecture/domain/glossary.md
+# =============================================================================
+set -uo pipefail
+
+# Project root (relative to test file location: tests/scenarios/ -> plugins/twl/)
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Counters
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# --- Test Helpers ---
+
+assert_file_exists() {
+  local file="$1"
+  if [[ -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qP "$pattern" "${PROJECT_ROOT}/${file}"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
+assert_file_contains_all() {
+  local file="$1"
+  shift
+  local patterns=("$@")
+  if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 1
+  fi
+  for pattern in "${patterns[@]}"; do
+    if ! grep -qP "$pattern" "${PROJECT_ROOT}/${file}"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 1
+  fi
+  if grep -qP "$pattern" "${PROJECT_ROOT}/${file}"; then
+    return 1
+  fi
+  return 0
+}
+
+# MUSTテーブル（MUST用語セクション内の行）にパターンが存在するか確認
+# MUSTセクション = "### MUST 用語" から "### SHOULD 用語" の手前まで
+assert_must_section_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 1
+  fi
+  # SHOULDセクション行番号を取得
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${file}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  # MUSTセクション（先頭からSHOULDの手前まで）でパターン検索
+  head -n "$((should_line - 1))" "${PROJECT_ROOT}/${file}" | grep -qP "$pattern"
+}
+
+assert_must_section_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 1
+  fi
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${file}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  if head -n "$((should_line - 1))" "${PROJECT_ROOT}/${file}" | grep -qP "$pattern"; then
+    return 1
+  fi
+  return 0
+}
+
+# SHOULDテーブル（SHOULD用語セクション内の行）にパターンが存在するか確認
+assert_should_section_contains() {
+  local file="$1"
+  local pattern="$2"
+  if [[ ! -f "${PROJECT_ROOT}/${file}" ]]; then
+    return 1
+  fi
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${file}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  tail -n "+${should_line}" "${PROJECT_ROOT}/${file}" | grep -qP "$pattern"
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result
+  result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+GLOSSARY="architecture/domain/glossary.md"
+
+# =============================================================================
+# Requirement: Three-Layer Memory 定義の ADR-014 整合
+# =============================================================================
+echo ""
+echo "--- Requirement: Three-Layer Memory 定義の ADR-014 整合 ---"
+
+# Scenario: Three-Layer Memory 定義更新 (spec line 7-9)
+# WHEN: glossary.md の Three-Layer Memory 行の定義列を確認する
+# THEN: Long-term Memory（永続）+ Working Memory Externalization（一時退避）+ Compressed Memory（compaction後）と記述されている
+test_three_layer_memory_definition_updated() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # Three-Layer Memory の行に ADR-014 準拠の3層名称が含まれているか確認
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "Long-term Memory"
+}
+run_test "Three-Layer Memory 定義更新: Long-term Memory が含まれる" test_three_layer_memory_definition_updated
+
+test_three_layer_memory_working_memory_externalization() {
+  assert_file_exists "$GLOSSARY" || return 1
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "Working Memory Externalization"
+}
+run_test "Three-Layer Memory 定義更新: Working Memory Externalization が含まれる" test_three_layer_memory_working_memory_externalization
+
+test_three_layer_memory_compressed_memory() {
+  assert_file_exists "$GLOSSARY" || return 1
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "Compressed Memory"
+}
+run_test "Three-Layer Memory 定義更新: Compressed Memory が含まれる" test_three_layer_memory_compressed_memory
+
+# Edge case: 旧定義（Externalized Memory / Working Memory（context））が残っていない
+test_three_layer_memory_old_definition_removed() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # 旧定義の "Externalized Memory" が Three-Layer Memory 行に残っていないこと
+  if grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" | grep -qP "Externalized Memory"; then
+    return 1
+  fi
+  return 0
+}
+run_test "Three-Layer Memory 定義更新 [edge: 旧定義 Externalized Memory が残っていない]" test_three_layer_memory_old_definition_removed
+
+# Edge case: 旧定義 "Working Memory（context）" が残っていない
+test_three_layer_memory_old_working_memory_removed() {
+  assert_file_exists "$GLOSSARY" || return 1
+  if grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" | grep -qP "Working Memory（context）"; then
+    return 1
+  fi
+  return 0
+}
+run_test "Three-Layer Memory 定義更新 [edge: 旧定義 Working Memory（context）が残っていない]" test_three_layer_memory_old_working_memory_removed
+
+# Edge case: 3層が全て同一行のテーブルセル内に記述されている
+test_three_layer_memory_all_layers_same_row() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # Three-Layer Memory 用語行が3層全てを含む1行になっている
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "Long-term Memory.*Working Memory Externalization.*Compressed Memory"
+}
+run_test "Three-Layer Memory 定義更新 [edge: 3層が同一行に記述]" test_three_layer_memory_all_layers_same_row
+
+# =============================================================================
+# Requirement: ADR-014 との整合確認
+# =============================================================================
+echo ""
+echo "--- Requirement: ADR-014 との整合確認 ---"
+
+# Scenario: ADR-014 との整合確認 (spec line 11-13)
+# WHEN: ADR-014 Decision 3 の層名称と glossary.md の Three-Layer Memory 定義を比較する
+# THEN: 3層すべての名称が ADR-014 の正式名称と完全一致している
+# ADR-014 Decision 3 正式名称: Long-term Memory / Working Memory Externalization / Compressed Memory
+
+test_adr014_layer1_exact_match() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # "Long-term Memory" が完全な形で（前後に余計な語なく）存在するか
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "\bLong-term Memory\b"
+}
+run_test "ADR-014 整合: Long-term Memory が完全一致" test_adr014_layer1_exact_match
+
+test_adr014_layer2_exact_match() {
+  assert_file_exists "$GLOSSARY" || return 1
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "\bWorking Memory Externalization\b"
+}
+run_test "ADR-014 整合: Working Memory Externalization が完全一致" test_adr014_layer2_exact_match
+
+test_adr014_layer3_exact_match() {
+  assert_file_exists "$GLOSSARY" || return 1
+  grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "\bCompressed Memory\b"
+}
+run_test "ADR-014 整合: Compressed Memory が完全一致" test_adr014_layer3_exact_match
+
+# Edge case: ADR-014 の非公式変形（Long Term Memory / WorkingMemory 等）が混入していない
+test_adr014_no_informal_variants() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # ハイフンなし "Long Term Memory" が Three-Layer Memory 行にない
+  if grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" | grep -qP "\bLong Term Memory\b"; then
+    return 1
+  fi
+  return 0
+}
+run_test "ADR-014 整合 [edge: 非公式変形 'Long Term Memory' が混入していない]" test_adr014_no_informal_variants
+
+# Edge case: Working Memory（ADR-014以前の略称）単体が Three-Layer Memory 定義に残っていない
+test_adr014_no_bare_working_memory() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # "Working Memory" が "Working Memory Externalization" の一部としてのみ現れること
+  # つまり "Working Memory" の後に "Externalization" が続かないケースがない
+  if grep -P "Three-Layer Memory" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -qP "\bWorking Memory\b(?!\s+Externalization)"; then
+    return 1
+  fi
+  return 0
+}
+run_test "ADR-014 整合 [edge: 'Working Memory' 単体が Three-Layer Memory 定義に残っていない]" test_adr014_no_bare_working_memory
+
+# =============================================================================
+# Requirement: Supervisor 6 用語の MUST セクション存在確認
+# =============================================================================
+echo ""
+echo "--- Requirement: Supervisor 6 用語の MUST セクション存在確認 ---"
+
+# Scenario: 6 用語の存在確認 (spec line 21-23)
+# WHEN: glossary.md の MUST テーブルを参照する
+# THEN: Supervisor, su-observer, SupervisorSession, su-compact, Three-Layer Memory, Wave の 6 用語が存在する
+
+test_must_has_supervisor() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| Supervisor \|"
+}
+run_test "MUST セクション: Supervisor が存在する" test_must_has_supervisor
+
+test_must_has_su_observer() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| su-observer \|"
+}
+run_test "MUST セクション: su-observer が存在する" test_must_has_su_observer
+
+test_must_has_supervisor_session() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| SupervisorSession \|"
+}
+run_test "MUST セクション: SupervisorSession が存在する" test_must_has_supervisor_session
+
+test_must_has_su_compact() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| su-compact \|"
+}
+run_test "MUST セクション: su-compact が存在する" test_must_has_su_compact
+
+test_must_has_three_layer_memory() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| Three-Layer Memory \|"
+}
+run_test "MUST セクション: Three-Layer Memory が存在する" test_must_has_three_layer_memory
+
+test_must_has_wave() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_contains "$GLOSSARY" "^\| Wave \|"
+}
+run_test "MUST セクション: Wave が存在する" test_must_has_wave
+
+# Edge case: 6用語が全て Supervision context に属している
+test_must_supervisor_terms_have_supervision_context() {
+  assert_file_exists "$GLOSSARY" || return 1
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${GLOSSARY}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  local must_content
+  must_content=$(head -n "$((should_line - 1))" "${PROJECT_ROOT}/${GLOSSARY}")
+  # Supervisor と SupervisorSession は Supervision context
+  echo "$must_content" | grep -P "^\| Supervisor \|" | grep -qP "Supervision" || return 1
+  echo "$must_content" | grep -P "^\| SupervisorSession \|" | grep -qP "Supervision" || return 1
+  echo "$must_content" | grep -P "^\| su-observer \|" | grep -qP "Supervision" || return 1
+  echo "$must_content" | grep -P "^\| su-compact \|" | grep -qP "Supervision" || return 1
+  echo "$must_content" | grep -P "^\| Three-Layer Memory \|" | grep -qP "Supervision" || return 1
+  return 0
+}
+run_test "MUST 6用語 [edge: 全て Supervision context に属している]" test_must_supervisor_terms_have_supervision_context
+
+# Edge case: MUSTテーブルの行数が正常（最低6つのSupervision用語行がある）
+test_must_section_has_six_supervision_terms() {
+  assert_file_exists "$GLOSSARY" || return 1
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${GLOSSARY}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  local count
+  count=$(head -n "$((should_line - 1))" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -cP "^\|.*\| Supervision" || true)
+  [[ $count -ge 6 ]]
+}
+run_test "MUST 6用語 [edge: Supervision context の行が6件以上ある]" test_must_section_has_six_supervision_terms
+
+# =============================================================================
+# Requirement: Observer 用語の MUST 外維持
+# =============================================================================
+echo ""
+echo "--- Requirement: Observer 用語の MUST 外維持 ---"
+
+# Scenario: Observer 用語の SHOULD 維持 (spec line 29-31)
+# WHEN: glossary.md の MUST テーブルを参照する
+# THEN: Observer, Observed, Live Observation の各用語が MUST テーブルに存在しない
+
+test_must_not_has_observer() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_not_contains "$GLOSSARY" "^\| Observer \|"
+}
+run_test "MUST テーブル外: Observer が MUST に存在しない" test_must_not_has_observer
+
+test_must_not_has_observed() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_not_contains "$GLOSSARY" "^\| Observed \|"
+}
+run_test "MUST テーブル外: Observed が MUST に存在しない" test_must_not_has_observed
+
+test_must_not_has_live_observation() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_not_contains "$GLOSSARY" "^\| Live Observation \|"
+}
+run_test "MUST テーブル外: Live Observation が MUST に存在しない" test_must_not_has_live_observation
+
+# Edge case: Observer 用語が Observation context のままである（context 列を確認）
+test_observer_terms_remain_observation_context() {
+  assert_file_exists "$GLOSSARY" || return 1
+  # Observer 行の context 列が Observation であること
+  grep -P "^\| Observer \|" "${PROJECT_ROOT}/${GLOSSARY}" | grep -qP "\| Observation"
+}
+run_test "Observer 用語 MUST 外 [edge: Observer の context が Observation のまま]" test_observer_terms_remain_observation_context
+
+test_observed_remains_observation_context() {
+  assert_file_exists "$GLOSSARY" || return 1
+  grep -P "^\| Observed \|" "${PROJECT_ROOT}/${GLOSSARY}" | grep -qP "\| Observation"
+}
+run_test "Observer 用語 MUST 外 [edge: Observed の context が Observation のまま]" test_observed_remains_observation_context
+
+# Scenario: Observer 用語の SHOULD 存在確認 (spec line 33-35)
+# WHEN: glossary.md の SHOULD テーブルを参照する
+# THEN: observer-evaluator 等の Observation context 用語が SHOULD テーブルに存在する
+
+test_should_has_observer_evaluator() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_should_section_contains "$GLOSSARY" "^\| observer-evaluator \|"
+}
+run_test "SHOULD テーブル: observer-evaluator が存在する" test_should_has_observer_evaluator
+
+# Edge case: SHOULDテーブルに Observation context の用語が複数ある
+test_should_has_multiple_observation_terms() {
+  assert_file_exists "$GLOSSARY" || return 1
+  local should_line
+  should_line=$(grep -n "### SHOULD 用語" "${PROJECT_ROOT}/${GLOSSARY}" | head -1 | cut -d: -f1)
+  if [[ -z "$should_line" ]]; then
+    return 1
+  fi
+  local count
+  count=$(tail -n "+${should_line}" "${PROJECT_ROOT}/${GLOSSARY}" \
+    | grep -cP "^\|.*\| Observation" || true)
+  [[ $count -ge 2 ]]
+}
+run_test "SHOULD テーブル [edge: Observation context の用語が複数存在する]" test_should_has_multiple_observation_terms
+
+# Edge case: co-self-improve が Observer 関連として MUST 外に維持されている
+test_must_not_has_co_self_improve() {
+  assert_file_exists "$GLOSSARY" || return 1
+  assert_must_section_not_contains "$GLOSSARY" "^\| co-self-improve \|"
+}
+run_test "Observer 用語 MUST 外 [edge: co-self-improve も MUST に含まれていない]" test_must_not_has_co_self_improve
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
docs(glossary): Three-Layer Memory 定義を ADR-014 準拠に修正

glossary.md の Three-Layer Memory 定義の層名称を
ADR-014 Decision 3 の正式名称に統一する。

- 修正前: Working Memory（context）+ Externalized Memory（doobidoo/ファイル）
- 修正後: Long-term Memory（永続）+ Working Memory Externalization（一時退避）

DeltaSpec issue-355 (proposal/design/specs/tasks) も追加。

Closes #355

Co-Authored-By: Claude <noreply@anthropic.com>