### PR TITLE
docs(CLAUDE.md): su-observer 役割説明を ADR-014 準拠に更新

### DIFF
--- a/deltaspec/changes/orchestrator-inject-next-workflow/test-mapping.yaml
+++ b/deltaspec/changes/orchestrator-inject-next-workflow/test-mapping.yaml
@@ -1,0 +1,378 @@
+change_id: orchestrator-inject-next-workflow
+generated_at: "2026-04-10T00:00:00Z"
+test_framework: bats
+scenarios:
+  # -------------------------------------------------------------------------
+  # Requirement: workflow_done フィールドの読み取り
+  # -------------------------------------------------------------------------
+  - id: "workflow-done-set"
+    name: "workflow_done が設定されている場合"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 7
+    requirement: "workflow_done フィールドの読み取り"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[workflow_done-set]: workflow_done が非空の場合に inject_next_workflow を呼ぶ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "workflow-done-inject-skip-nudge"
+    name: "workflow_done 非空かつ inject 成功時に check_and_nudge をスキップ"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 7
+    requirement: "workflow_done フィールドの読み取り"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[workflow_done-set]: workflow_done が非空かつ inject 成功時に check_and_nudge をスキップ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "workflow-done-empty"
+    name: "workflow_done が未設定の場合"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 11
+    requirement: "workflow_done フィールドの読み取り"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[workflow_done-empty]: workflow_done が空文字の場合に inject_next_workflow を呼ばない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "workflow-done-null-string"
+    name: "workflow_done が 'null' 文字列（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 11
+    requirement: "workflow_done フィールドの読み取り"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[workflow_done-null-string]: workflow_done が 'null' 文字列の場合に inject を呼ばない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: inject_next_workflow() 関数の実装
+  # -------------------------------------------------------------------------
+  - id: "inject-normal-flow"
+    name: "正常な inject フロー"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 21
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: 正常フローで tmux send-keys を実行する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-pr-merge"
+    name: "resolve_next_workflow が pr-merge を返した場合"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 25
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow[pr-merge]: inject をスキップする"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-pr-merge-full-path"
+    name: "resolve_next_workflow が /twl:workflow-pr-merge（完全パス）を返した場合（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 25
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[full-pr-merge-path]: /twl:workflow-pr-merge は inject スキップ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-resolve-fail"
+    name: "resolve_next_workflow が失敗した場合"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 29
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow[resolve-fail]: resolve 失敗時に戻り値 1 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-resolve-empty"
+    name: "resolve_next_workflow が exit 0 で空文字を返した場合（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 29
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[empty-skill]: resolve が空文字を返した場合は失敗する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: tmux pane 入力待ち確認
+  # -------------------------------------------------------------------------
+  - id: "prompt-detect-gt"
+    name: "プロンプト検出成功（> ）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 39
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: 正常フローで tmux send-keys を実行する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "prompt-detect-dollar"
+    name: "プロンプト検出成功（$ ）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 39
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: '$ ' プロンプトでも inject を実行する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "prompt-multiline-tail"
+    name: "複数行出力で末尾行がプロンプト（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 39
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[prompt]: 複数行出力で末尾行が '> ' の場合に検出される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "prompt-midline-not-detected"
+    name: "プロンプトが中間行にある場合は検出されない（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 39
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[prompt]: '$ ' プロンプトが中間行にあっても末尾行でないと検出されない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "prompt-timeout-exit1"
+    name: "3回リトライ後もプロンプト未検出"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 43
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow[timeout]: プロンプト未検出時に戻り値 1 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "prompt-timeout-retry-count"
+    name: "タイムアウト時に capture-pane が正確に3回呼ばれる（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 43
+    requirement: "tmux pane 入力待ち確認"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[timeout]: プロンプト未検出時に capture-pane を3回呼ぶ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: inject 履歴の state 記録
+  # -------------------------------------------------------------------------
+  - id: "state-workflow-injected"
+    name: "inject 成功後の履歴記録（workflow_injected）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 53
+    requirement: "inject 履歴の state 記録"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: inject 成功後に workflow_injected を state に記録する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "state-injected-at"
+    name: "inject 成功後の履歴記録（injected_at）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 53
+    requirement: "inject 履歴の state 記録"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: inject 成功後に injected_at を state に記録する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "state-injected-at-iso8601"
+    name: "injected_at が ISO8601 形式（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 53
+    requirement: "inject 履歴の state 記録"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[state]: injected_at が ISO8601 形式で記録される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: inject 成功後の NUDGE_COUNTS リセット
+  # -------------------------------------------------------------------------
+  - id: "nudge-counts-reset"
+    name: "inject 後の stall カウンターリセット"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 63
+    requirement: "inject 成功後の NUDGE_COUNTS リセット"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: inject 成功後に NUDGE_COUNTS をリセットする"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: inject イベントのログ出力
+  # -------------------------------------------------------------------------
+  - id: "log-inject-prefix"
+    name: "inject 実行ログ（[orchestrator] プレフィックス）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 73
+    requirement: "inject イベントのログ出力"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow: 正常フローで [orchestrator] inject ログを出力する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "log-warning-prefix"
+    name: "WARNING ログの [orchestrator] プレフィックス（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 73
+    requirement: "inject イベントのログ出力"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[log]: WARNING ログは [orchestrator] プレフィックスを含む（タイムアウト）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: check_and_nudge() の条件付きスキップ
+  # -------------------------------------------------------------------------
+  - id: "skip-nudge-on-inject-success"
+    name: "inject 成功後の nudge スキップ"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 83
+    requirement: "check_and_nudge() の条件付きスキップ"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[workflow_done-set]: workflow_done が非空かつ inject 成功時に check_and_nudge をスキップ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "no-skip-nudge-on-inject-fail"
+    name: "inject 失敗時は check_and_nudge を継続する（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 83
+    requirement: "check_and_nudge() の条件付きスキップ"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats"
+    test_name: "polling[inject-fail]: inject_next_workflow 失敗時は check_and_nudge を継続する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Security: allow-list バリデーション（エッジケース）
+  # -------------------------------------------------------------------------
+  - id: "security-invalid-skill"
+    name: "不正な skill 名は inject されない"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 17
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow.bats"
+    test_name: "inject_next_workflow[security]: 不正な skill 名は inject されない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "security-uppercase"
+    name: "大文字を含む skill 名は拒否される（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 17
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[security]: 大文字を含む skill 名は拒否される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "security-newline-injection"
+    name: "改行埋め込みによるコマンドインジェクション試みを無害化（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 17
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[security]: 改行を含む skill 名は改行除去後バリデーションされる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "security-empty-body"
+    name: "skill 名が /twl:workflow- だけ（本体なし）は拒否（エッジケース）"
+    spec_file: "specs/orchestrator/spec.md"
+    spec_line: 17
+    requirement: "inject_next_workflow() 関数の実装"
+    test_file: "plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats"
+    test_name: "inject_next_workflow[security]: skill 名が /twl:workflow- だけ（本体なし）は拒否される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -31,7 +31,7 @@ deps.yaml v3.0 がプラグイン構成の唯一の情報源。
 
 | supervisor | 役割 |
 |---|---|
