### PR TITLE
fix(co-self-improve): co-observer → su-observer 参照更新

### DIFF
--- a/deltaspec/changes/issue-369/.deltaspec.yaml
+++ b/deltaspec/changes/issue-369/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-369
+status: pending

--- a/deltaspec/changes/issue-369/design.md
+++ b/deltaspec/changes/issue-369/design.md
@@ -1,0 +1,25 @@
+## Context
+
+ADR-014 による supervisor 再設計で `co-observer` が `su-observer` に改名された（Issue #356 で SKILL.md 作成済み）。`co-self-improve` SKILL.md は旧名称を9箇所参照しており、`deps.yaml` の `spawnable_by` も古い値を持つ。変更は純粋なテキスト置換であり、機能ロジックへの影響はない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `co-self-improve/SKILL.md` 内の全 `co-observer` 参照を `su-observer` に更新する
+- `deps.yaml` の `co-self-improve` エントリ `spawnable_by` を `su-observer` に更新する
+
+**Non-Goals:**
+- `co-self-improve` の動作変更
+- 他のスキルの参照更新
+- アーキテクチャや依存関係の変更
+
+## Decisions
+
+1. **一括置換**: SKILL.md 内の全 `co-observer` をテキスト置換で `su-observer` に変更する。対象行: L5, L7, L13, L20, L27, L28, L41, L47, L49
+2. **deps.yaml 更新**: `loom` CLI ではなく直接 Edit ツールで `spawnable_by` を更新する（構造変更ではないため）
+3. **検証方法**: 変更後に `grep co-observer` で残存参照がないことを確認する
+
+## Risks / Trade-offs
+
+- **リスク**: なし（純粋なテキスト置換、機能変更なし）
+- **トレードオフ**: なし

--- a/deltaspec/changes/issue-369/proposal.md
+++ b/deltaspec/changes/issue-369/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`co-self-improve` SKILL.md が旧コンポーネント名 `co-observer` を参照しており、ADR-014 による supervisor 再設計で名称が `su-observer` に変更された後も更新されていない。参照不整合を解消し、ドキュメントとシステム実態を一致させる必要がある。
+
+## What Changes
+
+- `plugins/twl/skills/co-self-improve/SKILL.md`: 全 `co-observer` 参照 (L5, L7, L13, L20, L27, L28, L41, L47, L49) を `su-observer` に更新
+  - frontmatter の `spawnable_by: [co-observer]` → `spawnable_by: [su-observer]`
+  - 本文内のコンポーネント名参照を全て更新
+  - DEPRECATED セクションの「co-observer の supervise モード」→「su-observer の supervise モード」
+- `deps.yaml`: `co-self-improve` エントリの `spawnable_by` を `su-observer` に更新
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- `co-self-improve` スキルが正しい supervisor コンポーネント (`su-observer`) から spawn されることを示す frontmatter を持つ
+- ドキュメント内のコンポーネント参照が現行アーキテクチャと一致する
+
+## Impact
+
+- `plugins/twl/skills/co-self-improve/SKILL.md`: テキスト更新のみ（機能変更なし）
+- `deps.yaml`: `spawnable_by` フィールド更新のみ
+- 依存コンポーネント: なし（参照更新のみ、動作変更なし）

--- a/deltaspec/changes/issue-369/specs/reference/reference-update.md
+++ b/deltaspec/changes/issue-369/specs/reference/reference-update.md
@@ -1,0 +1,25 @@
+## MODIFIED Requirements
+
+### Requirement: co-self-improve SKILL.md 参照更新
+
+`co-self-improve/SKILL.md` 内の全 `co-observer` 参照を `su-observer` に更新しなければならない（SHALL）。frontmatter `spawnable_by`、本文、DEPRECATED セクションを含む全9箇所が対象である。
+
+#### Scenario: SKILL.md 参照が su-observer に更新されている
+- **WHEN** `plugins/twl/skills/co-self-improve/SKILL.md` を参照したとき
+- **THEN** `co-observer` という文字列が1つも存在せず、全て `su-observer` に置き換わっている
+
+#### Scenario: frontmatter の spawnable_by が更新されている
+- **WHEN** `plugins/twl/skills/co-self-improve/SKILL.md` の frontmatter を確認したとき
+- **THEN** `spawnable_by: [su-observer]` と記載されている
+
+#### Scenario: DEPRECATED セクションが正しく更新されている
+- **WHEN** DEPRECATED セクションを確認したとき
+- **THEN** 「su-observer の supervise モードに移管」と記述されている
+
+### Requirement: deps.yaml spawnable_by 更新
+
+`deps.yaml` の `co-self-improve` エントリの `spawnable_by` フィールドを `su-observer` に更新しなければならない（SHALL）。
+
+#### Scenario: deps.yaml が su-observer を参照している
+- **WHEN** `deps.yaml` の `co-self-improve` エントリを確認したとき
+- **THEN** `spawnable_by` が `[su-observer]` を含み、`co-observer` を含まない

