### PR TITLE
[Feature] PreToolUse gate + 自動完了検知で spec-review の N Issue × 3 specialist を機械的に保証

### DIFF
--- a/.dev-session/01.5-ac-checklist.md
+++ b/.dev-session/01.5-ac-checklist.md
@@ -1,7 +1,12 @@
-## 受け入れ基準（Issue #438）
+## 受け入れ基準（Issue #446）
 
-1. orchestrator polling loop が Pilot の Bash timeout/cancel に影響されず持続する
-2. inject_next_workflow の実行結果（成功/失敗/理由）が `.autopilot/trace/` に記録される
-3. co-autopilot SKILL.md に chain bypass 禁止と停止時正規手順が明記されている
-4. autopilot.md に不変条件 M が追加されている
-5. setup → test-ready → pr-verify の chain 遷移が自動的に完了する（手動テストで確認）
+1. `spec-review-session-init.sh 3`（total=3 で初期化）実行で `/tmp/.spec-review-session-{hash}.json` が `{"total":3,"completed":0,"issues":{}}` で作成される
+2. 3/3 specialist 完了時に `check-specialist-completeness.sh` がセッション state の completed を flock 付きで自動インクリメントする
+3. `completed < total` の状態で `/twl:issue-review-aggregate` を Skill 呼び出しすると PreToolUse hook が `permissionDecision: "deny"` を返す
+4. deny メッセージに残り Issue 数と `/twl:issue-spec-review` 呼び出し指示が含まれる
+5. `completed == total` の状態で `issue-review-aggregate` が正常に実行される
+6. gate 通過後にセッション state file + lock file が自動クリーンアップされる
+7. `workflow-issue-refine/SKILL.md` Step 3b にセッション初期化手順が記載されている
+8. `hooks/hooks.json` の PreToolUse に `"matcher": "Skill"` + gate hook が登録されている
+9. `issue-mgmt.md` Constraints に制約 IM-7（specialist spawn の機械的保証）が追記されている
+10. `deps.yaml` に `spec-review-session-init`, `pre-tool-use-spec-review-gate` が script エントリとして登録されている

--- a/deltaspec/changes/issue-446/.deltaspec.yaml
+++ b/deltaspec/changes/issue-446/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 446
+name: issue-446
+status: pending

--- a/deltaspec/changes/issue-446/design.md
+++ b/deltaspec/changes/issue-446/design.md
@@ -1,0 +1,51 @@
+## Context
+
+`workflow-issue-refine` は複数 Issue に対して `issue-spec-review` を N 回呼ぶループ構造を持つが、このループは現在プロンプト指示のみで保証されている。#445 で各 `issue-spec-review` 内の 3 specialist 追跡（PostToolUse hook によるマニフェスト管理）は復旧するが、N Issue × 3 specialist の全完了をセッションレベルで集約する仕組みは存在しない。
+
+本設計では `/tmp` 上のセッション状態ファイルと PreToolUse hook を組み合わせ、forward progression gate を機械的に実現する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `workflow-issue-refine` が N Issue に対して全 `issue-spec-review` を実行し終えるまで `issue-review-aggregate` への進行を机ブロックする
+- セッション state は flock ベースの競合制御で並列書き込みに対応する
+- spec-review context 以外（phase-review 等）には一切影響しない
+
+**Non-Goals:**
+
+- 外部オーケストレーター・永続化 DB の導入（後続 Issue で対応）
+- issue-spec-review 内のマニフェスト書き出し修正（#445 で対応済み）
+- flock なしのシンプルな state 管理（競合制御を省略しない）
+
+## Decisions
+
+### セッション state ファイルの設計
+
+- **パス**: `/tmp/.spec-review-session-{hash}.json`
+  - hash 算出: `printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}'`
+  - 同一プロジェクト内でセッションをユニークに特定する
+- **構造**: `{"total": N, "completed": 0, "issues": {}}`
+  - `total`: `spec-review-session-init.sh N` で設定
+  - `completed`: specialist 完了ごとにインクリメント
+  - `issues`: 将来の拡張用（本 Issue では未使用）
+- **競合制御**: `flock /tmp/.spec-review-session-{hash}.lock` で read-modify-write をアトミックに実行
+
+### PreToolUse gate の実装方針
+
+- `hooks.json` の PreToolUse に `"matcher": "Skill"` エントリを追加
+- `pre-tool-use-spec-review-gate.sh` は `jq -r '.tool_input.skill'` でスキル名を取得し `issue-review-aggregate` のみをターゲットにする（`pre-tool-use-host-safety.sh` の `tool_input.command` 検査と同パターン）
+- `completed < total` の場合: `permissionDecision: "deny"` + 残り Issue 数と `/twl:issue-spec-review` 呼び出し誘導メッセージを返す
+- `completed == total` の場合: gate 通過 → state file + lock file をクリーンアップ
+
+### check-specialist-completeness.sh 拡張の方針
+
+- マニフェストファイル名から context を抽出するロジックを既存コードに追加
+- `spec-review-` prefix を持つ context の場合のみセッション state を更新する
+- 他の context（phase-review など）は既存の動作を維持する
+
+## Risks / Trade-offs
+
+- **`/tmp` のライフサイクル**: プロセス再起動や OS 再起動でセッション state が消える。意図的な設計（一時的なセッション管理）だが、異常終了後にセッションが残留する可能性がある → `spec-review-session-init.sh` が既存 state を上書き初期化することで対処
+- **flock のデッドロック**: hook 実行が中断された場合にロックが解放されない可能性がある → `flock -w 5`（タイムアウト付き）を使用
+- **セッション state ファイルが存在しない場合**: gate が state ファイルを見つけられない場合はブロックしない（gate miss は安全側のフォールバック）→ 初期化未実施の場合に gate が無効化されるリスクを明示的に受け入れる

--- a/deltaspec/changes/issue-446/proposal.md
+++ b/deltaspec/changes/issue-446/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+`workflow-issue-refine` が複数 Issue に対して `issue-spec-review` を N 回呼ぶという外側ループの保証がプロンプトベースのみであり、LLM が Issue 数を削減しても forward progression が可能な状態になっている。セッションレベルの完了数追跡 + PreToolUse deny ゲートにより、全 Issue のレビュー完了を機械的に強制する。
+
+## What Changes
+
+- 新規 `scripts/spec-review-session-init.sh`: Issue 数を受け取りセッション状態ファイル（`/tmp/.spec-review-session-{hash}.json`）を作成
+- 新規 `scripts/hooks/pre-tool-use-spec-review-gate.sh`: PreToolUse で `Skill(issue-review-aggregate)` を `completed < total` 時に deny
+- `scripts/hooks/check-specialist-completeness.sh` 拡張: 3/3 specialist 完了時に spec-review context のみセッション state の completed を flock 付きでインクリメント
+- `hooks/hooks.json`: PreToolUse エントリに `"matcher": "Skill"` + gate hook を追加登録
+- `skills/workflow-issue-refine/SKILL.md`: Step 3b 冒頭にセッション初期化ステップを追加
+- `architecture/domain/contexts/issue-mgmt.md`: 制約 IM-7（specialist spawn の機械的保証）を追記
+- `deps.yaml`: `spec-review-session-init`, `pre-tool-use-spec-review-gate` を script エントリとして追加
+
+## Capabilities
+
+### New Capabilities
+
+- **セッション状態管理**: `spec-review-session-init.sh N` でセッション state ファイルを初期化し、N Issue 分の completed カウントを管理する
+- **PreToolUse gate**: `pre-tool-use-spec-review-gate.sh` が `Skill` ツール呼び出し時に `issue-review-aggregate` を検出し、`completed < total` なら deny（残り Issue 数と `issue-spec-review` 呼び出し指示を添える）
+
+### Modified Capabilities
+
+- **自動完了検知の拡張**: `check-specialist-completeness.sh` が 3/3 specialist 完了時に spec-review context の場合にのみセッション state の completed を flock 付きでインクリメント（他コンテキストへの影響なし）
+- **workflow-issue-refine**: Step 3b 冒頭に `spec-review-session-init.sh` 呼び出しを追加し、Issue 数でセッションを初期化する
+
+## Impact
+
+- `plugins/twl/scripts/` — 新規スクリプト 2 ファイル追加（spec-review-session-init.sh, pre-tool-use-spec-review-gate.sh）
+- `plugins/twl/scripts/hooks/check-specialist-completeness.sh` — セッション state インクリメントロジック追加
+- `plugins/twl/hooks/hooks.json` — PreToolUse hook エントリ追加
+- `plugins/twl/skills/workflow-issue-refine/SKILL.md` — セッション初期化ステップ追加
+- `plugins/twl/architecture/domain/contexts/issue-mgmt.md` — 制約 IM-7 追記
+- `plugins/twl/deps.yaml` — 2 エントリ追加
+- `#445` の PostToolUse hook が前提条件（マニフェスト追跡機能が存在する必要がある）

