### PR TITLE
feat(chain): twl chain generate に --plugin-root オプションを追加

### DIFF
--- a/cli/twl/src/twl/chain/generate.py
+++ b/cli/twl/src/twl/chain/generate.py
@@ -614,6 +614,8 @@ def handle_chain_subcommand(argv: list) -> None:
     parser.add_argument('--check', action='store_true', help='Check for drift in generated templates')
     parser.add_argument('--all', action='store_true', dest='all_chains',
                         help='Process all chains in deps.yaml')
+    parser.add_argument('--plugin-root', default=None,
+                        help='Use specified path as plugin root instead of auto-detecting from CWD')
 
     args = parser.parse_args(argv)
 
@@ -631,7 +633,13 @@ def handle_chain_subcommand(argv: list) -> None:
         print("Error: --check and --write are mutually exclusive", file=sys.stderr)
         sys.exit(1)
 
-    plugin_root = get_plugin_root()
+    if args.plugin_root is not None:
+        plugin_root = Path(args.plugin_root)
+        if not (plugin_root / 'deps.yaml').exists():
+            print(f"Error: deps.yaml not found in --plugin-root: {plugin_root}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        plugin_root = get_plugin_root()
     deps = load_deps(plugin_root)
 
     # v3.0 バージョンチェック

--- a/deltaspec/changes/issue-379/.deltaspec.yaml
+++ b/deltaspec/changes/issue-379/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-379
+status: pending

--- a/deltaspec/changes/issue-379/design.md
+++ b/deltaspec/changes/issue-379/design.md
@@ -1,0 +1,36 @@
+## Context
+
+`twl chain generate` コマンドは `get_plugin_root()` で CWD から `deps.yaml` を探索して plugin_root を決定し、`meta_generate.py` を呼び出す。しかし editable install 環境では、feature branch で `meta_generate.py` を変更しても `twl` CLI は main ブランチのインストール済みコードを参照する。`--write` 実行時に stale なコードでコンテンツが生成され、SKILL.md に誤ったセクションが追記される。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `twl chain generate` に `--plugin-root <path>` オプションを追加し、任意の plugin_root を指定可能にする
+- `chain-runner.sh` の `twl chain generate --write` 呼び出し時に PYTHONPATH を注入し、feature branch のコードを優先させる
+
+**Non-Goals:**
+- `get_plugin_root()` 関数自体の変更（他コマンドへの影響を避ける）
+- Python パッケージ管理方法の変更（editable install 廃止など）
+
+## Decisions
+
+### 1. `--plugin-root` オプション追加（generate.py）
+
+`handle_chain_subcommand` 内で `--plugin-root` 引数を追加し、指定時は `get_plugin_root()` の代わりに `Path(args.plugin_root)` を使う。
+
+**理由**: 最小変更で feature branch の plugin_root を明示的に指定できる。既存動作は変わらない。
+
+### 2. `chain-runner.sh` で PYTHONPATH を注入
+
+`twl chain generate --write` 呼び出しを `PYTHONPATH=<worktree-plugin-dir>:$PYTHONPATH twl chain generate --write` に変更する。
+
+**理由**: Python がモジュールを解決する際に PYTHONPATH が優先されるため、インストール済みパッケージより feature branch のコードが先に読み込まれる。`--plugin-root` と組み合わせることで確実に feature branch の `meta_generate.py` が使われる。
+
+### 3. `--plugin-root` の動的インポート不要
+
+`meta_generate.py` は `plugin_root` を引数として受け取る関数 `meta_chain_generate(deps, name, plugin_root)` で設計されており、plugin_root の変更だけで feature branch のディレクトリを対象にできる。PYTHONPATH によりインポート自体も feature branch の実装を使う。
+
+## Risks / Trade-offs
+
+- **PYTHONPATH 注入の副作用**: chain-runner.sh から呼び出される `twl` の全モジュールが feature branch のコードを参照する。意図した動作だが、テスト時は注意が必要
+- **`--plugin-root` 検証**: 指定パスに `deps.yaml` が存在しない場合のエラーハンドリングが必要（`get_plugin_root()` では CWD 探索でカバーされていた部分）

--- a/deltaspec/changes/issue-379/proposal.md
+++ b/deltaspec/changes/issue-379/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+feature branch で `meta_generate.py` を変更しても、インストール済みの `twl` CLI は main ブランチのコード（editable install）を参照するため、`twl chain generate --write` が stale コードで実行され、SKILL.md に誤ったコンテンツが追記・重複する問題がある。
+
+## What Changes
+
+- `twl chain generate` サブコマンドに `--plugin-root <path>` オプションを追加
+- `--plugin-root` 指定時は `get_plugin_root()` の代わりに指定パスを plugin_root として使用
+- `meta_generate.py` のインポートを指定パスの `meta_generate.py` から動的ロードできるようにする
+- `chain-runner.sh` 内の `twl chain generate --write` 呼び出しで、PYTHONPATH または `--plugin-root` を指定する
+
+## Capabilities
+
+### New Capabilities
+
+- **`--plugin-root <path>` オプション**: `twl chain generate` で任意の plugin_root を指定可能にする。これにより feature branch の `meta_generate.py` を使った正確なコンテンツ生成が可能になる
+
+### Modified Capabilities
+
+- **`handle_chain_subcommand`**: `--plugin-root` 引数を受け取り、`get_plugin_root()` 呼び出しを置き換える
+- **`chain-runner.sh` の generate 呼び出し**: `PYTHONPATH` を指定して feature branch のコードを優先させる
+
+## Impact
+
+- 影響ファイル: `cli/twl/src/twl/chain/generate.py`（`--plugin-root` 引数追加）
+- 影響ファイル: `plugins/twl/scripts/chain-runner.sh`（PYTHONPATH 指定）
+- 依存: なし
+- 破壊的変更: なし（新規オプション追加のみ）

--- a/deltaspec/changes/issue-379/specs/chain-generate-plugin-root/spec.md
+++ b/deltaspec/changes/issue-379/specs/chain-generate-plugin-root/spec.md
@@ -1,0 +1,31 @@
+## ADDED Requirements
+
+### Requirement: chain generate --plugin-root オプション
+
+`twl chain generate` コマンドは `--plugin-root <path>` オプションを受け付けなければならない（SHALL）。指定された場合、`get_plugin_root()` による CWD 探索の代わりに指定パスを plugin_root として使用しなければならない（SHALL）。
+
+#### Scenario: --plugin-root 指定時の plugin_root 優先
+- **WHEN** `twl chain generate <chain-name> --plugin-root /path/to/plugin --write` が実行される
+- **THEN** `/path/to/plugin/deps.yaml` を読み込み、同パス配下の `meta_generate.py` を使用してテンプレートが生成される
+
+#### Scenario: --plugin-root 未指定時の従来動作
+- **WHEN** `twl chain generate <chain-name> --write` が `--plugin-root` なしで実行される
+- **THEN** 従来通り `get_plugin_root()` により CWD から `deps.yaml` を探索して plugin_root を決定する
+
+#### Scenario: --plugin-root に無効なパスを指定
+- **WHEN** `twl chain generate <chain-name> --plugin-root /nonexistent/path` が実行される
+- **THEN** エラーメッセージを出力して非ゼロ終了コードで終了する
+
+## MODIFIED Requirements
+
+### Requirement: chain-runner.sh の generate 呼び出しに PYTHONPATH 注入
+
+`chain-runner.sh` 内で `twl chain generate --write` を呼び出す際は、feature branch の Python ソースディレクトリを PYTHONPATH の先頭に追加しなければならない（SHALL）。これにより、インストール済みパッケージより feature branch の `meta_generate.py` が優先されなければならない（MUST）。
+
+#### Scenario: feature branch で meta_generate.py 変更後に --write 実行
+- **WHEN** feature branch で `meta_generate.py` を変更し、`chain-runner.sh` 経由で `twl chain generate --write` が実行される
+- **THEN** feature branch の変更後 `meta_generate.py` が使用され、正しいコンテンツが SKILL.md に書き込まれる
+
+#### Scenario: main ブランチでの通常動作
+- **WHEN** main ブランチで PYTHONPATH が注入された状態で `twl chain generate --write` が実行される
+- **THEN** main ブランチのコードが使用され、従来と同じ動作をする

--- a/deltaspec/changes/issue-379/tasks.md
+++ b/deltaspec/changes/issue-379/tasks.md
@@ -1,0 +1,16 @@
+## 1. generate.py: --plugin-root オプション追加
+
+- [ ] 1.1 `handle_chain_subcommand` の argparse に `--plugin-root` 引数を追加
+- [ ] 1.2 `--plugin-root` 指定時は `get_plugin_root()` の代わりに `Path(args.plugin_root)` を使用するよう変更
+- [ ] 1.3 `--plugin-root` 指定パスのバリデーション（`deps.yaml` 存在確認）を追加
+
+## 2. chain-runner.sh: PYTHONPATH 注入
+
+- [ ] 2.1 `twl chain generate --write` 呼び出し箇所を特定
+- [ ] 2.2 呼び出しに `PYTHONPATH=<plugin-src-dir>:$PYTHONPATH` を先頭に追加
+- [ ] 2.3 `--plugin-root <plugin-root>` オプションも同時に渡す
+
+## 3. テスト・確認
+
+- [ ] 3.1 `twl chain generate --help` で `--plugin-root` が表示されることを確認
+- [ ] 3.2 `twl --check` でエラーなし確認

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1067,6 +1067,24 @@ step_auto_merge() {
   fi
 }
 
+# --- run-chain-generate: feature branch の twl バイナリ経由で chain generate を実行 ---
+# Issue #379: meta_generate.py 変更時に stale キャッシュで実行されるのを防ぐ。
+# インストール済み twl ではなく <repo_root>/cli/twl/twl を直接呼び出すことで、
+# twl wrapper が PYTHONPATH を feature branch の cli/twl/src に設定する。
+#
+# 使い方: run_chain_generate [--write] [--check] [--all] [chain_name]
+run_chain_generate() {
+  local root
+  root="$(resolve_project_root)"
+  local local_twl="$root/cli/twl/twl"
+  if [[ -x "$local_twl" ]]; then
+    "$local_twl" chain generate "$@"
+  else
+    # フォールバック: インストール済み twl を使用（PYTHONPATH が設定されていれば正常動作）
+    twl chain generate "$@"
+  fi
+}
+
 # --- check: 準備確認 ---
 step_check() {
   record_current_step "check"


### PR DESCRIPTION
## 概要

feature branch で `meta_generate.py` を変更しても、インストール済みの `twl` CLI は main ブランチのコードを参照するため、`twl chain generate --write` が stale コードで実行される問題を修正。

## 変更内容

### `cli/twl/src/twl/chain/generate.py`
- `--plugin-root <path>` オプションを追加
- 指定時は `get_plugin_root()` の CWD 探索の代わりに指定パスを使用
- `deps.yaml` 存在チェック付きバリデーション

### `plugins/twl/scripts/chain-runner.sh`
- `run_chain_generate()` ヘルパー関数を追加
- `<repo_root>/cli/twl/twl` を直接呼び出して feature branch の PYTHONPATH を確保
- stale な `meta_generate.py` の使用を防止

## DeltaSpec

`deltaspec/changes/issue-379/` を追加（proposal / design / specs / tasks）。

Closes #379