--- a/deltaspec/changes/issue-369/tasks.md
+++ b/deltaspec/changes/issue-369/tasks.md
@@ -1,0 +1,14 @@
+## 1. SKILL.md 参照更新
+
+- [ ] 1.1 `plugins/twl/skills/co-self-improve/SKILL.md` の全 `co-observer` 参照を `su-observer` に更新（L5, L7, L13, L20, L27, L28, L41, L47, L49）
+- [ ] 1.2 frontmatter `spawnable_by: [co-observer]` → `spawnable_by: [su-observer]` 変更を確認
+- [ ] 1.3 DEPRECATED セクション「co-observer の supervise モード」→「su-observer の supervise モード」変更を確認
+
+## 2. deps.yaml 更新
+
+- [ ] 2.1 `deps.yaml` の `co-self-improve` エントリ `spawnable_by` を `su-observer` に更新
+
+## 3. 検証
+
+- [ ] 3.1 `grep -r "co-observer" plugins/twl/skills/co-self-improve/` で残存参照がないことを確認
+- [ ] 3.2 `twl --validate` または `twl --check` でバリデーション通過を確認

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -267,7 +267,7 @@ skills:
     path: skills/co-self-improve/SKILL.md
     effort: high
     tools: [Agent(observer-evaluator)]
-    spawnable_by: [user]
+    spawnable_by: [user, su-observer]
     can_spawn: [workflow, atomic, specialist, reference]
     calls:
       - workflow: workflow-observe-loop  # 子 5 で実装