--- a/deltaspec/changes/issue-446/specs/pretooluse-gate/spec.md
+++ b/deltaspec/changes/issue-446/specs/pretooluse-gate/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: セッション初期化スクリプト（spec-review-session-init.sh）
+
+`spec-review-session-init.sh <N>` は `/tmp/.spec-review-session-{hash}.json` を `{"total": N, "completed": 0, "issues": {}}` で作成しなければならない（SHALL）。hash は `printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}'` で算出する。既存 state ファイルが存在する場合は上書き初期化する。
+
+#### Scenario: 正常初期化
+- **WHEN** `spec-review-session-init.sh 3` を実行する
+- **THEN** `/tmp/.spec-review-session-{hash}.json` が `{"total":3,"completed":0,"issues":{}}` で作成される
+
+#### Scenario: 既存 state 上書き
+- **WHEN** 既存の state ファイルが存在する状態で `spec-review-session-init.sh 5` を実行する
+- **THEN** state ファイルが `{"total":5,"completed":0,"issues":{}}` に上書きされる
+
+---
+
+### Requirement: PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）
+
+`pre-tool-use-spec-review-gate.sh` は `Skill` ツールの `tool_input.skill` が `issue-review-aggregate` のとき、セッション state の `completed < total` であれば `permissionDecision: "deny"` を返さなければならない（SHALL）。deny メッセージには残り Issue 数と `/twl:issue-spec-review` 呼び出し指示を含める。
+
+#### Scenario: completed < total でブロック
+- **WHEN** セッション state が `{"total":3,"completed":1,"issues":{}}` の状態で `Skill(issue-review-aggregate)` が呼ばれる
+- **THEN** PreToolUse hook が `{"permissionDecision":"deny","message":"spec-review 残り 2 Issue が未完了です。先に /twl:issue-spec-review を実行してください。"}` を返す
+
+#### Scenario: completed == total でゲート通過
+- **WHEN** セッション state が `{"total":3,"completed":3,"issues":{}}` の状態で `Skill(issue-review-aggregate)` が呼ばれる
+- **THEN** PreToolUse hook がブロックせず、state file と lock file がクリーンアップされる
+
+#### Scenario: state ファイル不在（フォールバック）
+- **WHEN** セッション state ファイルが存在しない状態で `Skill(issue-review-aggregate)` が呼ばれる
+- **THEN** PreToolUse hook はブロックしない（安全側フォールバック）
+
+---
+
+### Requirement: hooks.json への PreToolUse 登録
+
+`hooks/hooks.json` の PreToolUse エントリに `"matcher": "Skill"` + `pre-tool-use-spec-review-gate.sh` を登録しなければならない（SHALL）。
+
+#### Scenario: hooks.json 登録確認
+- **WHEN** `hooks.json` の PreToolUse セクションを参照する
+- **THEN** `{"matcher": "Skill", "hooks": [{"type": "command", "command": "...pre-tool-use-spec-review-gate.sh"}]}` エントリが存在する
+
+## MODIFIED Requirements
+
+### Requirement: check-specialist-completeness.sh の spec-review context フィルタ
+
+`check-specialist-completeness.sh` は 3/3 specialist 完了時にマニフェストの context が `spec-review-` prefix を持つ場合のみ、セッション state の completed を flock 付きでインクリメントしなければならない（SHALL）。他 context には一切影響してはならない（MUST NOT）。
+
+#### Scenario: spec-review context でインクリメント
+- **WHEN** マニフェストの context が `spec-review-issue-123` で 3/3 specialist が完了する
+- **THEN** `/tmp/.spec-review-session-{hash}.json` の completed が 1 増加する
+
+#### Scenario: 他 context への非影響
+- **WHEN** マニフェストの context が `phase-review-xxx` で 3/3 specialist が完了する
+- **THEN** セッション state は変更されない
+
+---
+
+### Requirement: workflow-issue-refine Step 3b へのセッション初期化追加
+
+`workflow-issue-refine/SKILL.md` の Step 3b 冒頭は `spec-review-session-init.sh <N>` 呼び出しを含まなければならない（SHALL）。N は処理する Issue 数である。
+
+#### Scenario: セッション初期化ステップの存在確認
+- **WHEN** `workflow-issue-refine/SKILL.md` の Step 3b を参照する
+- **THEN** `spec-review-session-init.sh` の呼び出し手順が記載されている
+
+---
+
+### Requirement: architecture/domain/contexts/issue-mgmt.md への制約 IM-7 追記
+
+`issue-mgmt.md` の Constraints セクションに制約 IM-7（「specialist spawn は機械的に保証しなければならない（SHALL）」）を追記しなければならない（SHALL）。
+
+#### Scenario: IM-7 制約の存在確認
+- **WHEN** `architecture/domain/contexts/issue-mgmt.md` の Constraints セクションを参照する
+- **THEN** IM-7 として specialist spawn の機械的保証を規定するエントリが存在する
+
+---
+
+### Requirement: deps.yaml への新規スクリプト登録
+
+`deps.yaml` に `spec-review-session-init` および `pre-tool-use-spec-review-gate` が script エントリとして登録されなければならない（SHALL）。
+
+#### Scenario: deps.yaml エントリ確認
+- **WHEN** `deps.yaml` を参照する
+- **THEN** `spec-review-session-init` と `pre-tool-use-spec-review-gate` が script タイプで登録されている

--- a/deltaspec/changes/issue-446/tasks.md
+++ b/deltaspec/changes/issue-446/tasks.md
@@ -1,0 +1,28 @@
+## 1. 新規スクリプト作成
+
+- [ ] 1.1 `plugins/twl/scripts/spec-review-session-init.sh` を新規作成（total 引数でセッション state ファイルを初期化、flock 対応）
+- [ ] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh` を新規作成（Skill/issue-review-aggregate を検出し completed < total なら deny）
+
+## 2. 既存スクリプト拡張
+
+- [ ] 2.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に spec-review context フィルタを追加（3/3 完了時に `spec-review-` prefix context のみ completed をインクリメント）
+
+## 3. hooks.json 登録
+
+- [ ] 3.1 `plugins/twl/hooks/hooks.json` の PreToolUse に `"matcher": "Skill"` + `pre-tool-use-spec-review-gate.sh` エントリを追加
+
+## 4. SKILL.md・アーキテクチャ更新
+
+- [ ] 4.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` の Step 3b 冒頭に `spec-review-session-init.sh <N>` 呼び出しを追加
+- [ ] 4.2 `plugins/twl/architecture/domain/contexts/issue-mgmt.md` の Constraints セクションに制約 IM-7 を追記
+
+## 5. deps.yaml 更新
+
+- [ ] 5.1 `plugins/twl/deps.yaml` に `spec-review-session-init` (script) と `pre-tool-use-spec-review-gate` (script) エントリを追加
+- [ ] 5.2 `loom --check` でグラフ整合性を確認
+
+## 6. 動作確認
+
+- [ ] 6.1 `spec-review-session-init.sh 3` が state ファイルを正しく作成することを確認
+- [ ] 6.2 `completed < total` の状態で `issue-review-aggregate` が deny されることを確認
+- [ ] 6.3 `completed == total` の状態で gate が通過し state ファイルが削除されることを確認

--- a/deltaspec/changes/issue-446/tasks.md
+++ b/deltaspec/changes/issue-446/tasks.md
@@ -1,28 +1,28 @@
 ## 1. 新規スクリプト作成
 
-- [ ] 1.1 `plugins/twl/scripts/spec-review-session-init.sh` を新規作成（total 引数でセッション state ファイルを初期化、flock 対応）
-- [ ] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh` を新規作成（Skill/issue-review-aggregate を検出し completed < total なら deny）
+- [x] 1.1 `plugins/twl/scripts/spec-review-session-init.sh` を新規作成（total 引数でセッション state ファイルを初期化、flock 対応）
+- [x] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh` を新規作成（Skill/issue-review-aggregate を検出し completed < total なら deny）
 
 ## 2. 既存スクリプト拡張
 
-- [ ] 2.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に spec-review context フィルタを追加（3/3 完了時に `spec-review-` prefix context のみ completed をインクリメント）
+- [x] 2.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に spec-review context フィルタを追加（3/3 完了時に `spec-review-` prefix context のみ completed をインクリメント）
 
 ## 3. hooks.json 登録
 
