### PR TITLE
feat(autopilot): 不変条件L追加 - マージ実行責務の明文化

### DIFF
--- a/deltaspec/changes/issue-405/.deltaspec.yaml
+++ b/deltaspec/changes/issue-405/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-405
+status: pending

--- a/deltaspec/changes/issue-405/design.md
+++ b/deltaspec/changes/issue-405/design.md
@@ -1,0 +1,26 @@
+## Context
+
+ADR-014 で Orchestrator が mergegate.py 経由でマージを実行する設計が定義されているが、autopilot.md の不変条件にはこの責務分担が明記されていない。また autopilot-orchestrator.sh の fallback パス（line 868 付近）に「auto-merge.sh にフォールバック」というコメントがあるが、実際のコードは `return 1` するだけで auto-merge.sh を呼び出していない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- autopilot.md の Constraints セクションに不変条件 L を追加し、マージ実行責務を明文化する
+- autopilot-orchestrator.sh の fallback パスのコメントを実態に合わせて修正する
+
+**Non-Goals:**
+- auto-merge.sh、mergegate.py、chain-runner.sh のコード変更
+- 既存のマージフロー動作変更
+- Observer の intervene-auto.md の変更
+
+## Decisions
+
+1. **不変条件 L の文言**: 「autopilot 時のマージ実行は Orchestrator の mergegate.py 経由のみ。Worker chain の auto-merge ステップは merge-ready 宣言のみを行い、マージは実行しない」
+   - 既存の不変条件（K: Pilot 実装禁止等）のパターンに倣い簡潔に記述する
+
+2. **コメント修正箇所**: autopilot-orchestrator.sh の fallback パスのコメントを「実際は return 1 のみ（auto-merge.sh は呼び出さない）」の旨に修正する
+
+## Risks / Trade-offs
+
+- リスクなし（ドキュメント・コメントのみの変更）
+- autopilot.md に不変条件を追加することで将来の設計変更時に制約として機能する（意図的）

--- a/deltaspec/changes/issue-405/proposal.md
+++ b/deltaspec/changes/issue-405/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+autopilot.md の不変条件として「autopilot 時のマージ実行責務」が明文化されていないため、設計意図が architecture 層で不明確になっている。また autopilot-orchestrator.sh の fallback パスのコメントが実態と乖離している。
+
+## What Changes
+
+- `architecture/autopilot.md`
+  - Constraints セクションに不変条件 L を追加:「autopilot 時のマージ実行は Orchestrator の mergegate.py 経由のみ。Worker chain の auto-merge ステップは merge-ready 宣言のみを行い、マージは実行しない」
+- `plugins/twl/scripts/autopilot-orchestrator.sh`
+  - line 868 付近の fallback パスのコメントを実態に合わせて修正（「auto-merge.sh にフォールバック」→ 実際は `return 1` のみ）
+
+## Capabilities
+
+### New Capabilities
+
+なし（ドキュメント・コメント修正のみ）
+
+### Modified Capabilities
+
+- **autopilot.md 不変条件**: マージ実行責務が L として明文化される（autopilot 時は Orchestrator の mergegate.py 経由のみ）
+- **autopilot-orchestrator.sh**: fallback パスのコメントが実態に即した記述に修正される
+
+## Impact
+
+- 影響コード: `architecture/autopilot.md`, `plugins/twl/scripts/autopilot-orchestrator.sh`
+- API/依存変更なし
+- auto-merge.sh、mergegate.py、chain-runner.sh は変更なし

--- a/deltaspec/changes/issue-405/specs/autopilot-invariant-l/spec.md
+++ b/deltaspec/changes/issue-405/specs/autopilot-invariant-l/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: 不変条件 L — autopilot マージ実行責務の明文化
+
+autopilot.md の Constraints セクションに不変条件 L を追加しなければならない（SHALL）。不変条件 L は「autopilot 時のマージ実行は Orchestrator の mergegate.py 経由のみ。Worker chain の auto-merge ステップは merge-ready 宣言のみを行い、マージは実行しない」と明記されなければならない（SHALL）。
+
+#### Scenario: autopilot.md に不変条件 L が存在する
+- **WHEN** `architecture/autopilot.md` の Constraints セクションを参照する
+- **THEN** 不変条件 L として「autopilot 時のマージ実行は Orchestrator の mergegate.py 経由のみ」が記載されている
+
+#### Scenario: Worker chain の auto-merge 責務が明示されている
+- **WHEN** autopilot.md の不変条件 L を参照する
+- **THEN** 「Worker chain の auto-merge ステップは merge-ready 宣言のみを行い、マージは実行しない」と明記されている
+
+## MODIFIED Requirements
+
+### Requirement: autopilot-orchestrator.sh fallback パスのコメント修正
+
+autopilot-orchestrator.sh の fallback パス（line 868 付近）のコメントは実態（`return 1` のみで auto-merge.sh を呼び出さない）に合わせて修正しなければならない（SHALL）。誤解を招く「auto-merge.sh にフォールバック」という表現を削除または修正しなければならない（MUST）。
+
+#### Scenario: fallback パスのコメントが実態に即している
+- **WHEN** `plugins/twl/scripts/autopilot-orchestrator.sh` の fallback パス（line 868 付近）を参照する
+- **THEN** コメントが「実際は return 1 のみ（auto-merge.sh は呼び出さない）」など実態を正確に反映している
+
+#### Scenario: auto-merge.sh、mergegate.py、chain-runner.sh が変更されていない
+- **WHEN** `git diff` で変更ファイルを確認する
+- **THEN** `auto-merge.sh`、`mergegate.py`、`chain-runner.sh` のいずれにも変更が含まれていない

