### PR TITLE
fix(step_check): monorepo 配下のテストディレクトリを検出するよう修正

### DIFF
--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -433,14 +433,18 @@ class ChainRunner:
         else:
             print("DeltaSpec: N/A")
 
-        # Tests
-        tests_dir = root / "tests"
+        # Tests（monorepo 対応: root/tests/, root/*/tests/, root/*/*/tests/ を走査）
+        test_patterns = ("**/*.sh", "**/*.bats", "**/*.test.*", "**/*.R", "**/*.py")
         test_found = False
-        if tests_dir.is_dir():
-            for pattern in ("**/*.sh", "**/*.bats", "**/*.test.*", "**/*.R", "**/*.py"):
-                if any(tests_dir.glob(pattern)):
-                    test_found = True
-                    break
+        candidate_dirs = [root / "tests"] + list(root.glob("*/tests")) + list(root.glob("*/*/tests"))
+        for tests_dir in candidate_dirs:
+            if tests_dir.is_dir():
+                for pattern in test_patterns:
+                    if any(tests_dir.glob(pattern)):
+                        test_found = True
+                        break
+            if test_found:
+                break
         if test_found:
             print("Tests: PASS")
         else:

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -411,3 +411,74 @@ class TestStepInit:
         assert result["recommended_action"] == "direct"
         assert result.get("deltaspec") is False
         assert result.get("is_direct") is True
+
+
+# ---------------------------------------------------------------------------
+# step_check — monorepo test directory detection (Issue #406)
+# ---------------------------------------------------------------------------
+
+
+class TestStepCheckMonorepo:
+    """step_check が monorepo 構造のテストディレクトリを正しく検出する。"""
+
+    def _make_runner(self, tmp_path: Path, autopilot_dir: Path) -> ChainRunner:
+        scripts_root = tmp_path / "scripts"
+        scripts_root.mkdir(exist_ok=True)
+        return ChainRunner(scripts_root=scripts_root, autopilot_dir=autopilot_dir)
+
+    def _setup_ci(self, root: Path) -> None:
+        """CI/CD と DeltaSpec を用意してチェック以外の FAIL を防ぐ。"""
+        (root / ".github" / "workflows").mkdir(parents=True, exist_ok=True)
+        (root / ".github" / "workflows" / "ci.yml").touch()
+        (root / "deltaspec" / "changes" / "some-change").mkdir(parents=True, exist_ok=True)
+        (root / "deltaspec" / "changes" / "some-change" / "proposal.md").touch()
+
+    def test_root_tests_dir_passes(self, tmp_path: Path, autopilot_dir: Path) -> None:
+        """AC-3: $root/tests/ にテストがあれば PASS（単一リポ退行なし）。"""
+        root = tmp_path / "project"
+        root.mkdir()
+        self._setup_ci(root)
+        (root / "tests").mkdir()
+        (root / "tests" / "foo.bats").touch()
+
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with patch.object(runner, "_project_root", return_value=root):
+            result = runner.step_check()
+        assert result is True
+
+    def test_component_tests_depth1_passes(self, tmp_path: Path, autopilot_dir: Path) -> None:
+        """AC-2: $root/tests/ 不在でも $root/*/tests/ にテストがあれば PASS。"""
+        root = tmp_path / "project"
+        root.mkdir()
+        self._setup_ci(root)
+        (root / "plugins" / "twl" / "tests").mkdir(parents=True)
+        (root / "plugins" / "twl" / "tests" / "spec.bats").touch()
+
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with patch.object(runner, "_project_root", return_value=root):
+            result = runner.step_check()
+        assert result is True
+
+    def test_component_tests_depth2_passes(self, tmp_path: Path, autopilot_dir: Path) -> None:
+        """AC-1: $root/*/*/tests/ にテストがあれば PASS。"""
+        root = tmp_path / "project"
+        root.mkdir()
+        self._setup_ci(root)
+        (root / "cli" / "twl" / "tests").mkdir(parents=True)
+        (root / "cli" / "twl" / "tests" / "test_chain.py").touch()
+
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with patch.object(runner, "_project_root", return_value=root):
+            result = runner.step_check()
+        assert result is True
+
+    def test_no_tests_fails(self, tmp_path: Path, autopilot_dir: Path) -> None:
+        """テストファイルが一切なければ FAIL。"""
+        root = tmp_path / "project"
+        root.mkdir()
+        self._setup_ci(root)
+
+        runner = self._make_runner(tmp_path, autopilot_dir)
+        with patch.object(runner, "_project_root", return_value=root):
+            result = runner.step_check()
+        assert result is False

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -451,8 +451,8 @@ class TestStepCheckMonorepo:
         root = tmp_path / "project"
         root.mkdir()
         self._setup_ci(root)