-- [ ] 3.1 `plugins/twl/hooks/hooks.json` の PreToolUse に `"matcher": "Skill"` + `pre-tool-use-spec-review-gate.sh` エントリを追加
+- [x] 3.1 `plugins/twl/hooks/hooks.json` の PreToolUse に `"matcher": "Skill"` + `pre-tool-use-spec-review-gate.sh` エントリを追加
 
 ## 4. SKILL.md・アーキテクチャ更新
 
-- [ ] 4.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` の Step 3b 冒頭に `spec-review-session-init.sh <N>` 呼び出しを追加
-- [ ] 4.2 `plugins/twl/architecture/domain/contexts/issue-mgmt.md` の Constraints セクションに制約 IM-7 を追記
+- [x] 4.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` の Step 3b 冒頭に `spec-review-session-init.sh <N>` 呼び出しを追加
+- [x] 4.2 `plugins/twl/architecture/domain/contexts/issue-mgmt.md` の Constraints セクションに制約 IM-7 を追記
 
 ## 5. deps.yaml 更新
 
-- [ ] 5.1 `plugins/twl/deps.yaml` に `spec-review-session-init` (script) と `pre-tool-use-spec-review-gate` (script) エントリを追加
-- [ ] 5.2 `loom --check` でグラフ整合性を確認
+- [x] 5.1 `plugins/twl/deps.yaml` に `spec-review-session-init` (script) と `pre-tool-use-spec-review-gate` (script) エントリを追加
+- [x] 5.2 `loom check` でグラフ整合性を確認（OK: 227, Missing: 0）
 
 ## 6. 動作確認
 
-- [ ] 6.1 `spec-review-session-init.sh 3` が state ファイルを正しく作成することを確認
-- [ ] 6.2 `completed < total` の状態で `issue-review-aggregate` が deny されることを確認
-- [ ] 6.3 `completed == total` の状態で gate が通過し state ファイルが削除されることを確認
+- [x] 6.1 `spec-review-session-init.sh 3` が state ファイルを正しく作成することを確認
+- [x] 6.2 `completed < total` の状態で `issue-review-aggregate` が deny されることを確認
+- [x] 6.3 `completed == total` の状態で gate が通過し state ファイルが削除されることを確認

--- a/deltaspec/changes/issue-446/test-mapping.yaml
+++ b/deltaspec/changes/issue-446/test-mapping.yaml
@@ -1,0 +1,180 @@
+change_id: issue-446
+generated_at: "2026-04-11T00:00:00Z"
+test_framework: bats
+scenarios:
+  # -------------------------------------------------------------------------
+  # Requirement: セッション初期化スクリプト（spec-review-session-init.sh）
+  # -------------------------------------------------------------------------
+  - id: "session-init-normal"
+    name: "正常初期化"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 7
+    requirement: "セッション初期化スクリプト（spec-review-session-init.sh）"
+    test_file: "plugins/twl/tests/bats/scripts/spec-review-session-init.bats"
+    test_name: "正常初期化: total=3 で state ファイルが作成される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "session-init-overwrite"
+    name: "既存 state 上書き"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 11
+    requirement: "セッション初期化スクリプト（spec-review-session-init.sh）"
+    test_file: "plugins/twl/tests/bats/scripts/spec-review-session-init.bats"
+    test_name: "既存 state ファイルを上書き初期化する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）
+  # -------------------------------------------------------------------------
+  - id: "gate-deny-incomplete"
+    name: "completed < total でブロック"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 21
+    requirement: "PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-spec-review-gate.bats"
+    test_name: "completed < total のとき deny を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "gate-pass-complete"
+    name: "completed == total でゲート通過"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 25
+    requirement: "PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-spec-review-gate.bats"
+    test_name: "completed == total のときゲートを通過する（deny しない）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "gate-fallback-no-state"
+    name: "state ファイル不在（フォールバック）"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 29
+    requirement: "PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-spec-review-gate.bats"
+    test_name: "state ファイル不在でもブロックしない（安全側フォールバック）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: hooks.json への PreToolUse 登録
+  # -------------------------------------------------------------------------
+  - id: "hooks-json-skill-entry"
+    name: "hooks.json 登録確認"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 39
+    requirement: "hooks.json への PreToolUse 登録"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "hooks.json の PreToolUse に Skill matcher + pre-tool-use-spec-review-gate.sh が登録されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: check-specialist-completeness.sh の spec-review context フィルタ
+  # -------------------------------------------------------------------------
+  - id: "csc-spec-review-increment"
+    name: "spec-review context でインクリメント"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 49
+    requirement: "check-specialist-completeness.sh の spec-review context フィルタ"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "spec-review-* context で 3/3 完了時に session state completed がインクリメントされる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "csc-other-context-no-effect"
+    name: "他 context への非影響"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 53
+    requirement: "check-specialist-completeness.sh の spec-review context フィルタ"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "phase-review-* context では session state completed が変更されない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: workflow-issue-refine Step 3b へのセッション初期化追加
+  # -------------------------------------------------------------------------
+  - id: "skillmd-step3b-init-present"
+    name: "セッション初期化ステップの存在確認"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 63
+    requirement: "workflow-issue-refine Step 3b へのセッション初期化追加"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "workflow-issue-refine/SKILL.md の Step 3b に spec-review-session-init.sh の呼び出しが記載されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: architecture/domain/contexts/issue-mgmt.md への制約 IM-7 追記
+  # -------------------------------------------------------------------------
+  - id: "issue-mgmt-im7-exists"
+    name: "IM-7 制約の存在確認"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 73
+    requirement: "architecture/domain/contexts/issue-mgmt.md への制約 IM-7 追記"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "architecture/domain/contexts/issue-mgmt.md に制約 IM-7 が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: deps.yaml への新規スクリプト登録
+  # -------------------------------------------------------------------------
+  - id: "deps-yaml-session-init"
+    name: "deps.yaml エントリ確認（spec-review-session-init）"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 83
+    requirement: "deps.yaml への新規スクリプト登録"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "deps.yaml に spec-review-session-init が登録されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "deps-yaml-gate"
+    name: "deps.yaml エントリ確認（pre-tool-use-spec-review-gate）"
+    spec_file: "specs/pretooluse-gate/spec.md"
+    spec_line: 83
+    requirement: "deps.yaml への新規スクリプト登録"
+    test_file: "plugins/twl/tests/scenarios/spec-review-gate.test.sh"
+    test_name: "deps.yaml に pre-tool-use-spec-review-gate が登録されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/architecture/domain/contexts/issue-mgmt.md
+++ b/plugins/twl/architecture/domain/contexts/issue-mgmt.md
@@ -133,6 +133,7 @@ flowchart TD
 - **制約 IM-4**: 他セッションの `.controller-issue/<other-session-id>/` を削除してはならない（SHALL）。セッション間分離保証
 - **制約 IM-5**: specialist が実行中のまま後続ステップに進んではならない（SHALL）。全 specialist の結果が揃うまで待機必須
 - **制約 IM-6**: ユーザー確認なしで Issue をクローズ・統合してはならない（SHALL）
+- **制約 IM-7**: N Issue × 3 specialist の全完了は機械的に保証しなければならない（SHALL）。`spec-review-session-init.sh` によるセッション state + PreToolUse gate により、全 Issue の `issue-spec-review` 完了前に `issue-review-aggregate` への forward progression を機械的にブロックする
 
 ## Rules
 

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2493,6 +2493,16 @@ scripts:
     path: scripts/spec-review-manifest.sh
     description: "issue-spec-review 必須 specialist リスト出力（3 行 = 3 agent type）"
 
+  spec-review-session-init:
+    type: script
+    path: scripts/spec-review-session-init.sh
+    description: "spec-review セッション state ファイルを初期化（total 引数で Issue 数を設定、flock 競合制御付き）"
+
+  pre-tool-use-spec-review-gate:
+    type: script
+    path: scripts/hooks/pre-tool-use-spec-review-gate.sh
+    description: "PreToolUse gate: completed < total の間 issue-review-aggregate を deny する（Skill tool matcher）"
+
   pr-review-manifest:
     type: script
     path: scripts/pr-review-manifest.sh

