### PR TITLE
fix: CLAUDE.md Controller 数を6つに修正し Supervisor セクション追加

### DIFF
--- a/deltaspec/changes/issue-394/.deltaspec.yaml
+++ b/deltaspec/changes/issue-394/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-394
+status: pending

--- a/deltaspec/changes/issue-394/design.md
+++ b/deltaspec/changes/issue-394/design.md
@@ -1,0 +1,23 @@
+## Context
+
+ADR-014 の Decision 1 により `co-observer` が `su-observer`（Supervisor クラス）に改名された。`plugins/twl/CLAUDE.md` は LLM セッション起動時に参照されるドキュメントであり、旧記述が残ることで Controller 数が7つと誤認識される。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `plugins/twl/CLAUDE.md` の Controller 数を6つに修正する
+- `su-observer` を Supervisor として明示する
+
+**Non-Goals:**
+- コードや他ドキュメントの変更
+- ADR-014 本体の変更
+
+## Decisions
+
+- Controller テーブルを6行に縮小し `co-observer` 行を削除
+- 「Supervisor は1つ」の見出しと `su-observer` テーブルを追加
+- ヘッダー「Controller は7つ」を「Controller は6つ」に変更
+
+## Risks / Trade-offs
+
+- 変更はドキュメントのみのため技術的リスクなし

--- a/deltaspec/changes/issue-394/proposal.md
+++ b/deltaspec/changes/issue-394/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`plugins/twl/CLAUDE.md` の「Controller は7つ」記述が、ADR-014 で確定した設計（Controller は6つ + Supervisor は1つ）に追従していない。`co-observer` は `su-observer`（Supervisor 型）に改名されたが、CLAUDE.md には旧名のまま Controller として列挙されており、LLM のセッション起動時に参照されると ADR-014 の設計意図と矛盾する。
+
+## What Changes
+
+- `plugins/twl/CLAUDE.md` の「Controller は7つ」→「Controller は6つ」に変更
+- Controller テーブルから `co-observer` 行を削除
+- Controller テーブルの後に「Supervisor は1つ」セクションを追加
+- `su-observer`（Supervisor 型）を別テーブルで記載
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- **CLAUDE.md ドキュメント**: Controller/Supervisor の区別が ADR-014 の設計と一致
+
+## Impact
+
+- `plugins/twl/CLAUDE.md` のみ変更（ドキュメント更新のみ）
+- コード実装への影響なし

--- a/deltaspec/changes/issue-394/specs/claudemd-controller-count/spec.md
+++ b/deltaspec/changes/issue-394/specs/claudemd-controller-count/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Controller 数の正確な記述
+`plugins/twl/CLAUDE.md` の Controller セクションは、ADR-014 に準拠した正確な数（6つ）を記述しなければならない（SHALL）。
+
+#### Scenario: CLAUDE.md Controller セクション確認
+- **WHEN** `plugins/twl/CLAUDE.md` を参照する
+- **THEN** 「Controller は6つ」という見出しが存在し、6行の Controller テーブルが表示される
+
+### Requirement: co-observer の除去
+`plugins/twl/CLAUDE.md` の Controller テーブルから `co-observer` 行を削除しなければならない（SHALL）。
+
+#### Scenario: co-observer がControllerテーブルに存在しない
+- **WHEN** `plugins/twl/CLAUDE.md` の Controller テーブルを参照する
+- **THEN** `co-observer` 行が存在しない
+
+### Requirement: Supervisor セクションの追加
+`plugins/twl/CLAUDE.md` に Supervisor（`su-observer`）を明示するセクションを追加しなければならない（SHALL）。
+
+#### Scenario: Supervisor セクションの存在
+- **WHEN** `plugins/twl/CLAUDE.md` を参照する
+- **THEN** 「Supervisor は1つ」の見出しと `su-observer` を含むテーブルが存在する

--- a/deltaspec/changes/issue-394/tasks.md
+++ b/deltaspec/changes/issue-394/tasks.md
@@ -1,0 +1,9 @@
+## 1. CLAUDE.md Controller セクション更新
+
+- [x] 1.1 「Controller は7つ」見出しを「Controller は6つ」に変更
+- [x] 1.2 Controller テーブルから `co-observer` 行を削除
+
+## 2. Supervisor セクション追加
+
+- [x] 2.1 Controller テーブルの後に「Supervisor は1つ」見出しを追加
+- [x] 2.2 `su-observer` を含む Supervisor テーブルを追加

--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -16,7 +16,7 @@ Claude Code twl plugin（chain-driven + autopilot-first）。TWiLL モノリポ 
 
 deps.yaml v3.0 がプラグイン構成の唯一の情報源。
 
-### Controller は7つ
+### Controller は6つ
 
 | controller | 役割 |
 |---|---|
@@ -26,7 +26,12 @@ deps.yaml v3.0 がプラグイン構成の唯一の情報源。
 | co-architect | アーキテクチャ設計 |
 | co-utility | スタンドアロンユーティリティ操作 |
 | co-self-improve | ライブセッション観察と能動的 self-improvement（out-of-process observation） |
-| co-observer | controller の動作を監視・介入するメタ認知レイヤー |
+
+### Supervisor は1つ
+
+| supervisor | 役割 |
+|---|---|
+| su-observer | controller の動作を監視・介入するメタ認知レイヤー（ADR-014） |
 
 ## Bare repo 構造検証（セッション開始時チェック）
 


### PR DESCRIPTION
## 概要

plugins/twl/CLAUDE.md の「Controller は7つ」記述を ADR-014 に準拠した「Controller は6つ + Supervisor は1つ」に更新する。

## 変更内容

- 「Controller は7つ」見出しを「Controller は6つ」に変更
- Controller テーブルから `co-observer` 行を削除
- Controller テーブルの後に「Supervisor は1つ」セクションを追加
- `su-observer` を Supervisor 型として別テーブルで記載

Closes #394