--- a/plugins/twl/docs/deps-co-autopilot.dot
+++ b/plugins/twl/docs/deps-co-autopilot.dot
@@ -11,7 +11,7 @@ digraph Dependencies {
     fontsize=14;
 
     // L0: Controller Skills
-    skill_co_autopilot [label="twl:co-autopilot\n(2,801 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
+    skill_co_autopilot [label="twl:co-autopilot\n(2,688 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
 
     // L0: Launchers
 

--- a/plugins/twl/docs/deps-co-autopilot.svg
+++ b/plugins/twl/docs/deps-co-autopilot.svg
@@ -15,7 +15,7 @@
 <title>skill_co_autopilot</title>
 <ellipse fill="#c8e6c9" stroke="black" cx="65.76" cy="-1369.49" rx="65.52" ry="21.43"/>
 <text text-anchor="middle" x="65.76" y="-1372.49" font-family="Helvetica,sans-Serif" font-size="10.00">twl:co&#45;autopilot</text>
-<text text-anchor="middle" x="65.76" y="-1361.49" font-family="Helvetica,sans-Serif" font-size="10.00">(2,801 tok)</text>
+<text text-anchor="middle" x="65.76" y="-1361.49" font-family="Helvetica,sans-Serif" font-size="10.00">(2,688 tok)</text>
 </g>
 <!-- skill_workflow_setup -->
 <g id="node2" class="node">

--- a/plugins/twl/docs/deps.dot
+++ b/plugins/twl/docs/deps.dot
@@ -8,7 +8,7 @@ digraph Dependencies {
     edge [fontname="Helvetica", fontsize=9];
 
     // L0: Controller Skills
-    skill_co_autopilot [label="twl:co-autopilot\n(2,801 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
+    skill_co_autopilot [label="twl:co-autopilot\n(2,688 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_issue [label="twl:co-issue\n(1,413 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_project [label="twl:co-project\n(1,625 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_architect [label="twl:co-architect\n(1,357 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
@@ -57,7 +57,7 @@ digraph Dependencies {
     skill_test_scenario_catalog [label="twl:test-scenario-catalog\n(1,714 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_observation_pattern_catalog [label="twl:observation-pattern-catalog\n(725 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_load_test_baselines [label="twl:load-test-baselines\n(670 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
-    skill_intervention_catalog [label="twl:intervention-catalog\n(1,673 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
+    skill_intervention_catalog [label="twl:intervention-catalog\n(1,675 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
 
     // L1: Direct Commands
     cmd_self_improve_review [label="self-improve-review\n(1,167 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
@@ -130,9 +130,9 @@ digraph Dependencies {
     cmd_issue_draft_from_observation [label="issue-draft-from-observation\n(591 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
     cmd_observe_and_detect [label="observe-and-detect\n(460 tok)", shape=box, style=filled, fillcolor="#bbdefb"];
     cmd_observe_retrospective [label="observe-retrospective\n(521 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
-    cmd_intervene_auto [label="intervene-auto\n(707 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
-    cmd_intervene_confirm [label="intervene-confirm\n(882 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
-    cmd_intervene_escalate [label="intervene-escalate\n(1,078 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
+    cmd_intervene_auto [label="intervene-auto\n(708 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
+    cmd_intervene_confirm [label="intervene-confirm\n(883 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
+    cmd_intervene_escalate [label="intervene-escalate\n(1,080 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
     cmd_test_project_init [label="test-project-init\n(847 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
     cmd_test_project_reset [label="test-project-reset\n(443 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];
     cmd_test_project_scenario_load [label="test-project-scenario-load\n(861 tok)", shape=box, style=filled, fillcolor="#e3f2fd"];

--- a/plugins/twl/docs/deps.svg
+++ b/plugins/twl/docs/deps.svg
@@ -19,7 +19,7 @@
 <title>skill_co_autopilot</title>
 <ellipse fill="#c8e6c9" stroke="black" cx="80" cy="-7091" rx="65.52" ry="21.43"/>
 <text text-anchor="middle" x="80" y="-7094" font-family="Helvetica,sans-Serif" font-size="10.00">twl:co&#45;autopilot</text>
-<text text-anchor="middle" x="80" y="-7083" font-family="Helvetica,sans-Serif" font-size="10.00">(2,801 tok)</text>
+<text text-anchor="middle" x="80" y="-7083" font-family="Helvetica,sans-Serif" font-size="10.00">(2,688 tok)</text>
 </g>
 <!-- skill_workflow_setup -->
 <g id="node7" class="node">
@@ -2031,7 +2031,7 @@
 <polyline fill="none" stroke="black" points="1776.14,-1985 1776.14,-1979 "/>
 <polyline fill="none" stroke="black" points="1782.14,-1979 1776.14,-1979 "/>
 <text text-anchor="middle" x="1715.14" y="-1970" font-family="Helvetica,sans-Serif" font-size="10.00">twl:intervention&#45;catalog</text>
-<text text-anchor="middle" x="1715.14" y="-1959" font-family="Helvetica,sans-Serif" font-size="10.00">(1,673 tok)</text>
+<text text-anchor="middle" x="1715.14" y="-1959" font-family="Helvetica,sans-Serif" font-size="10.00">(1,675 tok)</text>
 </g>
 <!-- skill_intervention_catalog&#45;&gt;skill_observation_pattern_catalog -->
 <!-- cmd_self_improve_review&#45;&gt;skill_workflow_setup -->
@@ -2459,7 +2459,7 @@
 <title>cmd_intervene_auto</title>
 <polygon fill="#e3f2fd" stroke="black" points="628.68,-2180 539.68,-2180 539.68,-2144 628.68,-2144 628.68,-2180"/>
 <text text-anchor="middle" x="584.18" y="-2165" font-family="Helvetica,sans-Serif" font-size="10.00">intervene&#45;auto</text>
-<text text-anchor="middle" x="584.18" y="-2154" font-family="Helvetica,sans-Serif" font-size="10.00">(707 tok)</text>
+<text text-anchor="middle" x="584.18" y="-2154" font-family="Helvetica,sans-Serif" font-size="10.00">(708 tok)</text>
 </g>
 <!-- cmd_intervene_auto&#45;&gt;skill_intervention_catalog -->
 <g id="edge187" class="edge">
@@ -2472,7 +2472,7 @@
 <title>cmd_intervene_confirm</title>
 <polygon fill="#e3f2fd" stroke="black" points="636.18,-2122 532.18,-2122 532.18,-2086 636.18,-2086 636.18,-2122"/>
 <text text-anchor="middle" x="584.18" y="-2107" font-family="Helvetica,sans-Serif" font-size="10.00">intervene&#45;confirm</text>
-<text text-anchor="middle" x="584.18" y="-2096" font-family="Helvetica,sans-Serif" font-size="10.00">(882 tok)</text>
+<text text-anchor="middle" x="584.18" y="-2096" font-family="Helvetica,sans-Serif" font-size="10.00">(883 tok)</text>
 </g>
 <!-- cmd_intervene_auto&#45;&gt;cmd_intervene_confirm -->
 <!-- cmd_intervene_confirm&#45;&gt;skill_intervention_catalog -->
@@ -2486,7 +2486,7 @@
 <title>cmd_intervene_escalate</title>
 <polygon fill="#e3f2fd" stroke="black" points="638.18,-2064 530.18,-2064 530.18,-2028 638.18,-2028 638.18,-2064"/>
 <text text-anchor="middle" x="584.18" y="-2049" font-family="Helvetica,sans-Serif" font-size="10.00">intervene&#45;escalate</text>
-<text text-anchor="middle" x="584.18" y="-2038" font-family="Helvetica,sans-Serif" font-size="10.00">(1,078 tok)</text>
+<text text-anchor="middle" x="584.18" y="-2038" font-family="Helvetica,sans-Serif" font-size="10.00">(1,080 tok)</text>
 </g>
 <!-- cmd_intervene_confirm&#45;&gt;cmd_intervene_escalate -->
 <!-- cmd_intervene_escalate&#45;&gt;skill_intervention_catalog -->

--- a/plugins/twl/skills/co-self-improve/SKILL.md
+++ b/plugins/twl/skills/co-self-improve/SKILL.md
@@ -2,30 +2,30 @@
 name: twl:co-self-improve
 description: |
   テストシナリオ実行と self-improvement arm。
-  co-observer から委譲されるテスト実行モード（scenario-run）と、
+  su-observer から委譲されるテスト実行モード（scenario-run）と、
   テストプロジェクト管理、過去観察の retrospect を担う。
-  直接セッション監視は co-observer に移管済み（observe モード: deprecated）。
+  直接セッション監視は su-observer に移管済み（observe モード: deprecated）。
 
   Use when user: says co-self-improve/壁打ち/テストプロジェクト/load test/scenario,
   wants to run test scenarios on test-target worktree,
   wants to manage the test project,
   wants to retrospect past observations.
-  Observation/監視 → co-observer を使うこと。
+  Observation/監視 → su-observer を使うこと。
 type: controller
 effort: high
 tools:
 - Agent(observer-evaluator)
 spawnable_by:
 - user
-- co-observer
+- su-observer
 ---
 
 # co-self-improve
 
 テストシナリオ実行 arm。scenario-run / retrospect / test-project-manage の 3 モードに特化する。
 
-**位置づけ**: co-observer（上位）から委譲されるテスト実行モードとして機能する。
-セッション監視・介入は co-observer が担い、co-self-improve はシナリオ実行と知識蓄積に集中する。
+**位置づけ**: su-observer（上位）から委譲されるテスト実行モードとして機能する。
+セッション監視・介入は su-observer が担い、co-self-improve はシナリオ実行と知識蓄積に集中する。
 
 ## Step 0: モード判定
 
@@ -38,15 +38,15 @@ spawnable_by:
 | test-project-manage | init / reset / status / clean / cleanup | Step 4 |
 
 > **注意**: `observe / 観察 / 監視` キーワードは **deprecated**。
-> セッション監視は co-observer の supervise モードを使用してください。
+> セッション監視は su-observer の supervise モードを使用してください。
 
 引数なし or 曖昧な場合は AskUserQuestion で 3 モードから選択させる。
 
 ## [DEPRECATED] observe モード
 
-このモードは co-observer の supervise モードに移管されました。
+このモードは su-observer の supervise モードに移管されました。
 `observe / 観察 / 監視` のキーワードが入力された場合は、
-AskUserQuestion で co-observer への誘導を行う。
+AskUserQuestion で su-observer への誘導を行う。
 
 ## Step 1: scenario-run モード — シナリオ選択 + spawn
 


### PR DESCRIPTION
## 変更内容

- `plugins/twl/skills/co-self-improve/SKILL.md` の全9箇所の `co-observer` 参照を `su-observer` に更新
  - frontmatter `spawnable_by`: `[co-observer]` → `[su-observer]`
  - 本文の参照 (L5, L7, L13, L27, L28, L41)
  - DEPRECATED セクション (L47, L49)
- `plugins/twl/deps.yaml` の `co-self-improve.spawnable_by` に `su-observer` を追加

## AC 確認

- [x] co-observer 参照が全て su-observer に更新されている
- [x] テスト委譲関係が正確に記述されている
- [x] SKILL.md frontmatter の `spawnable_by: [su-observer]` に変更
- [x] deps.yaml の co-self-improve エントリの spawnable_by も su-observer に更新
- [x] DEPRECATED セクション「su-observer の supervise モードに移管」に更新

Closes #369