### PR TITLE
feat(#368): su-observer SKILL.md Step 4 Wave 管理フロー最終化

### DIFF
--- a/deltaspec/changes/issue-368/.deltaspec.yaml
+++ b/deltaspec/changes/issue-368/.deltaspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-10

--- a/deltaspec/changes/issue-368/design.md
+++ b/deltaspec/changes/issue-368/design.md
@@ -1,0 +1,54 @@
+## Context
+
+現行 su-observer SKILL.md の Step 4 は以下のプレースホルダーのみ:
+```
+## Step 4: Wave 管理（後続 Issue で詳細化）
+> NOTE: このステップは後続 Issue で詳細実装される。基本構造のみ定義。
+Wave 単位の co-autopilot 起動・完了検知・結果集約を担う。
+```
+
+設計文書 `architecture/designs/su-observer-skill-design.md` の Step 2（autopilot モード）は 8 サブステップで Wave 管理の完全フローを定義している。この差分を実装する。
+
+既存コマンド:
+- `commands/wave-collect.md`: plan.yaml から Issue リストを取得し、Wave サマリを `.supervisor/wave-{N}-summary.md` に生成
+- `commands/externalize-state.md`: `--trigger wave_complete` で Wave 完了状態を外部化
+
+Step 6（SU-6 制約）は既に "Step 4 の wave-collect 実行後" を参照しており、Step 4 への実装追加と整合する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Step 4 に Wave 管理の完全なフロー（8 サブステップ）を記述する
+- wave-collect の呼出（WAVE_NUM 引数付き）を明示する
+- externalize-state の呼出（--trigger wave_complete）を wave-collect 後に明示する
+- su-compact の呼出（SU-6 制約）を明示する
+- 次 Wave への繰り返しと全 Wave 完了時のサマリ報告を記述する
+
+**Non-Goals:**
+
+- wave-collect.md / externalize-state.md / su-compact 自体の変更
+- Step 0 のモード dispatch テーブルの変更
+- Step 6（SU-6 制約ブロック）の変更（既に Step 4 wave-collect を参照済み）
+
+## Decisions
+
+**D-1: NOTE プレースホルダーを完全なフローで差し替える**
+
+既存の NOTE 行と 1 行説明を削除し、設計文書の Step 2 フロー（8 サブステップ）で置き換える。Step 番号は現行 SKILL.md の Step 4 のまま変更しない。
+
+**D-2: 呼出順序は wave-collect → externalize-state → su-compact**
+
+1. `commands/wave-collect.md` を Read → 実行（WAVE_NUM 付き）
+2. `commands/externalize-state.md` を Read → 実行（--trigger wave_complete）
+3. `Skill(twl:su-compact)` を呼び出す（SU-6 制約）
+
+**D-3: 次 Wave ループは明示的に記述する**
+
+次 Wave の Issue がある場合は Step 4-2 に戻ることを明示する。全 Wave 完了時はサマリ報告してユーザーに返す。
+
+## Risks / Trade-offs
+
+**R-1: 設計文書 Step 2 と現 SKILL.md Step 4 のステップ番号不一致**
+
+Issue #368 本文は「Step 2（autopilot モード）」と記述しているが、現 SKILL.md では Step 4 が Wave 管理。Step 番号は変更せず Step 4 に実装し、SU-6 の参照（"Step 4 の wave-collect 実行後"）と整合させる。

--- a/deltaspec/changes/issue-368/proposal.md
+++ b/deltaspec/changes/issue-368/proposal.md
@@ -1,0 +1,22 @@
+## Why
+
+su-observer SKILL.md の Step 4（Wave 管理）が NOTE プレースホルダーのみで、Wave 分割→co-autopilot spawn→observe→wave-collect→externalize-state→su-compact の完全なフローが未実装。Supervisor として Wave を自律実行するためのフローが必要。
+
+## What Changes
+
+- `plugins/twl/skills/su-observer/SKILL.md`: Step 4（Wave 管理）を NOTE プレースホルダーから完全な実装フロー（8ステップ）に差し替え。wave-collect と externalize-state の呼出順序・引数を明示。SU-6 制約との連携を明示。
+
+## Capabilities
+
+### New Capabilities
+
+- su-observer が autopilot モードで Wave 管理を完全に実行できる（Wave 分割→spawn→observe→collect→compact の全サイクル）
+- Wave 完了時に wave-collect で結果収集 → externalize-state --trigger wave_complete で状態外部化 → su-compact で compaction の順序が明示される
+
+### Modified Capabilities
+
+- Step 4 の Wave 管理が NOTE プレースホルダーから完全なフロー定義に昇格
+
+## Impact
+
+- `plugins/twl/skills/su-observer/SKILL.md`: Step 4 の書き換え（他ステップへの影響なし）

--- a/deltaspec/changes/issue-368/specs/wave-management/spec.md
+++ b/deltaspec/changes/issue-368/specs/wave-management/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Wave 管理フローの完全実装
+
+su-observer SKILL.md の Step 4 は、Wave 分割計画から co-autopilot spawn、観察ループ、wave-collect、externalize-state、su-compact までの完全な 8 サブステップフローを記述しなければならない（SHALL）。
+
+#### Scenario: Wave 管理フロー記述の検証
+- **WHEN** `plugins/twl/skills/su-observer/SKILL.md` の Step 4 を参照する
+- **THEN** Wave 分割計画→co-autopilot spawn→observe ループ→Wave 完了検知→wave-collect→externalize-state→su-compact→次 Wave ループの 8 ステップが記述されている
+
+### Requirement: wave-collect 呼出の明示
+
+Step 4 は Wave 完了検知後に `commands/wave-collect.md` を Read → 実行し、WAVE_NUM 引数を渡すことを明示しなければならない（SHALL）。
+
+#### Scenario: wave-collect 呼出の確認
+- **WHEN** Step 4 の Wave 完了ステップを参照する
+- **THEN** `commands/wave-collect.md` を Read → 実行（WAVE_NUM 付き）が記述されている
+
+### Requirement: externalize-state 呼出の明示
+
+Step 4 は wave-collect 実行後に `commands/externalize-state.md` を Read → 実行し、`--trigger wave_complete` を渡すことを明示しなければならない（SHALL）。
+
+#### Scenario: externalize-state 呼出の確認
+- **WHEN** Step 4 の状態外部化ステップを参照する
+- **THEN** `commands/externalize-state.md` を Read → 実行（--trigger wave_complete）が wave-collect の後に記述されている
+
+### Requirement: SU-6 制約の組み込み
+
+Step 4 は Wave 完了後に `Skill(twl:su-compact)` を呼び出す SU-6 制約が実フローとして組み込まれていなければならない（SHALL）。
+
+#### Scenario: SU-6 組み込みの確認
+- **WHEN** Step 4 の su-compact 呼出ステップを参照する
+- **THEN** `Skill(twl:su-compact)` の呼び出しが externalize-state の後に記述されており、SU-6 制約として明示されている

--- a/deltaspec/changes/issue-368/tasks.md
+++ b/deltaspec/changes/issue-368/tasks.md
@@ -1,0 +1,12 @@
+## 1. su-observer SKILL.md Step 4 更新
+
+- [x] 1.1 Step 4 の NOTE プレースホルダー行と 1 行説明を削除
+- [x] 1.2 Wave 管理の完全フロー（8 サブステップ）を記述
+  - [x] 1.2.1 Issue 群の Wave 分割計画（または既存計画の継続）
+  - [x] 1.2.2 Wave N の Issue リスト確定
+  - [x] 1.2.3 `session:spawn` で co-autopilot 起動（引数付き）
+  - [x] 1.2.4 observe ループ開始（Step 5 の observe を定期実行）
+  - [x] 1.2.5 Wave 完了検知 → `commands/wave-collect.md` Read → 実行（WAVE_NUM 引数付き）
+  - [x] 1.2.6 `commands/externalize-state.md` Read → 実行（--trigger wave_complete）
+  - [x] 1.2.7 `Skill(twl:su-compact)` 呼び出し（SU-6 制約）
+  - [x] 1.2.8 次 Wave がある場合は Step 4-2 に戻る。全 Wave 完了でサマリ報告

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -70,11 +70,23 @@ spawnable_by:
 4. 新たな Issue 化が必要か AskUserQuestion で確認
 5. 承認時のみ Issue draft 生成（`commands/issue-draft-from-observation.md`）
 
-## Step 4: Wave 管理（後続 Issue で詳細化）
+## Step 4: Wave 管理 — co-autopilot spawn + 結果収集
 
-> **NOTE**: このステップは後続 Issue で詳細実装される。基本構造のみ定義。
-
-Wave 単位の co-autopilot 起動・完了検知・結果集約を担う。
+1. Issue 群の Wave 分割を計画（または既存の Wave 計画を継続）
+   - `.autopilot/plan.yaml` の phases を確認し、未完了の Wave を特定する
+2. Wave N の Issue リストを確定し、ユーザーに提示して承認を得る
+3. `Skill(twl:session:spawn)` で co-autopilot を起動:
+   ```
+   /session:spawn co-autopilot --issues <issue_list> --wave <N>
+   ```
+4. observe ループを開始（Step 5 の observe を定期実行）
+   - co-autopilot の進捗を監視し、問題を検知したら介入する
+5. Wave 完了を検知したら結果を収集:
+   - `commands/wave-collect.md` を Read → 実行（`WAVE_NUM=<N>` を環境変数で渡す）
+6. 状態を外部化:
+   - `commands/externalize-state.md` を Read → 実行（`--trigger wave_complete`）
+7. SU-6 制約: `Skill(twl:su-compact)` を呼び出して知識外部化 + compaction を実行する
+8. 次 Wave の Issue がある場合は Step 4-2 に戻る。全 Wave 完了時はサマリをユーザーに報告して Step 1 へ戻る
 
 ## Step 5: Long-term Memory 保存（後続 Issue で詳細化）
 


### PR DESCRIPTION
feat(#368): su-observer SKILL.md Step 4 Wave 管理フロー最終化

wave-collect + externalize-state + su-compact の完全なフロー（8 サブステップ）を追加。
NOTE プレースホルダーを削除し、具体的な呼出手順を明示。

Closes #368