-        (root / "plugins" / "twl" / "tests").mkdir(parents=True)
-        (root / "plugins" / "twl" / "tests" / "spec.bats").touch()
+        (root / "plugins" / "tests").mkdir(parents=True)
+        (root / "plugins" / "tests" / "spec.bats").touch()
 
         runner = self._make_runner(tmp_path, autopilot_dir)
         with patch.object(runner, "_project_root", return_value=root):

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1040,8 +1040,16 @@ step_check() {
     echo "DeltaSpec: N/A"
   fi
 
-  # テスト
-  if find "$root/tests/" \( -name "*.sh" -o -name "*.bats" -o -name "*.test.*" -o -name "*.R" -o -name "*.py" \) -print -quit 2>/dev/null | grep -q .; then
+  # テスト（monorepo 対応: $root/tests/, $root/*/tests/, $root/*/*/tests/ を走査）
+  local test_found=false
+  local _test_dir
+  for _test_dir in "$root/tests" "$root"/*/tests "$root"/*/*/tests; do
+    if find "$_test_dir" \( -name "*.sh" -o -name "*.bats" -o -name "*.test.*" -o -name "*.R" -o -name "*.py" \) -print -quit 2>/dev/null | grep -q .; then
+      test_found=true
+      break
+    fi
+  done
+  if $test_found; then
     echo "Tests: PASS"
   else
     echo "Tests: FAIL (テストファイルなし)"

--- a/plugins/twl/tests/bats/scripts/chain-runner-step-check.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-step-check.bats
@@ -1,0 +1,117 @@
+#!/usr/bin/env bats
+# chain-runner-step-check.bats - unit tests for step_check() in chain-runner.sh
+#
+# Issue: #406 — step_check が monorepo-level tests/ を期待し全件 FAIL
+#
+# Coverage:
+#   AC-1: $root/tests/, $root/*/tests/, $root/*/*/tests/ いずれかにテストがあれば PASS
+#   AC-2: $root/tests/ 不在でもコンポーネント配下にテストがあれば FAIL にならない
+#   AC-3: 単一リポ（$root/tests/ 存在）の退行がない
+
+load '../helpers/common'
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*)
+        echo "fix/406-stepcheck-monorepo-level-tests-fail" ;;
+      *"rev-parse --show-toplevel"*)
+        echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*)
+        echo "$SANDBOX/.git" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  stub_command "gh" 'exit 0'
+
+  mkdir -p "$SANDBOX/scripts/lib"
+  cat > "$SANDBOX/scripts/lib/resolve-project.sh" <<'RESOLVE_PROJECT'
+#!/usr/bin/env bash
+resolve_project() {
+  echo "6 PVT_project_id shuu5 twill-ecosystem shuu5/twill"
+}
+RESOLVE_PROJECT
+  chmod +x "$SANDBOX/scripts/lib/resolve-project.sh"
+
+  # .github/workflows をデフォルトで用意
+  mkdir -p "$SANDBOX/.github/workflows"
+  touch "$SANDBOX/.github/workflows/ci.yml"
+
+  # deltaspec/changes/proposal.md をデフォルトで用意
+  mkdir -p "$SANDBOX/deltaspec/changes/some-change"
+  touch "$SANDBOX/deltaspec/changes/some-change/proposal.md"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: 単一リポ（$root/tests/ 存在）— 退行なし
+# ---------------------------------------------------------------------------
+
+@test "step_check: \$root/tests/ にテストがあれば Tests: PASS" {
+  mkdir -p "$SANDBOX/tests"
+  touch "$SANDBOX/tests/foo.bats"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" check
+  assert_output --partial "Tests: PASS"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: monorepo — $root/tests/ 不在でもコンポーネント配下があれば PASS
+# ---------------------------------------------------------------------------
+
+@test "step_check: \$root/tests/ 不在でも \$root/plugins/twl/tests/ にテストがあれば Tests: PASS" {
+  mkdir -p "$SANDBOX/plugins/twl/tests"
+  touch "$SANDBOX/plugins/twl/tests/foo.bats"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" check
+  assert_output --partial "Tests: PASS"
+  assert_success
+}
+
+@test "step_check: \$root/tests/ 不在でも \$root/cli/twl/tests/ にテストがあれば Tests: PASS" {
+  mkdir -p "$SANDBOX/cli/twl/tests"
+  touch "$SANDBOX/cli/twl/tests/test_chain.py"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" check
+  assert_output --partial "Tests: PASS"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC-1: $root/*/tests/ パターン（深さ1）
+# ---------------------------------------------------------------------------
+
+@test "step_check: \$root/*/tests/ 配下のテストを検出できる" {
+  mkdir -p "$SANDBOX/plugins/tests"
+  touch "$SANDBOX/plugins/tests/spec.sh"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" check
+  assert_output --partial "Tests: PASS"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# テストが全く存在しない場合は FAIL
+# ---------------------------------------------------------------------------
+
+@test "step_check: テストファイルが一切なければ Tests: FAIL" {
+  # tests/ ディレクトリを作らない
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" check
+  assert_output --partial "Tests: FAIL"
+  assert_failure
+}


### PR DESCRIPTION
## 概要

Issue #406: `step_check` が `$root/tests/` のみを参照するため、twill monorepo でテストが全件 FAIL していた問題を修正。

## 変更内容

- `chain-runner.sh`: `step_check` の Tests チェックを `$root/tests/`, `$root/*/tests/`, `$root/*/*/tests/` を走査するよう修正
- `chain.py`: 同 Python 実装を `candidate_dirs` リストで同等の走査に修正
- `chain-runner-step-check.bats`: AC-1/AC-2/AC-3 をカバーする bats テスト追加（5件）
- `test_autopilot_chain.py`: TestStepCheckMonorepo クラスで Python 側のテスト追加（4件）

## 受け入れ基準

- [x] AC-1: step_check が `$root/tests/`, `$root/*/tests/`, `$root/*/*/tests/` を走査
- [x] AC-2: `$root/tests/` 不在でもコンポーネント配下テストがあれば PASS
- [x] AC-3: 単一リポ（`$root/tests/` 存在）での退行なし

Closes #406