### PR TITLE
fix(autopilot): enforce invariant C - prohibit Worker from calling gh pr merge directly (#404)

### DIFF
--- a/deltaspec/changes/issue-404/.deltaspec.yaml
+++ b/deltaspec/changes/issue-404/.deltaspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/deltaspec/changes/issue-404/design.md
+++ b/deltaspec/changes/issue-404/design.md
@@ -1,0 +1,36 @@
+## Context
+
+不変条件 C（Worker マージ禁止）は `autopilot.md` に定義されているが、Worker が実際に参照する SKILL.md と起動コンテキストに禁止が明記されていない。auto-merge.sh には 4-layer ガード（IS_AUTOPILOT チェック等）が実装されているが、Worker が auto-merge.sh を経由せず直接 `gh pr merge` を呼ぶと全てのガードが無効になる。
+
+**問題の根本**: ガードは auto-merge.sh 内にあるが、Worker が auto-merge.sh を参照することは保証されていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- workflow-pr-merge/SKILL.md に `gh pr merge` 直接実行禁止を明記（不変条件 C）
+- autopilot-launch.sh の Worker 起動コンテキスト注入に merge 禁止テキストを追加
+- co-autopilot/SKILL.md の不変条件 C に enforcement 箇所の参照リンクを追記
+
+**Non-Goals:**
+- auto-merge.sh の 4-layer ガード修正（既存ガードは維持）
+- autopilot.md の不変条件定義の変更
+- Worker の実装フロー変更（`chain-runner.sh auto-merge` の呼び出しは既存のまま）
+
+## Decisions
+
+**Decision 1: workflow-pr-merge/SKILL.md への禁止追記箇所**
+
+既存の「禁止事項」セクション（不変条件 E, F を記載）の先頭に不変条件 C を追加する。既存の構造を壊さずに最優先で目に入る位置に配置。
+
+**Decision 2: autopilot-launch.sh の注入パターン**
+
+quick ラベル注入（line 232-242）と同一パターン（`CONTEXT` 変数への追記）を使用。常時注入（ラベル条件なし）とする。注入テキストは固定文字列として autopilot-launch.sh 内に記述。
+
+**Decision 3: co-autopilot/SKILL.md の参照リンク**
+
+不変条件一覧（line 117）の不変条件 C 記述に enforcement 箇所への参照を追記する。内容の詳細展開は不要、パス参照のみ。
+
+## Risks / Trade-offs
+
+- **リスク**: 固定テキスト注入はプロンプト長を増やすが、禁止ルール 1 件分なので影響は最小
+- **トレードオフ**: 起動コンテキストへの注入は all-or-nothing（条件分岐なし）。不変条件 C はどの Issue でも適用すべきため問題なし

--- a/deltaspec/changes/issue-404/proposal.md
+++ b/deltaspec/changes/issue-404/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+不変条件 C（Worker マージ禁止）は autopilot.md に定義されているが、Worker が実際に参照する workflow-pr-merge/SKILL.md と Worker 起動コンテキストに明示的禁止が記載されていない。その結果 Worker が `gh pr merge --squash` を直接実行し、ac-verify / merge-gate / auto-merge.sh の全ガードをバイパスするケースが複数発生した。
+
+## What Changes
+
+- `plugins/twl/skills/workflow-pr-merge/SKILL.md`: 禁止事項セクションに「Worker は `gh pr merge` を直接実行してはならない（不変条件 C）」を追記
+- `plugins/twl/scripts/autopilot-launch.sh`: Worker 起動コンテキスト注入に `gh pr merge` 直接実行禁止を固定テキストとして追加
+- `plugins/twl/skills/co-autopilot/SKILL.md`: 不変条件 C の enforcement 箇所への参照リンクを追記
+
+## Capabilities
+
+### New Capabilities
+
+なし（enforcement 強化のみ）
+
+### Modified Capabilities
+
+- workflow-pr-merge/SKILL.md: 不変条件 C の明示的禁止を追加（Worker が参照するドキュメントにガードを追加）
+- autopilot-launch.sh: Worker 起動時の system prompt に merge 禁止コンテキストを注入
+- co-autopilot/SKILL.md: 不変条件 C の enforcement 箇所参照リンクを追加
+
+## Impact
+
+- 変更ファイル: 3 ファイル（SKILL.md × 2 + autopilot-launch.sh）
+- auto-merge.sh の 4-layer ガードは変更なし（既存ガードを補完する形）
+- 動作変更なし（禁止ルールの明文化のみ）

--- a/deltaspec/changes/issue-404/specs/invariant-c-enforcement/spec.md
+++ b/deltaspec/changes/issue-404/specs/invariant-c-enforcement/spec.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: workflow-pr-merge/SKILL.md に不変条件 C 禁止を明記
+
+Worker が workflow-pr-merge/SKILL.md を参照した際に、`gh pr merge` 直接実行が禁止されていることを明確に認識できなければならない（SHALL）。禁止事項セクションに不変条件 C として「Worker は `gh pr merge` を直接実行してはならない。マージは必ず `chain-runner.sh auto-merge` 経由で auto-merge.sh のガードを通すこと」が明記されていなければならない（MUST）。
+
+#### Scenario: Worker が workflow-pr-merge を参照する
+- **WHEN** Worker が workflow-pr-merge/SKILL.md の禁止事項セクションを読む
+- **THEN** 「Worker は `gh pr merge` を直接実行してはならない（不変条件 C）」という禁止文が明記されている
+
+#### Scenario: 不変条件 C と E, F が同一セクションに存在する
+- **WHEN** 禁止事項セクションを確認する
+- **THEN** 不変条件 C（マージ禁止）、E（リトライ）、F（rebase 禁止）が全て記載されている
+
+### Requirement: autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入
+
+autopilot-launch.sh が Worker を起動する際、`gh pr merge` 直接実行を禁止する固定テキストをシステムプロンプトとして注入しなければならない（MUST）。注入は quick ラベル注入と同一パターン（`CONTEXT` 変数への追記）を使用し、全 Issue で常時注入されなければならない（SHALL）。
+
+#### Scenario: Worker 起動時に merge 禁止コンテキストが注入される
+- **WHEN** autopilot-launch.sh が Worker（Claude Code）を起動する
+- **THEN** `--append-system-prompt` に「`gh pr merge` の直接実行は禁止。マージ権限は Pilot のみ（不変条件 C）」というテキストが含まれている
+
+#### Scenario: quick ラベルと同時に適用される
+- **WHEN** quick ラベル付き Issue で Worker を起動する
+- **THEN** merge 禁止コンテキストと quick 指示の両方がシステムプロンプトに注入される
+
+### Requirement: co-autopilot/SKILL.md の不変条件 C に enforcement 参照を追記
+
+co-autopilot/SKILL.md の不変条件一覧（不変条件 C の記述）に、enforcement が定義されているファイルへの参照リンクが含まれていなければならない（SHALL）。内容の詳細展開は不要で、ファイルパスの参照のみで良い（MUST）。
+
+#### Scenario: Pilot が不変条件 C の enforcement 箇所を確認する
+- **WHEN** co-autopilot/SKILL.md の不変条件セクションを参照する
+- **THEN** 不変条件 C の記述に「enforcement: workflow-pr-merge/SKILL.md 禁止事項セクション + autopilot-launch.sh 起動コンテキスト参照」が含まれている
+
+### Requirement: auto-merge.sh の既存ガードを維持
+
+auto-merge.sh の 4-layer ガード（IS_AUTOPILOT チェック等）は変更されてはならない（MUST NOT）。
+
+#### Scenario: auto-merge.sh のガードが正常に動作する
+- **WHEN** auto-merge.sh が IS_AUTOPILOT=true で実行される
+- **THEN** merge-ready 宣言のみ行い、`gh pr merge` は実行しない（既存動作）

--- a/deltaspec/changes/issue-404/tasks.md
+++ b/deltaspec/changes/issue-404/tasks.md
@@ -1,0 +1,17 @@
+## 1. workflow-pr-merge/SKILL.md 禁止事項セクション更新
+
+- [ ] 1.1 plugins/twl/skills/workflow-pr-merge/SKILL.md の禁止事項セクション先頭に「Worker は `gh pr merge` を直接実行してはならない。マージは必ず `chain-runner.sh auto-merge` 経由で auto-merge.sh のガードを通すこと（不変条件 C）」を追記
+
+## 2. autopilot-launch.sh Worker 起動コンテキスト注入
+
+- [ ] 2.1 plugins/twl/scripts/autopilot-launch.sh の quick ラベル注入ブロック（line 232-242）の直後に、merge 禁止テキストを CONTEXT に常時追記するブロックを追加（quick ラベルの有無に関わらず全 Worker 起動時に注入）
+
+## 3. co-autopilot/SKILL.md 不変条件 C 参照更新
+
+- [ ] 3.1 plugins/twl/skills/co-autopilot/SKILL.md の不変条件一覧（C=Worker マージ禁止 の記述）に「enforcement: workflow-pr-merge/SKILL.md 禁止事項セクション + autopilot-launch.sh 起動コンテキスト参照」を追記
+
+## 4. 検証
+
+- [ ] 4.1 auto-merge.sh の内容が変更されていないことを確認（既存の 4-layer ガードが維持されていること）
+- [ ] 4.2 workflow-pr-merge/SKILL.md に不変条件 C, E, F が全て記載されていることを確認
+- [ ] 4.3 autopilot-launch.sh の CONTEXT 変数に merge 禁止テキストが含まれることをコード上で確認

--- a/deltaspec/changes/issue-404/tasks.md
+++ b/deltaspec/changes/issue-404/tasks.md
@@ -1,17 +1,17 @@
 ## 1. workflow-pr-merge/SKILL.md 禁止事項セクション更新
 
-- [ ] 1.1 plugins/twl/skills/workflow-pr-merge/SKILL.md の禁止事項セクション先頭に「Worker は `gh pr merge` を直接実行してはならない。マージは必ず `chain-runner.sh auto-merge` 経由で auto-merge.sh のガードを通すこと（不変条件 C）」を追記
+- [x] 1.1 plugins/twl/skills/workflow-pr-merge/SKILL.md の禁止事項セクション先頭に「Worker は `gh pr merge` を直接実行してはならない。マージは必ず `chain-runner.sh auto-merge` 経由で auto-merge.sh のガードを通すこと（不変条件 C）」を追記
 
 ## 2. autopilot-launch.sh Worker 起動コンテキスト注入
 
-- [ ] 2.1 plugins/twl/scripts/autopilot-launch.sh の quick ラベル注入ブロック（line 232-242）の直後に、merge 禁止テキストを CONTEXT に常時追記するブロックを追加（quick ラベルの有無に関わらず全 Worker 起動時に注入）
+- [x] 2.1 plugins/twl/scripts/autopilot-launch.sh の quick ラベル注入ブロック（line 232-242）の直後に、merge 禁止テキストを CONTEXT に常時追記するブロックを追加（quick ラベルの有無に関わらず全 Worker 起動時に注入）
 
 ## 3. co-autopilot/SKILL.md 不変条件 C 参照更新
 
-- [ ] 3.1 plugins/twl/skills/co-autopilot/SKILL.md の不変条件一覧（C=Worker マージ禁止 の記述）に「enforcement: workflow-pr-merge/SKILL.md 禁止事項セクション + autopilot-launch.sh 起動コンテキスト参照」を追記
+- [x] 3.1 plugins/twl/skills/co-autopilot/SKILL.md の不変条件一覧（C=Worker マージ禁止 の記述）に「enforcement: workflow-pr-merge/SKILL.md 禁止事項セクション + autopilot-launch.sh 起動コンテキスト参照」を追記
 
 ## 4. 検証
 
-- [ ] 4.1 auto-merge.sh の内容が変更されていないことを確認（既存の 4-layer ガードが維持されていること）
-- [ ] 4.2 workflow-pr-merge/SKILL.md に不変条件 C, E, F が全て記載されていることを確認
-- [ ] 4.3 autopilot-launch.sh の CONTEXT 変数に merge 禁止テキストが含まれることをコード上で確認
+- [x] 4.1 auto-merge.sh の内容が変更されていないことを確認（既存の 4-layer ガードが維持されていること）
+- [x] 4.2 workflow-pr-merge/SKILL.md に不変条件 C, E, F が全て記載されていることを確認
+- [x] 4.3 autopilot-launch.sh の CONTEXT 変数に merge 禁止テキストが含まれることをコード上で確認

--- a/deltaspec/changes/issue-404/test-mapping.yaml
+++ b/deltaspec/changes/issue-404/test-mapping.yaml
@@ -1,0 +1,107 @@
+change_id: issue-404
+generated_at: "2026-04-10T09:19:44Z"
+test_framework: bats
+scenarios:
+  - id: "worker-merge-context-injected"
+    name: "Worker 起動時に merge 禁止コンテキストが注入される"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 19
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context: Worker 起動時に --append-system-prompt が付与される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "worker-merge-context-gh-pr-merge-text"
+    name: "Worker 起動時に merge 禁止コンテキストが注入される (gh pr merge テキスト)"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 19
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context: --append-system-prompt に 'gh pr merge' 禁止テキストが含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "worker-merge-context-invariant-c-reference"
+    name: "Worker 起動時に merge 禁止コンテキストが注入される (不変条件 C 参照)"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 19
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context: --append-system-prompt に '不変条件 C' への言及が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "worker-merge-context-pilot-only"
+    name: "Worker 起動時に merge 禁止コンテキストが注入される (Pilot のみ)"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 19
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context: --append-system-prompt にマージ権限は Pilot のみという内容が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "worker-merge-context-always-injected"
+    name: "Worker 起動時に merge 禁止コンテキストが注入される (常時注入)"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 19
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context: --context オプション未指定でも merge 禁止コンテキストが注入される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "quick-and-merge-context-both-injected"
+    name: "quick ラベルと同時に適用される"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 23
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context+quick: quick ラベルあり Issue で merge 禁止と quick 指示の両方が注入される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "quick-label-no-merge-context-missing"
+    name: "quick ラベルと同時に適用される (quick なしでも merge 禁止は注入)"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 23
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context+quick: quick ラベルなしでも merge 禁止コンテキストは注入される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "quick-label-only-no-quick-instruction-leaked"
+    name: "quick ラベルなし → quick 指示は注入されない（エッジケース）"
+    spec_file: "specs/invariant-c-enforcement/spec.md"
+    spec_line: 23
+    requirement: "autopilot-launch.sh の Worker 起動コンテキストに merge 禁止を注入"
+    test_file: "plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats"
+    test_name: "merge-context+quick: quick ラベルなし → --append-system-prompt に quick 指示は含まれない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -229,6 +229,18 @@ if gh issue view "$ISSUE" $GH_ISSUE_REPO_FLAG --json labels --jq '.labels[].name
   IS_QUICK_LAUNCH=true
 fi
 
+# --- merge 禁止コンテキストを CONTEXT に常時注入（不変条件 C enforcement）---
+# Worker は gh pr merge を直接実行してはならない（不変条件 C）。
+# quick ラベルの有無に関係なく全 Issue で常時注入する。
+MERGE_PROHIBITION_CONTEXT="[不変条件 C] gh pr merge の直接実行は禁止。マージ権限は Pilot のみ（不変条件 C）。マージは必ず chain-runner.sh auto-merge 経由で auto-merge.sh のガードを通すこと。"
+if [[ -n "$CONTEXT" ]]; then
+  CONTEXT="${CONTEXT}
+
+${MERGE_PROHIBITION_CONTEXT}"
+else
+  CONTEXT="$MERGE_PROHIBITION_CONTEXT"
+fi
+
 # --- quick 指示をシステムプロンプトとして CONTEXT に追記 ---
 if [[ "$IS_QUICK_LAUNCH" == "true" ]]; then
   QUICK_INSTRUCTION="[quick Issue] このIssueにはquickラベルが付いています。workflow-test-readyは実行してはいけません。直接実装→commit→push→PR作成（'source \"\${CLAUDE_PLUGIN_ROOT}/scripts/lib/pr-create-helper.sh\" && pr_create_with_closes \"${ISSUE}\" quick' を実行し、PR 本文に必ず 'Closes #${ISSUE}' を機械的に挿入する）→merge-gateのみを実行してください。"

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -116,6 +116,8 @@ issue-{N}.json の status から自動判定:
 
 不変条件 A〜K の正典は `plugins/twl/architecture/domain/contexts/autopilot.md`（A=状態一意, B=Worktree 削除 Pilot 専任, C=Worker マージ禁止, D=fail skip 伝播, E=merge-gate リトライ最大1, F=merge 失敗時 rebase 禁止, G=クラッシュ検知, H=deps.yaml 変更排他, I=循環依存拒否, J=merge 前 base drift 検知, K=Pilot 実装禁止）。本文中の ID 参照のみが各 Step の制約根拠。
 
+不変条件 C enforcement 箇所: `plugins/twl/skills/workflow-pr-merge/SKILL.md` 禁止事項セクション + `plugins/twl/scripts/autopilot-launch.sh` 起動コンテキスト参照。
+
 ## Emergency Bypass
 
 co-autopilot 自体の障害時のみ手動パスを許可。bypass 使用時は retrospective で理由を記録。障害時は `commands/autopilot-phase-execute.md`・`commands/autopilot-poll.md`・`commands/autopilot-summary.md` を Read → 手動実行。

--- a/plugins/twl/skills/workflow-pr-merge/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-merge/SKILL.md
@@ -30,6 +30,10 @@ workflow-pr-cycle を 3 分割した第3段階。E2E 検証、レポート、マ
 
 ## ドメインルール
 
+### 禁止事項（不変条件 C enforcement）
+
+Worker は `gh pr merge` を直接実行してはならない（不変条件 C）。マージは必ず `chain-runner.sh auto-merge` 経由で auto-merge.sh のガードを通すこと。`gh pr merge --squash` 等の直接呼び出しは ac-verify / merge-gate / auto-merge.sh の全ガードをバイパスするため厳禁。
+
 ### merge-gate エスカレーション条件
 
 merge-gate が REJECT を返した場合の処理（不変条件 E: リトライ最大 1 回）:

--- a/plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-launch-merge-context.bats
@@ -1,0 +1,348 @@
+#!/usr/bin/env bats
+# autopilot-launch-merge-context.bats
+# Unit tests for autopilot-launch.sh: merge 禁止コンテキスト注入ロジック
+#
+# Spec: deltaspec/changes/issue-404/specs/invariant-c-enforcement/spec.md
+#
+# Coverage:
+#   Scenario 3: Worker 起動時に merge 禁止コンテキストが注入される
+#     WHEN autopilot-launch.sh が Worker（Claude Code）を起動する
+#     THEN --append-system-prompt に「gh pr merge の直接実行は禁止。マージ権限は Pilot のみ（不変条件 C）」
+#          というテキストが含まれている
+#
+#   Scenario 4: quick ラベルと同時に適用される
+#     WHEN quick ラベル付き Issue で Worker を起動する
+#     THEN merge 禁止コンテキストと quick 指示の両方がシステムプロンプトに注入される
+#
+# Edge cases:
+#   - --context オプションで既存コンテキストがある場合でも merge 禁止が追加される
+#   - merge 禁止テキストが --append-system-prompt として cld に渡される
+#   - quick ラベルなしの通常 Issue でも merge 禁止が注入される（全 Issue 常時注入）
+#
+# 注記:
+#   autopilot-launch.sh は printf '%q' でコンテキスト文字列をシェルエスケープして
+#   tmux new-window に渡す。そのため tmux スタブが受け取る引数には
+#   "gh\ pr\ merge" のようにバックスラッシュエスケープが含まれる。
+#   アサーションは grep で部分一致を確認する（バックスラッシュの有無を問わない）。
+
+load '../helpers/common'
+
+# ---------------------------------------------------------------------------
+# Setup: autopilot-launch.sh のコンテキスト構築ロジックを検証するための
+#        test double スクリプトを用意する。
+#
+# テスト戦略:
+#   autopilot-launch.sh は tmux new-window を呼ぶため、
+#   tmux をスタブして cld の起動コマンドライン全体を TMUX_CMD_FILE に記録する。
+#   printf '%q' によるエスケープを考慮し、grep で部分一致を確認する。
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  # tmux スタブ: new-window の起動コマンドを記録する
+  TMUX_CMD_FILE="$SANDBOX/tmux-new-window.txt"
+  export TMUX_CMD_FILE
+  cat > "$STUB_BIN/tmux" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  new-window)
+    # コマンド全体を記録（エスケープ済み引数を含む）
+    printf '%s\n' "\$*" >> "${TMUX_CMD_FILE}"
+    exit 0 ;;
+  set-option|set-hook|display-message|list-windows)
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/tmux"
+
+  # cld スタブ: 起動されたことを記録する（tmux スタブ内で実行されるため通常は不要）
+  cat > "$STUB_BIN/cld" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$STUB_BIN/cld"
+
+  # gh スタブ: デフォルトは quick ラベルなし（空出力）
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  # git スタブ
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse"*) echo "$SANDBOX" ;;
+      *"worktree list"*) echo "" ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  # python3 スタブ: state write/read を無害化
+  # worktree create は失敗させて WORKTREE_DIR が空のままにする
+  cat > "$STUB_BIN/python3" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree create"*) exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/python3"
+
+  # .autopilot ディレクトリと最低限の session.json を用意
+  mkdir -p "$SANDBOX/.autopilot/trace"
+  cat > "$SANDBOX/.autopilot/session.json" <<JSON
+{"session_id": "test-session-404", "started_at": "2026-04-10T00:00:00Z"}
+JSON
+
+  # テスト対象のプロジェクトディレクトリ（standard repo として扱う）
+  mkdir -p "$SANDBOX/project/.git"
+  TEST_PROJECT_DIR="$SANDBOX/project"
+  export TEST_PROJECT_DIR
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# ヘルパー: autopilot-launch.sh を実行して tmux new-window コマンドを記録する
+# ---------------------------------------------------------------------------
+
+_run_launch() {
+  local issue="${1:-42}"
+  local extra_args="${2:-}"
+  # shellcheck disable=SC2086
+  run bash "$SANDBOX/scripts/autopilot-launch.sh" \
+    --issue "$issue" \
+    --project-dir "$TEST_PROJECT_DIR" \
+    --autopilot-dir "$SANDBOX/.autopilot" \
+    $extra_args
+}
+
+# tmux new-window に渡されたコマンド文字列全体を返す
+_get_tmux_cmd() {
+  cat "$TMUX_CMD_FILE" 2>/dev/null || echo ""
+}
+
+# tmux コマンド内に指定キーワードが含まれるか確認（grep ベース）
+# printf '%q' によるエスケープ（スペースを \ でエスケープ）を考慮するため、
+# キーワードのスペースを "[ \\\\]+" にして grep する
+_tmux_cmd_contains() {
+  local keyword="$1"
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  # バックスラッシュエスケープを除去してから検索
+  echo "$tmux_cmd" | tr -d '\\' | grep -qF "$keyword"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: Worker 起動時に merge 禁止コンテキストが注入される
+# ---------------------------------------------------------------------------
+
+# WHEN autopilot-launch.sh が Worker（Claude Code）を起動する
+# THEN --append-system-prompt に「gh pr merge の直接実行は禁止。マージ権限は Pilot のみ（不変条件 C）」
+#      というテキストが含まれている
+@test "merge-context: Worker 起動時に --append-system-prompt が付与される" {
+  _run_launch 42
+
+  # tmux new-window が実行されたことを確認
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  echo "$tmux_cmd" | grep -q "\-\-append-system-prompt"
+}
+
+@test "merge-context: --append-system-prompt に 'gh pr merge' 禁止テキストが含まれる" {
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+@test "merge-context: --append-system-prompt に '不変条件 C' への言及が含まれる" {
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains "不変条件 C"
+}
+
+@test "merge-context: --append-system-prompt にマージ権限は Pilot のみという内容が含まれる" {
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains "Pilot"
+}
+
+# Edge case: --context オプションなし（デフォルト）でも merge 禁止が注入される
+@test "merge-context: --context オプション未指定でも merge 禁止コンテキストが注入される" {
+  _run_launch 42
+
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  echo "$tmux_cmd" | grep -q "\-\-append-system-prompt"
+  _tmux_cmd_contains "gh pr merge"
+}
+
+# Edge case: --context オプションありの場合、既存コンテキストに merge 禁止が追加される
+@test "merge-context: --context オプション指定時も merge 禁止が追加される" {
+  _run_launch 42 "--context カスタムコンテキスト"
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+# Edge case: merge 禁止は全 Issue（Issue 番号に関係なく）に注入される
+@test "merge-context: Issue 番号 1 でも merge 禁止コンテキストが注入される（全 Issue 常時注入）" {
+  _run_launch 1
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+@test "merge-context: Issue 番号 999 でも merge 禁止コンテキストが注入される（全 Issue 常時注入）" {
+  _run_launch 999
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: quick ラベルと同時に適用される
+# ---------------------------------------------------------------------------
+
+# WHEN quick ラベル付き Issue で Worker を起動する
+# THEN merge 禁止コンテキストと quick 指示の両方がシステムプロンプトに注入される
+@test "merge-context+quick: quick ラベルあり Issue で merge 禁止コンテキストが注入される" {
+  # quick ラベルを返す gh スタブ
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "quick" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+@test "merge-context+quick: quick ラベルあり Issue で quick 指示が注入される" {
+  # quick ラベルを返す gh スタブ
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "quick" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  _run_launch 42
+
+  assert_success
+  # quick 指示（workflow-test-ready の言及）が含まれること
+  _tmux_cmd_contains "workflow-test-ready"
+}
+
+@test "merge-context+quick: quick ラベルあり Issue で merge 禁止と quick 指示の両方が注入される" {
+  # quick ラベルを返す gh スタブ
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "quick" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  _run_launch 42
+
+  assert_success
+
+  # merge 禁止と quick 指示の両方が --append-system-prompt に含まれること
+  _tmux_cmd_contains "gh pr merge"
+  _tmux_cmd_contains "不変条件 C"
+  _tmux_cmd_contains "workflow-test-ready"
+}
+
+# Edge case: quick ラベルなしの通常 Issue でも merge 禁止が注入される
+@test "merge-context+quick: quick ラベルなしでも merge 禁止コンテキストは注入される" {
+  # quick ラベルなし（デフォルト: 空出力）
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains "gh pr merge"
+}
+
+# Edge case: quick ラベルなし → quick 指示は注入されない（merge 禁止のみ）
+@test "merge-context+quick: quick ラベルなし → --append-system-prompt に quick 指示は含まれない" {
+  # quick ラベルなし（空返却）
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*"--jq"*)
+        echo "" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  _run_launch 42
+
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+
+  # merge 禁止は含まれる
+  _tmux_cmd_contains "gh pr merge"
+  # quick 指示（workflow-test-readyは実行してはいけません）は含まれない
+  ! echo "$tmux_cmd" | tr -d '\\' | grep -qF "workflow-test-readyは実行してはいけません"
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases: CONTEXT 変数の構築ロジック検証
+# ---------------------------------------------------------------------------
+
+@test "merge-context: --append-system-prompt が cld コマンドの引数として渡される" {
+  _run_launch 42
+
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+
+  # tmux new-window の中に cld コマンドが含まれ、
+  # --append-system-prompt が cld に渡されていること
+  echo "$tmux_cmd" | grep -q "cld"
+  echo "$tmux_cmd" | grep -q "\-\-append-system-prompt"
+}
+
+# merge 禁止コンテキスト注入は条件分岐なしの常時注入（ラベル検出に依存しない）
+@test "merge-context: gh ラベル取得が失敗しても merge 禁止コンテキストは注入される（フォールバック安全性）" {
+  # gh が全て失敗するスタブ
+  stub_command "gh" 'exit 1'
+
+  _run_launch 42
+
+  # gh 失敗は Worker 起動を阻害しない
+  # merge 禁止コンテキストは gh ラベル検出に依存しないため常時注入される
+  _tmux_cmd_contains "gh pr merge"
+}


### PR DESCRIPTION
fix(autopilot): enforce invariant C - prohibit Worker from calling gh pr merge directly (#404)

- Add explicit prohibition in workflow-pr-merge/SKILL.md (invariant C enforcement section)
- Inject merge prohibition context into Worker startup via autopilot-launch.sh (same pattern as quick label injection)
- Add enforcement reference links to co-autopilot/SKILL.md invariant C description
- Add unit tests for merge context injection in autopilot-launch-merge-context.bats

Closes #404