### PR TITLE
feat(#439): merge-gate に phase-review checkpoint 必須ゲートを追加

### DIFF
--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -40,6 +40,7 @@ _PR_RE = re.compile(r"^\d+$")
 _BRANCH_RE = re.compile(r"^[a-zA-Z0-9._/\-]+$")
 _OWNER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 _REPO_RE = re.compile(r"^[a-zA-Z0-9_.-]+$")
+_ASCII_PRINTABLE = re.compile(r"[^\x20-\x7e]")
 
 
 class MergeGateError(Exception):
@@ -142,10 +143,11 @@ def _check_phase_review_guard(
     - If checkpoint has CRITICAL findings with confidence >= 80, raise MergeGateError.
     """
     # Label-based skip (scope/direct or quick)
-    if _PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels):
+    matched_labels = _PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels)
+    if matched_labels:
         print(
             "[merge-gate] INFO: phase-review チェックをスキップしました"
-            f"（ラベル: {_PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels)}）",
+            f"（ラベル: {', '.join(sorted(matched_labels))}）",
             file=sys.stderr,
         )
         return
@@ -180,9 +182,8 @@ def _check_phase_review_guard(
         and f.get("confidence", 0) >= 80
     ]
     if blocking:
-        _ASCII_PRINTABLE = re.compile(r"[^\x20-\x7e]")
         details = "; ".join(
-            _ASCII_PRINTABLE.sub("?", f.get("message", "no message"))
+            _ASCII_PRINTABLE.sub("?", str(f.get("message", "no message")))
             for f in blocking
         )
         raise MergeGateError(

--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -125,6 +125,58 @@ def _check_running_guard(autopilot_status: str) -> None:
         )
 
 
+_PHASE_REVIEW_SKIP_LABELS = frozenset({"scope/direct", "quick"})
+
+
+def _check_phase_review_guard(
+    autopilot_dir: Path,
+    issue_labels: list[str],
+    force: bool,
+) -> None:
+    """Reject merge when phase-review checkpoint is absent or has CRITICAL findings.
+
+    Skip logic:
+    - If the issue has a scope/direct or quick label, skip all checks.
+    - If --force is set and checkpoint is absent, emit a WARNING but continue.
+    - If checkpoint is absent (and not skipped), raise MergeGateError.
+    - If checkpoint has CRITICAL findings with confidence >= 80, raise MergeGateError.
+    """
+    # Label-based skip (scope/direct or quick)
+    if _PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels):
+        return
+
+    checkpoint_file = autopilot_dir / "checkpoints" / "phase-review.json"
+
+    if not checkpoint_file.exists():
+        if force:
+            print(
+                "[merge-gate] WARNING: phase-review checkpoint が不在です"
+                "（--force により続行）",
+                file=sys.stderr,
+            )
+            return
+        raise MergeGateError(
+            "phase-review checkpoint が不在です。specialist review を実行してください"
+        )
+
+    # Read and check CRITICAL findings
+    try:
+        data = json.loads(checkpoint_file.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise MergeGateError(f"phase-review checkpoint の読み込みに失敗しました: {exc}") from exc
+
+    findings = data.get("findings", [])
+    blocking = [
+        f for f in findings
+        if f.get("severity") == "CRITICAL" and f.get("confidence", 0) >= 80
+    ]
+    if blocking:
+        details = "; ".join(f.get("message", "no message") for f in blocking)
+        raise MergeGateError(
+            f"phase-review で CRITICAL findings が検出されました（{len(blocking)} 件）: {details}"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Board status update helper
 # ---------------------------------------------------------------------------
@@ -239,6 +291,14 @@ class MergeGate:
         if not self.force:
             _check_running_guard(autopilot_status)
 
+        # Pre-merge check: phase-review checkpoint guard (Issue #439).
+        issue_labels = self._get_issue_labels()
+        _check_phase_review_guard(
+            autopilot_dir=self.autopilot_dir,
+            issue_labels=issue_labels,
+            force=self.force,
+        )
+
         repo_mode = _detect_repo_mode()
         gh_repo_flag = self._gh_repo_flag()
 
@@ -338,6 +398,21 @@ class MergeGate:
         if self.repo_owner and self.repo_name:
             return ["-R", f"{self.repo_owner}/{self.repo_name}"]
         return []
+
+    def _get_issue_labels(self) -> list[str]:
+        """Return list of label names for this issue. Returns [] on error."""
+        gh_repo_flag = self._gh_repo_flag()
+        result = subprocess.run(
+            ["gh", "issue", "view", self.issue, *gh_repo_flag,
+             "--json", "labels", "-q", "[.labels[].name]"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return []
+        try:
+            return json.loads(result.stdout.strip())
+        except (json.JSONDecodeError, TypeError):
+            return []
 
     def _gh_issue_state(self, gh_repo_flag: list[str]) -> str:
         """Return GitHub Issue state ('OPEN', 'CLOSED', or '' on error)."""

--- a/cli/twl/src/twl/autopilot/mergegate.py
+++ b/cli/twl/src/twl/autopilot/mergegate.py
@@ -143,6 +143,11 @@ def _check_phase_review_guard(
     """
     # Label-based skip (scope/direct or quick)
     if _PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels):
+        print(
+            "[merge-gate] INFO: phase-review チェックをスキップしました"
+            f"（ラベル: {_PHASE_REVIEW_SKIP_LABELS.intersection(issue_labels)}）",
+            file=sys.stderr,
+        )
         return
 
     checkpoint_file = autopilot_dir / "checkpoints" / "phase-review.json"
@@ -166,12 +171,20 @@ def _check_phase_review_guard(
         raise MergeGateError(f"phase-review checkpoint の読み込みに失敗しました: {exc}") from exc
 
     findings = data.get("findings", [])
+    if not isinstance(findings, list):
+        findings = []
     blocking = [
         f for f in findings
-        if f.get("severity") == "CRITICAL" and f.get("confidence", 0) >= 80
+        if isinstance(f, dict)
+        and f.get("severity") == "CRITICAL"
+        and f.get("confidence", 0) >= 80
     ]
     if blocking:
-        details = "; ".join(f.get("message", "no message") for f in blocking)
+        _ASCII_PRINTABLE = re.compile(r"[^\x20-\x7e]")
+        details = "; ".join(
+            _ASCII_PRINTABLE.sub("?", f.get("message", "no message"))
+            for f in blocking
+        )
         raise MergeGateError(
             f"phase-review で CRITICAL findings が検出されました（{len(blocking)} 件）: {details}"
         )

--- a/cli/twl/tests/autopilot/test_merge_gate_phase_review.py
+++ b/cli/twl/tests/autopilot/test_merge_gate_phase_review.py
@@ -1,0 +1,644 @@
+"""Tests for MergeGate phase-review checkpoint guard.
+
+Covers (issue-439 spec: deltaspec/changes/issue-439/specs/phase-review-guard/spec.md):
+
+  Requirement: phase-review checkpoint 存在チェック
+    - phase-review checkpoint が不在の場合は REJECT
+    - scope/direct ラベル付き Issue は phase-review チェックをスキップ
+    - quick ラベル付き Issue は phase-review チェックをスキップ
+
+  Requirement: phase-review CRITICAL findings の統合
+    - phase-review に CRITICAL findings がある場合は REJECT
+    - phase-review に CRITICAL findings がない場合は継続
+
+  Requirement: --force 使用時の phase-review 不在 WARNING
+    - --force 使用時も phase-review 不在は WARNING 記録
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from twl.autopilot.mergegate import MergeGate, MergeGateError, _check_phase_review_guard
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autopilot_dir(tmp_path: Path) -> Path:
+    """Autopilot directory with checkpoints subdirectory."""
+    d = tmp_path / ".autopilot"
+    d.mkdir()
+    (d / "issues").mkdir()
+    (d / "checkpoints").mkdir()
+    return d
+
+
+@pytest.fixture
+def scripts_root(tmp_path: Path) -> Path:
+    d = tmp_path / "scripts"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def gate(autopilot_dir: Path, scripts_root: Path) -> MergeGate:
+    return MergeGate(
+        issue="439",
+        pr_number="500",
+        branch="feat/439-phase-review-guard",
+        autopilot_dir=autopilot_dir,
+        scripts_root=scripts_root,
+    )
+
+
+@pytest.fixture
+def gate_force(autopilot_dir: Path, scripts_root: Path) -> MergeGate:
+    return MergeGate(
+        issue="439",
+        pr_number="500",
+        branch="feat/439-phase-review-guard",
+        autopilot_dir=autopilot_dir,
+        scripts_root=scripts_root,
+        force=True,
+    )
+
+
+def _phase_review_json(
+    *,
+    findings: list[dict] | None = None,
+    status: str = "PASS",
+) -> dict:
+    """Build a minimal phase-review.json payload."""
+    findings = findings or []
+    critical_count = sum(
+        1 for f in findings if f.get("severity") == "CRITICAL"
+    )
+    return {
+        "step": "phase-review",
+        "status": status,
+        "findings_summary": f"{critical_count} CRITICAL, 0 WARNING",
+        "critical_count": critical_count,
+        "findings": findings,
+        "timestamp": "2026-04-11T00:00:00Z",
+    }
+
+
+def _write_phase_review(autopilot_dir: Path, data: dict) -> Path:
+    """Write phase-review.json to the checkpoints directory."""
+    ckpt_file = autopilot_dir / "checkpoints" / "phase-review.json"
+    ckpt_file.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+    return ckpt_file
+
+
+# ---------------------------------------------------------------------------
+# Requirement: phase-review checkpoint 存在チェック
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseReviewCheckpointPresence:
+    """
+    Scenario: phase-review checkpoint が不在の場合は REJECT
+    WHEN: .autopilot/checkpoints/phase-review.json が存在しない状態で merge-gate が実行される
+    THEN: merge-gate は REJECT を返し、
+          「phase-review checkpoint が不在です。specialist review を実行してください」
+          というエラーメッセージを出力する
+    """
+
+    def test_missing_checkpoint_raises_error(self, autopilot_dir: Path) -> None:
+        """phase-review.json が不在の場合、MergeGateError を送出する。"""
+        # checkpoint ファイルを作成しない
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        with pytest.raises(MergeGateError, match="phase-review checkpoint が不在です"):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_missing_checkpoint_error_message_includes_specialist_review(
+        self, autopilot_dir: Path
+    ) -> None:
+        """エラーメッセージに「specialist review を実行してください」が含まれる。"""
+        with pytest.raises(MergeGateError, match="specialist review を実行してください"):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_present_checkpoint_without_critical_findings_does_not_raise(
+        self, autopilot_dir: Path
+    ) -> None:
+        """checkpoint が存在し CRITICAL findings がない場合は例外を送出しない。"""
+        _write_phase_review(autopilot_dir, _phase_review_json())
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=False,
+        )
+
+    def test_missing_checkpoint_raises_even_when_checkpoints_dir_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """checkpoints ディレクトリ自体が存在しない場合も REJECT。"""
+        autopilot_dir = tmp_path / ".autopilot"
+        autopilot_dir.mkdir()
+        # checkpoints/ を作成しない
+
+        with pytest.raises(MergeGateError, match="phase-review checkpoint が不在です"):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: phase-review checkpoint 存在チェック（スキップ条件）
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseReviewCheckpointSkipLabels:
+    """
+    Scenario: scope/direct ラベル付き Issue は phase-review チェックをスキップ
+    WHEN: Issue に scope/direct ラベルが付与されており、
+          phase-review.json が不在の状態で merge-gate が実行される
+    THEN: merge-gate は phase-review チェックをスキップし、
+          他のチェックの結果で判定を続行する
+
+    Scenario: quick ラベル付き Issue は phase-review チェックをスキップ
+    WHEN: Issue に quick ラベルが付与されており、
+          phase-review.json が不在の状態で merge-gate が実行される
+    THEN: merge-gate は phase-review チェックをスキップし、
+          他のチェックの結果で判定を続行する
+    """
+
+    def test_scope_direct_label_skips_check_when_checkpoint_missing(
+        self, autopilot_dir: Path
+    ) -> None:
+        """scope/direct ラベルがある場合、checkpoint 不在でも例外を送出しない。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=["scope/direct"],
+            force=False,
+        )
+
+    def test_quick_label_skips_check_when_checkpoint_missing(
+        self, autopilot_dir: Path
+    ) -> None:
+        """quick ラベルがある場合、checkpoint 不在でも例外を送出しない。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=["quick"],
+            force=False,
+        )
+
+    def test_scope_direct_label_also_skips_critical_findings_check(
+        self, autopilot_dir: Path
+    ) -> None:
+        """scope/direct ラベルがある場合、CRITICAL findings があっても例外を送出しない。"""
+        findings = [
+            {"severity": "CRITICAL", "confidence": 90, "message": "critical issue"},
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        # Should not raise — label-based skip applies to all phase-review checks
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=["scope/direct"],
+            force=False,
+        )
+
+    def test_quick_label_also_skips_critical_findings_check(
+        self, autopilot_dir: Path
+    ) -> None:
+        """quick ラベルがある場合、CRITICAL findings があっても例外を送出しない。"""
+        findings = [
+            {"severity": "CRITICAL", "confidence": 95, "message": "critical issue"},
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=["quick"],
+            force=False,
+        )
+
+    def test_unrelated_label_does_not_skip_check(self, autopilot_dir: Path) -> None:
+        """関係のないラベルは phase-review チェックをスキップしない。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        with pytest.raises(MergeGateError, match="phase-review checkpoint が不在です"):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=["bug", "enhancement"],
+                force=False,
+            )
+
+    def test_multiple_labels_including_quick_skips_check(
+        self, autopilot_dir: Path
+    ) -> None:
+        """複数ラベル中に quick が含まれる場合もスキップ。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=["bug", "quick", "enhancement"],
+            force=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: phase-review CRITICAL findings の統合
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseReviewCriticalFindings:
+    """
+    Scenario: phase-review に CRITICAL findings がある場合は REJECT
+    WHEN: .autopilot/checkpoints/phase-review.json に confidence >= 80 の CRITICAL finding が
+          含まれる状態で merge-gate が実行される
+    THEN: merge-gate は REJECT を返し、該当 finding の詳細をエラーメッセージに含める
+
+    Scenario: phase-review に CRITICAL findings がない場合は継続
+    WHEN: .autopilot/checkpoints/phase-review.json が存在し、
+          confidence >= 80 の CRITICAL finding が含まれない状態で merge-gate が実行される
+    THEN: merge-gate は phase-review チェックを通過し、他のチェックの結果で判定を続行する
+    """
+
+    def test_critical_finding_with_high_confidence_raises_error(
+        self, autopilot_dir: Path
+    ) -> None:
+        """confidence >= 80 の CRITICAL finding がある場合、MergeGateError を送出する。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 85,
+                "message": "security vulnerability detected",
+                "file": "src/auth.py",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        with pytest.raises(MergeGateError):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_critical_finding_error_message_includes_finding_details(
+        self, autopilot_dir: Path
+    ) -> None:
+        """エラーメッセージに finding の詳細（message）が含まれる。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 90,
+                "message": "type invariant violation found",
+                "file": "src/core.py",
+                "line": 42,
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        with pytest.raises(MergeGateError, match="type invariant violation found"):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_critical_finding_at_exactly_80_confidence_raises_error(
+        self, autopilot_dir: Path
+    ) -> None:
+        """confidence が境界値 80 の CRITICAL finding もエラーを送出する。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 80,
+                "message": "boundary confidence critical issue",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        with pytest.raises(MergeGateError):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_critical_finding_below_80_confidence_does_not_raise(
+        self, autopilot_dir: Path
+    ) -> None:
+        """confidence < 80 の CRITICAL finding はエラーを送出しない。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 79,
+                "message": "low confidence critical issue",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="WARN"),
+        )
+
+        # Should not raise — confidence below threshold
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=False,
+        )
+
+    def test_no_critical_findings_does_not_raise(self, autopilot_dir: Path) -> None:
+        """CRITICAL findings が存在しない場合は例外を送出しない。"""
+        findings = [
+            {
+                "severity": "WARNING",
+                "confidence": 95,
+                "message": "minor style issue",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="WARN"),
+        )
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=False,
+        )
+
+    def test_empty_findings_list_does_not_raise(self, autopilot_dir: Path) -> None:
+        """findings が空リストの場合は例外を送出しない。"""
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=[], status="PASS"),
+        )
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=False,
+        )
+
+    def test_multiple_critical_findings_all_included_in_error(
+        self, autopilot_dir: Path
+    ) -> None:
+        """複数の CRITICAL findings がある場合、最初の finding の詳細がエラーに含まれる。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 85,
+                "message": "first critical issue",
+            },
+            {
+                "severity": "CRITICAL",
+                "confidence": 90,
+                "message": "second critical issue",
+            },
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        with pytest.raises(MergeGateError):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=False,
+            )
+
+    def test_critical_finding_missing_confidence_field_does_not_raise(
+        self, autopilot_dir: Path
+    ) -> None:
+        """confidence フィールドが欠落した CRITICAL finding は threshold 判定対象外。"""
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "message": "no confidence field",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="WARN"),
+        )
+
+        # confidence フィールド欠落時の扱いは実装次第だが、
+        # 存在チェックはパスしているため実装に従う。
+        # confidence 欠落は threshold 未達として扱う (0 < 80) ことを期待。
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: --force 使用時の phase-review 不在 WARNING
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseReviewForceWarning:
+    """
+    Scenario: --force 使用時も phase-review 不在は WARNING 記録
+    WHEN: --force オプションを使用して merge-gate が実行され、
+          phase-review.json が不在の場合
+    THEN: merge-gate は REJECT を返さずに続行するが、
+          「WARNING: phase-review checkpoint が不在です（--force により続行）」
+          というメッセージをログに記録する
+    """
+
+    def test_force_mode_does_not_raise_when_checkpoint_missing(
+        self, autopilot_dir: Path
+    ) -> None:
+        """--force 時は checkpoint 不在でも MergeGateError を送出しない。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        # Should not raise
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=True,
+        )
+
+    def test_force_mode_logs_warning_message_when_checkpoint_missing(
+        self, autopilot_dir: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """--force 時は checkpoint 不在で WARNING メッセージを出力する。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=True,
+        )
+
+        captured = capsys.readouterr()
+        # WARNING は stdout または stderr に出力される
+        combined_output = captured.out + captured.err
+        assert "WARNING" in combined_output
+        assert "phase-review checkpoint が不在です" in combined_output
+
+    def test_force_mode_warning_message_mentions_force_flag(
+        self, autopilot_dir: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """WARNING メッセージに「--force により続行」が含まれる。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        _check_phase_review_guard(
+            autopilot_dir=autopilot_dir,
+            issue_labels=[],
+            force=True,
+        )
+
+        captured = capsys.readouterr()
+        combined_output = captured.out + captured.err
+        assert "--force" in combined_output or "force" in combined_output.lower()
+
+    def test_force_mode_still_rejects_critical_findings(
+        self, autopilot_dir: Path
+    ) -> None:
+        """--force でも CRITICAL findings (confidence >= 80) がある場合は REJECT する。
+
+        NOTE: --force の免除対象は「checkpoint 不在」のみ。
+        CRITICAL findings がある場合の挙動は仕様の明示がないため、
+        このテストは最も厳格な解釈（REJECT 継続）を前提とする。
+        実装によっては xfail となる可能性がある。
+        """
+        findings = [
+            {
+                "severity": "CRITICAL",
+                "confidence": 85,
+                "message": "critical finding in force mode",
+            }
+        ]
+        _write_phase_review(
+            autopilot_dir,
+            _phase_review_json(findings=findings, status="FAIL"),
+        )
+
+        # --force は checkpoint 不在のみをバイパスする。
+        # CRITICAL findings が存在する場合は --force でも REJECT。
+        with pytest.raises(MergeGateError):
+            _check_phase_review_guard(
+                autopilot_dir=autopilot_dir,
+                issue_labels=[],
+                force=True,
+            )
+
+
+# ---------------------------------------------------------------------------
+# MergeGate.execute() 統合: phase-review guard が呼ばれること
+# ---------------------------------------------------------------------------
+
+
+class TestMergeGateExecuteIntegration:
+    """execute() が _check_phase_review_guard を呼び出すことを確認する統合テスト。"""
+
+    def _patch_execute_base(self) -> list:
+        """execute() の外部依存をすべてモックするパッチリスト。"""
+        return [
+            patch("os.getcwd", return_value="/home/user/projects/main"),
+            patch("twl.autopilot.mergegate._check_worker_window_guard"),
+            patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"),
+            patch("twl.autopilot.mergegate._state_write"),
+            patch("twl.autopilot.mergegate._board_update"),
+            patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"),
+            patch.object(MergeGate, "_verify_and_close_issue", return_value=True),
+            patch(
+                "subprocess.run",
+                return_value=MagicMock(returncode=0, stdout=""),
+            ),
+        ]
+
+    def test_execute_calls_phase_review_guard(
+        self, gate: MergeGate
+    ) -> None:
+        """execute() は _check_phase_review_guard（またはメソッド相当）を呼び出す。"""
+        with patch("twl.autopilot.mergegate._check_phase_review_guard") as mock_guard, \
+             patch("os.getcwd", return_value="/home/user/projects/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch.object(MergeGate, "_verify_and_close_issue", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            gate.execute()
+            mock_guard.assert_called_once()
+
+    def test_execute_rejects_when_phase_review_guard_raises(
+        self, gate: MergeGate, autopilot_dir: Path
+    ) -> None:
+        """phase-review checkpoint 不在時、execute() は MergeGateError を送出する。"""
+        # checkpoint を作成しない（不在状態）
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        with patch("os.getcwd", return_value="/home/user/projects/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            with pytest.raises((MergeGateError, SystemExit)):
+                gate.execute()
+
+    def test_execute_force_continues_when_phase_review_checkpoint_missing(
+        self, gate_force: MergeGate, autopilot_dir: Path
+    ) -> None:
+        """--force 時は checkpoint 不在でも execute() が続行する。"""
+        assert not (autopilot_dir / "checkpoints" / "phase-review.json").exists()
+
+        with patch("os.getcwd", return_value="/home/user/projects/main"), \
+             patch("twl.autopilot.mergegate._check_worker_window_guard"), \
+             patch("twl.autopilot.mergegate._state_read", return_value="merge-ready"), \
+             patch("twl.autopilot.mergegate._state_write"), \
+             patch("twl.autopilot.mergegate._board_update"), \
+             patch("twl.autopilot.mergegate._detect_repo_mode", return_value="standard"), \
+             patch.object(MergeGate, "_verify_and_close_issue", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            # Should not raise
+            gate_force.execute()

--- a/deltaspec/changes/issue-439/.deltaspec.yaml
+++ b/deltaspec/changes/issue-439/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 439
+name: issue-439
+status: pending

--- a/deltaspec/changes/issue-439/design.md
+++ b/deltaspec/changes/issue-439/design.md
@@ -1,0 +1,59 @@
+## Context
+
+merge-gate はプルリクエストのマージ前最終判定を担う composite ステップ。現在は ac-verify checkpoint と all-pass-check checkpoint を読み込むが、phase-review checkpoint（specialist review 結果）は読み込んでいない。
+
+phase-review は `workflow-pr-verify` チェーン内の `phase-review` ステップでのみ実行される。chain が実行されなければ checkpoint は生成されず、merge-gate はそれを検出しない。Wave 18-25 で 28 PRs が specialist review なしでマージされた実績がある。
+
+修正対象:
+- `plugins/twl/commands/merge-gate.md` — ドメインルール記述
+- `cli/twl/src/twl/autopilot/mergegate.py` — 実装（merge 判定ロジック）
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- merge-gate が `phase-review.json` checkpoint の存在を検査する
+- `phase-review.json` 不在時に REJECT を返す
+- `scope/direct` / `quick` ラベル付き Issue は phase-review チェックをスキップ
+- `phase-review.json` の CRITICAL findings (confidence >= 80) を判定に統合
+- `--force` 実行時も phase-review 不在を WARNING としてログ記録
+
+**Non-Goals:**
+
+- phase-review 自体の実行ロジックの変更
+- ac-verify checkpoint の既存ロジックの変更
+- worktree-guard / worker-window-guard / running-guard の変更
+
+## Decisions
+
+### 1. merge-gate.md への phase-review checkpoint 統合
+
+`checkpoint 統合（MUST）` セクションに以下を追加:
+
+```bash
+PHASE_REVIEW_STATUS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field status 2>/dev/null || echo "MISSING")
+PHASE_REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field findings 2>/dev/null || echo "[]")
+```
+
+### 2. scope/direct / quick ラベル例外
+
+`gh issue view "$ISSUE_NUM" --json labels` でラベルを取得し、`scope/direct` または `quick` が含まれる場合は phase-review チェックをスキップ。
+
+### 3. REJECT 条件の拡張
+
+既存の severity フィルタ判定セクションを拡張:
+- `PHASE_REVIEW_STATUS == "MISSING"` かつ例外ラベルなし → REJECT
+- COMBINED_FINDINGS に phase-review の CRITICAL findings も統合
+- `--force` 使用時でも MISSING は WARNING ログを出力
+
+### 4. mergegate.py への _check_phase_review_guard() 追加
+
+merge-gate.md のドメインルールに対応して、Python 実装側にも `_check_phase_review_guard()` を追加し、`execute()` メソッドの checkpoint 検査フローで呼び出す。
+
+ただし、merge-gate.md は LLM composite コマンドであり、実際の checkpoint 読み取りと判定は LLM が担う。mergegate.py はコマンドオーケストレーター（`auto-merge` モード）で使用されるため、Python 側にも同等のガードを追加する。
+
+## Risks / Trade-offs
+
+- **既存テストへの影響**: phase-review.json が存在しない既存テスト環境では REJECT が返る。テストフィクスチャに phase-review.json を追加する必要がある。
+- **スキップ条件の判定**: `scope/direct` / `quick` ラベルの取得は GitHub API 呼び出しを必要とする。API 失敗時はチェックを続行（fail-open ではなく、ラベル不明の場合は phase-review 必須とする）。
+- **後方互換性**: 既存の autopilot Wave では phase-review.json が生成されていない可能性があるが、本 fix はこれを意図的に REJECT する（防衛的設計）。

--- a/deltaspec/changes/issue-439/proposal.md
+++ b/deltaspec/changes/issue-439/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+merge-gate が `phase-review` checkpoint（specialist review 結果）を検査せず、specialist review が完全にスキップされても PASS してしまう。defense-in-depth として phase-review checkpoint の必須チェックを追加し、review なしマージを防止する。
+
+## What Changes
+
+- `mergegate.py` に `phase-review.json` 存在チェックを追加
+- `phase-review.json` が不在の場合に REJECT を返すロジックを実装
+- `scope/direct` / `quick` ラベル付き Issue はチェックをスキップ
+- `phase-review.json` の CRITICAL findings (confidence >= 80) を merge-gate 判定に統合
+- `--force` 使用時でも phase-review 不在は WARNING としてログ記録
+- `merge-gate.md` コマンドドキュメントに phase-review チェックの説明を追記
+
+## Capabilities
+
+### New Capabilities
+
+- merge-gate が `phase-review.json` checkpoint の存在を検査する
+- `phase-review.json` 不在時に REJECT を返す（silent fail 防止）
+- phase-review の CRITICAL findings を merge-gate 判定に統合する
+- `--force` 実行時も phase-review スキップを WARNING としてログ記録する
+
+### Modified Capabilities
+
+- merge-gate の判定ロジックに `_check_phase_review_guard()` を追加
+- `scope/direct` / `quick` ラベル付き Issue では phase-review チェックをスキップ
+
+## Impact
+
+- `cli/twl/src/twl/autopilot/mergegate.py`: `_check_phase_review_guard()` 追加、既存 guard chain に統合
+- `plugins/twl/commands/merge-gate.md`: phase-review チェックの説明追記
+- `.autopilot/checkpoints/phase-review.json`: 読み込み対象として追加

--- a/deltaspec/changes/issue-439/specs/phase-review-guard/spec.md
+++ b/deltaspec/changes/issue-439/specs/phase-review-guard/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: phase-review checkpoint 存在チェック
+
+merge-gate は `phase-review.json` checkpoint の存在を検査しなければならない（SHALL）。`phase-review.json` が不在の場合、merge-gate は REJECT を返さなければならない（MUST）。
+
+#### Scenario: phase-review checkpoint が不在の場合は REJECT
+- **WHEN** `.autopilot/checkpoints/phase-review.json` が存在しない状態で merge-gate が実行される
+- **THEN** merge-gate は REJECT を返し、「phase-review checkpoint が不在です。specialist review を実行してください」というエラーメッセージを出力する
+
+#### Scenario: scope/direct ラベル付き Issue は phase-review チェックをスキップ
+- **WHEN** Issue に `scope/direct` ラベルが付与されており、`phase-review.json` が不在の状態で merge-gate が実行される
+- **THEN** merge-gate は phase-review チェックをスキップし、他のチェックの結果で判定を続行する
+
+#### Scenario: quick ラベル付き Issue は phase-review チェックをスキップ
+- **WHEN** Issue に `quick` ラベルが付与されており、`phase-review.json` が不在の状態で merge-gate が実行される
+- **THEN** merge-gate は phase-review チェックをスキップし、他のチェックの結果で判定を続行する
+
+### Requirement: phase-review CRITICAL findings の統合
+
+merge-gate は `phase-review.json` が存在する場合、その CRITICAL findings (confidence >= 80) を判定に統合しなければならない（MUST）。
+
+#### Scenario: phase-review に CRITICAL findings がある場合は REJECT
+- **WHEN** `.autopilot/checkpoints/phase-review.json` に confidence >= 80 の CRITICAL finding が含まれる状態で merge-gate が実行される
+- **THEN** merge-gate は REJECT を返し、該当 finding の詳細をエラーメッセージに含める
+
+#### Scenario: phase-review に CRITICAL findings がない場合は継続
+- **WHEN** `.autopilot/checkpoints/phase-review.json` が存在し、confidence >= 80 の CRITICAL finding が含まれない状態で merge-gate が実行される
+- **THEN** merge-gate は phase-review チェックを通過し、他のチェックの結果で判定を続行する
+
+### Requirement: --force 使用時の phase-review 不在 WARNING
+
+`--force` オプション使用時でも、phase-review checkpoint が不在の場合は WARNING としてログに記録しなければならない（SHALL）。
+
+#### Scenario: --force 使用時も phase-review 不在は WARNING 記録
+- **WHEN** `--force` オプションを使用して merge-gate が実行され、`phase-review.json` が不在の場合
+- **THEN** merge-gate は REJECT を返さずに続行するが、「WARNING: phase-review checkpoint が不在です（--force により続行）」というメッセージをログに記録する

--- a/deltaspec/changes/issue-439/tasks.md
+++ b/deltaspec/changes/issue-439/tasks.md
@@ -1,0 +1,20 @@
+## 1. mergegate.py 実装
+
+- [x] 1.1 `_check_phase_review_guard()` 関数を追加（checkpoint 不在チェック + scope/direct/quick ラベル例外）
+- [x] 1.2 `_check_phase_review_findings()` ロジックを追加（CRITICAL findings (confidence >= 80) の統合）
+- [x] 1.3 `execute()` メソッドの checkpoint 検査フローに phase-review ガードを組み込む
+- [x] 1.4 `--force` 使用時に phase-review 不在を WARNING ログに記録する処理を追加
+
+## 2. merge-gate.md 更新
+
+- [x] 2.1 `checkpoint 統合（MUST）` セクションに phase-review checkpoint の読み込み処理を追記
+- [x] 2.2 `severity フィルタ判定` セクションに phase-review MISSING 条件の REJECT ルールを追記
+- [x] 2.3 `scope/direct` / `quick` ラベル例外の処理フローを記述
+
+## 3. テスト
+
+- [x] 3.1 phase-review.json 不在時に REJECT を返すユニットテストを追加
+- [x] 3.2 scope/direct ラベル付き Issue では phase-review チェックがスキップされるテストを追加
+- [x] 3.3 quick ラベル付き Issue では phase-review チェックがスキップされるテストを追加
+- [x] 3.4 phase-review に CRITICAL findings がある場合の REJECT テストを追加
+- [x] 3.5 --force 使用時に WARNING が記録されるテストを追加

--- a/deltaspec/changes/issue-439/test-mapping.yaml
+++ b/deltaspec/changes/issue-439/test-mapping.yaml
@@ -1,0 +1,159 @@
+change_id: issue-439
+generated_at: "2026-04-11T00:00:00Z"
+test_framework: pytest
+scenarios:
+  - id: "phase-review-checkpoint-missing-reject"
+    name: "phase-review checkpoint が不在の場合は REJECT"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 7
+    requirement: "phase-review checkpoint 存在チェック"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCheckpointPresence::test_missing_checkpoint_raises_error"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-checkpoint-missing-error-message"
+    name: "phase-review checkpoint が不在のエラーメッセージに specialist review が含まれる"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 7
+    requirement: "phase-review checkpoint 存在チェック"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCheckpointPresence::test_missing_checkpoint_error_message_includes_specialist_review"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-checkpoint-present-no-critical-pass"
+    name: "phase-review checkpoint が存在し CRITICAL findings なしで通過"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 7
+    requirement: "phase-review checkpoint 存在チェック"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCheckpointPresence::test_present_checkpoint_without_critical_findings_does_not_raise"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-scope-direct-label-skip"
+    name: "scope/direct ラベル付き Issue は phase-review チェックをスキップ"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 11
+    requirement: "phase-review checkpoint 存在チェック"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCheckpointSkipLabels::test_scope_direct_label_skips_check_when_checkpoint_missing"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-quick-label-skip"
+    name: "quick ラベル付き Issue は phase-review チェックをスキップ"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 16
+    requirement: "phase-review checkpoint 存在チェック"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCheckpointSkipLabels::test_quick_label_skips_check_when_checkpoint_missing"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-critical-findings-reject"
+    name: "phase-review に CRITICAL findings がある場合は REJECT"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 23
+    requirement: "phase-review CRITICAL findings の統合"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCriticalFindings::test_critical_finding_with_high_confidence_raises_error"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-critical-findings-message-details"
+    name: "CRITICAL finding のエラーメッセージに finding 詳細が含まれる"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 23
+    requirement: "phase-review CRITICAL findings の統合"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCriticalFindings::test_critical_finding_error_message_includes_finding_details"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-critical-findings-confidence-boundary"
+    name: "confidence 境界値 80 の CRITICAL finding もエラー"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 23
+    requirement: "phase-review CRITICAL findings の統合"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCriticalFindings::test_critical_finding_at_exactly_80_confidence_raises_error"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-critical-findings-below-threshold-pass"
+    name: "confidence < 80 の CRITICAL finding は継続"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 27
+    requirement: "phase-review CRITICAL findings の統合"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCriticalFindings::test_critical_finding_below_80_confidence_does_not_raise"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-no-critical-findings-pass"
+    name: "phase-review に CRITICAL findings がない場合は継続"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 27
+    requirement: "phase-review CRITICAL findings の統合"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewCriticalFindings::test_no_critical_findings_does_not_raise"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-force-no-reject-on-missing"
+    name: "--force 使用時も phase-review 不在は WARNING 記録（REJECT しない）"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 35
+    requirement: "--force 使用時の phase-review 不在 WARNING"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewForceWarning::test_force_mode_does_not_raise_when_checkpoint_missing"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "phase-review-force-warning-message"
+    name: "--force 使用時の WARNING メッセージ内容"
+    spec_file: "specs/phase-review-guard/spec.md"
+    spec_line: 35
+    requirement: "--force 使用時の phase-review 不在 WARNING"
+    test_file: "cli/twl/tests/autopilot/test_merge_gate_phase_review.py"
+    test_name: "TestPhaseReviewForceWarning::test_force_mode_logs_warning_message_when_checkpoint_missing"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/commands/merge-gate.md
+++ b/plugins/twl/commands/merge-gate.md
@@ -63,10 +63,30 @@ fi
 
 ```bash
 AC_VERIFY_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --field findings 2>/dev/null || echo "[]")
-COMBINED_FINDINGS=$(jq -s 'add' <(echo "$FINDINGS") <(echo "$AC_VERIFY_FINDINGS"))
+PHASE_REVIEW_STATUS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field status 2>/dev/null || echo "MISSING")
+PHASE_REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field findings 2>/dev/null || echo "[]")
+COMBINED_FINDINGS=$(jq -s 'add' <(echo "$FINDINGS") <(echo "$AC_VERIFY_FINDINGS") <(echo "$PHASE_REVIEW_FINDINGS"))
 ```
 
 all-pass-check checkpoint も同形式で読み込む。ac-verify checkpoint 不在時は WARN を出して継続（autopilot 配下では異常ケース）。
+
+### phase-review checkpoint 必須チェック（MUST）
+
+phase-review checkpoint は merge-gate の必須ゲートである（defense-in-depth、Issue #439）。
+
+```bash
+ISSUE_NUM=$(source "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-issue-num.sh" 2>/dev/null || true; resolve_issue_num 2>/dev/null || echo "")
+ISSUE_LABELS=$(gh issue view "$ISSUE_NUM" --json labels -q '[.labels[].name]' 2>/dev/null || echo "[]")
+SKIP_PHASE_REVIEW=false
+for label in $(echo "$ISSUE_LABELS" | jq -r '.[]'); do
+  [[ "$label" == "scope/direct" || "$label" == "quick" ]] && SKIP_PHASE_REVIEW=true && break
+done
+```
+
+- `SKIP_PHASE_REVIEW=false` かつ `PHASE_REVIEW_STATUS == "MISSING"` の場合:
+  - `--force` フラグなし → **REJECT**: 「phase-review checkpoint が不在です。specialist review を実行してください」
+  - `--force` フラグあり → **WARNING** ログ記録して継続: 「WARNING: phase-review checkpoint が不在です（--force により続行）」
+- `SKIP_PHASE_REVIEW=true` の場合: phase-review チェックをスキップ（`scope/direct` / `quick` ラベル付き Issue は軽微変更のため除外）
 
 ### severity フィルタ判定（機械的のみ）
 
@@ -75,6 +95,8 @@ BLOCKING = COMBINED_FINDINGS WHERE severity == "CRITICAL" AND confidence >= 80
 PASS  ⇔ BLOCKING == 0
 REJECT ⇔ BLOCKING >= 1
 ```
+
+phase-review の CRITICAL findings (confidence >= 80) も COMBINED_FINDINGS に含まれるため、自動統合される。
 
 ### PASS / REJECT 時の状態遷移
 


### PR DESCRIPTION
## 概要

merge-gate が `phase-review` checkpoint（specialist review 結果）を検査せず、specialist review が完全にスキップされても PASS してしまう問題を修正する。

Closes #439

## 変更内容

- `cli/twl/src/twl/autopilot/mergegate.py`: `_check_phase_review_guard()` を追加
  - `phase-review.json` 存在チェック（不在 → REJECT）
  - `scope/direct` / `quick` ラベル例外（ラベルスキップ監査ログ付き）
  - CRITICAL findings (confidence >= 80) 統合
  - `--force` 時の WARNING ログ
  - findings 型ガード、ログインジェクション対策（ASCII サニタイズ）
- `plugins/twl/commands/merge-gate.md`: phase-review checkpoint 必須チェックセクション追加
- `cli/twl/tests/autopilot/test_merge_gate_phase_review.py`: 新規ユニットテスト（644行）
- `deltaspec/changes/issue-439/`: DeltaSpec artifacts

## tech-debt Issues
- [#461](https://github.com/shuu5/twill/issues/461): test_merge_gate_phase_review.py 分割
- [#462](https://github.com/shuu5/twill/issues/462): mergegate.py モジュール分割