--- a/plugins/twl/hooks/hooks.json
+++ b/plugins/twl/hooks/hooks.json
@@ -30,6 +30,16 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool-use-spec-review-gate.sh",
+            "timeout": 10000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -78,7 +78,25 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
     <( [[ -f "$SPAWNED_FILE" ]] && LC_ALL=C sort "$SPAWNED_FILE" || true ))
 
   if [[ ${#MISSING[@]} -eq 0 ]]; then
-    # All specialists spawned for this context, noop
+    # All specialists spawned for this context
+    # spec-review- context の場合: セッション state の completed をインクリメント
+    if [[ "$CONTEXT" == spec-review-* ]]; then
+      HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+      SESSION_STATE="/tmp/.spec-review-session-${HASH}.json"
+      SESSION_LOCK="/tmp/.spec-review-session-${HASH}.lock"
+      if [[ -f "$SESSION_STATE" && ! -L "$SESSION_STATE" ]]; then
+        {
+          flock -w 5 8 || true
+          CURRENT=$(jq -r '.completed // 0' "$SESSION_STATE" 2>/dev/null || echo "0")
+          if [[ "$CURRENT" =~ ^[0-9]+$ ]]; then
+            jq ".completed = (.completed + 1)" "$SESSION_STATE" > "${SESSION_STATE}.tmp" \
+              && mv "${SESSION_STATE}.tmp" "$SESSION_STATE"
+          fi
+        } 8>"$SESSION_LOCK"
+      fi
+    fi
+    # Clean up manifest and spawned tracking files
+    rm -f "$MANIFEST_FILE" "$SPAWNED_FILE"
     continue
   fi
 

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -85,12 +85,29 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
       SESSION_STATE="/tmp/.spec-review-session-${HASH}.json"
       SESSION_LOCK="/tmp/.spec-review-session-${HASH}.lock"
       if [[ -f "$SESSION_STATE" && ! -L "$SESSION_STATE" ]]; then
+        # flock 失敗時はサイレントスキップではなく警告を出す（カウント消失防止）
         {
-          flock -w 5 8 || true
-          CURRENT=$(jq -r '.completed // 0' "$SESSION_STATE" 2>/dev/null || echo "0")
-          if [[ "$CURRENT" =~ ^[0-9]+$ ]]; then
-            jq ".completed = (.completed + 1)" "$SESSION_STATE" > "${SESSION_STATE}.tmp" \
-              && mv "${SESSION_STATE}.tmp" "$SESSION_STATE"
+          if ! flock -w 5 8; then
+            printf '⚠ spec-review session: flock 取得失敗（タイムアウト）— completed インクリメントをスキップ [context: %s]\n' "$CONTEXT"
+          else
+            # .tmp ファイルが残留しないよう trap でクリーンアップ
+            # (サブシェル内なので trap はこの flock ブロックのみに影響)
+            # SESSION_STATE の symlink 再チェック（flock 取得後）
+            if [[ -L "$SESSION_STATE" ]]; then
+              printf '⚠ spec-review session: STATE_FILE が symlink — インクリメントをスキップ [context: %s]\n' "$CONTEXT"
+            elif [[ ! -L "${SESSION_STATE}.tmp" ]]; then
+              CURRENT=$(jq -r '.completed // 0' "$SESSION_STATE" 2>/dev/null || echo "0")
+              if [[ "$CURRENT" =~ ^[0-9]+$ ]]; then
+                if jq ".completed = (.completed + 1)" "$SESSION_STATE" > "${SESSION_STATE}.tmp"; then
+                  mv "${SESSION_STATE}.tmp" "$SESSION_STATE"
+                else
+                  rm -f "${SESSION_STATE}.tmp"
+                  printf '⚠ spec-review session: jq 失敗 — completed インクリメントをスキップ [context: %s]\n' "$CONTEXT"
+                fi
+              fi
+            else
+              printf '⚠ spec-review session: .tmp ファイルが symlink — インクリメントをスキップ [context: %s]\n' "$CONTEXT"
+            fi
           fi
         } 8>"$SESSION_LOCK"
       fi

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -84,14 +84,15 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
       HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
       SESSION_STATE="/tmp/.spec-review-session-${HASH}.json"
       SESSION_LOCK="/tmp/.spec-review-session-${HASH}.lock"
-      if [[ -f "$SESSION_STATE" && ! -L "$SESSION_STATE" ]]; then
+      # SESSION_LOCK の symlink チェック（flock 前に実施 — symlink following 対策）
+      if [[ -L "$SESSION_LOCK" ]]; then
+        printf '⚠ spec-review session: SESSION_LOCK が symlink — インクリメントをスキップ [context: %s]\n' "$CONTEXT"
+      elif [[ -f "$SESSION_STATE" && ! -L "$SESSION_STATE" ]]; then
         # flock 失敗時はサイレントスキップではなく警告を出す（カウント消失防止）
         {
           if ! flock -w 5 8; then
             printf '⚠ spec-review session: flock 取得失敗（タイムアウト）— completed インクリメントをスキップ [context: %s]\n' "$CONTEXT"
           else
-            # .tmp ファイルが残留しないよう trap でクリーンアップ
-            # (サブシェル内なので trap はこの flock ブロックのみに影響)
             # SESSION_STATE の symlink 再チェック（flock 取得後）
             if [[ -L "$SESSION_STATE" ]]; then
               printf '⚠ spec-review session: STATE_FILE が symlink — インクリメントをスキップ [context: %s]\n' "$CONTEXT"
@@ -110,6 +111,8 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
             fi
           fi
         } 8>"$SESSION_LOCK"
+        # SESSION_LOCK クリーンアップ（flock 解放後）
+        rm -f "$SESSION_LOCK"
       fi
     fi
     # Clean up manifest and spawned tracking files

--- a/plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# PreToolUse hook: spec-review 完了ゲート
+#
+# Skill(issue-review-aggregate) 呼び出し時に、セッション state の
+# completed < total であれば deny する。
+#
+# 動作:
+#   - tool_input.skill が "issue-review-aggregate" のときのみ発火
+#   - セッション state ファイルが存在しない場合: フォールバック（通過）
+#   - completed < total: deny（残り Issue 数と issue-spec-review 呼び出し指示）
+#   - completed == total: 通過 → state file + lock file をクリーンアップ
+#
+# セッション state: /tmp/.spec-review-session-{hash}.json
+# hash: CLAUDE_PROJECT_ROOT または PWD から cksum 算出
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || echo "")
+
+# JSON パース失敗 → no-op
+if ! printf '%s' "$payload" | jq empty 2>/dev/null; then
+  exit 0
+fi
+
+# Skill tool 以外 → no-op
+tool_name=$(printf '%s' "$payload" | jq -r '.tool_name // empty')
+if [[ "$tool_name" != "Skill" ]]; then
+  exit 0
+fi
+
+# skill 名を取得
+skill_name=$(printf '%s' "$payload" | jq -r '.tool_input.skill // empty')
+if [[ "$skill_name" != "issue-review-aggregate" ]]; then
+  exit 0
+fi
+
+# hash 算出
+HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+STATE_FILE="/tmp/.spec-review-session-${HASH}.json"
+LOCK_FILE="/tmp/.spec-review-session-${HASH}.lock"
+
+# state ファイル不在 → フォールバック（通過）
+if [[ ! -f "$STATE_FILE" ]]; then
+  exit 0
+fi
+
+# state を読み取る（flock 付き）
+{
+  flock -w 5 9 || exit 0  # ロック取得失敗 → フォールバック（通過）
+
+  # Refuse symlinks
+  if [[ -L "$STATE_FILE" ]]; then
+    exit 0
+  fi
+
+  TOTAL=$(jq -r '.total // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+  COMPLETED=$(jq -r '.completed // 0' "$STATE_FILE" 2>/dev/null || echo "0")
+
+  # 数値バリデーション
+  if ! [[ "$TOTAL" =~ ^[0-9]+$ ]] || ! [[ "$COMPLETED" =~ ^[0-9]+$ ]]; then
+    exit 0
+  fi
+
+  if [[ "$COMPLETED" -lt "$TOTAL" ]]; then
+    REMAINING=$(( TOTAL - COMPLETED ))
+    REASON="spec-review ゲート: 残り ${REMAINING} Issue が未完了です（${COMPLETED}/${TOTAL} 完了）。先に /twl:issue-spec-review を ${REMAINING} 回実行してください。"
+    jq -nc \
+      --arg reason "$REASON" \
+      '{
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: $reason
+        }
+      }'
+    exit 0
+  fi
+
+  # completed >= total → 通過 + クリーンアップ
+  rm -f "$STATE_FILE" "$LOCK_FILE"
+
+} 9>"$LOCK_FILE"
+
+exit 0

--- a/plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh
@@ -39,8 +39,14 @@ HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
 STATE_FILE="/tmp/.spec-review-session-${HASH}.json"
 LOCK_FILE="/tmp/.spec-review-session-${HASH}.lock"
 
-# state ファイル不在 → フォールバック（通過）
-if [[ ! -f "$STATE_FILE" ]]; then
+# LOCK_FILE の symlink チェック（flock 前に実施 — TOCTOU 対策）
+if [[ -L "$LOCK_FILE" ]]; then
+  exit 0
+fi
+
+# state ファイルの事前チェック（symlink + 存在）
+# flock 取得前に -f と -L を同時検査して TOCTOU ウィンドウを最小化
+if [[ -L "$STATE_FILE" || ! -f "$STATE_FILE" ]]; then
   exit 0
 fi
 
@@ -48,16 +54,16 @@ fi
 {
   flock -w 5 9 || exit 0  # ロック取得失敗 → フォールバック（通過）
 
-  # Refuse symlinks
-  if [[ -L "$STATE_FILE" ]]; then
+  # flock 取得後に再チェック（TOCTOU ウィンドウを閉じる）
+  if [[ -L "$STATE_FILE" || ! -f "$STATE_FILE" ]]; then
     exit 0
   fi
 
   TOTAL=$(jq -r '.total // 0' "$STATE_FILE" 2>/dev/null || echo "0")
   COMPLETED=$(jq -r '.completed // 0' "$STATE_FILE" 2>/dev/null || echo "0")
 
-  # 数値バリデーション
-  if ! [[ "$TOTAL" =~ ^[0-9]+$ ]] || ! [[ "$COMPLETED" =~ ^[0-9]+$ ]]; then
+  # 数値バリデーション（TOTAL=0 はフォールバック通過）
+  if ! [[ "$TOTAL" =~ ^[0-9]+$ ]] || ! [[ "$COMPLETED" =~ ^[0-9]+$ ]] || [[ "$TOTAL" -eq 0 ]]; then
     exit 0
   fi
 
@@ -77,8 +83,11 @@ fi
   fi
 
   # completed >= total → 通過 + クリーンアップ
-  rm -f "$STATE_FILE" "$LOCK_FILE"
+  rm -f "$STATE_FILE"
 
 } 9>"$LOCK_FILE"
+
+# LOCK_FILE は flock ブロック外でクリーンアップ（flock 解放後）
+rm -f "$LOCK_FILE"
 
 exit 0

--- a/plugins/twl/scripts/spec-review-session-init.sh
+++ b/plugins/twl/scripts/spec-review-session-init.sh
@@ -8,7 +8,7 @@
 #   hash: CLAUDE_PROJECT_ROOT または PWD から cksum で算出
 # 競合制御: flock を使用
 
-set -uo pipefail
+set -euo pipefail
 
 TOTAL="${1:-}"
 if [[ -z "$TOTAL" ]]; then
@@ -27,9 +27,26 @@ HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
 STATE_FILE="/tmp/.spec-review-session-${HASH}.json"
 LOCK_FILE="/tmp/.spec-review-session-${HASH}.lock"
 
+# LOCK_FILE の symlink チェック
+if [[ -L "$LOCK_FILE" ]]; then
+  echo "Error: LOCK_FILE is a symlink — aborting" >&2
+  exit 1
+fi
+
+# STATE_FILE への書き込み前に symlink チェック（symlink attack 対策）
+if [[ -L "$STATE_FILE" ]]; then
+  echo "Error: STATE_FILE is a symlink — aborting" >&2
+  exit 1
+fi
+
 # flock 付きで state ファイルを書き込み（既存があれば上書き初期化）
 {
   flock -w 5 9 || { echo "Error: failed to acquire lock on $LOCK_FILE" >&2; exit 1; }
+  # flock 取得後に再チェック（TOCTOU ウィンドウ）
+  if [[ -L "$STATE_FILE" ]]; then
+    echo "Error: STATE_FILE became a symlink — aborting" >&2
+    exit 1
+  fi
   printf '{"total":%d,"completed":0,"issues":{}}\n' "$TOTAL" > "$STATE_FILE"
 } 9>"$LOCK_FILE"
 

--- a/plugins/twl/scripts/spec-review-session-init.sh
+++ b/plugins/twl/scripts/spec-review-session-init.sh
@@ -50,4 +50,7 @@ fi
   printf '{"total":%d,"completed":0,"issues":{}}\n' "$TOTAL" > "$STATE_FILE"
 } 9>"$LOCK_FILE"
 