--- a/deltaspec/changes/issue-405/tasks.md
+++ b/deltaspec/changes/issue-405/tasks.md
@@ -1,0 +1,14 @@
+## 1. autopilot.md に不変条件 L を追加
+
+- [ ] 1.1 `architecture/autopilot.md` の Constraints セクションを確認する
+- [ ] 1.2 不変条件 L「autopilot 時のマージ実行は Orchestrator の mergegate.py 経由のみ。Worker chain の auto-merge ステップは merge-ready 宣言のみを行い、マージは実行しない」を追加する
+
+## 2. autopilot-orchestrator.sh の fallback パスのコメント修正
+
+- [ ] 2.1 `plugins/twl/scripts/autopilot-orchestrator.sh` の line 868 付近の fallback パスを確認する
+- [ ] 2.2 「auto-merge.sh にフォールバック」などの誤解を招くコメントを実態（`return 1` のみ）に合わせて修正する
+
+## 3. 検証
+
+- [ ] 3.1 `git diff` で変更ファイルが `architecture/autopilot.md` と `autopilot-orchestrator.sh` のみであることを確認する
+- [ ] 3.2 auto-merge.sh、mergegate.py、chain-runner.sh に変更がないことを確認する

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -193,7 +193,7 @@ stateDiagram-v2
 
 ## Constraints
 
-### 不変条件（11件）
+### 不変条件（12件）
 
 | ID | 不変条件 | 概要 | DeltaSpec 参照 |
 |----|----------|------|----------------|
@@ -208,6 +208,7 @@ stateDiagram-v2
 | **I** | 循環依存拒否 | plan.yaml 生成時に循環依存を検出した場合、拒否 | autopilot-lifecycle.md#scenario-循環依存拒否 |
 | **J** | merge 前 base drift 検知 | merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止する | merge-gate.md#scenario-merge前-base-drift検知 |
 | **K** | Pilot 実装禁止 | Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可 | autopilot-lifecycle.md#scenario-不変条件-k-pilot実装禁止228 |
+| **L** | autopilot マージ実行責務 | autopilot 時のマージ実行は Orchestrator の `mergegate.py` 経由のみ。Worker chain の auto-merge ステップは `merge-ready` 宣言のみを行い、マージは実行しない | |
 
 ### 並行性の制約
 

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -865,8 +865,8 @@ run_merge_gate() {
   branch=$(python3 -m twl.autopilot.state read --type issue "${_state_read_repo_args[@]}" --issue "$issue" --field branch 2>/dev/null || echo "")
 
   if [[ -z "$pr_number" || -z "$branch" ]]; then
-    echo "[orchestrator] Issue #${issue}: PR 番号またはブランチが取得できません — auto-merge.sh にフォールバック" >&2
-    # auto-merge.sh は自身で PR 情報を解決可能な場合がある
+    echo "[orchestrator] Issue #${issue}: PR 番号またはブランチが取得できません — mergegate.py の実行をスキップ" >&2
+    # PR 情報が不足しているため mergegate.py を実行できない（auto-merge.sh は呼び出さない）
     return 1
   fi
 


### PR DESCRIPTION
autopilot 時のマージ実行責務を不変条件 L として architecture 層に明文化し、autopilot-orchestrator.sh の fallback パスのコメントを実態に合わせて修正する。

## 変更内容

- `plugins/twl/architecture/domain/contexts/autopilot.md`: 不変条件 L を追加（不変条件 12 件に更新）
- `plugins/twl/scripts/autopilot-orchestrator.sh`: fallback パスのコメントを実態（return 1 のみ）に合わせて修正
- `deltaspec/changes/issue-405/`: DeltaSpec 一式（proposal / design / specs / tasks）

## 変更なし

- `auto-merge.sh`、`mergegate.py`、`chain-runner.sh` は変更なし（AC-3）

Closes #405