-| su-observer | controller の動作を監視・介入するメタ認知レイヤー（ADR-014） |
+| su-observer | プロジェクト常駐のメタ認知・Wave 管理・知識外部化（ADR-014） |
 
 ## Bare repo 構造検証（セッション開始時チェック）
 

--- a/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats
+++ b/plugins/twl/tests/unit/inject-next-workflow/inject-next-workflow-edge-cases.bats
@@ -1,0 +1,450 @@
+#!/usr/bin/env bats
+# inject-next-workflow-edge-cases.bats
+# Requirement: inject_next_workflow() — エッジケース・境界値テスト
+# Spec: deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# 既存の inject-next-workflow.bats が正常系・基本エラー系をカバー済み。
+# 本ファイルは以下のエッジケースに特化:
+#   - プロンプト境界値（末尾空白なし、複数行末尾、$ 後に文字続き）
+#   - resolve_next_workflow 空文字返却（exit 0 だが空文字）
+#   - /twl:workflow-pr-merge の完全パス形式も pr-merge 扱い
+#   - 数字のみ・大文字混在の不正 skill 名
+#   - 改行埋め込みによるコマンドインジェクション試みを改行除去で無害化
+#   - 引数の issue 番号が特殊文字を含む場合のログ出力
+#   - injected_at が ISO8601 形式であること
+#   - NUDGE_COUNTS リセット後に check_and_nudge がゼロから再カウントされること
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: テスト double を生成（inject-next-workflow.bats と同形式）
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  STATE_FILE="$SANDBOX/state.log"
+  export CALLS_LOG STATE_FILE
+
+  cat > "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" << 'DISPATCH_EOF'
+#!/usr/bin/env bash
+# inject-next-workflow-dispatch.sh (edge-cases variant)
+# inject_next_workflow() の test double — エッジケース用
+#
+# 注: NEXT_WORKFLOW / PANE_OUTPUT に空文字を渡す場合は
+#     NEXT_WORKFLOW_EMPTY=1 / PANE_OUTPUT_EMPTY=1 を使う（:-展開回避）
+set -uo pipefail
+
+issue="$1"
+window_name="$2"
+
+# 空文字 override フラグ
+if [[ "${NEXT_WORKFLOW_EMPTY:-0}" == "1" ]]; then
+  NEXT_WORKFLOW=""
+else
+  NEXT_WORKFLOW="${NEXT_WORKFLOW:-/twl:workflow-pr-verify}"
+fi
+RESOLVE_EXIT="${RESOLVE_EXIT:-0}"
+if [[ "${PANE_OUTPUT_EMPTY:-0}" == "1" ]]; then
+  PANE_OUTPUT=""
+else
+  PANE_OUTPUT="${PANE_OUTPUT:-"> "}"
+fi
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+STATE_FILE="${STATE_FILE:-/dev/null}"
+declare -A NUDGE_COUNTS=()
+
+# --- resolve_next_workflow 呼び出し ---
+echo "resolve_next_workflow --issue $issue" >> "$CALLS_LOG"
+if [[ "$RESOLVE_EXIT" -ne 0 ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+  exit 1
+fi
+next_skill="$NEXT_WORKFLOW"
+
+# 空文字チェック（exit 0 だが空文字の場合）
+if [[ -z "$next_skill" ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+  exit 1
+fi
+
+# --- allow-list バリデーション（コマンドインジェクション防止） ---
+_skill_safe="${next_skill//$'\n'/}"  # 改行除去
+if [[ "$_skill_safe" == "pr-merge" || "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
+  echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
+  echo "state_write workflow_done=null" >> "$STATE_FILE"
+  exit 0
+fi
+if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe:0:200}' — inject スキップ" >&2
+  exit 1
+fi
+
+# --- tmux pane 入力待ち確認（最大3回、2秒間隔） ---
+_prompt_re='[>$][[:space:]]*$'
+prompt_found=0
+for i in 1 2 3; do
+  echo "tmux capture-pane -p -t $window_name" >> "$CALLS_LOG"
+  pane_tail=$(echo "$PANE_OUTPUT" | tail -1)
+  if [[ "$pane_tail" =~ $_prompt_re ]]; then
+    prompt_found=1
+    break
+  fi
+  sleep 0.01
+done
+
+if [[ "$prompt_found" -eq 0 ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — ${POLL_INTERVAL:-10}秒後に再チェック" >&2
+  exit 1
+fi
+
+# --- inject 実行 ---
+echo "tmux send-keys -t $window_name $_skill_safe" >> "$CALLS_LOG"
+echo "[orchestrator] Issue #${issue}: inject_next_workflow — $_skill_safe" >&2
+
+# --- workflow_done クリア ---
+echo "state_write workflow_done=null" >> "$STATE_FILE"
+
+# --- inject 履歴記録 ---
+injected_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "state_write workflow_injected=$_skill_safe" >> "$STATE_FILE"
+echo "state_write injected_at=$injected_at" >> "$STATE_FILE"
+
+# --- NUDGE_COUNTS リセット ---
+NUDGE_COUNTS[$issue]=0
+echo "nudge_counts_reset issue=$issue" >> "$CALLS_LOG"
+
+exit 0
+DISPATCH_EOF
+  chmod +x "$SANDBOX/scripts/inject-next-workflow-dispatch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: resolve_next_workflow が exit 0 で空文字を返す
+# WHEN resolve が exit 0 だが stdout が空の場合
+# THEN WARNING ログを出力し戻り値 1 で終了する（inject 失敗として扱う）
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[empty-skill]: resolve が空文字を返した場合は失敗する" {
+  NEXT_WORKFLOW_EMPTY=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+}
+
+@test "inject_next_workflow[empty-skill]: resolve 空文字時に WARNING ログを出力する" {
+  NEXT_WORKFLOW_EMPTY=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: resolve_next_workflow 失敗"
+}
+
+@test "inject_next_workflow[empty-skill]: resolve 空文字時に tmux send-keys を呼ばない" {
+  NEXT_WORKFLOW_EMPTY=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: /twl:workflow-pr-merge の完全パス形式（pr-merge 別名）
+# WHEN resolve が "/twl:workflow-pr-merge" を返す（フルパス形式）
+# THEN "pr-merge" と同様に inject スキップ、workflow_done のみクリア
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[full-pr-merge-path]: /twl:workflow-pr-merge は inject スキップ" {
+  NEXT_WORKFLOW="/twl:workflow-pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[full-pr-merge-path]: /twl:workflow-pr-merge 時に workflow_done をクリアする" {
+  NEXT_WORKFLOW="/twl:workflow-pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "state_write workflow_done=null" "$STATE_FILE"
+}
+
+@test "inject_next_workflow[full-pr-merge-path]: merge-gate 委譲ログを出力する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-merge" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "merge-gate フローに委譲"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 大文字を含む skill 名は拒否される
+# WHEN resolve が "/twl:workflow-PR-verify"（大文字含む）を返す
+# THEN バリデーション失敗で inject スキップ
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[security]: 大文字を含む skill 名は拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-PR-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: 数字始まりの skill セグメントは拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-1abc" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: ダブルダッシュを含む skill 名は allow-list を通過する（実装動作の文書化）" {
+  # 正規表現 ^/twl:workflow-[a-z][a-z0-9-]*$ は連続ハイフンを明示的に禁止しない
+  # このテストは実装の現在の動作（許可）を文書化する
+  NEXT_WORKFLOW="/twl:workflow-pr--verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[security]: アンダースコアを含む skill 名は拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-pr_verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: 改行を含む skill 名は改行除去後バリデーションされる" {
+  # 改行埋め込みで "valid\nmalicious" → 改行除去で "validmalicious" → 不正パターンで拒否
+  # または改行で "/twl:workflow-valid\nrm -rf" → 除去後 "/twl:workflow-validrm -rf" → 拒否
+  NEXT_WORKFLOW=$'/twl:workflow-valid\nrm -rf /' \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "inject_next_workflow[security]: スペースを含む skill 名は拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-pr verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: プロンプト検出の境界値
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[prompt]: 末尾が '> ' のみ（LF なし）でも検出される" {
+  # printf で末尾改行なしのプロンプトを模擬
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[prompt]: 複数行出力で末尾行が '> ' の場合に検出される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT=$'some output line\nanother line\n> ' \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[prompt]: '$ ' プロンプトが中間行にあっても末尾行でないと検出されない" {
+  # 末尾行が "Working..." → プロンプト未検出
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT=$'$ \nWorking...' \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: inject タイムアウト"
+}
+
+@test "inject_next_workflow[prompt]: プロンプト後に余分なスペースが複数ある場合も検出される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT=">   " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[prompt]: プロンプト文字なしの空行はタイムアウトとなる" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT_EMPTY=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "WARNING: inject タイムアウト"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 3回リトライの回数確認
+# WHEN tmux capture-pane が3回ともプロンプトなし
+# THEN capture-pane が正確に3回呼ばれる
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[timeout]: プロンプト未検出時に capture-pane を3回呼ぶ" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  local count
+  count=$(grep -c "tmux capture-pane -p -t ap-#340" "$CALLS_LOG" 2>/dev/null || echo 0)
+  [[ "$count" -eq 3 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: inject 成功後の injected_at が ISO8601 形式
+# WHEN inject が成功する
+# THEN injected_at の値が "%Y-%m-%dT%H:%M:%SZ" 形式を満たす
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[state]: injected_at が ISO8601 形式で記録される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  # ISO8601 パターン: 2024-01-01T00:00:00Z
+  grep -qE "state_write injected_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" "$STATE_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: workflow_done クリアの順序（inject 成功時と pr-merge 時の両方で必須）
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[order]: inject 成功時に workflow_done クリアが workflow_injected より先に記録される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  local line_clear line_injected
+  line_clear=$(grep -n "state_write workflow_done=null" "$STATE_FILE" | head -1 | cut -d: -f1)
+  line_injected=$(grep -n "state_write workflow_injected=" "$STATE_FILE" | head -1 | cut -d: -f1)
+  [[ -n "$line_clear" && -n "$line_injected" ]]
+  [[ "$line_clear" -lt "$line_injected" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: ログメッセージに [orchestrator] プレフィックスが含まれる
+# Requirement: inject イベントのログ出力
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[log]: inject 実行ログは [orchestrator] プレフィックスを含む" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "[orchestrator]"
+}
+
+@test "inject_next_workflow[log]: WARNING ログは [orchestrator] プレフィックスを含む（タイムアウト）" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "[orchestrator]"
+  assert_output --partial "WARNING"
+}
+
+@test "inject_next_workflow[log]: WARNING ログは [orchestrator] プレフィックスを含む（resolve 失敗）" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  assert_output --partial "[orchestrator]"
+  assert_output --partial "WARNING"
+}
+
+@test "inject_next_workflow[log]: inject ログに Issue 番号が含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "Issue #340"
+}
+
+@test "inject_next_workflow[log]: inject ログに skill 名が含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  assert_output --partial "inject_next_workflow — /twl:workflow-pr-verify"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 異なる Issue 番号でも正しく動作する
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[issue-num]: Issue 番号 1（最小値）で正常動作する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "1" "ap-#1"
+
+  assert_success
+  assert_output --partial "Issue #1"
+  grep -q "tmux send-keys -t ap-#1 /twl:workflow-pr-verify" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[issue-num]: 大きな Issue 番号（4桁）で正常動作する" {
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "9999" "ap-#9999"
+
+  assert_success
+  assert_output --partial "Issue #9999"
+  grep -q "nudge_counts_reset issue=9999" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 許可されている最長の skill 名
+# ---------------------------------------------------------------------------
+
+@test "inject_next_workflow[security]: 長い kebab チェーン skill 名は許可される" {
+  NEXT_WORKFLOW="/twl:workflow-pr-fix-rebase-retry" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#340 /twl:workflow-pr-fix-rebase-retry" "$CALLS_LOG"
+}
+
+@test "inject_next_workflow[security]: skill 名が /twl:workflow- だけ（本体なし）は拒否される" {
+  NEXT_WORKFLOW="/twl:workflow-" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/inject-next-workflow-dispatch.sh" "340" "ap-#340"
+
+  assert_failure
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}

--- a/plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats
+++ b/plugins/twl/tests/unit/inject-next-workflow/workflow-done-polling.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+# workflow-done-polling.bats
+# Requirement: workflow_done フィールドの読み取り / check_and_nudge の条件付きスキップ
+# Spec: deltaspec/changes/orchestrator-inject-next-workflow/specs/orchestrator/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# このファイルは polling ループ内での workflow_done 検知ロジックを単体テストする。
+# autopilot-orchestrator.sh の poll_single() 内分岐を test double で再現し、
+# 以下の境界値・エッジケースを検証する:
+#
+#   - workflow_done が非空の値 → inject_next_workflow() を呼ぶ
+#   - workflow_done が空文字 → check_and_nudge() を呼ぶ（inject しない）
+#   - workflow_done が "null" 文字列 → 空と同等として check_and_nudge() を呼ぶ
+#   - inject_next_workflow() 成功（exit 0）→ inject_matched=1 → check_and_nudge スキップ
+#   - inject_next_workflow() 失敗（exit 1）→ inject_matched=0 → check_and_nudge を継続
+#   - workflow_done が設定済みで inject 失敗 → check_and_nudge を継続する
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: polling ループの workflow_done 分岐を再現するテスト double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  export CALLS_LOG
+
+  # polling-branch.sh: poll_single() の workflow_done 分岐を独立再現
+  # Env:
+  #   WORKFLOW_DONE_VALUE  - state read の返り値（空文字 / "null" / スキル名 など）
+  #   INJECT_EXIT          - inject_next_workflow() の終了コード（0=成功, 1=失敗）
+  #   CALLS_LOG            - 呼び出し記録ファイル
+  cat > "$SANDBOX/scripts/polling-branch.sh" << 'POLLING_EOF'
+#!/usr/bin/env bash
+# polling-branch.sh
+# poll_single() の status=running ブランチの workflow_done 検知部分を再現
+set -uo pipefail
+
+WORKFLOW_DONE_VALUE="${WORKFLOW_DONE_VALUE:-}"
+INJECT_EXIT="${INJECT_EXIT:-0}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+
+# --- simulate: state read --field workflow_done ---
+workflow_done="$WORKFLOW_DONE_VALUE"
+echo "state_read workflow_done" >> "$CALLS_LOG"
+
+inject_matched=0
+
+if [[ -n "$workflow_done" && "$workflow_done" != "null" ]]; then
+  # inject_next_workflow() を呼ぶ
+  echo "inject_next_workflow called" >> "$CALLS_LOG"
+  if [[ "$INJECT_EXIT" -eq 0 ]]; then
+    inject_matched=1
+  fi
+fi
+
+if [[ "$inject_matched" -eq 0 ]]; then
+  echo "check_and_nudge called" >> "$CALLS_LOG"
+fi
+
+exit 0
+POLLING_EOF
+  chmod +x "$SANDBOX/scripts/polling-branch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: workflow_done が設定されている場合
+# WHEN status=running 中に workflow_done が非空の値を持つ
+# THEN inject_next_workflow() を呼び出す
+# ---------------------------------------------------------------------------
+
+@test "polling[workflow_done-set]: workflow_done が非空の場合に inject_next_workflow を呼ぶ" {
+  WORKFLOW_DONE_VALUE="/twl:workflow-pr-verify" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+}
+
+@test "polling[workflow_done-set]: workflow_done が非空かつ inject 成功時に check_and_nudge をスキップ" {
+  WORKFLOW_DONE_VALUE="/twl:workflow-pr-verify" \
+  INJECT_EXIT=0 \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+  ! grep -q "check_and_nudge called" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: workflow_done が未設定の場合
+# WHEN status=running 中に workflow_done が空文字
+# THEN inject_next_workflow() を呼ばず check_and_nudge() を継続する
+# ---------------------------------------------------------------------------
+
+@test "polling[workflow_done-empty]: workflow_done が空文字の場合に inject_next_workflow を呼ばない" {
+  WORKFLOW_DONE_VALUE="" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  ! grep -q "inject_next_workflow called" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "polling[workflow_done-empty]: workflow_done が空文字の場合に check_and_nudge を呼ぶ" {
+  WORKFLOW_DONE_VALUE="" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "check_and_nudge called" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: workflow_done が "null" 文字列の場合は未設定扱い
+# WHEN workflow_done フィールドが "null" 文字列（JSON null の文字列表現）
+# THEN 空文字と同等として check_and_nudge() を呼ぶ
+# ---------------------------------------------------------------------------
+
+@test "polling[workflow_done-null-string]: workflow_done が 'null' 文字列の場合に inject を呼ばない" {
+  WORKFLOW_DONE_VALUE="null" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  ! grep -q "inject_next_workflow called" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "polling[workflow_done-null-string]: workflow_done が 'null' 文字列の場合に check_and_nudge を呼ぶ" {
+  WORKFLOW_DONE_VALUE="null" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "check_and_nudge called" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: workflow_done が設定されているが inject が失敗した場合
+# Requirement: check_and_nudge() の条件付きスキップ
+# WHEN inject_next_workflow() が戻り値 1 で失敗する
+# THEN inject_matched=0 なので check_and_nudge() を呼ぶ
+# ---------------------------------------------------------------------------
+
+@test "polling[inject-fail]: inject_next_workflow 失敗時は check_and_nudge を継続する" {
+  WORKFLOW_DONE_VALUE="/twl:workflow-pr-verify" \
+  INJECT_EXIT=1 \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+  grep -q "check_and_nudge called" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: state read は常に1回呼ばれる（ショートサーキット確認）
+# ---------------------------------------------------------------------------
+
+@test "polling[state-read]: workflow_done の state read は1回呼ばれる（非空の場合）" {
+  WORKFLOW_DONE_VALUE="/twl:workflow-pr-verify" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  local count
+  count=$(grep -c "state_read workflow_done" "$CALLS_LOG" 2>/dev/null || echo 0)
+  [[ "$count" -eq 1 ]]
+}
+
+@test "polling[state-read]: workflow_done の state read は1回呼ばれる（空の場合）" {
+  WORKFLOW_DONE_VALUE="" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  local count
+  count=$(grep -c "state_read workflow_done" "$CALLS_LOG" 2>/dev/null || echo 0)
+  [[ "$count" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: workflow_done に whitespace のみの値は非空扱いになるか
+# 実装: [[ -n "$workflow_done" ]] → スペースも非空として検知される
+# WHEN workflow_done がスペース1文字
+# THEN -n 条件で真になり inject を呼ぶ（実装の動作を文書化）
+# ---------------------------------------------------------------------------
+
+@test "polling[whitespace]: workflow_done がスペース1文字の場合は非空扱いで inject を呼ぶ" {
+  WORKFLOW_DONE_VALUE=" " \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  # スペースは -n で真になる（bash の動作として文書化）
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: workflow_done に "0" や "false" の場合も非空扱い
+# ---------------------------------------------------------------------------
+
+@test "polling[truthy-values]: workflow_done が '0' でも inject を呼ぶ（非空として扱う）" {
+  WORKFLOW_DONE_VALUE="0" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+}
+
+@test "polling[truthy-values]: workflow_done が 'false' でも inject を呼ぶ（非空として扱う）" {
+  WORKFLOW_DONE_VALUE="false" \
+    run bash "$SANDBOX/scripts/polling-branch.sh"
+
+  assert_success
+  grep -q "inject_next_workflow called" "$CALLS_LOG"
+}


### PR DESCRIPTION
## 概要

plugins/twl/CLAUDE.md の Supervisor テーブルで su-observer の役割説明を更新する。

## 変更内容

- **変更前**: `controller の動作を監視・介入するメタ認知レイヤー（ADR-014）`
- **変更後**: `プロジェクト常駐のメタ認知・Wave 管理・知識外部化（ADR-014）`

SKILL.md の description と整合させ、Wave 管理・知識外部化の責務を明示する。

## AC 確認

- [x] plugins/twl/CLAUDE.md の controller テーブルに su-observer が記載されている
- [x] co-observer の記載がない
- [x] Supervisor の役割説明が正確（ADR-014 準拠）

Closes #358