### PR TITLE
fix(chain-runner): step_next_step/chain-status が DIRECT_SKIP_STEPS を参照するよう修正 (#381)

### DIFF
--- a/deltaspec/changes/issue-381/.deltaspec.yaml
+++ b/deltaspec/changes/issue-381/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-381
+status: pending

--- a/deltaspec/changes/issue-381/design.md
+++ b/deltaspec/changes/issue-381/design.md
@@ -1,0 +1,46 @@
+## Context
+
+`chain-runner.sh` は `chain-steps.sh` を source して `QUICK_SKIP_STEPS` と `DIRECT_SKIP_STEPS` の両配列を取得する。`step_next_step()` と `step_chain_status()` は `is_quick` フラグによる `QUICK_SKIP_STEPS` スキップを実装しているが、`mode=direct` による `DIRECT_SKIP_STEPS` スキップを実装していない。Python `chain.py` の `next_step()` は両方を正しく処理しており、Bash と Python の間に実装差異がある（ADR-015 Decision 3 参照）。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `step_next_step()` に `mode=direct` 時の `DIRECT_SKIP_STEPS` スキップロジックを追加する
+- `step_chain_status()` に `mode=direct` 時のスキップ表示を追加する
+- Python `chain.py` の `next_step()` と動作を一致させる
+
+**Non-Goals:**
+- `chain-steps.sh` の `DIRECT_SKIP_STEPS` 定義変更
+- Python `chain.py` の変更
+- その他の `step_*` 関数への影響
+
+## Decisions
+
+**Decision 1: `mode` の state 読み込み**
+
+`step_next_step()` は既に `is_quick` を `python3 -m twl.autopilot.state read ... --field is_quick` で取得している。同じパターンで `mode` を取得し、`"direct"` と比較する。
+
+実装イメージ:
+```bash
+# mode を state から取得
+local mode
+mode="$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --field mode 2>/dev/null || echo "")"
+
+# ...ループ内...
+if [[ "$mode" == "direct" ]] && printf '%s\n' "${DIRECT_SKIP_STEPS[@]}" | grep -qxF "$step"; then
+  continue
+fi
+```
+
+**Decision 2: `step_chain_status()` の表示**
+
+`QUICK_SKIP_STEPS` スキップ時は `(skipped/quick)` ラベルを付けている。`DIRECT_SKIP_STEPS` スキップ時は `(skipped/direct)` ラベルを付け、同じ `⊘` 記号を使う。
+
+**Decision 3: mode 取得失敗時のデフォルト**
+
+`mode` 取得に失敗した場合は空文字列として扱い、`DIRECT_SKIP_STEPS` スキップを行わない（既存の `is_quick` と同様）。
+
+## Risks / Trade-offs
+
+- **影響範囲は最小**: `step_next_step()` と `step_chain_status()` の 2 関数のみ変更。他のロジックに影響なし。
+- **state 読み込みコスト**: `mode` 取得のために `python3 -m twl.autopilot.state read` を 1 回追加するが、既存の `is_quick` 取得と同様のパターンで問題なし。

--- a/deltaspec/changes/issue-381/proposal.md
+++ b/deltaspec/changes/issue-381/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`chain-runner.sh` の `step_next_step()` は `QUICK_SKIP_STEPS` のみを参照し、`DIRECT_SKIP_STEPS` を参照していない。`mode=direct` が state に書き込まれても、Bash 実行経路では `change-propose`・`change-id-resolve`・`change-apply` がスキップされず、Python `chain.py` との動作不一致が発生する。
+
+## What Changes
+
+- `plugins/twl/scripts/chain-runner.sh`
+  - `step_next_step()`: `is_quick` チェックに加え `mode=direct` かつ `DIRECT_SKIP_STEPS` に含まれるステップをスキップするロジックを追加
+  - `step_chain_status()`: 表示ループに `DIRECT_SKIP_STEPS` スキップ判定を追加（`(skipped/direct)` ラベル付き）
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- `mode=direct` 時、`change-propose`・`change-id-resolve`・`change-apply` ステップが `step_next_step()` でスキップされる（Python `chain.py` と同一動作）
+- `chain-status` コマンドが `mode=direct` 時のスキップステップを `⊘ ... (skipped/direct)` で正しく表示する
+
+## Impact
+
+- `plugins/twl/scripts/chain-runner.sh`（`step_next_step` と `step_chain_status` の 2 関数のみ）

--- a/deltaspec/changes/issue-381/specs/chain-runner-direct-skip/spec.md
+++ b/deltaspec/changes/issue-381/specs/chain-runner-direct-skip/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: step_next_step が DIRECT_SKIP_STEPS を参照する
+
+`chain-runner.sh` の `step_next_step()` は `mode=direct` 時に `DIRECT_SKIP_STEPS` に含まれるステップをスキップしなければならない（SHALL）。
+
+#### Scenario: mode=direct 時に change-propose がスキップされる
+- **WHEN** state の `mode` フィールドが `"direct"` であり、`step_next_step` が `change-propose` の前のステップを `current_step` として呼ばれる
+- **THEN** `change-propose` を返さず、`DIRECT_SKIP_STEPS` に含まれない次のステップを返す
+
+#### Scenario: mode=direct 時に change-id-resolve がスキップされる
+- **WHEN** state の `mode` フィールドが `"direct"` であり、`step_next_step` が `change-id-resolve` の前のステップを `current_step` として呼ばれる
+- **THEN** `change-id-resolve` を返さず、`DIRECT_SKIP_STEPS` に含まれない次のステップを返す
+
+#### Scenario: mode=direct 時に change-apply がスキップされる
+- **WHEN** state の `mode` フィールドが `"direct"` であり、`step_next_step` が `change-apply` の前のステップを `current_step` として呼ばれる
+- **THEN** `change-apply` を返さず、`DIRECT_SKIP_STEPS` に含まれない次のステップを返す
+
+#### Scenario: mode が direct 以外の場合は DIRECT_SKIP_STEPS をスキップしない
+- **WHEN** state の `mode` フィールドが `"propose"` または `"apply"` であり、`step_next_step` が呼ばれる
+- **THEN** `DIRECT_SKIP_STEPS` に含まれるステップも通常通り返す
+
+### Requirement: step_chain_status が DIRECT_SKIP_STEPS を正しく表示する
+
+`chain-runner.sh` の `step_chain_status()` は `mode=direct` 時に `DIRECT_SKIP_STEPS` に含まれるステップを `⊘ ... (skipped/direct)` として表示しなければならない（SHALL）。
+
+#### Scenario: mode=direct 時に skipped/direct ラベルが表示される
+- **WHEN** state の `mode` フィールドが `"direct"` であり、`chain-status` コマンドが実行される
+- **THEN** `change-propose`・`change-id-resolve`・`change-apply` のステップに `⊘ <step> [<dispatch>] (skipped/direct)` が表示される
+
+#### Scenario: mode が direct 以外の場合は通常表示される
+- **WHEN** state の `mode` フィールドが `"direct"` でない場合に `chain-status` コマンドが実行される
+- **THEN** `DIRECT_SKIP_STEPS` に含まれるステップが `(skipped/direct)` として表示されない

--- a/deltaspec/changes/issue-381/tasks.md
+++ b/deltaspec/changes/issue-381/tasks.md
@@ -1,0 +1,12 @@
+## 1. chain-runner.sh 修正
+
+- [x] 1.1 `step_next_step()` に `mode` の state 読み込みを追加する（`is_quick` と同パターン）
+- [x] 1.2 `step_next_step()` のループ内に `mode=direct` かつ `DIRECT_SKIP_STEPS` に含まれる場合の `continue` を追加する
+- [x] 1.3 `step_chain_status()` に `mode` の state 読み込みを追加する
+- [x] 1.4 `step_chain_status()` のループ内に `mode=direct` かつ `DIRECT_SKIP_STEPS` に含まれる場合の `⊘ ... (skipped/direct)` 表示を追加する
+
+## 2. 検証
+
+- [x] 2.1 `mode=direct` で `step_next_step` を呼び、`change-propose` がスキップされることを確認する（手動またはユニットテスト）
+- [x] 2.2 `mode=direct` で `chain-status` を呼び、`(skipped/direct)` ラベルが表示されることを確認する
+- [x] 2.3 `mode=propose` では通常動作することを確認する

--- a/deltaspec/changes/issue-381/test-mapping.yaml
+++ b/deltaspec/changes/issue-381/test-mapping.yaml
@@ -1,0 +1,81 @@
+change_id: issue-381
+generated_at: "2026-04-10T00:00:00Z"
+test_framework: bash-bats-style
+scenarios:
+  - id: "step-next-step-skips-change-propose-mode-direct"
+    name: "mode=direct 時に change-propose がスキップされる"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 7
+    requirement: "step_next_step が DIRECT_SKIP_STEPS を参照する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_next_step [Scenario: mode=direct 時に change-propose がスキップされる] DIRECT_SKIP_STEPS を参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-next-step-skips-change-id-resolve-mode-direct"
+    name: "mode=direct 時に change-id-resolve がスキップされる"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 11
+    requirement: "step_next_step が DIRECT_SKIP_STEPS を参照する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_next_step [Scenario: mode=direct 時に change-id-resolve がスキップされる] DIRECT_SKIP_STEPS+change-id-resolve を参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-next-step-skips-change-apply-mode-direct"
+    name: "mode=direct 時に change-apply がスキップされる"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 15
+    requirement: "step_next_step が DIRECT_SKIP_STEPS を参照する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_next_step [Scenario: mode=direct 時に change-apply がスキップされる] DIRECT_SKIP_STEPS+change-apply を参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-next-step-no-skip-when-not-direct"
+    name: "mode が direct 以外の場合は DIRECT_SKIP_STEPS をスキップしない"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 19
+    requirement: "step_next_step が DIRECT_SKIP_STEPS を参照する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_next_step [Scenario: mode が direct 以外はスキップしない] is_direct または mode==\"direct\" 条件判定を使用する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-chain-status-shows-skipped-direct-label"
+    name: "mode=direct 時に skipped/direct ラベルが表示される"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 27
+    requirement: "step_chain_status が DIRECT_SKIP_STEPS を正しく表示する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_chain_status [Scenario: mode=direct 時に skipped/direct ラベルが表示される]"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-chain-status-no-direct-label-when-not-direct"
+    name: "mode が direct 以外の場合は通常表示される"
+    spec_file: "specs/chain-runner-direct-skip/spec.md"
+    spec_line: 31
+    requirement: "step_chain_status が DIRECT_SKIP_STEPS を正しく表示する"
+    test_file: "plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh"
+    test_name: "step_chain_status [Scenario: mode が direct 以外は通常表示] DIRECT_SKIP_STEPS を条件参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -592,12 +592,20 @@ step_next_step() {
   is_quick="$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --field is_quick 2>/dev/null || echo "")"
   [[ "$is_quick" == "true" ]] || is_quick="false"
 
+  # mode を state から取得（存在しない場合は空文字列）
+  local mode
+  mode="$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --field mode 2>/dev/null || echo "")"
+
   # current_step のインデックスを探す
   local found=false
   for step in "${CHAIN_STEPS[@]}"; do
     if [[ "$found" == "true" ]]; then
       # is_quick=true かつ QUICK_SKIP_STEPS に含まれるステップはスキップ
       if [[ "$is_quick" == "true" ]] && printf '%s\n' "${QUICK_SKIP_STEPS[@]}" | grep -qxF "$step"; then
+        continue
+      fi
+      # mode=direct かつ DIRECT_SKIP_STEPS に含まれるステップはスキップ
+      if [[ "$mode" == "direct" ]] && printf '%s\n' "${DIRECT_SKIP_STEPS[@]}" | grep -qxF "$step"; then
         continue
       fi
       if $output_json; then
@@ -724,7 +732,12 @@ step_chain_status() {
     --type issue --issue "$issue_num" --field is_quick 2>/dev/null || echo "false")"
   [[ "$is_quick" == "true" ]] || is_quick="false"
 
-  echo "chain-status: Issue #${issue_num} (is_quick=${is_quick}, current=${current_step:-none})"
+  local mode
+  mode="$(python3 -m twl.autopilot.state read \
+    --autopilot-dir "$(resolve_autopilot_dir)" \
+    --type issue --issue "$issue_num" --field mode 2>/dev/null || echo "")"
+
+  echo "chain-status: Issue #${issue_num} (is_quick=${is_quick}, mode=${mode:-none}, current=${current_step:-none})"
   echo "---"
 
   local found_current=false
@@ -734,6 +747,11 @@ step_chain_status() {
 
     if [[ "$is_quick" == "true" ]] && printf '%s\n' "${QUICK_SKIP_STEPS[@]}" | grep -qxF "$step"; then
       echo "  ⊘ ${step} ${type_label} (skipped/quick)"
+      continue
+    fi
+
+    if [[ "$mode" == "direct" ]] && printf '%s\n' "${DIRECT_SKIP_STEPS[@]}" | grep -qxF "$step"; then
+      echo "  ⊘ ${step} ${type_label} (skipped/direct)"
       continue
     fi
 

--- a/plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh
+++ b/plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Document Verification Tests: chain-runner-direct-skip
+# Generated from: deltaspec/changes/issue-381/specs/chain-runner-direct-skip/spec.md
+# Coverage level: edge-cases
+#
+# These are document verification tests that confirm chain-runner.sh contains
+# the correct structural patterns for DIRECT_SKIP_STEPS / mode=direct support.
+# Runtime/behavioral tests are out of scope until the fix is applied.
+# =============================================================================
+set -uo pipefail
+
+# Project root (relative to test file location)
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Counters
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# --- Test Helpers ---
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "${PROJECT_ROOT}/${file}" ]]
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qiP "$pattern" "${PROJECT_ROOT}/${file}"
+}
+
+assert_file_contains_all() {
+  local file="$1"
+  shift
+  local patterns=("$@")
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  for pattern in "${patterns[@]}"; do
+    grep -qiP "$pattern" "${PROJECT_ROOT}/${file}" || return 1
+  done
+  return 0
+}
+
+# Assert that a pattern appears within the same function block as an anchor pattern.
+# Uses awk to extract the function body and then searches within it.
+assert_pattern_in_function() {
+  local file="$1"
+  local func_name="$2"  # function anchor (regex for grep)
+  local pattern="$3"    # pattern to find within the function
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  # Extract lines from function definition to the next top-level function or EOF
+  awk "/^${func_name}[[:space:]]*\(\)/{found=1} found{print} /^[a-z_].*\(\)[[:space:]]*\{/{if(!/${func_name}/)found=0}" \
+    "${PROJECT_ROOT}/${file}" | grep -qiP "$pattern"
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result
+  result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+TARGET="scripts/chain-runner.sh"
+STEPS_FILE="scripts/chain-steps.sh"
+
+# =============================================================================
+# Requirement: step_next_step が DIRECT_SKIP_STEPS を参照する
+# =============================================================================
+echo ""
+echo "--- Requirement: step_next_step が DIRECT_SKIP_STEPS を参照する ---"
+
+# Scenario: mode=direct 時に change-propose がスキップされる
+# WHEN: step_next_step が呼ばれる
+# THEN: DIRECT_SKIP_STEPS を参照して change-propose をスキップする
+test_step_next_step_references_direct_skip_steps() {
+  assert_file_exists "$TARGET" || return 1
+  # step_next_step 関数内に DIRECT_SKIP_STEPS への参照があること
+  assert_pattern_in_function "$TARGET" "step_next_step" "DIRECT_SKIP_STEPS"
+}
+run_test "step_next_step [Scenario: mode=direct 時に change-propose がスキップされる] DIRECT_SKIP_STEPS を参照する" \
+  test_step_next_step_references_direct_skip_steps
+
+# Scenario: mode=direct 時に change-id-resolve がスキップされる
+# WHEN: step_next_step が change-id-resolve の前のステップを current_step として呼ばれる
+# THEN: DIRECT_SKIP_STEPS を確認して change-id-resolve を飛ばす
+test_step_next_step_skips_change_id_resolve() {
+  assert_file_exists "$TARGET" || return 1
+  # DIRECT_SKIP_STEPS が chain-steps.sh で change-id-resolve を含むこと（SSOT確認）
+  assert_file_exists "$STEPS_FILE" || return 1
+  assert_file_contains "$STEPS_FILE" "change-id-resolve" || return 1
+  # step_next_step が DIRECT_SKIP_STEPS を参照していること
+  assert_pattern_in_function "$TARGET" "step_next_step" "DIRECT_SKIP_STEPS"
+}
+run_test "step_next_step [Scenario: mode=direct 時に change-id-resolve がスキップされる] DIRECT_SKIP_STEPS+change-id-resolve を参照する" \
+  test_step_next_step_skips_change_id_resolve
+
+# Scenario: mode=direct 時に change-apply がスキップされる
+# WHEN: step_next_step が change-apply の前のステップを current_step として呼ばれる
+# THEN: DIRECT_SKIP_STEPS を確認して change-apply を飛ばす
+test_step_next_step_skips_change_apply() {
+  assert_file_exists "$TARGET" || return 1
+  assert_file_exists "$STEPS_FILE" || return 1
+  assert_file_contains "$STEPS_FILE" "change-apply" || return 1
+  assert_pattern_in_function "$TARGET" "step_next_step" "DIRECT_SKIP_STEPS"
+}
+run_test "step_next_step [Scenario: mode=direct 時に change-apply がスキップされる] DIRECT_SKIP_STEPS+change-apply を参照する" \
+  test_step_next_step_skips_change_apply
+
+# Scenario: mode が direct 以外の場合は DIRECT_SKIP_STEPS をスキップしない
+# WHEN: mode が "propose" または "apply" のとき
+# THEN: スキップロジックが mode="direct" 条件付きであること
+test_step_next_step_direct_mode_conditional() {
+  assert_file_exists "$TARGET" || return 1
+  # is_direct 変数または mode == "direct" 比較が step_next_step 内にあること
+  assert_pattern_in_function "$TARGET" "step_next_step" 'is_direct|mode.*==.*"direct"|"direct".*mode'
+}
+run_test "step_next_step [Scenario: mode が direct 以外はスキップしない] is_direct または mode==\"direct\" 条件判定を使用する" \
+  test_step_next_step_direct_mode_conditional
+
+# Edge case: step_next_step が state から mode フィールドを読む
+test_step_next_step_reads_mode_from_state() {
+  assert_file_exists "$TARGET" || return 1
+  # twl.autopilot.state read と mode を同一関数内で参照
+  assert_pattern_in_function "$TARGET" "step_next_step" "autopilot.state read.*mode|--field mode|mode.*autopilot"
+}
+run_test "step_next_step [edge: state から mode フィールドを読む]" \
+  test_step_next_step_reads_mode_from_state
+
+# Edge case: DIRECT_SKIP_STEPS が chain-steps.sh で定義されていること（SSOT）
+test_direct_skip_steps_defined_in_chain_steps() {
+  assert_file_exists "$STEPS_FILE" || return 1
+  assert_file_contains "$STEPS_FILE" "DIRECT_SKIP_STEPS" || return 1
+}
+run_test "chain-steps.sh [edge: DIRECT_SKIP_STEPS が SSOT として定義されている]" \
+  test_direct_skip_steps_defined_in_chain_steps
+
+# Edge case: DIRECT_SKIP_STEPS に change-propose / change-id-resolve / change-apply が含まれること
+test_direct_skip_steps_contains_required_steps() {
+  assert_file_exists "$STEPS_FILE" || return 1
+  assert_file_contains_all "$STEPS_FILE" \
+    "change-propose" \
+    "change-id-resolve" \
+    "change-apply"
+}
+run_test "chain-steps.sh [edge: DIRECT_SKIP_STEPS に change-propose / change-id-resolve / change-apply が含まれる]" \
+  test_direct_skip_steps_contains_required_steps
+
+# =============================================================================
+# Requirement: step_chain_status が DIRECT_SKIP_STEPS を正しく表示する
+# =============================================================================
+echo ""
+echo "--- Requirement: step_chain_status が DIRECT_SKIP_STEPS を正しく表示する ---"
+
+# Scenario: mode=direct 時に skipped/direct ラベルが表示される
+# WHEN: mode="direct" で chain-status が実行される
+# THEN: skipped/direct ラベルが表示される
+test_step_chain_status_shows_skipped_direct_label() {
+  assert_file_exists "$TARGET" || return 1
+  # step_chain_status 内に "skipped/direct" 文字列があること
+  assert_pattern_in_function "$TARGET" "step_chain_status" "skipped/direct"
+}
+run_test "step_chain_status [Scenario: mode=direct 時に skipped/direct ラベルが表示される]" \
+  test_step_chain_status_shows_skipped_direct_label
+
+# Scenario: mode が direct 以外の場合は通常表示される
+# THEN: skipped/direct ラベルは mode=direct 条件付きであること
+test_step_chain_status_direct_mode_conditional() {
+  assert_file_exists "$TARGET" || return 1
+  # step_chain_status 内に DIRECT_SKIP_STEPS への参照があること
+  assert_pattern_in_function "$TARGET" "step_chain_status" "DIRECT_SKIP_STEPS"
+}
+run_test "step_chain_status [Scenario: mode が direct 以外は通常表示] DIRECT_SKIP_STEPS を条件参照する" \
+  test_step_chain_status_direct_mode_conditional
+
+# Edge case: step_chain_status が state から mode フィールドを読む
+test_step_chain_status_reads_mode_from_state() {
+  assert_file_exists "$TARGET" || return 1
+  assert_pattern_in_function "$TARGET" "step_chain_status" "autopilot.state read.*mode|--field mode|mode.*autopilot|is_direct"
+}
+run_test "step_chain_status [edge: state から mode フィールドを読む]" \
+  test_step_chain_status_reads_mode_from_state
+
+# Edge case: step_chain_status に ⊘ ... (skipped/direct) パターンが存在する
+test_step_chain_status_shows_circle_slash_direct() {
+  assert_file_exists "$TARGET" || return 1
+  # skipped/direct リテラルが step_chain_status 内に存在すること（⊘付きの行）
+  assert_pattern_in_function "$TARGET" "step_chain_status" "skipped/direct"
+}
+run_test "step_chain_status [edge: ⊘ ... (skipped/direct) パターンが存在する]" \
+  test_step_chain_status_shows_circle_slash_direct
+
+# Edge case: step_chain_status が既存の skipped/quick と同じ構造パターンで skipped/direct を実装する
+test_step_chain_status_parallel_skip_pattern() {
+  assert_file_exists "$TARGET" || return 1
+  # skipped/quick が存在する（既存パターン）
+  assert_pattern_in_function "$TARGET" "step_chain_status" "skipped/quick" || return 1
+}
+run_test "step_chain_status [edge: skipped/quick の既存パターンと並列構造]" \
+  test_step_chain_status_parallel_skip_pattern
+
+# =============================================================================
+# Structural: chain-runner.sh が chain-steps.sh を source している
+# =============================================================================
+echo ""
+echo "--- Structural: chain-runner.sh が chain-steps.sh を source する ---"
+
+test_chain_runner_sources_chain_steps() {
+  assert_file_exists "$TARGET" || return 1
+  assert_file_contains "$TARGET" "source.*chain-steps\.sh" || return 1
+}
+run_test "chain-runner.sh が chain-steps.sh を source している" \
+  test_chain_runner_sources_chain_steps
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
## 概要

`chain-runner.sh` の `step_next_step()` が `QUICK_SKIP_STEPS` のみを参照し、`DIRECT_SKIP_STEPS` を参照していなかった問題を修正する。

## 変更内容

- `step_next_step()`: `mode=direct` 時に `DIRECT_SKIP_STEPS` に含まれるステップをスキップするロジックを追加
- `step_chain_status()`: `mode=direct` 時に `⊘ ... (skipped/direct)` 表示を追加
- Python `chain.py` の `next_step()` と動作を一致させる（ADR-015 Decision 3）

## テスト

`plugins/twl/tests/scenarios/chain-runner-direct-skip.test.sh`: 13 tests PASS

Closes #381