+# LOCK_FILE クリーンアップ（flock 解放後）
+rm -f "$LOCK_FILE"
+
 echo "✓ spec-review session initialized: total=${TOTAL}, state=${STATE_FILE}"

--- a/plugins/twl/scripts/spec-review-session-init.sh
+++ b/plugins/twl/scripts/spec-review-session-init.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# spec-review-session-init.sh — spec-review セッション state を初期化する
+#
+# 使用方法: spec-review-session-init.sh <total>
+#   total: レビュー対象 Issue 数
+#
+# セッション state ファイル: /tmp/.spec-review-session-{hash}.json
+#   hash: CLAUDE_PROJECT_ROOT または PWD から cksum で算出
+# 競合制御: flock を使用
+
+set -uo pipefail
+
+TOTAL="${1:-}"
+if [[ -z "$TOTAL" ]]; then
+  echo "Usage: spec-review-session-init.sh <total>" >&2
+  exit 1
+fi
+
+# total が正の整数か検証
+if ! [[ "$TOTAL" =~ ^[0-9]+$ ]] || [[ "$TOTAL" -eq 0 ]]; then
+  echo "Error: total must be a positive integer, got: $TOTAL" >&2
+  exit 1
+fi
+
+# hash 算出（プロジェクトルートまたは PWD から）
+HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+STATE_FILE="/tmp/.spec-review-session-${HASH}.json"
+LOCK_FILE="/tmp/.spec-review-session-${HASH}.lock"
+
+# flock 付きで state ファイルを書き込み（既存があれば上書き初期化）
+{
+  flock -w 5 9 || { echo "Error: failed to acquire lock on $LOCK_FILE" >&2; exit 1; }
+  printf '{"total":%d,"completed":0,"issues":{}}\n' "$TOTAL" > "$STATE_FILE"
+} 9>"$LOCK_FILE"
+
+echo "✓ spec-review session initialized: total=${TOTAL}, state=${STATE_FILE}"

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -38,6 +38,14 @@ co-issue Phase 3（Per-Issue 精緻化ループ）のロジックを担当する
 
 ## Step 3b: specialist レビュー（MUST -- spawn 粒度・同期バリア厳守）
 
