### PR TITLE
fix(autopilot): orchestrator 持続実行 + chain bypass 禁止 + 不変条件 M (#438)

### DIFF
--- a/.dev-session/01.5-ac-checklist.md
+++ b/.dev-session/01.5-ac-checklist.md
@@ -1,7 +1,7 @@
-## 受け入れ基準（Issue #387）
+## 受け入れ基準（Issue #438）
 
-1. Pilot が起動時にエラー0回で plan.yaml 生成 → session 初期化 → orchestrator 起動まで到達する
-2. SKILL.md に autopilot-plan.sh の引数フォーマットが明記されている
-3. SKILL.md に python-env.sh の source 指示がある
-4. SKILL.md に orchestrator --session-file の絶対パス例がある
-5. twl --check PASS
+1. orchestrator polling loop が Pilot の Bash timeout/cancel に影響されず持続する
+2. inject_next_workflow の実行結果（成功/失敗/理由）が `.autopilot/trace/` に記録される
+3. co-autopilot SKILL.md に chain bypass 禁止と停止時正規手順が明記されている
+4. autopilot.md に不変条件 M が追加されている
+5. setup → test-ready → pr-verify の chain 遷移が自動的に完了する（手動テストで確認）

--- a/deltaspec/changes/issue-438/.deltaspec.yaml
+++ b/deltaspec/changes/issue-438/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-10
+name: issue-438
+status: pending

--- a/deltaspec/changes/issue-438/design.md
+++ b/deltaspec/changes/issue-438/design.md
@@ -1,0 +1,90 @@
+## Context
+
+autopilot-orchestrator.sh の polling loop は Pilot の Bash context 内で同期実行される。Pilot が新しいメッセージを受信すると実行中の Bash タスクは cancel され、orchestrator プロセスも停止する。`inject_next_workflow()` の実装自体は正しい（L746-812）が「呼ばれない」のが根本問題。
+
+Wave 18-25 で 28 PRs（#407-#434）が specialist review なしでマージされたのは、chain 停止後に Pilot が独自判断で Worker に直接 nudge → PR 作成 → merge を実行したため。co-autopilot SKILL.md に chain bypass 禁止ルールが明記されておらず、不変条件 M も存在しなかった。
+
+**orchestrator 停止の3パターン:**
+1. Pilot が `Bash(timeout=10m)` で orchestrator を実行 → timeout で kill
+2. Pilot context window 内の Bash タスクとして管理 → 新メッセージで cancel
+3. バックグラウンド実行でも Pilot の context switch で orphan 化
+
+**inject_next_workflow の追加リスク（現状）:**
+- Worker プロンプト検出（正規表現 `[>$][[:space:]]*$`）が3回リトライ後タイムアウト → silent return 1
+- tmux send-keys のエラーが `/dev/null` にリダイレクトされ silent fail
+- 実行結果がログに残らないためデバッグ不能
+
+## Goals / Non-Goals
+
+**Goals:**
+- orchestrator polling loop が Pilot の Bash timeout/cancel に影響されず持続する
+- `inject_next_workflow()` の実行結果（成功/失敗/理由）が `.autopilot/trace/` に記録される
+- co-autopilot SKILL.md に chain bypass 禁止と chain 停止時の正規復旧手順が明記される
+- autopilot.md に不変条件 M が追加される
+- setup → test-ready → pr-verify の chain 遷移が自動的に完了する
+
+**Non-Goals:**
+- orchestrator の全面的なアーキテクチャ刷新（systemd 化、daemon 化等）
+- inject_next_workflow の retry ロジック追加（別 Issue 相当）
+- resolve_next_workflow の内部ロジック変更
+
+## Decisions
+
+### 1. orchestrator 持続実行: nohup + disown パターン
+
+co-autopilot SKILL.md の Step 4 orchestrator 起動コードを `nohup ... &` + `disown` に変更する。これにより Pilot の Bash プロセスが終了しても orchestrator は独立プロセスとして継続する。
+
+```bash
+# 変更前
+bash autopilot-orchestrator.sh \
+  --plan "$PLAN_FILE" --phase "$PHASE" ...
+
+# 変更後
+nohup bash autopilot-orchestrator.sh \
+  --plan "$PLAN_FILE" --phase "$PHASE" \
+  >> "${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE}.log" 2>&1 &
+disown
+ORCH_PID=$!
+echo "[orchestrator] PID=${ORCH_PID} 起動 (nohup)" >&2
+```
+
+ただし Pilot は orchestrator が完了したことを知る必要がある。PHASE_COMPLETE イベントの検知に `tail -f` + grep を使う（orchestrator が trace ログに PHASE_COMPLETE を出力する）。
+
+**代替案との比較:**
+- systemd unit: セットアップコストが高い、ポータビリティ低下
+- tmux new-window: Pilot の tmux セッション依存、複雑化
+- nohup/disown: 最小変更、既存の co-autopilot SKILL.md との整合性が高い
+
+### 2. trace ログ記録
+
+`inject_next_workflow()` の実行結果を `.autopilot/trace/inject-{YYYYMMDD}.log` に追記する。
+
+フォーマット:
+```
+[2026-04-10T14:30:00Z] issue=438 skill=/twl:workflow-test-ready result=success
+[2026-04-10T14:35:00Z] issue=438 skill=RESOLVE_FAILED result=skip reason="resolve_next_workflow exit=1"
+```
+
+orchestrator 起動時に trace ディレクトリを作成（`mkdir -p "${AUTOPILOT_DIR}/trace"`）。
+
+### 3. chain bypass 禁止ルール（co-autopilot SKILL.md）
+
+co-autopilot SKILL.md の「禁止事項（MUST NOT）」セクションに追加:
+- Worker chain 停止時に Pilot が直接 nudge して PR 作成 → マージを実行してはならない
+- chain 停止時の正規手順: orchestrator 再起動 or 手動 `twl:workflow-<name>` inject
+
+「chain 停止検知」セクションを新設し、復旧手順を明記する。
+
+### 4. 不変条件 M 追加（autopilot.md）
+
+```
+| **M** | chain 遷移は orchestrator/手動 inject のみ | chain 遷移（workflow_done 検知後の次 workflow 起動）は orchestrator の inject_next_workflow または手動 skill inject（`/twl:workflow-<name>`）のみ許可。Pilot の直接 nudge による chain bypass は禁止 | |
+```
+
+不変条件数を 12 → 13 に更新。
+
+## Risks / Trade-offs
+
+- **nohup プロセスの孤立リスク**: Pilot がクラッシュした場合、orchestrator が孤立プロセスとして残る。既存の crash-detect.sh（不変条件 G）が Worker をカバーするが orchestrator 自体のクリーンアップは手動が必要。→ trace ログの PID 記録で特定可能にする
+- **SKILL.md 変更の即効性**: ルール追加後も Pilot の既存コンテキストには反映されない。次回セッションから有効。これは許容範囲
+- **trace ログ肥大化**: 長時間セッションでログが大きくなる。rotate は未実装だが MVP では許容

--- a/deltaspec/changes/issue-438/proposal.md
+++ b/deltaspec/changes/issue-438/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+autopilot-orchestrator の polling loop が Pilot の Bash context 内で実行されるため、timeout/cancel で停止し `inject_next_workflow()` が呼ばれない。結果として setup → test-ready → pr-verify の chain 遷移が全て停止し、specialist review を含む pr-verify chain がスキップされる。Wave 18-25 で 28 PRs が specialist review なしでマージされた。
+
+## What Changes
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh`
+  - Pilot Bash context 外で持続する実行モードを追加（nohup/disown による独立プロセス化）
+  - `inject_next_workflow()` の実行結果（成功/失敗/理由）を `.autopilot/trace/` に記録し、silent fail を排除
+- `plugins/twl/skills/co-autopilot/SKILL.md`
+  - chain bypass 禁止（Worker chain 停止時は orchestrator 再起動 or 手動 re-inject のみ）を明記
+  - chain 停止時の正規復旧手順を追加
+- `plugins/twl/architecture/domain/contexts/autopilot.md`
+  - 不変条件 M「chain 遷移は orchestrator inject または手動 skill inject のみ。Pilot の直接 nudge による chain bypass は禁止」を追加
+
+## Capabilities
+
+### New Capabilities
+
+- orchestrator が Pilot の Bash timeout/cancel に影響されず持続する（nohup 実行モード）
+- `inject_next_workflow()` の実行ログが `.autopilot/trace/` に書き込まれ、デバッグ可能になる
+- 不変条件 M により chain bypass パターンがルールレベルで禁止される
+
+### Modified Capabilities
+
+- orchestrator 起動: Pilot は Bash 直接実行ではなく nohup/disown 経由で起動する
+- co-autopilot SKILL.md: chain 停止時の手順が「orchestrator 再起動 or 手動 re-inject」に限定され、直接 nudge が禁止される
+
+## Impact
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh`（実行モード変更、ログ追加）
+- `plugins/twl/skills/co-autopilot/SKILL.md`（chain bypass 禁止ルール追加）
+- `plugins/twl/architecture/domain/contexts/autopilot.md`（不変条件 M 追加）

--- a/deltaspec/changes/issue-438/specs/chain-bypass-prohibition/spec.md
+++ b/deltaspec/changes/issue-438/specs/chain-bypass-prohibition/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: chain bypass 禁止の明文化（co-autopilot SKILL.md）
+Worker chain が停止した場合、Pilot は直接 nudge して PR 作成 → マージを実行してはならない（MUST NOT）。chain 停止時の正規復旧手順のみが許可される。
+
+#### Scenario: chain 停止時に Pilot が直接 nudge を行わない
+- **WHEN** Worker の chain 遷移が停止し、orchestrator が inject を実行していない状態で Pilot が停止を検知する
+- **THEN** Pilot は orchestrator 再起動または手動 `/twl:workflow-<name>` inject を実行し、直接 nudge によるチェーン迂回を行わない
+
+#### Scenario: chain 停止時の正規復旧手順が定義されている
+- **WHEN** orchestrator が停止して chain 遷移が行われない状態が検知される
+- **THEN** Pilot は co-autopilot SKILL.md に記載された復旧手順（orchestrator 再起動 or 手動 skill inject）に従い chain を再開する
+
+### Requirement: 不変条件 M（autopilot.md）
+chain 遷移（workflow_done 検知後の次 workflow 起動）は orchestrator の `inject_next_workflow` または手動 skill inject（`/twl:workflow-<name>`）のみ許可されなければならない（SHALL）。Pilot の直接 nudge による chain bypass は禁止される。
+
+#### Scenario: 不変条件 M が autopilot.md に追加される
+- **WHEN** autopilot.md の不変条件テーブルを参照する
+- **THEN** 不変条件 M「chain 遷移は orchestrator/手動 inject のみ」が定義されており、Pilot の直接 nudge による chain bypass が禁止であることが明記されている
+
+#### Scenario: 不変条件 M の参照先が co-autopilot SKILL.md に記載される
+- **WHEN** co-autopilot SKILL.md の禁止事項セクションを参照する
+- **THEN** chain bypass 禁止が不変条件 M として参照され、正規復旧手順へのリンクが明記されている

--- a/deltaspec/changes/issue-438/specs/orchestrator-persistence/spec.md
+++ b/deltaspec/changes/issue-438/specs/orchestrator-persistence/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: orchestrator nohup 実行
+orchestrator polling loop は Pilot の Bash context 外で持続的に実行されなければならない（SHALL）。Pilot が新しいメッセージを受信しても orchestrator プロセスは停止してはならない。
+
+#### Scenario: Pilot がメッセージを受信しても orchestrator が継続する
+- **WHEN** Pilot が orchestrator 起動後に新しいユーザーメッセージを受信する
+- **THEN** orchestrator プロセスは停止せず polling loop を継続し、`inject_next_workflow()` が正常に呼ばれる
+
+#### Scenario: orchestrator PID がトレースログに記録される
+- **WHEN** Pilot が orchestrator を nohup/disown で起動する
+- **THEN** orchestrator の PID と起動時刻が `.autopilot/trace/orchestrator-phase-{N}.log` に記録される
+
+## MODIFIED Requirements
+
+### Requirement: inject_next_workflow 実行結果のトレース記録
+`inject_next_workflow()` の実行結果（成功/失敗/理由）は `.autopilot/trace/inject-{YYYYMMDD}.log` に記録されなければならない（MUST）。silent fail を排除する。
+
+#### Scenario: inject 成功時にトレースが記録される
+- **WHEN** `inject_next_workflow()` が `/twl:workflow-test-ready` を Worker に inject する
+- **THEN** `.autopilot/trace/inject-{YYYYMMDD}.log` に `result=success` エントリが追記される
+
+#### Scenario: inject 失敗時（resolve 失敗）にトレースが記録される
+- **WHEN** `resolve_next_workflow` が exit code 1 で失敗する
+- **THEN** `.autopilot/trace/inject-{YYYYMMDD}.log` に `result=skip reason="resolve_next_workflow exit=1"` エントリが追記される
+
+#### Scenario: inject 失敗時（prompt 未検出）にトレースが記録される
+- **WHEN** tmux pane の prompt 検出が3回リトライ後タイムアウトする
+- **THEN** `.autopilot/trace/inject-{YYYYMMDD}.log` に `result=timeout reason="prompt not found"` エントリが追記される

--- a/deltaspec/changes/issue-438/tasks.md
+++ b/deltaspec/changes/issue-438/tasks.md
@@ -1,0 +1,18 @@
+## 1. autopilot-orchestrator.sh: nohup 実行モード + trace ログ
+
+- [x] 1.1 `plugins/twl/scripts/autopilot-orchestrator.sh`: `.autopilot/trace/` ディレクトリ作成処理を追加（`mkdir -p "${AUTOPILOT_DIR}/trace"`）
+- [x] 1.2 `inject_next_workflow()` に trace ログ記録処理を追加（成功/失敗/理由を `.autopilot/trace/inject-{YYYYMMDD}.log` に追記）
+- [x] 1.3 tmux send-keys のエラーを trace ログにリダイレクト（`/dev/null` への silent discard を排除）
+- [x] 1.4 orchestrator の PID と起動時刻を trace ログに記録する処理を追加
+
+## 2. co-autopilot SKILL.md: chain bypass 禁止ルール追加
+
+- [x] 2.1 `plugins/twl/skills/co-autopilot/SKILL.md` の Step 4 orchestrator 起動コードを nohup/disown パターンに変更
+- [x] 2.2 PHASE_COMPLETE 検知ロジック（`tail -f` + grep）を Step 4 に追加
+- [x] 2.3 「chain 停止時の復旧手順」セクションを追加（orchestrator 再起動 or 手動 `/twl:workflow-<name>` inject）
+- [x] 2.4 「禁止事項（MUST NOT）」セクションに chain bypass 禁止を追加（不変条件 M 参照）
+
+## 3. autopilot.md: 不変条件 M 追加
+
+- [x] 3.1 `plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件テーブルに不変条件 M を追加
+- [x] 3.2 不変条件数を「12件」→「13件」に更新

--- a/deltaspec/changes/issue-438/test-mapping.yaml
+++ b/deltaspec/changes/issue-438/test-mapping.yaml
@@ -1,0 +1,120 @@
+change_id: issue-438
+generated_at: "2026-04-10T14:40:20Z"
+test_framework: bats+sh
+scenarios:
+
+  # ===========================================================================
+  # Spec: orchestrator-persistence
+  # ===========================================================================
+
+  - id: "orchestrator-persistence--pilot-receives-message-orchestrator-continues"
+    name: "Pilot がメッセージを受信しても orchestrator が継続する"
+    spec_file: "specs/orchestrator-persistence/spec.md"
+    spec_line: 6
+    requirement: "orchestrator nohup 実行"
+    test_file: "plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats"
+    test_name: "orchestrator[persistence]: autopilot-orchestrator.sh が存在する / inject_next_workflow 関数が定義されている"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "orchestrator-persistence--pid-recorded-in-trace-log"
+    name: "orchestrator PID がトレースログに記録される"
+    spec_file: "specs/orchestrator-persistence/spec.md"
+    spec_line: 10
+    requirement: "orchestrator nohup 実行"
+    test_file: "plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats"
+    test_name: "orchestrator[pid-trace]: orchestrator_pid がログに記録される / started_at が ISO8601 形式でログに記録される"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "orchestrator-persistence--inject-success-trace"
+    name: "inject 成功時にトレースが記録される"
+    spec_file: "specs/orchestrator-persistence/spec.md"
+    spec_line: 19
+    requirement: "inject_next_workflow 実行結果のトレース記録"
+    test_file: "plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats"
+    test_name: "inject-trace[success]: inject 成功時に result=success が記録される"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "orchestrator-persistence--inject-resolve-fail-trace"
+    name: "inject 失敗時（resolve 失敗）にトレースが記録される"
+    spec_file: "specs/orchestrator-persistence/spec.md"
+    spec_line: 23
+    requirement: "inject_next_workflow 実行結果のトレース記録"
+    test_file: "plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats"
+    test_name: "inject-trace[resolve-fail]: resolve 失敗時に result=skip が記録される / reason が resolve_next_workflow exit=1 を含む"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "orchestrator-persistence--inject-timeout-trace"
+    name: "inject 失敗時（prompt 未検出）にトレースが記録される"
+    spec_file: "specs/orchestrator-persistence/spec.md"
+    spec_line: 27
+    requirement: "inject_next_workflow 実行結果のトレース記録"
+    test_file: "plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats"
+    test_name: "inject-trace[timeout]: prompt 未検出時に result=timeout が記録される / reason が prompt not found を含む"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ===========================================================================
+  # Spec: chain-bypass-prohibition
+  # ===========================================================================
+
+  - id: "chain-bypass-prohibition--pilot-no-direct-nudge-on-chain-stop"
+    name: "chain 停止時に Pilot が直接 nudge を行わない"
+    spec_file: "specs/chain-bypass-prohibition/spec.md"
+    spec_line: 6
+    requirement: "chain bypass 禁止の明文化（co-autopilot SKILL.md）"
+    test_file: "plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh"
+    test_name: "SKILL.md に chain bypass 禁止が明記されている"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "chain-bypass-prohibition--recovery-procedure-defined"
+    name: "chain 停止時の正規復旧手順が定義されている"
+    spec_file: "specs/chain-bypass-prohibition/spec.md"
+    spec_line: 10
+    requirement: "chain bypass 禁止の明文化（co-autopilot SKILL.md）"
+    test_file: "plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh"
+    test_name: "SKILL.md に正規復旧手順（再起動 + 手動 inject の両方）が記載されている"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "chain-bypass-prohibition--invariant-m-in-autopilot-md"
+    name: "不変条件 M が autopilot.md に追加される"
+    spec_file: "specs/chain-bypass-prohibition/spec.md"
+    spec_line: 17
+    requirement: "不変条件 M（autopilot.md）"
+    test_file: "plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh"
+    test_name: "autopilot.md の不変条件テーブルに ID M が定義されている / 不変条件 M が chain 遷移は inject のみ許可と定義している"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "chain-bypass-prohibition--invariant-m-referenced-in-skill-md"
+    name: "不変条件 M の参照先が co-autopilot SKILL.md に記載される"
+    spec_file: "specs/chain-bypass-prohibition/spec.md"
+    spec_line: 21
+    requirement: "不変条件 M（autopilot.md）"
+    test_file: "plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh"
+    test_name: "SKILL.md が不変条件 M を参照している / SKILL.md の不変条件 M 参照に正規復旧手順へのリンクが付随している"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -193,7 +193,7 @@ stateDiagram-v2
 
 ## Constraints
 
-### 不変条件（12件）
+### 不変条件（13件）
 
 | ID | 不変条件 | 概要 | DeltaSpec 参照 |
 |----|----------|------|----------------|
@@ -209,6 +209,7 @@ stateDiagram-v2
 | **J** | merge 前 base drift 検知 | merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止する | merge-gate.md#scenario-merge前-base-drift検知 |
 | **K** | Pilot 実装禁止 | Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可 | autopilot-lifecycle.md#scenario-不変条件-k-pilot実装禁止228 |
 | **L** | autopilot マージ実行責務 | autopilot 時のマージ実行は Orchestrator の `mergegate.py` 経由のみ。Worker chain の auto-merge ステップは `merge-ready` 宣言のみを行い、マージは実行しない | |
+| **M** | chain 遷移は orchestrator/手動 inject のみ | chain 遷移（workflow_done 検知後の次 workflow 起動）は orchestrator の `inject_next_workflow` または手動 skill inject（`/twl:workflow-<name>`）のみ許可。Pilot の直接 nudge による chain bypass は禁止。chain 停止時は orchestrator 再起動または手動 inject で chain を再開する（co-autopilot SKILL.md「chain 停止時の復旧手順」参照） | issue-438 |
 
 ### 並行性の制約
 

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -748,6 +748,7 @@ inject_next_workflow() {
   local window_name="$2"
 
   # --- trace ログファイル ---
+  mkdir -p "${AUTOPILOT_DIR}/trace" 2>/dev/null || true  # SUMMARY_MODE 等での再利用を考慮して関数内でも保証
   local _trace_log="${AUTOPILOT_DIR}/trace/inject-$(date -u +%Y%m%d).log"
   local _trace_ts
   _trace_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
@@ -803,13 +804,18 @@ inject_next_workflow() {
   echo "[orchestrator] Issue #${issue}: inject_next_workflow — ${_skill_safe}" >&2
   local _send_err
   _send_err=$(tmux send-keys -t "$window_name" "$_skill_safe" Enter 2>&1) || {
+    _send_err="${_send_err//$'\n'/ }"  # ログインジェクション防止（改行除去）
     echo "[orchestrator] Issue #${issue}: WARNING: tmux send-keys 失敗 — ${_send_err}" >&2
-    echo "[${_trace_ts}] issue=${issue} skill=${_skill_safe} result=error reason=\"tmux send-keys failed: ${_send_err}\"" >> "$_trace_log" 2>/dev/null || true
+    local _err_ts
+    _err_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    echo "[${_err_ts}] issue=${issue} skill=${_skill_safe} result=error reason=\"tmux send-keys failed: ${_send_err}\"" >> "$_trace_log" 2>/dev/null || true
     return 1
   }
 
-  # --- trace ログ: inject 成功 ---
-  echo "[${_trace_ts}] issue=${issue} skill=${_skill_safe} result=success" >> "$_trace_log" 2>/dev/null || true
+  # --- trace ログ: inject 成功（タイムスタンプを inject 完了後に再取得） ---
+  local _success_ts
+  _success_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[${_success_ts}] issue=${issue} skill=${_skill_safe} result=success" >> "$_trace_log" 2>/dev/null || true
 
   # --- workflow_done クリア ---
   python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -747,11 +747,17 @@ inject_next_workflow() {
   local issue="$1"
   local window_name="$2"
 
+  # --- trace ログファイル ---
+  local _trace_log="${AUTOPILOT_DIR}/trace/inject-$(date -u +%Y%m%d).log"
+  local _trace_ts
+  _trace_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
   # --- resolve_next_workflow CLI で次の workflow を決定 ---
   local next_skill next_skill_exit=0
   next_skill=$(python3 -m twl.autopilot.resolve_next_workflow --issue "$issue" 2>/dev/null) || next_skill_exit=$?
   if [[ "$next_skill_exit" -ne 0 || -z "$next_skill" ]]; then
     echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+    echo "[${_trace_ts}] issue=${issue} skill=RESOLVE_FAILED result=skip reason=\"resolve_next_workflow exit=${next_skill_exit}\"" >> "$_trace_log" 2>/dev/null || true
     return 1
   fi
 
@@ -762,12 +768,14 @@ inject_next_workflow() {
   if [[ "$_skill_safe" == "pr-merge" || "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
     # terminal workflow: inject せず merge-gate フローに委譲
     echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
+    echo "[${_trace_ts}] issue=${issue} skill=pr-merge result=skip reason=\"terminal workflow, delegated to merge-gate\"" >> "$_trace_log" 2>/dev/null || true
     python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
       --set "workflow_done=null" 2>/dev/null || true
     return 0
   fi
   if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
     echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe:0:200}' — inject スキップ" >&2
+    echo "[${_trace_ts}] issue=${issue} skill=INVALID result=skip reason=\"invalid skill name\"" >> "$_trace_log" 2>/dev/null || true
     return 1
   fi
 
@@ -787,12 +795,21 @@ inject_next_workflow() {
 
   if [[ "$prompt_found" -eq 0 ]]; then
     echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — ${POLL_INTERVAL:-10}秒後に再チェック" >&2
+    echo "[${_trace_ts}] issue=${issue} skill=${_skill_safe} result=timeout reason=\"prompt not found after 3 retries\"" >> "$_trace_log" 2>/dev/null || true
     return 1
   fi
 
   # --- inject 実行（バリデーション済みの _skill_safe を使用） ---
   echo "[orchestrator] Issue #${issue}: inject_next_workflow — ${_skill_safe}" >&2
-  tmux send-keys -t "$window_name" "$_skill_safe" Enter 2>/dev/null || true
+  local _send_err
+  _send_err=$(tmux send-keys -t "$window_name" "$_skill_safe" Enter 2>&1) || {
+    echo "[orchestrator] Issue #${issue}: WARNING: tmux send-keys 失敗 — ${_send_err}" >&2
+    echo "[${_trace_ts}] issue=${issue} skill=${_skill_safe} result=error reason=\"tmux send-keys failed: ${_send_err}\"" >> "$_trace_log" 2>/dev/null || true
+    return 1
+  }
+
+  # --- trace ログ: inject 成功 ---
+  echo "[${_trace_ts}] issue=${issue} skill=${_skill_safe} result=success" >> "$_trace_log" 2>/dev/null || true
 
   # --- workflow_done クリア ---
   python3 -m twl.autopilot.state write --type issue --issue "$issue" --role pilot \
@@ -1086,6 +1103,7 @@ fi
 
 # --- Phase 実行 ---
 mkdir -p "$AUTOPILOT_DIR/logs"
+mkdir -p "$AUTOPILOT_DIR/trace"
 
 # model 解決: CLI arg > plan.yaml > デフォルト（sonnet）
 if [[ -z "$WORKER_MODEL" && -f "$PLAN_FILE" ]]; then
@@ -1099,6 +1117,9 @@ if [[ -z "$WORKER_MODEL" ]]; then
 fi
 
 echo "[orchestrator] Phase ${PHASE} 開始" >&2
+# --- trace: PID と起動時刻を記録 ---
+_orch_started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+echo "[${_orch_started_at}] orchestrator_pid=$$ phase=${PHASE} started_at=${_orch_started_at}" >> "${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE}.log" 2>/dev/null || true
 
 # Step 1: Phase 内 Issue リスト取得
 get_phase_issues "$PHASE" "$PLAN_FILE"

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -85,19 +85,40 @@ co-autopilot は su-observer の存在を前提とせず動作する。su-observ
 
 ## Step 4: Phase ループ（orchestrator 委譲）
 
-`autopilot-orchestrator.sh` で Phase 実行を委譲。`--session-file` には `$AUTOPILOT_DIR` を使った絶対パスを指定すること（相対パス・セッション ID 直接渡しは不可）:
+`autopilot-orchestrator.sh` で Phase 実行を委譲。Pilot の Bash context 外で持続実行するため **nohup/disown** を使用すること（不変条件 M — Pilot timeout/cancel による chain 停止防止）。`--session-file` には `$AUTOPILOT_DIR` を使った絶対パスを指定すること（相対パス・セッション ID 直接渡しは不可）:
 
 ```bash
-bash autopilot-orchestrator.sh \
+mkdir -p "${AUTOPILOT_DIR}/trace"
+_ORCH_LOG="${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE_NUM}.log"
+nohup bash autopilot-orchestrator.sh \
   --plan "${AUTOPILOT_DIR}/plan.yaml" \
   --phase "$PHASE_NUM" \
   --session-file "${AUTOPILOT_DIR}/session.json" \
   --project-dir "$PROJECT_DIR" \
   --autopilot-dir "$AUTOPILOT_DIR" \
-  ${REPOS_ARG:-}
+  ${REPOS_ARG:-} \
+  >> "$_ORCH_LOG" 2>&1 &
+disown
+_ORCH_PID=$!
+echo "[co-autopilot] orchestrator PID=${_ORCH_PID} 起動 (nohup) → ログ: ${_ORCH_LOG}" >&2
 ```
 
-orchestrator は JSON レポート（PHASE_COMPLETE）を返す。実装詳細（batch 分割・Worker 起動・ポーリング・merge-gate・skip 伝播 [不変条件 D]）は orchestrator が正典。Pilot LLM の責務は計画承認・retrospective・cross-issue 分析に限定。
+PHASE_COMPLETE 検知（orchestrator が trace ログに `PHASE_COMPLETE` を出力するまで待機）:
+
+```bash
+# PHASE_COMPLETE を検知するまで polling（最大 MAX_POLL 回 × POLL_INTERVAL 秒）
+_poll_count=0
+while [[ "$_poll_count" -lt "${MAX_POLL:-720}" ]]; do
+  if grep -q "PHASE_COMPLETE" "$_ORCH_LOG" 2>/dev/null; then
+    echo "[co-autopilot] PHASE_COMPLETE 検知" >&2
+    break
+  fi
+  sleep "${POLL_INTERVAL:-10}"
+  _poll_count=$((_poll_count + 1))
+done
+```
+
+orchestrator は JSON レポート（PHASE_COMPLETE）を trace ログに出力する。実装詳細（batch 分割・Worker 起動・ポーリング・merge-gate・skip 伝播 [不変条件 D]）は orchestrator が正典。Pilot LLM の責務は計画承認・retrospective・cross-issue 分析に限定。
 <!-- NOTE: Pilot 用 atomic (autopilot-pilot-precheck, autopilot-pilot-rebase, autopilot-multi-source-verdict) 経由であれば、PR diff stat / AC spot-check 等の能動評価は許容される。設計原則 P1 (ADR-010) 参照。 -->
 
 ### Step 4.5: Phase 完了サニティチェック（MUST）
@@ -134,9 +155,42 @@ issue-{N}.json の status から自動判定:
 
 ## 不変条件
 
-不変条件 A〜K の正典は `plugins/twl/architecture/domain/contexts/autopilot.md`（A=状態一意, B=Worktree 削除 Pilot 専任, C=Worker マージ禁止, D=fail skip 伝播, E=merge-gate リトライ最大1, F=merge 失敗時 rebase 禁止, G=クラッシュ検知, H=deps.yaml 変更排他, I=循環依存拒否, J=merge 前 base drift 検知, K=Pilot 実装禁止）。本文中の ID 参照のみが各 Step の制約根拠。
+不変条件 A〜M の正典は `plugins/twl/architecture/domain/contexts/autopilot.md`（A=状態一意, B=Worktree 削除 Pilot 専任, C=Worker マージ禁止, D=fail skip 伝播, E=merge-gate リトライ最大1, F=merge 失敗時 rebase 禁止, G=クラッシュ検知, H=deps.yaml 変更排他, I=循環依存拒否, J=merge 前 base drift 検知, K=Pilot 実装禁止, L=autopilot マージ実行責務, M=chain 遷移は orchestrator/手動 inject のみ）。本文中の ID 参照のみが各 Step の制約根拠。
 
 不変条件 C enforcement 箇所: `plugins/twl/skills/workflow-pr-merge/SKILL.md` 禁止事項セクション + `plugins/twl/scripts/autopilot-launch.sh` 起動コンテキスト参照。
+
+## chain 停止時の復旧手順（MUST）
+
+orchestrator が停止して chain 遷移が行われない場合、以下の正規手順のみ許可される（不変条件 M）:
+
+### 1. orchestrator 再起動
+```bash
+# trace ログで停止確認
+cat "${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE_NUM}.log" | tail -20
+
+# orchestrator を nohup で再起動（Step 4 のコマンドを再実行）
+mkdir -p "${AUTOPILOT_DIR}/trace"
+nohup bash autopilot-orchestrator.sh \
+  --plan "${AUTOPILOT_DIR}/plan.yaml" \
+  --phase "$PHASE_NUM" \
+  --session-file "${AUTOPILOT_DIR}/session.json" \
+  --project-dir "$PROJECT_DIR" \
+  --autopilot-dir "$AUTOPILOT_DIR" \
+  >> "${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE_NUM}.log" 2>&1 &
+disown
+```
+
+### 2. 手動 workflow inject
+orchestrator 再起動が困難な場合、Worker の tmux window に手動で次の workflow を inject する:
+```bash
+# Worker の現在 workflow_done 状態を確認
+python3 -m twl.autopilot.resolve_next_workflow --issue <ISSUE_NUM>
+
+# tmux で手動 inject（例: /twl:workflow-test-ready）
+tmux send-keys -t "<WORKER_WINDOW>" "/twl:workflow-test-ready" Enter
+```
+
+**禁止**: Pilot が Worker に直接 nudge して PR 作成 → マージを実行すること（不変条件 M）。chain を迂回した PR 作成は specialist review スキップを引き起こす。
 
 ## Emergency Bypass
 
@@ -168,5 +222,6 @@ python3 -m twl.autopilot.mergegate merge \
 - merge-gate 失敗時に rebase を試みてはならない（不変条件 F）
 - trivial change であっても co-autopilot を bypass してはならない（制約 AP-2）
 - Pilot は Worker の代わりに Issue を直接実装（`Agent(Implement Issue #N)` 等によるコード変更・PR 作成）してはならない（不変条件 K）。Worker 失敗時は根本原因分析 → Issue 化で対処する
+- **Worker chain 停止時に Pilot が直接 nudge して PR 作成 → マージを実行してはならない（不変条件 M）**。chain 停止時は「chain 停止時の復旧手順」に従い orchestrator 再起動 or 手動 workflow inject で chain を再開すること。specialist review をスキップしたマージは禁止
 
 Autopilot 制約の正典は `plugins/twl/architecture/domain/contexts/autopilot.md`

--- a/plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh
+++ b/plugins/twl/tests/scenarios/chain-bypass-prohibition.test.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Document Verification Tests: chain bypass 禁止
+# Generated from: deltaspec/changes/issue-438/specs/chain-bypass-prohibition/spec.md
+# Coverage level: edge-cases
+# Verifies:
+#   - co-autopilot SKILL.md に chain bypass 禁止ルールが記載されている
+#   - autopilot.md に不変条件 M が定義されている
+#   - 正規復旧手順（orchestrator 再起動 or 手動 inject）が SKILL.md に記載されている
+# =============================================================================
+set -uo pipefail
+
+# Project root (relative to test file location)
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+# Counters
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# --- Test Helpers ---
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "${PROJECT_ROOT}/${file}" ]]
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qiP -- "$pattern" "${PROJECT_ROOT}/${file}"
+}
+
+assert_file_contains_all() {
+  local file="$1"
+  shift
+  local patterns=("$@")
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  for pattern in "${patterns[@]}"; do
+    if ! grep -qiP -- "$pattern" "${PROJECT_ROOT}/${file}"; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  if grep -qiP -- "$pattern" "${PROJECT_ROOT}/${file}"; then
+    return 1
+  fi
+  return 0
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result
+  result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++))
+}
+
+SKILL_MD="skills/co-autopilot/SKILL.md"
+AUTOPILOT_MD="architecture/domain/contexts/autopilot.md"
+
+# =============================================================================
+# Requirement: chain bypass 禁止の明文化（co-autopilot SKILL.md）
+# =============================================================================
+echo ""
+echo "--- Requirement: chain bypass 禁止（co-autopilot SKILL.md） ---"
+
+# Scenario: chain 停止時に Pilot が直接 nudge を行わない
+# WHEN Worker の chain 遷移が停止し、orchestrator が inject を実行していない状態で Pilot が停止を検知する
+# THEN Pilot は orchestrator 再起動または手動 /twl:workflow-<name> inject を実行し、直接 nudge によるチェーン迂回を行わない
+
+test_skill_md_exists() {
+  assert_file_exists "$SKILL_MD"
+}
+run_test "co-autopilot SKILL.md が存在する" test_skill_md_exists
+
+test_skill_md_chain_bypass_prohibition() {
+  assert_file_contains "$SKILL_MD" "chain.*bypass.*禁止|直接.*nudge.*してはならない|MUST NOT.*nudge|chain.*迂回"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md に chain bypass 禁止が明記されている" test_skill_md_chain_bypass_prohibition
+else
+  run_test_skip "SKILL.md に chain bypass 禁止が明記されている" "${SKILL_MD} not found"
+fi
+
+# Scenario: chain 停止時の正規復旧手順が定義されている
+# WHEN orchestrator が停止して chain 遷移が行われない状態が検知される
+# THEN Pilot は co-autopilot SKILL.md に記載された復旧手順（orchestrator 再起動 or 手動 skill inject）に従い chain を再開する
+
+test_skill_md_recovery_procedure_orchestrator_restart() {
+  assert_file_contains "$SKILL_MD" "orchestrator.*再起動|orchestrator.*restart"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md に orchestrator 再起動手順が記載されている" test_skill_md_recovery_procedure_orchestrator_restart
+else
+  run_test_skip "SKILL.md に orchestrator 再起動手順が記載されている" "${SKILL_MD} not found"
+fi
+
+test_skill_md_recovery_procedure_manual_inject() {
+  assert_file_contains "$SKILL_MD" "手動.*inject|manual.*inject|/twl:workflow-"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md に手動 skill inject 手順が記載されている" test_skill_md_recovery_procedure_manual_inject
+else
+  run_test_skip "SKILL.md に手動 skill inject 手順が記載されている" "${SKILL_MD} not found"
+fi
+
+test_skill_md_recovery_procedure_chain_resume() {
+  assert_file_contains_all "$SKILL_MD" \
+    "orchestrator.*再起動|orchestrator.*restart" \
+    "手動.*inject|/twl:workflow-"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md に正規復旧手順（再起動 + 手動 inject の両方）が記載されている" test_skill_md_recovery_procedure_chain_resume
+else
+  run_test_skip "SKILL.md に正規復旧手順（再起動 + 手動 inject の両方）が記載されている" "${SKILL_MD} not found"
+fi
+
+# Edge case: 禁止事項セクションに chain bypass が含まれる
+test_skill_md_prohibition_section() {
+  assert_file_contains "$SKILL_MD" "禁止事項|MUST NOT|禁止"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md に禁止事項セクションが存在する" test_skill_md_prohibition_section
+else
+  run_test_skip "SKILL.md に禁止事項セクションが存在する" "${SKILL_MD} not found"
+fi
+
+# Edge case: 不変条件 M への参照が SKILL.md に含まれる
+# Scenario: 不変条件 M の参照先が co-autopilot SKILL.md に記載される
+# WHEN co-autopilot SKILL.md の禁止事項セクションを参照する
+# THEN chain bypass 禁止が不変条件 M として参照され、正規復旧手順へのリンクが明記されている
+
+test_skill_md_invariant_m_reference() {
+  # 不変条件 M を M 単体 ID として参照（A〜K の K に含まれる M などは除外）
+  # grep -P で word boundary を使う: 不変条件\s+M\b または \*\*M\*\*
+  grep -qP "不変条件\s+M\b|\bM\s+(chain|bypass)|不変条件.*\bM\b.*chain|\*\*M\*\*" "${PROJECT_ROOT}/${SKILL_MD}"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md が不変条件 M を参照している" test_skill_md_invariant_m_reference
+else
+  run_test_skip "SKILL.md が不変条件 M を参照している" "${SKILL_MD} not found"
+fi
+
+test_skill_md_invariant_m_with_recovery_link() {
+  # 不変条件 M への言及 AND 復旧手順への参照が両方あること
+  grep -qP "不変条件\s+M\b|\bM\s+(chain|bypass)|\*\*M\*\*" "${PROJECT_ROOT}/${SKILL_MD}" || return 1
+  assert_file_contains "$SKILL_MD" "orchestrator.*再起動|手動.*inject|復旧"
+}
+if [[ -f "${PROJECT_ROOT}/${SKILL_MD}" ]]; then
+  run_test "SKILL.md の不変条件 M 参照に正規復旧手順へのリンクが付随している" test_skill_md_invariant_m_with_recovery_link
+else
+  run_test_skip "SKILL.md の不変条件 M 参照に正規復旧手順へのリンクが付随している" "${SKILL_MD} not found"
+fi
+
+# =============================================================================
+# Requirement: 不変条件 M（autopilot.md）
+# =============================================================================
+echo ""
+echo "--- Requirement: 不変条件 M（autopilot.md） ---"
+
+# Scenario: 不変条件 M が autopilot.md に追加される
+# WHEN autopilot.md の不変条件テーブルを参照する
+# THEN 不変条件 M「chain 遷移は orchestrator/手動 inject のみ」が定義されており、
+#      Pilot の直接 nudge による chain bypass が禁止であることが明記されている
+
+test_autopilot_md_exists() {
+  assert_file_exists "$AUTOPILOT_MD"
+}
+run_test "autopilot.md が存在する" test_autopilot_md_exists
+
+test_autopilot_md_invariant_table_exists() {
+  assert_file_contains "$AUTOPILOT_MD" "不変条件|Invariant"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "autopilot.md に不変条件テーブルが存在する" test_autopilot_md_invariant_table_exists
+else
+  run_test_skip "autopilot.md に不変条件テーブルが存在する" "${AUTOPILOT_MD} not found"
+fi
+
+test_autopilot_md_invariant_m_defined() {
+  # ID "M" が不変条件テーブルに存在する
+  assert_file_contains "$AUTOPILOT_MD" "\|\s*\*\*M\*\*\s*\||\|\s*M\s*\|"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "autopilot.md の不変条件テーブルに ID M が定義されている" test_autopilot_md_invariant_m_defined
+else
+  run_test_skip "autopilot.md の不変条件テーブルに ID M が定義されている" "${AUTOPILOT_MD} not found"
+fi
+
+test_autopilot_md_invariant_m_content_inject_only() {
+  # chain 遷移は inject のみ許可という内容
+  assert_file_contains "$AUTOPILOT_MD" "inject.*のみ|inject.*only|inject_next_workflow.*のみ"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "不変条件 M が chain 遷移は inject のみ許可と定義している" test_autopilot_md_invariant_m_content_inject_only
+else
+  run_test_skip "不変条件 M が chain 遷移は inject のみ許可と定義している" "${AUTOPILOT_MD} not found"
+fi
+
+test_autopilot_md_invariant_m_prohibits_direct_nudge() {
+  # 不変条件 M の行に chain bypass 禁止が明記されている（不変条件 K などの false positive を避ける）
+  # 不変条件 M のテーブル行を探し、そこに chain bypass 禁止が含まれることを確認
+  grep -P "\|\s*\*\*M\*\*\s*\|" "${PROJECT_ROOT}/${AUTOPILOT_MD}" | grep -qiP "chain.*bypass.*禁止|直接.*nudge.*禁止|bypass.*禁止"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "不変条件 M が Pilot の直接 nudge による chain bypass を禁止と明記している" test_autopilot_md_invariant_m_prohibits_direct_nudge
+else
+  run_test_skip "不変条件 M が Pilot の直接 nudge による chain bypass を禁止と明記している" "${AUTOPILOT_MD} not found"
+fi
+
+# Edge case: 不変条件 M の後に DeltaSpec 参照が記載されている
+test_autopilot_md_invariant_m_deltaspec_ref() {
+  assert_file_contains "$AUTOPILOT_MD" "issue-438|chain-bypass-prohibition"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "autopilot.md の不変条件 M に DeltaSpec 参照が含まれる" test_autopilot_md_invariant_m_deltaspec_ref
+else
+  run_test_skip "autopilot.md の不変条件 M に DeltaSpec 参照が含まれる" "${AUTOPILOT_MD} not found"
+fi
+
+# Edge case: 不変条件の件数が 13 件（A-M）になっている
+test_autopilot_md_invariant_count() {
+  # M まで不変条件が定義されていれば 13 件（A-M）
+  local count
+  count=$(grep -cP '\|\s*\*\*[A-M]\*\*\s*\|' "${PROJECT_ROOT}/${AUTOPILOT_MD}" 2>/dev/null || echo 0)
+  [[ "$count" -ge 1 ]]
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "autopilot.md に不変条件 M の ID が存在する（A-M でカバー）" test_autopilot_md_invariant_count
+else
+  run_test_skip "autopilot.md に不変条件 M の ID が存在する（A-M でカバー）" "${AUTOPILOT_MD} not found"
+fi
+
+# Edge case: 不変条件 M のヘッダー件数表記も更新されている
+test_autopilot_md_invariant_header_count() {
+  # 「13件」または「A-M」または「13 件」のいずれかが記載されている
+  assert_file_contains "$AUTOPILOT_MD" "13件|13 件|A-M|A〜M"
+}
+if [[ -f "${PROJECT_ROOT}/${AUTOPILOT_MD}" ]]; then
+  run_test "autopilot.md の不変条件件数ヘッダーが 13 件（A-M）に更新されている" test_autopilot_md_invariant_header_count
+else
+  run_test_skip "autopilot.md の不変条件件数ヘッダーが 13 件（A-M）に更新されている" "${AUTOPILOT_MD} not found"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL

--- a/plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats
+++ b/plugins/twl/tests/unit/orchestrator-nohup-trace/orchestrator-nohup-trace.bats
@@ -1,0 +1,425 @@
+#!/usr/bin/env bats
+# orchestrator-nohup-trace.bats
+# Requirement: orchestrator nohup 実行 + inject_next_workflow トレース記録
+# Spec: deltaspec/changes/issue-438/specs/orchestrator-persistence/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# 検証する仕様:
+#   1. orchestrator が nohup/disown 起動後も継続すること（PID + 起動時刻が trace に記録される）
+#   2. inject_next_workflow() の実行結果が .autopilot/trace/inject-{YYYYMMDD}.log に記録される
+#      - 成功時: result=success
+#      - resolve 失敗時: result=skip reason="resolve_next_workflow exit=1"
+#      - prompt 未検出時: result=timeout reason="prompt not found"
+#
+# test double: orchestrator-trace-dispatch.sh
+#   Env:
+#     RESOLVE_EXIT   - resolve_next_workflow の終了コード（デフォルト: 0）
+#     PANE_OUTPUT    - tmux capture-pane の出力（デフォルト: "> "）
+#     TRACE_LOG_DIR  - トレースログディレクトリ（デフォルト: $SANDBOX/.autopilot/trace）
+#     CALLS_LOG      - 呼び出し記録ファイル
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: テスト double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  TRACE_LOG_DIR="$SANDBOX/.autopilot/trace"
+  export CALLS_LOG TRACE_LOG_DIR
+  mkdir -p "$TRACE_LOG_DIR"
+
+  # trace_log_date: 今日の YYYYMMDD
+  TRACE_DATE=$(date -u +"%Y%m%d")
+  export TRACE_DATE
+
+  # inject_next_workflow のトレース記録を含む test double
+  cat > "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" << 'DISPATCH_EOF'
+#!/usr/bin/env bash
+# orchestrator-trace-dispatch.sh
+# inject_next_workflow() + トレースログ記録の test double
+# Usage: <issue> <window_name>
+# Env:
+#   NEXT_WORKFLOW  - resolve_next_workflow の返り値（デフォルト: "/twl:workflow-pr-verify"）
+#   RESOLVE_EXIT   - resolve_next_workflow の終了コード（デフォルト: 0）
+#   PANE_OUTPUT    - tmux capture-pane の出力（デフォルト: "> "）
+#   TRACE_LOG_DIR  - トレースログ出力先ディレクトリ
+#   CALLS_LOG      - 呼び出し記録ファイル
+set -uo pipefail
+
+issue="$1"
+window_name="$2"
+
+NEXT_WORKFLOW="${NEXT_WORKFLOW:-/twl:workflow-pr-verify}"
+RESOLVE_EXIT="${RESOLVE_EXIT:-0}"
+PANE_OUTPUT="${PANE_OUTPUT:-"> "}"
+TRACE_LOG_DIR="${TRACE_LOG_DIR:-/tmp/autopilot-trace}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+
+mkdir -p "$TRACE_LOG_DIR"
+trace_date=$(date -u +"%Y%m%d")
+INJECT_LOG="${TRACE_LOG_DIR}/inject-${trace_date}.log"
+
+# --- resolve_next_workflow 呼び出し ---
+echo "resolve_next_workflow --issue $issue" >> "$CALLS_LOG"
+if [[ "$RESOLVE_EXIT" -ne 0 ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+  # トレース: resolve 失敗
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=skip reason=\"resolve_next_workflow exit=1\"" >> "$INJECT_LOG"
+  exit 1
+fi
+next_skill="$NEXT_WORKFLOW"
+
+if [[ -z "$next_skill" ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: resolve_next_workflow 失敗 — inject スキップ" >&2
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=skip reason=\"resolve_next_workflow exit=1\"" >> "$INJECT_LOG"
+  exit 1
+fi
+
+# --- allow-list バリデーション ---
+_skill_safe="${next_skill//$'\n'/}"
+if [[ "$_skill_safe" == "pr-merge" || "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
+  echo "[orchestrator] Issue #${issue}: pr-merge 検出 — inject スキップ、merge-gate フローに委譲" >&2
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=skip reason=\"pr-merge terminal workflow\"" >> "$INJECT_LOG"
+  exit 0
+fi
+if [[ ! "$_skill_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: 不正な workflow skill '${_skill_safe:0:200}' — inject スキップ" >&2
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=skip reason=\"invalid skill name\"" >> "$INJECT_LOG"
+  exit 1
+fi
+
+# --- tmux pane 入力待ち確認（最大3回） ---
+_prompt_re='[>$][[:space:]]*$'
+prompt_found=0
+for _i in 1 2 3; do
+  echo "tmux capture-pane -p -t $window_name" >> "$CALLS_LOG"
+  pane_tail=$(echo "$PANE_OUTPUT" | tail -1)
+  if [[ "$pane_tail" =~ $_prompt_re ]]; then
+    prompt_found=1
+    break
+  fi
+  sleep 0.01
+done
+
+if [[ "$prompt_found" -eq 0 ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: inject タイムアウト — ${POLL_INTERVAL:-10}秒後に再チェック" >&2
+  # トレース: timeout
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=timeout reason=\"prompt not found\"" >> "$INJECT_LOG"
+  exit 1
+fi
+
+# --- inject 実行 ---
+echo "tmux send-keys -t $window_name $_skill_safe" >> "$CALLS_LOG"
+echo "[orchestrator] Issue #${issue}: inject_next_workflow — $_skill_safe" >&2
+
+# トレース: 成功
+echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) issue=${issue} result=success skill=${_skill_safe}" >> "$INJECT_LOG"
+
+exit 0
+DISPATCH_EOF
+  chmod +x "$SANDBOX/scripts/orchestrator-trace-dispatch.sh"
+
+  # orchestrator PID 記録スクリプト（nohup 起動シミュレーション）
+  cat > "$SANDBOX/scripts/orchestrator-pid-logger.sh" << 'PID_EOF'
+#!/usr/bin/env bash
+# orchestrator-pid-logger.sh
+# nohup 起動後の PID + 起動時刻をトレースログに記録する test double
+# Usage: <phase_num>
+# Env:
+#   TRACE_LOG_DIR - トレースログ出力先ディレクトリ
+set -uo pipefail
+
+phase_num="${1:-1}"
+TRACE_LOG_DIR="${TRACE_LOG_DIR:-/tmp/autopilot-trace}"
+mkdir -p "$TRACE_LOG_DIR"
+
+ORCHESTRATOR_LOG="${TRACE_LOG_DIR}/orchestrator-phase-${phase_num}.log"
+started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# $$ は本スクリプト自身の PID（orchestrator プロセスを代理）
+echo "orchestrator_pid=$$ started_at=${started_at} phase=${phase_num}" >> "$ORCHESTRATOR_LOG"
+echo "[orchestrator] Phase ${phase_num}: PID=$$, started_at=${started_at}" >&2
+PID_EOF
+  chmod +x "$SANDBOX/scripts/orchestrator-pid-logger.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: orchestrator nohup 実行
+# Spec: deltaspec/changes/issue-438/specs/orchestrator-persistence/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: orchestrator PID がトレースログに記録される
+# WHEN Pilot が orchestrator を nohup/disown で起動する
+# THEN orchestrator の PID と起動時刻が .autopilot/trace/orchestrator-phase-{N}.log に記録される
+# ---------------------------------------------------------------------------
+
+@test "orchestrator[pid-trace]: orchestrator-phase-1.log が作成される" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  assert_success
+  [[ -f "${TRACE_LOG_DIR}/orchestrator-phase-1.log" ]]
+}
+
+@test "orchestrator[pid-trace]: orchestrator_pid がログに記録される" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  assert_success
+  grep -q "orchestrator_pid=" "${TRACE_LOG_DIR}/orchestrator-phase-1.log"
+}
+
+@test "orchestrator[pid-trace]: started_at が ISO8601 形式でログに記録される" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  assert_success
+  grep -qE "started_at=[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z" \
+    "${TRACE_LOG_DIR}/orchestrator-phase-1.log"
+}
+
+@test "orchestrator[pid-trace]: phase 番号がログに記録される" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "3"
+
+  assert_success
+  [[ -f "${TRACE_LOG_DIR}/orchestrator-phase-3.log" ]]
+  grep -q "phase=3" "${TRACE_LOG_DIR}/orchestrator-phase-3.log"
+}
+
+@test "orchestrator[pid-trace]: PID は正の整数である" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  assert_success
+  local pid
+  pid=$(grep -oP 'orchestrator_pid=\K[0-9]+' "${TRACE_LOG_DIR}/orchestrator-phase-1.log")
+  [[ -n "$pid" && "$pid" -gt 0 ]]
+}
+
+@test "orchestrator[pid-trace]: stderr に [orchestrator] プレフィックス付きログを出力する" {
+  run bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  assert_success
+  assert_output --partial "[orchestrator]"
+  assert_output --partial "Phase 1"
+}
+
+# Edge case: 複数 Phase でそれぞれ独立したログファイルが作成される
+@test "orchestrator[pid-trace][edge]: Phase 1 と Phase 2 で別ファイルが作成される" {
+  bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+  bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "2"
+
+  [[ -f "${TRACE_LOG_DIR}/orchestrator-phase-1.log" ]]
+  [[ -f "${TRACE_LOG_DIR}/orchestrator-phase-2.log" ]]
+}
+
+# Edge case: ログファイルは追記形式（既存エントリが上書きされない）
+@test "orchestrator[pid-trace][edge]: ログは追記形式で既存エントリを保持する" {
+  bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+  bash "$SANDBOX/scripts/orchestrator-pid-logger.sh" "1"
+
+  local count
+  count=$(grep -c "orchestrator_pid=" "${TRACE_LOG_DIR}/orchestrator-phase-1.log")
+  [[ "$count" -ge 2 ]]
+}
+
+# ===========================================================================
+# Requirement: inject_next_workflow 実行結果のトレース記録
+# Spec: deltaspec/changes/issue-438/specs/orchestrator-persistence/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 成功時にトレースが記録される
+# WHEN inject_next_workflow() が /twl:workflow-test-ready を Worker に inject する
+# THEN .autopilot/trace/inject-{YYYYMMDD}.log に result=success エントリが追記される
+# ---------------------------------------------------------------------------
+
+@test "inject-trace[success]: inject 成功時に inject ログファイルが作成される" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  [[ -f "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log" ]]
+}
+
+@test "inject-trace[success]: inject 成功時に result=success が記録される" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  grep -q "result=success" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[success]: inject 成功時に skill 名がログに含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  grep -q "skill=/twl:workflow-test-ready" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[success]: inject 成功時に issue 番号がログに含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  grep -q "issue=438" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[success]: inject 成功ログに ISO8601 タイムスタンプが含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  grep -qE "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z " \
+    "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 失敗時（resolve 失敗）にトレースが記録される
+# WHEN resolve_next_workflow が exit code 1 で失敗する
+# THEN .autopilot/trace/inject-{YYYYMMDD}.log に result=skip reason="resolve_next_workflow exit=1" が追記される
+# ---------------------------------------------------------------------------
+
+@test "inject-trace[resolve-fail]: resolve 失敗時に inject ログファイルが作成される" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  [[ -f "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log" ]]
+}
+
+@test "inject-trace[resolve-fail]: resolve 失敗時に result=skip が記録される" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q "result=skip" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[resolve-fail]: resolve 失敗時に reason が resolve_next_workflow exit=1 を含む" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q 'reason="resolve_next_workflow exit=1"' "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[resolve-fail]: resolve 失敗時に issue 番号がログに含まれる" {
+  RESOLVE_EXIT=1 \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q "issue=438" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 失敗時（prompt 未検出）にトレースが記録される
+# WHEN tmux pane の prompt 検出が3回リトライ後タイムアウトする
+# THEN .autopilot/trace/inject-{YYYYMMDD}.log に result=timeout reason="prompt not found" が追記される
+# ---------------------------------------------------------------------------
+
+@test "inject-trace[timeout]: prompt 未検出時に inject ログファイルが作成される" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  [[ -f "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log" ]]
+}
+
+@test "inject-trace[timeout]: prompt 未検出時に result=timeout が記録される" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q "result=timeout" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[timeout]: prompt 未検出時に reason が prompt not found を含む" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q 'reason="prompt not found"' "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+@test "inject-trace[timeout]: prompt 未検出時に issue 番号がログに含まれる" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="Working..." \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_failure
+  grep -q "issue=438" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+# ---------------------------------------------------------------------------
+# Edge cases: ログファイル管理
+# ---------------------------------------------------------------------------
+
+# Edge case: 日付ごとにファイルが分かれる（ファイル名が YYYYMMDD 形式）
+@test "inject-trace[edge]: inject ログファイル名が inject-YYYYMMDD.log 形式" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" \
+  PANE_OUTPUT="> " \
+    run bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438"
+
+  assert_success
+  # ファイルが今日の日付で作成されている
+  local expected_file="${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+  [[ -f "$expected_file" ]]
+}
+
+# Edge case: 複数の inject 呼び出しが同一ログに追記される（silent fail 排除）
+@test "inject-trace[edge]: 複数回の失敗が同一ログに追記される（silent fail なし）" {
+  RESOLVE_EXIT=1 \
+    bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438" || true
+  PANE_OUTPUT="Working..." \
+    bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "438" "ap-#438" || true
+
+  local count
+  count=$(grep -c "issue=438" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log")
+  [[ "$count" -ge 2 ]]
+}
+
+# Edge case: 成功と失敗が混在してもそれぞれ記録される
+@test "inject-trace[edge]: 成功と失敗が同一ログに混在して記録される" {
+  NEXT_WORKFLOW="/twl:workflow-test-ready" PANE_OUTPUT="> " \
+    bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "100" "ap-#100" || true
+  RESOLVE_EXIT=1 \
+    bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "101" "ap-#101" || true
+  NEXT_WORKFLOW="/twl:workflow-pr-verify" PANE_OUTPUT="Working..." \
+    bash "$SANDBOX/scripts/orchestrator-trace-dispatch.sh" "102" "ap-#102" || true
+
+  grep -q "result=success" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+  grep -q "result=skip" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+  grep -q "result=timeout" "${TRACE_LOG_DIR}/inject-${TRACE_DATE}.log"
+}
+
+# ===========================================================================
+# Requirement: orchestrator 継続動作の文書確認
+# Scenario: Pilot がメッセージを受信しても orchestrator が継続する
+# WHEN Pilot が orchestrator 起動後に新しいユーザーメッセージを受信する
+# THEN orchestrator プロセスは停止せず polling loop を継続し、inject_next_workflow() が正常に呼ばれる
+# ===========================================================================
+
+# このシナリオは autopilot-orchestrator.sh が nohup/disown 経由で起動されることで実現する。
+# スクリプト実装のドキュメント検証として、scripts ファイルの内容を確認する。
+
+@test "orchestrator[persistence]: autopilot-orchestrator.sh が存在する" {
+  [[ -f "$SANDBOX/scripts/autopilot-orchestrator.sh" ]]
+}
+
+@test "orchestrator[persistence]: inject_next_workflow 関数が autopilot-orchestrator.sh に定義されている" {
+  grep -q "inject_next_workflow()" "$SANDBOX/scripts/autopilot-orchestrator.sh"
+}


### PR DESCRIPTION
## 概要

autopilot-orchestrator の polling loop が Pilot の Bash context 外で持続するよう修正。inject_next_workflow のトレースログ追加、chain bypass 禁止の不変条件 M を追加。

Closes #438

## 変更内容

### autopilot-orchestrator.sh
- `.autopilot/trace/` ディレクトリ作成を追加
- `inject_next_workflow()` に trace ログ記録（成功/失敗/理由 → `.autopilot/trace/inject-{YYYYMMDD}.log`）
- tmux send-keys エラーをキャプチャして trace ログに記録（silent fail 排除）
- `_send_err` の改行サニタイズ追加（ログインジェクション防止）
- inject 成功時のタイムスタンプを inject 完了後に再取得（精度向上）
- `inject_next_workflow()` 内で trace dir 存在を保証（SUMMARY_MODE 等での再利用考慮）
- Phase 開始時に orchestrator PID と起動時刻を trace ログに記録

### co-autopilot SKILL.md
- Step 4 orchestrator 起動コードを nohup/disown パターンに変更（不変条件 M）
- PHASE_COMPLETE 検知ロジック追加
- 「chain 停止時の復旧手順（MUST）」セクション追加
- 「禁止事項（MUST NOT）」に chain bypass 禁止追加（不変条件 M 参照）
- 不変条件リストを A〜M に更新

### autopilot.md
- 不変条件テーブルに不変条件 M を追加（12件 → 13件）

## DeltaSpec
- change-id: issue-438
- specs: orchestrator-persistence, chain-bypass-prohibition

## 関連 Issue
- Deferred: shuu5/twill#450（AC#5: E2E chain 遷移手動テスト証跡）