+**セッション初期化（MUST -- 最初に実行）**: `/twl:issue-spec-review` 呼び出し前に以下を実行する:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/spec-review-session-init.sh" <N>
+```
+
+`<N>` はレビュー対象の Issue 数。これにより `issue-review-aggregate` の呼び出しが全 Issue レビュー完了まで機械的にブロックされる。
+
 `/twl:issue-spec-review` を **1 Issue につき 1 回** 呼び出す。複数 Issue をまとめて 1 回の呼び出しに渡してはならない（MUST NOT）。
 
 - **spawn 数の公式**: N Issues -> N 回の `/twl:issue-spec-review` 呼び出し -> 各呼び出しが内部で 3 specialist を spawn -> 合計 3N specialist

--- a/plugins/twl/tests/bats/scripts/pre-tool-use-spec-review-gate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-tool-use-spec-review-gate.bats
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+# pre-tool-use-spec-review-gate.bats
+#
+# Tests for plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh
+#
+# Spec: deltaspec/changes/issue-446/specs/pretooluse-gate/spec.md
+#   Requirement: PreToolUse gate スクリプト（pre-tool-use-spec-review-gate.sh）
+#
+# Scenarios:
+#   1. completed < total でブロック: state={"total":3,"completed":1} + Skill(issue-review-aggregate) → deny JSON
+#   2. completed == total でゲート通過: state={"total":3,"completed":3} + Skill(issue-review-aggregate) → no deny
+#   3. state ファイル不在（フォールバック）: state ファイルなし + Skill(issue-review-aggregate) → no deny
+#   4. 対象外ツール(Edit) → noop
+#   5. Skill だが skill が issue-review-aggregate 以外 → noop
+#   6. deny メッセージに残り Issue 数を含む
+#   7. deny メッセージに /twl:issue-spec-review 呼び出し指示を含む
+#   8. completed == total 時、state file がクリーンアップされる
+#   9. completed == total 時、lock file がクリーンアップされる（存在する場合）
+#  10. 不正 JSON 入力 → noop (exit 0)
+#  11. state ファイルが symlink の場合 → noop（セキュリティ: フォールバック）
+#  12. completed > total（異常値）→ ゲート通過（安全側フォールバック）
+
+load '../helpers/common'
+
+HOOK_SRC=""
+
+setup() {
+  common_setup
+
+  HOOK_SRC="$(cd "$REPO_ROOT" && pwd)/scripts/hooks/pre-tool-use-spec-review-gate.sh"
+
+  # Override CLAUDE_PROJECT_ROOT to sandbox for predictable hash
+  export CLAUDE_PROJECT_ROOT="$SANDBOX"
+
+  EXPECTED_HASH=$(printf '%s' "$SANDBOX" | cksum | awk '{print $1}')
+  export EXPECTED_HASH
+  STATE_FILE="/tmp/.spec-review-session-${EXPECTED_HASH}.json"
+  export STATE_FILE
+  LOCK_FILE="/tmp/.spec-review-lock-${EXPECTED_HASH}"
+  export LOCK_FILE
+}
+
+teardown() {
+  rm -f "$STATE_FILE" "$LOCK_FILE" 2>/dev/null || true
+  common_teardown
+}
+
+# Helper: build a Skill tool_use JSON payload
+_skill_payload() {
+  local skill_name="$1"
+  jq -nc --arg s "$skill_name" '{tool_name:"Skill", tool_input:{skill:$s}}'
+}
+
+# Helper: invoke hook with given JSON payload
+_run_hook() {
+  local payload="$1"
+  echo "$payload" | bash "$HOOK_SRC"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: completed < total でブロック
+# WHEN state={"total":3,"completed":1} + Skill(issue-review-aggregate) が呼ばれる
+# THEN permissionDecision=deny + 残り Issue 数 + /twl:issue-spec-review 指示
+# ---------------------------------------------------------------------------
+@test "completed < total のとき deny を返す" {
+  printf '{"total":3,"completed":1,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' \
+    || { echo "expected deny, got: $output" >&2; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: deny メッセージに残り Issue 数を含む
+# ---------------------------------------------------------------------------
+@test "deny メッセージに残り Issue 数（2）が含まれる" {
+  printf '{"total":3,"completed":1,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  # remaining = 3 - 1 = 2
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("2")' \
+    || { echo "remaining count not in message: $output" >&2; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: deny メッセージに /twl:issue-spec-review 呼び出し指示を含む
+# ---------------------------------------------------------------------------
+@test "deny メッセージに /twl:issue-spec-review が含まれる" {
+  printf '{"total":3,"completed":1,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecisionReason | contains("/twl:issue-spec-review")' \
+    || { echo "/twl:issue-spec-review not in message: $output" >&2; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: completed == total でゲート通過
+# WHEN state={"total":3,"completed":3} + Skill(issue-review-aggregate) が呼ばれる
+# THEN deny を返さない
+# ---------------------------------------------------------------------------
+@test "completed == total のときゲートを通過する（deny しない）" {
+  printf '{"total":3,"completed":3,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  # No deny decision
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' 2>/dev/null; then
+    echo "unexpected deny when completed==total: $output" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 8: completed == total 時 state file がクリーンアップされる
+# ---------------------------------------------------------------------------
+@test "completed == total 時に state ファイルが削除される" {
+  printf '{"total":3,"completed":3,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$STATE_FILE" ] || { echo "state file not cleaned up" >&2; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 9: completed == total 時 lock file がクリーンアップされる（存在する場合）
+# ---------------------------------------------------------------------------
+@test "completed == total 時に lock ファイルが削除される（存在する場合）" {
+  printf '{"total":2,"completed":2,"issues":{}}' > "$STATE_FILE"
+  touch "$LOCK_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  [ ! -f "$LOCK_FILE" ] || { echo "lock file not cleaned up" >&2; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: state ファイル不在（フォールバック）
+# WHEN state ファイルなし + Skill(issue-review-aggregate) が呼ばれる
+# THEN deny しない（安全側フォールバック）
+# ---------------------------------------------------------------------------
+@test "state ファイル不在でもブロックしない（安全側フォールバック）" {
+  # Ensure state file does not exist
+  rm -f "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' 2>/dev/null; then
+    echo "unexpected deny when no state file: $output" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# edge: 対象外ツール(Edit) → noop（出力なし）
+# ---------------------------------------------------------------------------
+@test "対象外ツール (Edit) は noop" {
+  printf '{"total":3,"completed":0,"issues":{}}' > "$STATE_FILE"
+  local payload
+  payload=$(jq -nc '{tool_name:"Edit", tool_input:{file_path:"/tmp/foo.txt"}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: Skill だが skill が issue-review-aggregate 以外 → noop
+# ---------------------------------------------------------------------------
+@test "Skill ツールでも skill 名が issue-review-aggregate 以外なら noop" {
+  printf '{"total":3,"completed":0,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "other-skill")"
+  [ "$status" -eq 0 ]
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' 2>/dev/null; then
+    echo "unexpected deny for non-target skill: $output" >&2
+    return 1
+  fi
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: 不正 JSON 入力 → noop (exit 0)
+# ---------------------------------------------------------------------------
+@test "不正 JSON 入力は noop (exit 0)" {
+  run bash "$HOOK_SRC" <<< "not-a-json{"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: state ファイルが symlink → noop（セキュリティフォールバック）
+# ---------------------------------------------------------------------------
+@test "state ファイルが symlink の場合はブロックしない（フォールバック）" {
+  local real_file="${SANDBOX}/state-real.json"
+  printf '{"total":3,"completed":0,"issues":{}}' > "$real_file"
+  ln -s "$real_file" "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  # Should not deny (treat symlink as missing for security)
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' 2>/dev/null; then
+    echo "unexpected deny when state is symlink: $output" >&2
+    rm -f "$real_file"
+    return 1
+  fi
+  rm -f "$real_file"
+}
+
+# ---------------------------------------------------------------------------
+# edge: completed > total（異常値）→ ゲート通過（安全側フォールバック）
+# ---------------------------------------------------------------------------
+@test "completed > total の異常値でもブロックしない（安全側フォールバック）" {
+  printf '{"total":2,"completed":5,"issues":{}}' > "$STATE_FILE"
+  run _run_hook "$(_skill_payload "issue-review-aggregate")"
+  [ "$status" -eq 0 ]
+  if echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' 2>/dev/null; then
+    echo "unexpected deny when completed > total: $output" >&2
+    return 1
+  fi
+}

--- a/plugins/twl/tests/bats/scripts/spec-review-session-init.bats
+++ b/plugins/twl/tests/bats/scripts/spec-review-session-init.bats
@@ -1,0 +1,140 @@
+#!/usr/bin/env bats
+# spec-review-session-init.bats
+#
+# Tests for plugins/twl/scripts/spec-review-session-init.sh
+#
+# Spec: deltaspec/changes/issue-446/specs/pretooluse-gate/spec.md
+#   Requirement: セッション初期化スクリプト（spec-review-session-init.sh）
+#
+# Scenarios:
+#   1. 正常初期化: spec-review-session-init.sh 3 → state ファイルが {"total":3,"completed":0,"issues":{}} で作成される
+#   2. 既存 state 上書き: 既存ファイル存在 + spec-review-session-init.sh 5 → {"total":5,"completed":0,"issues":{}} に上書き
+#   3. edge: 引数なし → exit 非 0
+#   4. edge: 引数が非数値 → exit 非 0
+#   5. edge: 引数が 0 → exit 0 かつ total=0 で作成される
+#   6. edge: 引数が負数 → exit 非 0 または total<0 で拒否
+#   7. hash がプロジェクトルートから算出される
+#   8. 複数回実行でも state ファイルが同じパスに作成される
+
+load '../helpers/common'
+
+SCRIPT_SRC=""
+
+setup() {
+  common_setup
+
+  SCRIPT_SRC="$(cd "$REPO_ROOT" && pwd)/scripts/spec-review-session-init.sh"
+
+  # Override CLAUDE_PROJECT_ROOT to a known value for predictable hash
+  export CLAUDE_PROJECT_ROOT="$SANDBOX"
+
+  # Compute expected hash the same way the script does:
+  # printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}'
+  EXPECTED_HASH=$(printf '%s' "$SANDBOX" | cksum | awk '{print $1}')
+  export EXPECTED_HASH
+  EXPECTED_STATE_FILE="/tmp/.spec-review-session-${EXPECTED_HASH}.json"
+  export EXPECTED_STATE_FILE
+}
+
+teardown() {
+  rm -f "$EXPECTED_STATE_FILE" 2>/dev/null || true
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: 正常初期化
+# WHEN spec-review-session-init.sh 3 を実行する
+# THEN /tmp/.spec-review-session-{hash}.json が {"total":3,"completed":0,"issues":{}} で作成される
+# ---------------------------------------------------------------------------
+@test "正常初期化: total=3 で state ファイルが作成される" {
+  run bash "$SCRIPT_SRC" 3
+  [ "$status" -eq 0 ]
+  [ -f "$EXPECTED_STATE_FILE" ]
+
+  local total completed issues_keys
+  total=$(jq -r '.total' "$EXPECTED_STATE_FILE")
+  completed=$(jq -r '.completed' "$EXPECTED_STATE_FILE")
+  issues_keys=$(jq -r '.issues | keys | length' "$EXPECTED_STATE_FILE")
+
+  [ "$total" = "3" ]
+  [ "$completed" = "0" ]
+  [ "$issues_keys" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: 既存 state 上書き
+# WHEN 既存の state ファイルが存在する状態で spec-review-session-init.sh 5 を実行する
+# THEN state ファイルが {"total":5,"completed":0,"issues":{}} に上書きされる
+# ---------------------------------------------------------------------------
+@test "既存 state ファイルを上書き初期化する" {
+  # Pre-create a state file with old values
+  printf '{"total":10,"completed":7,"issues":{"123":"done"}}' > "$EXPECTED_STATE_FILE"
+
+  run bash "$SCRIPT_SRC" 5
+  [ "$status" -eq 0 ]
+  [ -f "$EXPECTED_STATE_FILE" ]
+
+  local total completed issues_keys
+  total=$(jq -r '.total' "$EXPECTED_STATE_FILE")
+  completed=$(jq -r '.completed' "$EXPECTED_STATE_FILE")
+  issues_keys=$(jq -r '.issues | keys | length' "$EXPECTED_STATE_FILE")
+
+  [ "$total" = "5" ]
+  [ "$completed" = "0" ]
+  [ "$issues_keys" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: 引数なし → exit 非 0
+# ---------------------------------------------------------------------------
+@test "引数なしは exit 非 0 で終了する" {
+  run bash "$SCRIPT_SRC"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: 引数が非数値 → exit 非 0
+# ---------------------------------------------------------------------------
+@test "非数値引数は exit 非 0 で終了する" {
+  run bash "$SCRIPT_SRC" "abc"
+  [ "$status" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: 引数が 0 → total=0 で作成
+# ---------------------------------------------------------------------------
+@test "引数 0 で total=0 の state ファイルが作成される" {
+  run bash "$SCRIPT_SRC" 0
+  [ "$status" -eq 0 ]
+  [ -f "$EXPECTED_STATE_FILE" ]
+  local total
+  total=$(jq -r '.total' "$EXPECTED_STATE_FILE")
+  [ "$total" = "0" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: hash がプロジェクトルートから算出される
+# ---------------------------------------------------------------------------
+@test "hash は CLAUDE_PROJECT_ROOT から算出される" {
+  run bash "$SCRIPT_SRC" 1
+  [ "$status" -eq 0 ]
+  # The state file must exist at the expected hash path
+  [ -f "$EXPECTED_STATE_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# edge: 複数回実行でも同じパスに上書き
+# ---------------------------------------------------------------------------
+@test "同じプロジェクトルートなら複数回実行でも同じパスに出力される" {
+  run bash "$SCRIPT_SRC" 2
+  [ "$status" -eq 0 ]
+  [ -f "$EXPECTED_STATE_FILE" ]
+
+  run bash "$SCRIPT_SRC" 4
+  [ "$status" -eq 0 ]
+  # Still the same file, now total=4
+  [ -f "$EXPECTED_STATE_FILE" ]
+  local total
+  total=$(jq -r '.total' "$EXPECTED_STATE_FILE")
+  [ "$total" = "4" ]
+}

--- a/plugins/twl/tests/scenarios/spec-review-gate.test.sh
+++ b/plugins/twl/tests/scenarios/spec-review-gate.test.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Integration Tests: Issue-446 spec-review gate
+#
+# Covers:
+#   1. check-specialist-completeness.sh の spec-review context フィルタ
+#      - spec-review-issue-NNN context で 3/3 完了 → session state completed++ される
+#      - phase-review-xxx context では session state は変更されない
+#   2. hooks.json への PreToolUse/Skill 登録
+#   3. workflow-issue-refine/SKILL.md の Step 3b に spec-review-session-init.sh 呼び出し
+#   4. architecture/domain/contexts/issue-mgmt.md の Constraints に IM-7 が存在
+#   5. deps.yaml に spec-review-session-init, pre-tool-use-spec-review-gate が登録
+# =============================================================================
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOK_SCRIPT="${PROJECT_ROOT}/scripts/hooks/check-specialist-completeness.sh"
+HOOKS_JSON="${PROJECT_ROOT}/hooks/hooks.json"
+SKILL_MD="${PROJECT_ROOT}/skills/workflow-issue-refine/SKILL.md"
+ISSUE_MGMT_MD="${PROJECT_ROOT}/architecture/domain/contexts/issue-mgmt.md"
+DEPS_YAML="${PROJECT_ROOT}/deps.yaml"
+INIT_SCRIPT="${PROJECT_ROOT}/scripts/spec-review-session-init.sh"
+GATE_SCRIPT="${PROJECT_ROOT}/scripts/hooks/pre-tool-use-spec-review-gate.sh"
+
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+# Unique per-process prefix to avoid /tmp collision in parallel runs
+CTX_PREFIX="srgtest-$$-$RANDOM"
+
+cleanup_ctx() {
+  local ctx="$1"
+  rm -f "/tmp/.specialist-manifest-${ctx}.txt" \
+        "/tmp/.specialist-spawned-${ctx}.txt"
+}
+
+# Compute session state file path from a project root value
+_state_file_for_root() {
+  local root="$1"
+  local hash
+  hash=$(printf '%s' "$root" | cksum | awk '{print $1}')
+  echo "/tmp/.spec-review-session-${hash}.json"
+}
+
+hook_input() {
+  local tool_name="$1"
+  local subagent_type="$2"
+  printf '{"tool_name":"%s","tool_input":{"subagent_type":"%s"}}' "$tool_name" "$subagent_type"
+}
+
+# ---------------------------------------------------------------------------
+# Requirement: check-specialist-completeness.sh — spec-review context でインクリメント
+#
+# WHEN マニフェストの context が spec-review-issue-123 で 3/3 specialist が完了する
+# THEN /tmp/.spec-review-session-{hash}.json の completed が 1 増加する
+# ---------------------------------------------------------------------------
+test_spec_review_context_increments_state() {
+  [[ -x "$HOOK_SCRIPT" ]] || { echo "hook not found: $HOOK_SCRIPT" >&2; return 1; }
+
+  local ctx="${CTX_PREFIX}-spec-review-issue-123"
+  local mf="/tmp/.specialist-manifest-${ctx}.txt"
+  local sf="/tmp/.specialist-spawned-${ctx}.txt"
+
+  # Use a temp dir as project root to get a predictable hash
+  local fake_root
+  fake_root=$(mktemp -d)
+  local state_file
+  state_file=$(_state_file_for_root "$fake_root")
+
+  # Initialize session state with completed=0
+  printf '{"total":1,"completed":0,"issues":{}}' > "$state_file"
+
+  # Set up manifest with 3 specialists
+  printf 'issue-critic\nissue-feasibility\nworker-codex-reviewer\n' > "$mf"
+
+  # Spawn all 3 specialists (simulate PostToolUse for each)
+  local specialists=("issue-critic" "issue-feasibility" "worker-codex-reviewer")
+  for sp in "${specialists[@]}"; do
+    CLAUDE_PROJECT_ROOT="$fake_root" hook_input "Agent" "twl:twl:${sp}" | bash "$HOOK_SCRIPT" >/dev/null 2>&1
+  done
+
+  # After all 3 done, the hook should have incremented completed
+  # (This tests that the hook calls increment logic when context matches spec-review-* prefix)
+  local completed
+  completed=$(jq -r '.completed' "$state_file" 2>/dev/null || echo "-1")
+
+  cleanup_ctx "$ctx"
+  rm -f "$state_file"
+  rm -rf "$fake_root"
+
+  # The completed count should be 1 (incremented once when all 3 specialists done)
+  if [[ "$completed" -eq 1 ]]; then
+    return 0
+  else
+    echo "expected completed=1, got: $completed" >&2
+    # If the hook doesn't yet implement increment, this test will FAIL as expected (pending)
+    return 1
+  fi
+}
+run_test "spec-review-* context で 3/3 完了時に session state completed がインクリメントされる" test_spec_review_context_increments_state
+
+# ---------------------------------------------------------------------------
+# Requirement: check-specialist-completeness.sh — 他 context への非影響
+#
+# WHEN マニフェストの context が phase-review-xxx で 3/3 specialist が完了する
+# THEN セッション state は変更されない
+# ---------------------------------------------------------------------------
+test_other_context_does_not_touch_state() {
+  [[ -x "$HOOK_SCRIPT" ]] || { echo "hook not found: $HOOK_SCRIPT" >&2; return 1; }
+
+  local ctx="${CTX_PREFIX}-phase-review-xxx"
+  local mf="/tmp/.specialist-manifest-${ctx}.txt"
+  local fake_root
+  fake_root=$(mktemp -d)
+  local state_file
+  state_file=$(_state_file_for_root "$fake_root")
+
+  # Initialize session state with completed=0
+  printf '{"total":1,"completed":0,"issues":{}}' > "$state_file"
+  local mtime_before
+  mtime_before=$(stat -c '%Y' "$state_file" 2>/dev/null || stat -f '%m' "$state_file" 2>/dev/null)
+
+  # Set up manifest
+  printf 'issue-critic\nissue-feasibility\nworker-codex-reviewer\n' > "$mf"
+
+  # Spawn all 3 specialists
+  local specialists=("issue-critic" "issue-feasibility" "worker-codex-reviewer")
+  for sp in "${specialists[@]}"; do
+    CLAUDE_PROJECT_ROOT="$fake_root" hook_input "Agent" "twl:twl:${sp}" | bash "$HOOK_SCRIPT" >/dev/null 2>&1
+  done
+
+  # State file should not have been modified
+  local completed
+  completed=$(jq -r '.completed' "$state_file" 2>/dev/null || echo "-1")
+
+  cleanup_ctx "$ctx"
+  rm -f "$state_file"
+  rm -rf "$fake_root"
+
+  if [[ "$completed" -eq 0 ]]; then
+    return 0
+  else
+    echo "expected completed=0 (unchanged), got: $completed" >&2
+    return 1
+  fi
+}
+run_test "phase-review-* context では session state completed が変更されない" test_other_context_does_not_touch_state
+
+# ---------------------------------------------------------------------------
+# Requirement: hooks.json への PreToolUse 登録確認
+#
+# WHEN hooks.json の PreToolUse セクションを参照する
+# THEN {"matcher":"Skill","hooks":[{"type":"command","command":"...pre-tool-use-spec-review-gate.sh"}]} エントリが存在する
+# ---------------------------------------------------------------------------
+test_hooks_json_pretooluse_skill_entry() {
+  [[ -f "$HOOKS_JSON" ]] || { echo "hooks.json not found: $HOOKS_JSON" >&2; return 1; }
+
+  # Check: PreToolUse には matcher="Skill" のエントリが存在する
+  jq -e '.hooks.PreToolUse[] | select(.matcher == "Skill")' "$HOOKS_JSON" >/dev/null 2>&1 \
+    || { echo "PreToolUse Skill matcher not found in hooks.json" >&2; return 1; }
+
+  # Check: そのエントリの hooks に pre-tool-use-spec-review-gate.sh が含まれる
+  jq -e '.hooks.PreToolUse[] | select(.matcher == "Skill") | .hooks[] | select(.command | contains("pre-tool-use-spec-review-gate.sh"))' \
+    "$HOOKS_JSON" >/dev/null 2>&1 \
+    || { echo "pre-tool-use-spec-review-gate.sh not registered under Skill matcher" >&2; return 1; }
+}
+run_test "hooks.json の PreToolUse に Skill matcher + pre-tool-use-spec-review-gate.sh が登録されている" test_hooks_json_pretooluse_skill_entry
+
+# ---------------------------------------------------------------------------
+# Requirement: workflow-issue-refine/SKILL.md の Step 3b にセッション初期化ステップ
+#
+# WHEN workflow-issue-refine/SKILL.md の Step 3b を参照する
+# THEN spec-review-session-init.sh の呼び出し手順が記載されている
+# ---------------------------------------------------------------------------
+test_skillmd_step3b_has_session_init() {
+  [[ -f "$SKILL_MD" ]] || { echo "SKILL.md not found: $SKILL_MD" >&2; return 1; }
+
+  grep -q "spec-review-session-init" "$SKILL_MD" \
+    || { echo "spec-review-session-init not found in SKILL.md" >&2; return 1; }
+}
+run_test "workflow-issue-refine/SKILL.md の Step 3b に spec-review-session-init.sh の呼び出しが記載されている" test_skillmd_step3b_has_session_init
+
+# ---------------------------------------------------------------------------
+# Requirement: issue-mgmt.md の Constraints に IM-7 が存在
+#
+# WHEN architecture/domain/contexts/issue-mgmt.md の Constraints セクションを参照する
+# THEN IM-7 として specialist spawn の機械的保証を規定するエントリが存在する
+# ---------------------------------------------------------------------------
+test_issue_mgmt_has_im7() {
+  [[ -f "$ISSUE_MGMT_MD" ]] || { echo "issue-mgmt.md not found: $ISSUE_MGMT_MD" >&2; return 1; }
+
+  grep -q "IM-7" "$ISSUE_MGMT_MD" \
+    || { echo "IM-7 not found in issue-mgmt.md" >&2; return 1; }
+}
+run_test "architecture/domain/contexts/issue-mgmt.md に制約 IM-7 が存在する" test_issue_mgmt_has_im7
+
+# ---------------------------------------------------------------------------
+# Requirement: deps.yaml に spec-review-session-init エントリが存在
+#
+# WHEN deps.yaml を参照する
+# THEN spec-review-session-init が script タイプで登録されている
+# ---------------------------------------------------------------------------
+test_deps_yaml_session_init_entry() {
+  [[ -f "$DEPS_YAML" ]] || { echo "deps.yaml not found: $DEPS_YAML" >&2; return 1; }
+
+  grep -q "spec-review-session-init" "$DEPS_YAML" \
+    || { echo "spec-review-session-init not found in deps.yaml" >&2; return 1; }
+}
+run_test "deps.yaml に spec-review-session-init が登録されている" test_deps_yaml_session_init_entry
+
+# ---------------------------------------------------------------------------
+# Requirement: deps.yaml に pre-tool-use-spec-review-gate エントリが存在
+#
+# WHEN deps.yaml を参照する
+# THEN pre-tool-use-spec-review-gate が script タイプで登録されている
+# ---------------------------------------------------------------------------
+test_deps_yaml_gate_entry() {
+  [[ -f "$DEPS_YAML" ]] || { echo "deps.yaml not found: $DEPS_YAML" >&2; return 1; }
+
+  grep -q "pre-tool-use-spec-review-gate" "$DEPS_YAML" \
+    || { echo "pre-tool-use-spec-review-gate not found in deps.yaml" >&2; return 1; }
+}
+run_test "deps.yaml に pre-tool-use-spec-review-gate が登録されている" test_deps_yaml_gate_entry
+
+# ---------------------------------------------------------------------------
+# Requirement: spec-review-session-init.sh が存在し実行可能
+# ---------------------------------------------------------------------------
+test_init_script_exists() {
+  [[ -f "$INIT_SCRIPT" ]] || { echo "missing: $INIT_SCRIPT" >&2; return 1; }
+  [[ -x "$INIT_SCRIPT" ]] || { echo "not executable: $INIT_SCRIPT" >&2; return 1; }
+}
+run_test "spec-review-session-init.sh が存在し実行可能である" test_init_script_exists
+
+# ---------------------------------------------------------------------------
+# Requirement: pre-tool-use-spec-review-gate.sh が存在し実行可能
+# ---------------------------------------------------------------------------
+test_gate_script_exists() {
+  [[ -f "$GATE_SCRIPT" ]] || { echo "missing: $GATE_SCRIPT" >&2; return 1; }
+  [[ -x "$GATE_SCRIPT" ]] || { echo "not executable: $GATE_SCRIPT" >&2; return 1; }
+}
+run_test "pre-tool-use-spec-review-gate.sh が存在し実行可能である" test_gate_script_exists
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
## 概要

PreToolUse gate + セッション state 管理により、`issue-review-aggregate` の呼び出しを全 Issue レビュー完了まで機械的にブロックする。

## 変更内容

- `scripts/spec-review-session-init.sh`（新規）: セッション state ファイル初期化
- `scripts/hooks/pre-tool-use-spec-review-gate.sh`（新規）: PreToolUse deny gate
- `scripts/hooks/check-specialist-completeness.sh`（修正）: spec-review context 完了時 completed インクリメント
- `hooks/hooks.json`（修正）: Skill matcher + gate hook 追加
- `skills/workflow-issue-refine/SKILL.md`（修正）: Step 3b にセッション初期化追加
- `architecture/domain/contexts/issue-mgmt.md`（修正）: 制約 IM-7 追記
- `deps.yaml`（修正）: 2 エントリ追加

Closes #446