### PR TITLE
[Feature] Bug 再現シナリオを test-scenario-catalog に追加（#436/#438/#439）

### DIFF
--- a/cli/twl/deltaspec/changes/issue-442/.deltaspec.yaml
+++ b/cli/twl/deltaspec/changes/issue-442/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 442
+name: issue-442
+status: pending

--- a/cli/twl/deltaspec/changes/issue-442/design.md
+++ b/cli/twl/deltaspec/changes/issue-442/design.md
@@ -1,0 +1,34 @@
+## Context
+
+`plugins/twl/refs/test-scenario-catalog.md` は co-self-improve framework がテスト実行時に参照するシナリオカタログ。現在 smoke-001/002 と regression-001/002 のみ定義されており、autopilot の full-chain 遷移および Bug #436/#438/#439 を再現するシナリオが存在しない。
+
+追加するシナリオはすべて既存の YAML フォーマット（level, description, issues_count, expected_duration_min/max, expected_conflicts, expected_pr_count, observer_polling_interval, issue_templates）に準拠する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- regression-003: DeltaSpec を伴う medium complexity Issue で setup→test-ready→pr-verify→pr-merge の全遷移を検証
+- regression-004: `twl spec new` を呼ぶ Issue body を定義し、`issue:` フィールド欠落（Bug #436）を誘発できる条件を記述
+- regression-005: 長時間実行が必要な Issue body を定義し、Orchestrator polling が 120 秒で timeout（Bug #438）を誘発できる条件を記述
+- regression-006: PR review をスキップさせる Issue body を定義し、`phase-review.json` 不在で merge-gate が PASS してしまう（Bug #439）を誘発できる条件を記述
+
+**Non-Goals:**
+- observation-pattern-catalog.md への検出パターン追加
+- `--real-issues` モードの実装
+- load level シナリオの定義
+- Bug 修正そのもの（別 Issue）
+
+## Decisions
+
+1. **regression-003 complexity**: medium（DeltaSpec + テスト生成 + PR review の全フロー）。trivial では chain 遷移が短縮されるため不適。
+2. **Bug 再現はシナリオ条件で記述**: actual fix は別 Issue 担当。各シナリオには「どの条件が Bug を誘発するか」を issue_templates の body に明記する。
+3. **expected_duration**: 各 Bug 再現の特性に応じて設定:
+   - regression-004 (#436): archive 失敗が即座に起きるため短め（10-20 分）
+   - regression-005 (#438): timeout 誘発のため長め（15-30 分）
+   - regression-006 (#439): merge-gate まで通るため中程度（10-25 分）
+4. **1 シナリオ 1 Issue**: Bug 再現シナリオは `issues_count: 1` で単純化。干渉なし（`expected_conflicts: 0`）。
+
+## Risks / Trade-offs
+
+- Bug 再現シナリオの issue_templates body は「Bug を誘発する条件」を含むため、Bug 修正後は false positive になる可能性がある。将来的にシナリオを `verified-fixed` ステータスに遷移させる仕組みが必要かもしれない（スコープ外）。
+- regression-005 の timeout 誘発は環境依存（Bash timeout 設定）のため、再現性が確実ではない場合がある。

--- a/cli/twl/deltaspec/changes/issue-442/proposal.md
+++ b/cli/twl/deltaspec/changes/issue-442/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+co-self-improve framework の test-scenario-catalog.md には smoke と regression-001/002 しかなく、autopilot の full-chain 遷移（setup → test-ready → pr-verify → pr-merge）を通すシナリオと、既知 Bug (#436/#438/#439) を再現するシナリオが存在しない。これらの欠如により、Bug 再現検証と chain 遷移の regression テストが不可能な状態である。
+
+## What Changes
+
+- `plugins/twl/refs/test-scenario-catalog.md` に 4 つの新規シナリオを追加:
+  - `regression-003`: full-chain regression（medium complexity Issue で chain 全遷移を通す）
+  - `regression-004`: Bug #436 再現（DeltaSpec を使う Issue で `issue:` フィールド欠落を誘発）
+  - `regression-005`: Bug #438 再現（長時間実行 Issue で Orchestrator polling timeout を誘発）
+  - `regression-006`: Bug #439 再現（merge-gate 到達時に `phase-review.json` 不在を誘発）
+
+## Capabilities
+
+### New Capabilities
+
+- **regression-003**: full-chain 遷移（setup→test-ready→pr-verify→pr-merge）を通す regression シナリオ
+- **regression-004**: Bug #436 (`twl spec new` が `.deltaspec.yaml` に `issue:` フィールドを生成しない) の再現シナリオ
+- **regression-005**: Bug #438 (orchestrator polling loop が Bash timeout 120秒で停止) の再現シナリオ
+- **regression-006**: Bug #439 (merge-gate が `phase-review.json` の存在を検査しない) の再現シナリオ
+
+### Modified Capabilities
+
+なし
+
+## Impact
+
+- **変更ファイル**: `plugins/twl/refs/test-scenario-catalog.md`（追記のみ、既存シナリオ変更なし）
+- **影響 API/依存**: なし
+- **テスト**: 本 PR 自体がテストシナリオ定義の追加であり、co-self-improve framework で利用される

--- a/cli/twl/deltaspec/changes/issue-442/specs/test-scenario-catalog/spec.md
+++ b/cli/twl/deltaspec/changes/issue-442/specs/test-scenario-catalog/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: regression-003 full-chain シナリオ
+
+test-scenario-catalog.md に regression-003 シナリオを追加しなければならない（SHALL）。このシナリオは DeltaSpec を伴う medium complexity Issue を使い、autopilot の full-chain 遷移（setup → test-ready → pr-verify → pr-merge）をすべて通すことを目的とする。
+
+#### Scenario: regression-003 フォーマット準拠
+
+- **WHEN** test-scenario-catalog.md を参照する
+- **THEN** regression-003 エントリが存在し、level=regression、issues_count=1、complexity=medium、expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+
+#### Scenario: regression-003 issue_template
+
+- **WHEN** regression-003 の issue_templates を展開する
+- **THEN** DeltaSpec を要求する Issue body が含まれており、setup → test-ready → pr-verify → pr-merge の全遷移を誘発できる
+
+### Requirement: regression-004 Bug #436 再現シナリオ
+
+test-scenario-catalog.md に regression-004 シナリオを追加しなければならない（SHALL）。このシナリオは `twl spec new` が `.deltaspec.yaml` に `issue:` フィールドを生成しない Bug #436 を再現するための条件を issue_templates に含む。
+
+#### Scenario: regression-004 フォーマット準拠
+
+- **WHEN** test-scenario-catalog.md を参照する
+- **THEN** regression-004 エントリが存在し、level=regression、issues_count=1、expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+
+#### Scenario: regression-004 Bug 再現条件
+
+- **WHEN** regression-004 の issue_templates を展開する
+- **THEN** Issue body に DeltaSpec（twl spec new）を使う指示が含まれており、orchestrator の `issue:` フィールド grep が 0 件ヒットして archive 失敗を誘発できる条件が記述されている
+
+### Requirement: regression-005 Bug #438 再現シナリオ
+
+test-scenario-catalog.md に regression-005 シナリオを追加しなければならない（SHALL）。このシナリオは orchestrator polling loop が Bash timeout（120 秒）で停止し `inject_next_workflow()` が呼ばれなくなる Bug #438 を再現するための条件を issue_templates に含む。
+
+#### Scenario: regression-005 フォーマット準拠
+
+- **WHEN** test-scenario-catalog.md を参照する
+- **THEN** regression-005 エントリが存在し、level=regression、issues_count=1、expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+
+#### Scenario: regression-005 Bug 再現条件
+
+- **WHEN** regression-005 の issue_templates を展開する
+- **THEN** Issue body に長時間実行（120 秒超）を要する処理を含む指示が記述されており、Orchestrator polling loop の timeout を誘発できる条件が明示されている
+
+### Requirement: regression-006 Bug #439 再現シナリオ
+
+test-scenario-catalog.md に regression-006 シナリオを追加しなければならない（SHALL）。このシナリオは merge-gate が `phase-review.json` の存在を検査しないため review なしでマージ PASS してしまう Bug #439 を再現するための条件を issue_templates に含む。
+
+#### Scenario: regression-006 フォーマット準拠
+
+- **WHEN** test-scenario-catalog.md を参照する
+- **THEN** regression-006 エントリが存在し、level=regression、issues_count=1、expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+
+#### Scenario: regression-006 Bug 再現条件
+
+- **WHEN** regression-006 の issue_templates を展開する
+- **THEN** Issue body に pr-verify の review フェーズをスキップさせる条件が含まれており、`phase-review.json` が生成されないまま merge-gate に到達できる状況が記述されている

--- a/cli/twl/deltaspec/changes/issue-442/tasks.md
+++ b/cli/twl/deltaspec/changes/issue-442/tasks.md
@@ -1,0 +1,11 @@
+## 1. シナリオ追加
+
+- [x] 1.1 regression-003（full-chain）シナリオを test-scenario-catalog.md に追加する
+- [x] 1.2 regression-004（Bug #436 再現）シナリオを test-scenario-catalog.md に追加する
+- [x] 1.3 regression-005（Bug #438 再現）シナリオを test-scenario-catalog.md に追加する
+- [x] 1.4 regression-006（Bug #439 再現）シナリオを test-scenario-catalog.md に追加する
+
+## 2. 検証
+
+- [x] 2.1 各シナリオの YAML フォーマットが既存の schema（level, description, issues_count, expected_duration_min/max, expected_conflicts, expected_pr_count, observer_polling_interval, issue_templates）に準拠していることを確認する
+- [x] 2.2 各 issue_template に Bug 再現条件が明記されていることを確認する

--- a/cli/twl/deltaspec/changes/issue-442/test-mapping.yaml
+++ b/cli/twl/deltaspec/changes/issue-442/test-mapping.yaml
@@ -1,0 +1,16 @@
+change: issue-442
+generated_at: 2026-04-11
+
+unit_tests:
+  - file: tests/scenarios/test_scenario_catalog_regression.py
+    scenarios:
+      - regression-003 フォーマット準拠
+      - regression-003 issue_template
+      - regression-004 フォーマット準拠
+      - regression-004 Bug 再現条件
+      - regression-005 フォーマット準拠
+      - regression-005 Bug 再現条件
+      - regression-006 フォーマット準拠
+      - regression-006 Bug 再現条件
+
+e2e_tests: []

--- a/cli/twl/tests/scenarios/test_scenario_catalog_regression.py
+++ b/cli/twl/tests/scenarios/test_scenario_catalog_regression.py
@@ -1,0 +1,781 @@
+"""Tests for Issue #442: test-scenario-catalog.md に regression-003〜006 追加.
+
+Spec: deltaspec/changes/issue-442/specs/test-scenario-catalog/spec.md
+
+Coverage:
+  Requirement: regression-003 full-chain シナリオ
+    - Scenario: regression-003 フォーマット準拠
+        WHEN: test-scenario-catalog.md を参照する
+        THEN: regression-003 エントリが存在し、level=regression、issues_count=1、
+              complexity=medium、expected_duration_min/max・expected_conflicts・
+              expected_pr_count が記載されている
+    - Scenario: regression-003 issue_template
+        WHEN: regression-003 の issue_templates を展開する
+        THEN: DeltaSpec を要求する Issue body が含まれており、
+              setup → test-ready → pr-verify → pr-merge の全遷移を誘発できる
+
+  Requirement: regression-004 Bug #436 再現シナリオ
+    - Scenario: regression-004 フォーマット準拠
+        WHEN: test-scenario-catalog.md を参照する
+        THEN: regression-004 エントリが存在し、level=regression、issues_count=1、
+              expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+    - Scenario: regression-004 Bug 再現条件
+        WHEN: regression-004 の issue_templates を展開する
+        THEN: Issue body に DeltaSpec（twl spec new）を使う指示が含まれており、
+              orchestrator の issue: フィールド grep が 0 件ヒットして archive 失敗を誘発できる
+              条件が記述されている
+
+  Requirement: regression-005 Bug #438 再現シナリオ
+    - Scenario: regression-005 フォーマット準拠
+        WHEN: test-scenario-catalog.md を参照する
+        THEN: regression-005 エントリが存在し、level=regression、issues_count=1、
+              expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+    - Scenario: regression-005 Bug 再現条件
+        WHEN: regression-005 の issue_templates を展開する
+        THEN: Issue body に長時間実行（120 秒超）を要する処理を含む指示が記述されており、
+              Orchestrator polling loop の timeout を誘発できる条件が明示されている
+
+  Requirement: regression-006 Bug #439 再現シナリオ
+    - Scenario: regression-006 フォーマット準拠
+        WHEN: test-scenario-catalog.md を参照する
+        THEN: regression-006 エントリが存在し、level=regression、issues_count=1、
+              expected_duration_min/max・expected_conflicts・expected_pr_count が記載されている
+    - Scenario: regression-006 Bug 再現条件
+        WHEN: regression-006 の issue_templates を展開する
+        THEN: Issue body に pr-verify の review フェーズをスキップさせる条件が含まれており、
+              phase-review.json が生成されないまま merge-gate に到達できる状況が記述されている
+
+  Edge cases (--coverage=edge-cases):
+    - YAML コードブロックが正しく抽出できること（フォーマット不正検出）
+    - 必須フィールドが欠落した場合にテストが明示的に失敗すること
+    - issue_templates が空でないこと
+    - issue_templates の各テンプレートに title / body / labels / complexity が存在すること
+    - body が空文字でないこと
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Catalog file location
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+_CATALOG_PATH = _REPO_ROOT / "plugins" / "twl" / "refs" / "test-scenario-catalog.md"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_catalog(catalog_path: Path) -> dict[str, Any]:
+    """Read test-scenario-catalog.md and return a dict of scenario_id -> parsed YAML."""
+    text = catalog_path.read_text(encoding="utf-8")
+
+    # Extract all fenced yaml code blocks
+    code_blocks = re.findall(r"```yaml\n(.*?)```", text, re.DOTALL)
+
+    scenarios: dict[str, Any] = {}
+    for block in code_blocks:
+        # Skip blocks that are schema examples (contain placeholder like "<scenario-id>")
+        if "<scenario-id>" in block:
+            continue
+        # Skip comment-only blocks
+        stripped = block.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        try:
+            parsed = yaml.safe_load(block)
+        except yaml.YAMLError:
+            continue
+        if isinstance(parsed, dict):
+            scenarios.update(parsed)
+
+    return scenarios
+
+
+_CATALOG: dict[str, Any] | None = None
+
+
+def _get_catalog() -> dict[str, Any]:
+    global _CATALOG
+    if _CATALOG is None:
+        _CATALOG = _parse_catalog(_CATALOG_PATH)
+    return _CATALOG
+
+
+def _get_scenario(scenario_id: str) -> dict[str, Any]:
+    catalog = _get_catalog()
+    assert scenario_id in catalog, (
+        f"Scenario '{scenario_id}' not found in {_CATALOG_PATH}. "
+        f"Available scenarios: {sorted(catalog.keys())}"
+    )
+    return catalog[scenario_id]
+
+
+# ---------------------------------------------------------------------------
+# catalog file existence guard
+# ---------------------------------------------------------------------------
+
+
+def test_catalog_file_exists() -> None:
+    """Catalog file must exist at plugins/twl/refs/test-scenario-catalog.md."""
+    assert _CATALOG_PATH.exists(), (
+        f"test-scenario-catalog.md not found at {_CATALOG_PATH}"
+    )
+
+
+# ===========================================================================
+# Requirement: regression-003 full-chain シナリオ
+# ===========================================================================
+
+
+class TestRegression003Format:
+    """Requirement: regression-003 full-chain シナリオ
+
+    Scenario: regression-003 フォーマット準拠
+    WHEN test-scenario-catalog.md を参照する
+    THEN regression-003 エントリが存在し level=regression issues_count=1
+         complexity=medium expected_duration_min/max expected_conflicts expected_pr_count が記載
+    """
+
+    def test_regression_003_entry_exists(self) -> None:
+        """WHEN catalog is loaded THEN regression-003 key is present."""
+        catalog = _get_catalog()
+        assert "regression-003" in catalog, (
+            "regression-003 must be defined in test-scenario-catalog.md"
+        )
+
+    def test_regression_003_level_is_regression(self) -> None:
+        """THEN level == 'regression'."""
+        sc = _get_scenario("regression-003")
+        assert sc.get("level") == "regression", (
+            f"regression-003 level must be 'regression', got: {sc.get('level')!r}"
+        )
+
+    def test_regression_003_issues_count_is_1(self) -> None:
+        """THEN issues_count == 1."""
+        sc = _get_scenario("regression-003")
+        assert sc.get("issues_count") == 1, (
+            f"regression-003 issues_count must be 1, got: {sc.get('issues_count')!r}"
+        )
+
+    def test_regression_003_complexity_is_medium(self) -> None:
+        """THEN issue_template complexity == 'medium' (regression-003 is medium complexity)."""
+        sc = _get_scenario("regression-003")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-003 must have at least one issue_template"
+        complexities = [t.get("complexity") for t in templates]
+        assert "medium" in complexities, (
+            f"regression-003 must have at least one issue_template with complexity=medium, "
+            f"got: {complexities}"
+        )
+
+    def test_regression_003_has_expected_duration_min(self) -> None:
+        """THEN expected_duration_min is present and is a positive integer."""
+        sc = _get_scenario("regression-003")
+        val = sc.get("expected_duration_min")
+        assert val is not None, "regression-003 must have expected_duration_min"
+        assert isinstance(val, int) and val > 0, (
+            f"expected_duration_min must be a positive int, got: {val!r}"
+        )
+
+    def test_regression_003_has_expected_duration_max(self) -> None:
+        """THEN expected_duration_max is present and >= expected_duration_min."""
+        sc = _get_scenario("regression-003")
+        min_val = sc.get("expected_duration_min")
+        max_val = sc.get("expected_duration_max")
+        assert max_val is not None, "regression-003 must have expected_duration_max"
+        assert isinstance(max_val, int) and max_val > 0, (
+            f"expected_duration_max must be a positive int, got: {max_val!r}"
+        )
+        if min_val is not None:
+            assert max_val >= min_val, (
+                f"expected_duration_max ({max_val}) must be >= expected_duration_min ({min_val})"
+            )
+
+    def test_regression_003_has_expected_conflicts(self) -> None:
+        """THEN expected_conflicts field is present and is a non-negative integer."""
+        sc = _get_scenario("regression-003")
+        val = sc.get("expected_conflicts")
+        assert val is not None, "regression-003 must have expected_conflicts"
+        assert isinstance(val, int) and val >= 0, (
+            f"expected_conflicts must be a non-negative int, got: {val!r}"
+        )
+
+    def test_regression_003_has_expected_pr_count(self) -> None:
+        """THEN expected_pr_count field is present and is a positive integer."""
+        sc = _get_scenario("regression-003")
+        val = sc.get("expected_pr_count")
+        assert val is not None, "regression-003 must have expected_pr_count"
+        assert isinstance(val, int) and val > 0, (
+            f"expected_pr_count must be a positive int, got: {val!r}"
+        )
+
+
+class TestRegression003IssueTemplate:
+    """Scenario: regression-003 issue_template
+    WHEN regression-003 の issue_templates を展開する
+    THEN DeltaSpec を要求する Issue body が含まれており
+         setup → test-ready → pr-verify → pr-merge の全遷移を誘発できる
+    """
+
+    def test_regression_003_templates_non_empty(self) -> None:
+        """THEN issue_templates list is not empty."""
+        sc = _get_scenario("regression-003")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-003 must have at least one issue_template"
+
+    def test_regression_003_template_has_title(self) -> None:
+        """THEN each issue_template has a non-empty title."""
+        sc = _get_scenario("regression-003")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert t.get("title"), (
+                f"regression-003 issue_templates[{i}] must have a non-empty title"
+            )
+
+    def test_regression_003_template_has_body(self) -> None:
+        """THEN each issue_template has a non-empty body."""
+        sc = _get_scenario("regression-003")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert t.get("body"), (
+                f"regression-003 issue_templates[{i}] must have a non-empty body"
+            )
+
+    def test_regression_003_template_has_labels(self) -> None:
+        """THEN each issue_template has a labels list."""
+        sc = _get_scenario("regression-003")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            labels = t.get("labels")
+            assert isinstance(labels, list) and len(labels) > 0, (
+                f"regression-003 issue_templates[{i}] must have a non-empty labels list"
+            )
+
+    def test_regression_003_body_mentions_deltaspec(self) -> None:
+        """THEN issue body contains reference to DeltaSpec / twl spec new."""
+        sc = _get_scenario("regression-003")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies).lower()
+        assert any(kw in combined for kw in ("deltaspec", "twl spec", "spec new", "spec-driven")), (
+            "regression-003 issue body must reference DeltaSpec (e.g. 'twl spec new' or 'DeltaSpec')"
+        )
+
+    def test_regression_003_body_enables_full_chain_transitions(self) -> None:
+        """THEN issue body contains enough content to drive setup→test-ready→pr-verify→pr-merge."""
+        sc = _get_scenario("regression-003")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies)
+        # Body should describe a substantive implementation task that drives all 4 autopilot phases.
+        # Minimum length check: trivial one-liners cannot drive the full chain.
+        assert len(combined) >= 100, (
+            f"regression-003 issue body is too short ({len(combined)} chars) to drive "
+            "setup→test-ready→pr-verify→pr-merge full chain"
+        )
+
+
+# ===========================================================================
+# Requirement: regression-004 Bug #436 再現シナリオ
+# ===========================================================================
+
+
+class TestRegression004Format:
+    """Requirement: regression-004 Bug #436 再現シナリオ
+
+    Scenario: regression-004 フォーマット準拠
+    WHEN test-scenario-catalog.md を参照する
+    THEN regression-004 エントリが存在し level=regression issues_count=1
+         expected_duration_min/max expected_conflicts expected_pr_count が記載
+    """
+
+    def test_regression_004_entry_exists(self) -> None:
+        """WHEN catalog is loaded THEN regression-004 key is present."""
+        catalog = _get_catalog()
+        assert "regression-004" in catalog, (
+            "regression-004 must be defined in test-scenario-catalog.md"
+        )
+
+    def test_regression_004_level_is_regression(self) -> None:
+        """THEN level == 'regression'."""
+        sc = _get_scenario("regression-004")
+        assert sc.get("level") == "regression", (
+            f"regression-004 level must be 'regression', got: {sc.get('level')!r}"
+        )
+
+    def test_regression_004_issues_count_is_1(self) -> None:
+        """THEN issues_count == 1."""
+        sc = _get_scenario("regression-004")
+        assert sc.get("issues_count") == 1, (
+            f"regression-004 issues_count must be 1, got: {sc.get('issues_count')!r}"
+        )
+
+    def test_regression_004_has_expected_duration_min(self) -> None:
+        """THEN expected_duration_min is present and positive."""
+        sc = _get_scenario("regression-004")
+        val = sc.get("expected_duration_min")
+        assert val is not None, "regression-004 must have expected_duration_min"
+        assert isinstance(val, int) and val > 0, (
+            f"expected_duration_min must be a positive int, got: {val!r}"
+        )
+
+    def test_regression_004_has_expected_duration_max(self) -> None:
+        """THEN expected_duration_max is present and >= expected_duration_min."""
+        sc = _get_scenario("regression-004")
+        min_val = sc.get("expected_duration_min")
+        max_val = sc.get("expected_duration_max")
+        assert max_val is not None, "regression-004 must have expected_duration_max"
+        assert isinstance(max_val, int) and max_val > 0
+        if min_val is not None:
+            assert max_val >= min_val
+
+    def test_regression_004_has_expected_conflicts(self) -> None:
+        """THEN expected_conflicts is present and non-negative."""
+        sc = _get_scenario("regression-004")
+        val = sc.get("expected_conflicts")
+        assert val is not None, "regression-004 must have expected_conflicts"
+        assert isinstance(val, int) and val >= 0
+
+    def test_regression_004_has_expected_pr_count(self) -> None:
+        """THEN expected_pr_count is present and positive."""
+        sc = _get_scenario("regression-004")
+        val = sc.get("expected_pr_count")
+        assert val is not None, "regression-004 must have expected_pr_count"
+        assert isinstance(val, int) and val > 0
+
+
+class TestRegression004BugReproCondition:
+    """Scenario: regression-004 Bug 再現条件
+    WHEN regression-004 の issue_templates を展開する
+    THEN Issue body に DeltaSpec（twl spec new）を使う指示が含まれており
+         orchestrator の issue: フィールド grep が 0 件ヒットして archive 失敗を誘発できる
+         条件が記述されている
+    """
+
+    def test_regression_004_templates_non_empty(self) -> None:
+        """THEN issue_templates list is not empty."""
+        sc = _get_scenario("regression-004")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-004 must have at least one issue_template"
+
+    def test_regression_004_body_references_twl_spec_new(self) -> None:
+        """THEN issue body explicitly instructs use of 'twl spec new'."""
+        sc = _get_scenario("regression-004")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies)
+        # Must contain 'twl spec new' or 'twl spec' instruction to reproduce Bug #436
+        assert any(
+            kw in combined for kw in ("twl spec new", "twl spec", "deltaspec", "DeltaSpec")
+        ), (
+            "regression-004 issue body must instruct the agent to run 'twl spec new' "
+            "(Bug #436 reproduction condition)"
+        )
+
+    def test_regression_004_body_describes_archive_failure_condition(self) -> None:
+        """THEN issue body contains condition that would cause archive failure via missing issue: field.
+
+        The body should describe an action that creates a .deltaspec.yaml without issue: field,
+        which is the core Bug #436 condition.
+        """
+        sc = _get_scenario("regression-004")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies).lower()
+        # Body should be substantive enough to describe the bug reproduction scenario
+        assert len(combined) >= 80, (
+            f"regression-004 body too short ({len(combined)} chars) to describe "
+            "Bug #436 archive-failure condition"
+        )
+
+    def test_regression_004_template_has_required_fields(self) -> None:
+        """THEN each issue_template has title, body, labels, complexity."""
+        sc = _get_scenario("regression-004")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert t.get("title"), f"regression-004 issue_templates[{i}] missing title"
+            assert t.get("body"), f"regression-004 issue_templates[{i}] missing body"
+            labels = t.get("labels")
+            assert isinstance(labels, list) and len(labels) > 0, (
+                f"regression-004 issue_templates[{i}] must have non-empty labels"
+            )
+
+
+# ===========================================================================
+# Requirement: regression-005 Bug #438 再現シナリオ
+# ===========================================================================
+
+
+class TestRegression005Format:
+    """Requirement: regression-005 Bug #438 再現シナリオ
+
+    Scenario: regression-005 フォーマット準拠
+    WHEN test-scenario-catalog.md を参照する
+    THEN regression-005 エントリが存在し level=regression issues_count=1
+         expected_duration_min/max expected_conflicts expected_pr_count が記載
+    """
+
+    def test_regression_005_entry_exists(self) -> None:
+        """WHEN catalog is loaded THEN regression-005 key is present."""
+        catalog = _get_catalog()
+        assert "regression-005" in catalog, (
+            "regression-005 must be defined in test-scenario-catalog.md"
+        )
+
+    def test_regression_005_level_is_regression(self) -> None:
+        """THEN level == 'regression'."""
+        sc = _get_scenario("regression-005")
+        assert sc.get("level") == "regression", (
+            f"regression-005 level must be 'regression', got: {sc.get('level')!r}"
+        )
+
+    def test_regression_005_issues_count_is_1(self) -> None:
+        """THEN issues_count == 1."""
+        sc = _get_scenario("regression-005")
+        assert sc.get("issues_count") == 1, (
+            f"regression-005 issues_count must be 1, got: {sc.get('issues_count')!r}"
+        )
+
+    def test_regression_005_has_expected_duration_min(self) -> None:
+        """THEN expected_duration_min is present and positive."""
+        sc = _get_scenario("regression-005")
+        val = sc.get("expected_duration_min")
+        assert val is not None, "regression-005 must have expected_duration_min"
+        assert isinstance(val, int) and val > 0
+
+    def test_regression_005_has_expected_duration_max(self) -> None:
+        """THEN expected_duration_max is present and >= expected_duration_min."""
+        sc = _get_scenario("regression-005")
+        min_val = sc.get("expected_duration_min")
+        max_val = sc.get("expected_duration_max")
+        assert max_val is not None, "regression-005 must have expected_duration_max"
+        assert isinstance(max_val, int) and max_val > 0
+        if min_val is not None:
+            assert max_val >= min_val
+
+    def test_regression_005_has_expected_conflicts(self) -> None:
+        """THEN expected_conflicts is present and non-negative."""
+        sc = _get_scenario("regression-005")
+        val = sc.get("expected_conflicts")
+        assert val is not None, "regression-005 must have expected_conflicts"
+        assert isinstance(val, int) and val >= 0
+
+    def test_regression_005_has_expected_pr_count(self) -> None:
+        """THEN expected_pr_count is present and positive."""
+        sc = _get_scenario("regression-005")
+        val = sc.get("expected_pr_count")
+        assert val is not None, "regression-005 must have expected_pr_count"
+        assert isinstance(val, int) and val > 0
+
+
+class TestRegression005BugReproCondition:
+    """Scenario: regression-005 Bug 再現条件
+    WHEN regression-005 の issue_templates を展開する
+    THEN Issue body に長時間実行（120 秒超）を要する処理を含む指示が記述されており
+         Orchestrator polling loop の timeout を誘発できる条件が明示されている
+    """
+
+    def test_regression_005_templates_non_empty(self) -> None:
+        """THEN issue_templates list is not empty."""
+        sc = _get_scenario("regression-005")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-005 must have at least one issue_template"
+
+    def test_regression_005_body_describes_long_running_task(self) -> None:
+        """THEN issue body describes a task requiring more than 120 seconds to reproduce Bug #438."""
+        sc = _get_scenario("regression-005")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies).lower()
+        # Body must indicate a long-running operation (sleep, wait, timeout, 120秒, etc.)
+        timeout_keywords = (
+            "120", "sleep", "wait", "timeout", "long", "秒", "時間", "遅延", "polling"
+        )
+        assert any(kw in combined for kw in timeout_keywords), (
+            "regression-005 issue body must describe a long-running task (>120s) "
+            "to reproduce Bug #438 Orchestrator polling timeout. "
+            f"Checked keywords: {timeout_keywords}"
+        )
+
+    def test_regression_005_body_timeout_condition_explicit(self) -> None:
+        """THEN body is substantive enough to contain explicit timeout condition."""
+        sc = _get_scenario("regression-005")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies)
+        assert len(combined) >= 80, (
+            f"regression-005 body too short ({len(combined)} chars) to describe "
+            "Bug #438 polling timeout reproduction condition"
+        )
+
+    def test_regression_005_template_has_required_fields(self) -> None:
+        """THEN each issue_template has title, body, labels."""
+        sc = _get_scenario("regression-005")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert t.get("title"), f"regression-005 issue_templates[{i}] missing title"
+            assert t.get("body"), f"regression-005 issue_templates[{i}] missing body"
+            labels = t.get("labels")
+            assert isinstance(labels, list) and len(labels) > 0, (
+                f"regression-005 issue_templates[{i}] must have non-empty labels"
+            )
+
+
+# ===========================================================================
+# Requirement: regression-006 Bug #439 再現シナリオ
+# ===========================================================================
+
+
+class TestRegression006Format:
+    """Requirement: regression-006 Bug #439 再現シナリオ
+
+    Scenario: regression-006 フォーマット準拠
+    WHEN test-scenario-catalog.md を参照する
+    THEN regression-006 エントリが存在し level=regression issues_count=1
+         expected_duration_min/max expected_conflicts expected_pr_count が記載
+    """
+
+    def test_regression_006_entry_exists(self) -> None:
+        """WHEN catalog is loaded THEN regression-006 key is present."""
+        catalog = _get_catalog()
+        assert "regression-006" in catalog, (
+            "regression-006 must be defined in test-scenario-catalog.md"
+        )
+
+    def test_regression_006_level_is_regression(self) -> None:
+        """THEN level == 'regression'."""
+        sc = _get_scenario("regression-006")
+        assert sc.get("level") == "regression", (
+            f"regression-006 level must be 'regression', got: {sc.get('level')!r}"
+        )
+
+    def test_regression_006_issues_count_is_1(self) -> None:
+        """THEN issues_count == 1."""
+        sc = _get_scenario("regression-006")
+        assert sc.get("issues_count") == 1, (
+            f"regression-006 issues_count must be 1, got: {sc.get('issues_count')!r}"
+        )
+
+    def test_regression_006_has_expected_duration_min(self) -> None:
+        """THEN expected_duration_min is present and positive."""
+        sc = _get_scenario("regression-006")
+        val = sc.get("expected_duration_min")
+        assert val is not None, "regression-006 must have expected_duration_min"
+        assert isinstance(val, int) and val > 0
+
+    def test_regression_006_has_expected_duration_max(self) -> None:
+        """THEN expected_duration_max is present and >= expected_duration_min."""
+        sc = _get_scenario("regression-006")
+        min_val = sc.get("expected_duration_min")
+        max_val = sc.get("expected_duration_max")
+        assert max_val is not None, "regression-006 must have expected_duration_max"
+        assert isinstance(max_val, int) and max_val > 0
+        if min_val is not None:
+            assert max_val >= min_val
+
+    def test_regression_006_has_expected_conflicts(self) -> None:
+        """THEN expected_conflicts is present and non-negative."""
+        sc = _get_scenario("regression-006")
+        val = sc.get("expected_conflicts")
+        assert val is not None, "regression-006 must have expected_conflicts"
+        assert isinstance(val, int) and val >= 0
+
+    def test_regression_006_has_expected_pr_count(self) -> None:
+        """THEN expected_pr_count is present and positive."""
+        sc = _get_scenario("regression-006")
+        val = sc.get("expected_pr_count")
+        assert val is not None, "regression-006 must have expected_pr_count"
+        assert isinstance(val, int) and val > 0
+
+
+class TestRegression006BugReproCondition:
+    """Scenario: regression-006 Bug 再現条件
+    WHEN regression-006 の issue_templates を展開する
+    THEN Issue body に pr-verify の review フェーズをスキップさせる条件が含まれており
+         phase-review.json が生成されないまま merge-gate に到達できる状況が記述されている
+    """
+
+    def test_regression_006_templates_non_empty(self) -> None:
+        """THEN issue_templates list is not empty."""
+        sc = _get_scenario("regression-006")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-006 must have at least one issue_template"
+
+    def test_regression_006_body_describes_review_skip_condition(self) -> None:
+        """THEN issue body describes condition that causes review phase to be skipped (Bug #439)."""
+        sc = _get_scenario("regression-006")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies).lower()
+        # Body should reference review, phase-review, pr-verify, or merge-gate
+        review_keywords = (
+            "review", "pr-verify", "phase-review", "merge-gate", "mergegate",
+            "レビュー", "skip", "スキップ"
+        )
+        assert any(kw in combined for kw in review_keywords), (
+            "regression-006 issue body must describe a condition that causes the review "
+            "phase to be skipped (Bug #439). "
+            f"Checked keywords: {review_keywords}"
+        )
+
+    def test_regression_006_body_references_phase_review_json(self) -> None:
+        """THEN body explicitly references phase-review.json or merge-gate condition."""
+        sc = _get_scenario("regression-006")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies)
+        assert any(
+            kw in combined
+            for kw in ("phase-review", "phase_review", "merge-gate", "merge_gate", "pr-verify")
+        ), (
+            "regression-006 issue body must reference 'phase-review.json' or 'merge-gate' "
+            "to describe the Bug #439 reproduction condition"
+        )
+
+    def test_regression_006_body_is_substantive(self) -> None:
+        """THEN body is long enough to contain the reproduction description."""
+        sc = _get_scenario("regression-006")
+        bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
+        combined = "\n".join(bodies)
+        assert len(combined) >= 80, (
+            f"regression-006 body too short ({len(combined)} chars) to describe "
+            "Bug #439 phase-review.json absence condition"
+        )
+
+    def test_regression_006_template_has_required_fields(self) -> None:
+        """THEN each issue_template has title, body, labels."""
+        sc = _get_scenario("regression-006")
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert t.get("title"), f"regression-006 issue_templates[{i}] missing title"
+            assert t.get("body"), f"regression-006 issue_templates[{i}] missing body"
+            labels = t.get("labels")
+            assert isinstance(labels, list) and len(labels) > 0, (
+                f"regression-006 issue_templates[{i}] must have non-empty labels"
+            )
+
+
+# ===========================================================================
+# Edge cases: フォーマット不正・フィールド欠落
+# ===========================================================================
+
+
+class TestCatalogEdgeCases:
+    """Edge cases: catalog format validation and field completeness."""
+
+    _REGRESSION_IDS = ["regression-003", "regression-004", "regression-005", "regression-006"]
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_has_description(self, scenario_id: str) -> None:
+        """THEN each new regression scenario has a non-empty description field."""
+        sc = _get_scenario(scenario_id)
+        desc = sc.get("description")
+        assert desc and isinstance(desc, str) and len(desc.strip()) > 0, (
+            f"{scenario_id} must have a non-empty 'description' field"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_level_is_valid(self, scenario_id: str) -> None:
+        """THEN level is one of smoke | regression | load."""
+        sc = _get_scenario(scenario_id)
+        valid_levels = {"smoke", "regression", "load"}
+        assert sc.get("level") in valid_levels, (
+            f"{scenario_id} level must be one of {valid_levels}, got: {sc.get('level')!r}"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_issues_count_positive_integer(self, scenario_id: str) -> None:
+        """THEN issues_count is a positive integer."""
+        sc = _get_scenario(scenario_id)
+        val = sc.get("issues_count")
+        assert isinstance(val, int) and val >= 1, (
+            f"{scenario_id} issues_count must be >= 1, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_duration_range_valid(self, scenario_id: str) -> None:
+        """THEN expected_duration_max >= expected_duration_min."""
+        sc = _get_scenario(scenario_id)
+        min_val = sc.get("expected_duration_min")
+        max_val = sc.get("expected_duration_max")
+        assert isinstance(min_val, int) and min_val > 0, (
+            f"{scenario_id} expected_duration_min must be a positive int"
+        )
+        assert isinstance(max_val, int) and max_val >= min_val, (
+            f"{scenario_id} expected_duration_max ({max_val}) must be >= "
+            f"expected_duration_min ({min_val})"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_issue_templates_not_empty(self, scenario_id: str) -> None:
+        """THEN issue_templates is a non-empty list."""
+        sc = _get_scenario(scenario_id)
+        templates = sc.get("issue_templates")
+        assert isinstance(templates, list) and len(templates) > 0, (
+            f"{scenario_id} issue_templates must be a non-empty list"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_each_template_has_title_body_labels(self, scenario_id: str) -> None:
+        """THEN each issue_template entry has non-empty title, body, and labels."""
+        sc = _get_scenario(scenario_id)
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            assert isinstance(t, dict), (
+                f"{scenario_id} issue_templates[{i}] must be a dict"
+            )
+            assert t.get("title") and isinstance(t["title"], str), (
+                f"{scenario_id} issue_templates[{i}].title must be a non-empty string"
+            )
+            assert t.get("body") and isinstance(t["body"], str), (
+                f"{scenario_id} issue_templates[{i}].body must be a non-empty string"
+            )
+            labels = t.get("labels")
+            assert isinstance(labels, list) and len(labels) > 0, (
+                f"{scenario_id} issue_templates[{i}].labels must be a non-empty list"
+            )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_each_template_complexity_valid(self, scenario_id: str) -> None:
+        """THEN each issue_template complexity is one of trivial | medium | complex."""
+        sc = _get_scenario(scenario_id)
+        valid_complexities = {"trivial", "medium", "complex"}
+        for i, t in enumerate(sc.get("issue_templates", [])):
+            complexity = t.get("complexity")
+            assert complexity in valid_complexities, (
+                f"{scenario_id} issue_templates[{i}].complexity must be one of "
+                f"{valid_complexities}, got: {complexity!r}"
+            )
+
+    def test_no_duplicate_scenario_ids_in_catalog(self) -> None:
+        """Edge case: YAML parsing must not silently merge duplicate keys.
+
+        yaml.safe_load deduplicates keys — we check the raw text has no duplicate top-level IDs.
+        """
+        text = _CATALOG_PATH.read_text(encoding="utf-8")
+        code_blocks = re.findall(r"```yaml\n(.*?)```", text, re.DOTALL)
+        seen: list[str] = []
+        for block in code_blocks:
+            if "<scenario-id>" in block or not block.strip():
+                continue
+            for line in block.splitlines():
+                m = re.match(r"^([a-z][\w-]+):\s*$", line)
+                if m:
+                    seen.append(m.group(1))
+        duplicates = {sid for sid in seen if seen.count(sid) > 1}
+        assert not duplicates, (
+            f"Duplicate scenario IDs found in catalog: {duplicates}"
+        )
+
+    def test_catalog_yaml_blocks_parseable(self) -> None:
+        """Edge case: all non-schema yaml blocks in catalog must parse without YAML errors."""
+        text = _CATALOG_PATH.read_text(encoding="utf-8")
+        code_blocks = re.findall(r"```yaml\n(.*?)```", text, re.DOTALL)
+        errors: list[str] = []
+        for i, block in enumerate(code_blocks):
+            if "<scenario-id>" in block or not block.strip():
+                continue
+            try:
+                yaml.safe_load(block)
+            except yaml.YAMLError as e:
+                errors.append(f"Block {i}: {e}")
+        assert not errors, (
+            f"YAML parse errors found in test-scenario-catalog.md:\n" +
+            "\n".join(errors)
+        )

--- a/cli/twl/tests/scenarios/test_scenario_catalog_regression.py
+++ b/cli/twl/tests/scenarios/test_scenario_catalog_regression.py
@@ -56,7 +56,6 @@ Coverage:
 from __future__ import annotations
 
 import re
-import sys
 from pathlib import Path
 from typing import Any
 
@@ -134,91 +133,8 @@ def test_catalog_file_exists() -> None:
 
 
 # ===========================================================================
-# Requirement: regression-003 full-chain シナリオ
+# Requirement: regression-003 issue_template（full-chain 固有）
 # ===========================================================================
-
-
-class TestRegression003Format:
-    """Requirement: regression-003 full-chain シナリオ
-
-    Scenario: regression-003 フォーマット準拠
-    WHEN test-scenario-catalog.md を参照する
-    THEN regression-003 エントリが存在し level=regression issues_count=1
-         complexity=medium expected_duration_min/max expected_conflicts expected_pr_count が記載
-    """
-
-    def test_regression_003_entry_exists(self) -> None:
-        """WHEN catalog is loaded THEN regression-003 key is present."""
-        catalog = _get_catalog()
-        assert "regression-003" in catalog, (
-            "regression-003 must be defined in test-scenario-catalog.md"
-        )
-
-    def test_regression_003_level_is_regression(self) -> None:
-        """THEN level == 'regression'."""
-        sc = _get_scenario("regression-003")
-        assert sc.get("level") == "regression", (
-            f"regression-003 level must be 'regression', got: {sc.get('level')!r}"
-        )
-
-    def test_regression_003_issues_count_is_1(self) -> None:
-        """THEN issues_count == 1."""
-        sc = _get_scenario("regression-003")
-        assert sc.get("issues_count") == 1, (
-            f"regression-003 issues_count must be 1, got: {sc.get('issues_count')!r}"
-        )
-
-    def test_regression_003_complexity_is_medium(self) -> None:
-        """THEN issue_template complexity == 'medium' (regression-003 is medium complexity)."""
-        sc = _get_scenario("regression-003")
-        templates = sc.get("issue_templates", [])
-        assert len(templates) > 0, "regression-003 must have at least one issue_template"
-        complexities = [t.get("complexity") for t in templates]
-        assert "medium" in complexities, (
-            f"regression-003 must have at least one issue_template with complexity=medium, "
-            f"got: {complexities}"
-        )
-
-    def test_regression_003_has_expected_duration_min(self) -> None:
-        """THEN expected_duration_min is present and is a positive integer."""
-        sc = _get_scenario("regression-003")
-        val = sc.get("expected_duration_min")
-        assert val is not None, "regression-003 must have expected_duration_min"
-        assert isinstance(val, int) and val > 0, (
-            f"expected_duration_min must be a positive int, got: {val!r}"
-        )
-
-    def test_regression_003_has_expected_duration_max(self) -> None:
-        """THEN expected_duration_max is present and >= expected_duration_min."""
-        sc = _get_scenario("regression-003")
-        min_val = sc.get("expected_duration_min")
-        max_val = sc.get("expected_duration_max")
-        assert max_val is not None, "regression-003 must have expected_duration_max"
-        assert isinstance(max_val, int) and max_val > 0, (
-            f"expected_duration_max must be a positive int, got: {max_val!r}"
-        )
-        if min_val is not None:
-            assert max_val >= min_val, (
-                f"expected_duration_max ({max_val}) must be >= expected_duration_min ({min_val})"
-            )
-
-    def test_regression_003_has_expected_conflicts(self) -> None:
-        """THEN expected_conflicts field is present and is a non-negative integer."""
-        sc = _get_scenario("regression-003")
-        val = sc.get("expected_conflicts")
-        assert val is not None, "regression-003 must have expected_conflicts"
-        assert isinstance(val, int) and val >= 0, (
-            f"expected_conflicts must be a non-negative int, got: {val!r}"
-        )
-
-    def test_regression_003_has_expected_pr_count(self) -> None:
-        """THEN expected_pr_count field is present and is a positive integer."""
-        sc = _get_scenario("regression-003")
-        val = sc.get("expected_pr_count")
-        assert val is not None, "regression-003 must have expected_pr_count"
-        assert isinstance(val, int) and val > 0, (
-            f"expected_pr_count must be a positive int, got: {val!r}"
-        )
 
 
 class TestRegression003IssueTemplate:
@@ -227,37 +143,6 @@ class TestRegression003IssueTemplate:
     THEN DeltaSpec を要求する Issue body が含まれており
          setup → test-ready → pr-verify → pr-merge の全遷移を誘発できる
     """
-
-    def test_regression_003_templates_non_empty(self) -> None:
-        """THEN issue_templates list is not empty."""
-        sc = _get_scenario("regression-003")
-        templates = sc.get("issue_templates", [])
-        assert len(templates) > 0, "regression-003 must have at least one issue_template"
-
-    def test_regression_003_template_has_title(self) -> None:
-        """THEN each issue_template has a non-empty title."""
-        sc = _get_scenario("regression-003")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            assert t.get("title"), (
-                f"regression-003 issue_templates[{i}] must have a non-empty title"
-            )
-
-    def test_regression_003_template_has_body(self) -> None:
-        """THEN each issue_template has a non-empty body."""
-        sc = _get_scenario("regression-003")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            assert t.get("body"), (
-                f"regression-003 issue_templates[{i}] must have a non-empty body"
-            )
-
-    def test_regression_003_template_has_labels(self) -> None:
-        """THEN each issue_template has a labels list."""
-        sc = _get_scenario("regression-003")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            labels = t.get("labels")
-            assert isinstance(labels, list) and len(labels) > 0, (
-                f"regression-003 issue_templates[{i}] must have a non-empty labels list"
-            )
 
     def test_regression_003_body_mentions_deltaspec(self) -> None:
         """THEN issue body contains reference to DeltaSpec / twl spec new."""
@@ -273,81 +158,26 @@ class TestRegression003IssueTemplate:
         sc = _get_scenario("regression-003")
         bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
         combined = "\n".join(bodies)
-        # Body should describe a substantive implementation task that drives all 4 autopilot phases.
-        # Minimum length check: trivial one-liners cannot drive the full chain.
         assert len(combined) >= 100, (
             f"regression-003 issue body is too short ({len(combined)} chars) to drive "
             "setup→test-ready→pr-verify→pr-merge full chain"
         )
 
+    def test_regression_003_complexity_is_medium(self) -> None:
+        """THEN issue_template complexity == 'medium' (regression-003 is medium complexity)."""
+        sc = _get_scenario("regression-003")
+        templates = sc.get("issue_templates", [])
+        assert len(templates) > 0, "regression-003 must have at least one issue_template"
+        complexities = [t.get("complexity") for t in templates]
+        assert "medium" in complexities, (
+            f"regression-003 must have at least one issue_template with complexity=medium, "
+            f"got: {complexities}"
+        )
+
 
 # ===========================================================================
-# Requirement: regression-004 Bug #436 再現シナリオ
+# Requirement: regression-004 Bug #436 再現条件（固有）
 # ===========================================================================
-
-
-class TestRegression004Format:
-    """Requirement: regression-004 Bug #436 再現シナリオ
-
-    Scenario: regression-004 フォーマット準拠
-    WHEN test-scenario-catalog.md を参照する
-    THEN regression-004 エントリが存在し level=regression issues_count=1
-         expected_duration_min/max expected_conflicts expected_pr_count が記載
-    """
-
-    def test_regression_004_entry_exists(self) -> None:
-        """WHEN catalog is loaded THEN regression-004 key is present."""
-        catalog = _get_catalog()
-        assert "regression-004" in catalog, (
-            "regression-004 must be defined in test-scenario-catalog.md"
-        )
-
-    def test_regression_004_level_is_regression(self) -> None:
-        """THEN level == 'regression'."""
-        sc = _get_scenario("regression-004")
-        assert sc.get("level") == "regression", (
-            f"regression-004 level must be 'regression', got: {sc.get('level')!r}"
-        )
-
-    def test_regression_004_issues_count_is_1(self) -> None:
-        """THEN issues_count == 1."""
-        sc = _get_scenario("regression-004")
-        assert sc.get("issues_count") == 1, (
-            f"regression-004 issues_count must be 1, got: {sc.get('issues_count')!r}"
-        )
-
-    def test_regression_004_has_expected_duration_min(self) -> None:
-        """THEN expected_duration_min is present and positive."""
-        sc = _get_scenario("regression-004")
-        val = sc.get("expected_duration_min")
-        assert val is not None, "regression-004 must have expected_duration_min"
-        assert isinstance(val, int) and val > 0, (
-            f"expected_duration_min must be a positive int, got: {val!r}"
-        )
-
-    def test_regression_004_has_expected_duration_max(self) -> None:
-        """THEN expected_duration_max is present and >= expected_duration_min."""
-        sc = _get_scenario("regression-004")
-        min_val = sc.get("expected_duration_min")
-        max_val = sc.get("expected_duration_max")
-        assert max_val is not None, "regression-004 must have expected_duration_max"
-        assert isinstance(max_val, int) and max_val > 0
-        if min_val is not None:
-            assert max_val >= min_val
-
-    def test_regression_004_has_expected_conflicts(self) -> None:
-        """THEN expected_conflicts is present and non-negative."""
-        sc = _get_scenario("regression-004")
-        val = sc.get("expected_conflicts")
-        assert val is not None, "regression-004 must have expected_conflicts"
-        assert isinstance(val, int) and val >= 0
-
-    def test_regression_004_has_expected_pr_count(self) -> None:
-        """THEN expected_pr_count is present and positive."""
-        sc = _get_scenario("regression-004")
-        val = sc.get("expected_pr_count")
-        assert val is not None, "regression-004 must have expected_pr_count"
-        assert isinstance(val, int) and val > 0
 
 
 class TestRegression004BugReproCondition:
@@ -358,18 +188,11 @@ class TestRegression004BugReproCondition:
          条件が記述されている
     """
 
-    def test_regression_004_templates_non_empty(self) -> None:
-        """THEN issue_templates list is not empty."""
-        sc = _get_scenario("regression-004")
-        templates = sc.get("issue_templates", [])
-        assert len(templates) > 0, "regression-004 must have at least one issue_template"
-
     def test_regression_004_body_references_twl_spec_new(self) -> None:
         """THEN issue body explicitly instructs use of 'twl spec new'."""
         sc = _get_scenario("regression-004")
         bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
         combined = "\n".join(bodies)
-        # Must contain 'twl spec new' or 'twl spec' instruction to reproduce Bug #436
         assert any(
             kw in combined for kw in ("twl spec new", "twl spec", "deltaspec", "DeltaSpec")
         ), (
@@ -378,97 +201,19 @@ class TestRegression004BugReproCondition:
         )
 
     def test_regression_004_body_describes_archive_failure_condition(self) -> None:
-        """THEN issue body contains condition that would cause archive failure via missing issue: field.
-
-        The body should describe an action that creates a .deltaspec.yaml without issue: field,
-        which is the core Bug #436 condition.
-        """
+        """THEN issue body is substantive enough to describe archive failure condition."""
         sc = _get_scenario("regression-004")
         bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
         combined = "\n".join(bodies).lower()
-        # Body should be substantive enough to describe the bug reproduction scenario
         assert len(combined) >= 80, (
             f"regression-004 body too short ({len(combined)} chars) to describe "
             "Bug #436 archive-failure condition"
         )
 
-    def test_regression_004_template_has_required_fields(self) -> None:
-        """THEN each issue_template has title, body, labels, complexity."""
-        sc = _get_scenario("regression-004")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            assert t.get("title"), f"regression-004 issue_templates[{i}] missing title"
-            assert t.get("body"), f"regression-004 issue_templates[{i}] missing body"
-            labels = t.get("labels")
-            assert isinstance(labels, list) and len(labels) > 0, (
-                f"regression-004 issue_templates[{i}] must have non-empty labels"
-            )
-
 
 # ===========================================================================
-# Requirement: regression-005 Bug #438 再現シナリオ
+# Requirement: regression-005 Bug #438 再現条件（固有）
 # ===========================================================================
-
-
-class TestRegression005Format:
-    """Requirement: regression-005 Bug #438 再現シナリオ
-
-    Scenario: regression-005 フォーマット準拠
-    WHEN test-scenario-catalog.md を参照する
-    THEN regression-005 エントリが存在し level=regression issues_count=1
-         expected_duration_min/max expected_conflicts expected_pr_count が記載
-    """
-
-    def test_regression_005_entry_exists(self) -> None:
-        """WHEN catalog is loaded THEN regression-005 key is present."""
-        catalog = _get_catalog()
-        assert "regression-005" in catalog, (
-            "regression-005 must be defined in test-scenario-catalog.md"
-        )
-
-    def test_regression_005_level_is_regression(self) -> None:
-        """THEN level == 'regression'."""
-        sc = _get_scenario("regression-005")
-        assert sc.get("level") == "regression", (
-            f"regression-005 level must be 'regression', got: {sc.get('level')!r}"
-        )
-
-    def test_regression_005_issues_count_is_1(self) -> None:
-        """THEN issues_count == 1."""
-        sc = _get_scenario("regression-005")
-        assert sc.get("issues_count") == 1, (
-            f"regression-005 issues_count must be 1, got: {sc.get('issues_count')!r}"
-        )
-
-    def test_regression_005_has_expected_duration_min(self) -> None:
-        """THEN expected_duration_min is present and positive."""
-        sc = _get_scenario("regression-005")
-        val = sc.get("expected_duration_min")
-        assert val is not None, "regression-005 must have expected_duration_min"
-        assert isinstance(val, int) and val > 0
-
-    def test_regression_005_has_expected_duration_max(self) -> None:
-        """THEN expected_duration_max is present and >= expected_duration_min."""
-        sc = _get_scenario("regression-005")
-        min_val = sc.get("expected_duration_min")
-        max_val = sc.get("expected_duration_max")
-        assert max_val is not None, "regression-005 must have expected_duration_max"
-        assert isinstance(max_val, int) and max_val > 0
-        if min_val is not None:
-            assert max_val >= min_val
-
-    def test_regression_005_has_expected_conflicts(self) -> None:
-        """THEN expected_conflicts is present and non-negative."""
-        sc = _get_scenario("regression-005")
-        val = sc.get("expected_conflicts")
-        assert val is not None, "regression-005 must have expected_conflicts"
-        assert isinstance(val, int) and val >= 0
-
-    def test_regression_005_has_expected_pr_count(self) -> None:
-        """THEN expected_pr_count is present and positive."""
-        sc = _get_scenario("regression-005")
-        val = sc.get("expected_pr_count")
-        assert val is not None, "regression-005 must have expected_pr_count"
-        assert isinstance(val, int) and val > 0
 
 
 class TestRegression005BugReproCondition:
@@ -478,18 +223,11 @@ class TestRegression005BugReproCondition:
          Orchestrator polling loop の timeout を誘発できる条件が明示されている
     """
 
-    def test_regression_005_templates_non_empty(self) -> None:
-        """THEN issue_templates list is not empty."""
-        sc = _get_scenario("regression-005")
-        templates = sc.get("issue_templates", [])
-        assert len(templates) > 0, "regression-005 must have at least one issue_template"
-
     def test_regression_005_body_describes_long_running_task(self) -> None:
         """THEN issue body describes a task requiring more than 120 seconds to reproduce Bug #438."""
         sc = _get_scenario("regression-005")
         bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
         combined = "\n".join(bodies).lower()
-        # Body must indicate a long-running operation (sleep, wait, timeout, 120秒, etc.)
         timeout_keywords = (
             "120", "sleep", "wait", "timeout", "long", "秒", "時間", "遅延", "polling"
         )
@@ -509,83 +247,10 @@ class TestRegression005BugReproCondition:
             "Bug #438 polling timeout reproduction condition"
         )
 
-    def test_regression_005_template_has_required_fields(self) -> None:
-        """THEN each issue_template has title, body, labels."""
-        sc = _get_scenario("regression-005")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            assert t.get("title"), f"regression-005 issue_templates[{i}] missing title"
-            assert t.get("body"), f"regression-005 issue_templates[{i}] missing body"
-            labels = t.get("labels")
-            assert isinstance(labels, list) and len(labels) > 0, (
-                f"regression-005 issue_templates[{i}] must have non-empty labels"
-            )
-
 
 # ===========================================================================
-# Requirement: regression-006 Bug #439 再現シナリオ
+# Requirement: regression-006 Bug #439 再現条件（固有）
 # ===========================================================================
-
-
-class TestRegression006Format:
-    """Requirement: regression-006 Bug #439 再現シナリオ
-
-    Scenario: regression-006 フォーマット準拠
-    WHEN test-scenario-catalog.md を参照する
-    THEN regression-006 エントリが存在し level=regression issues_count=1
-         expected_duration_min/max expected_conflicts expected_pr_count が記載
-    """
-
-    def test_regression_006_entry_exists(self) -> None:
-        """WHEN catalog is loaded THEN regression-006 key is present."""
-        catalog = _get_catalog()
-        assert "regression-006" in catalog, (
-            "regression-006 must be defined in test-scenario-catalog.md"
-        )
-
-    def test_regression_006_level_is_regression(self) -> None:
-        """THEN level == 'regression'."""
-        sc = _get_scenario("regression-006")
-        assert sc.get("level") == "regression", (
-            f"regression-006 level must be 'regression', got: {sc.get('level')!r}"
-        )
-
-    def test_regression_006_issues_count_is_1(self) -> None:
-        """THEN issues_count == 1."""
-        sc = _get_scenario("regression-006")
-        assert sc.get("issues_count") == 1, (
-            f"regression-006 issues_count must be 1, got: {sc.get('issues_count')!r}"
-        )
-
-    def test_regression_006_has_expected_duration_min(self) -> None:
-        """THEN expected_duration_min is present and positive."""
-        sc = _get_scenario("regression-006")
-        val = sc.get("expected_duration_min")
-        assert val is not None, "regression-006 must have expected_duration_min"
-        assert isinstance(val, int) and val > 0
-
-    def test_regression_006_has_expected_duration_max(self) -> None:
-        """THEN expected_duration_max is present and >= expected_duration_min."""
-        sc = _get_scenario("regression-006")
-        min_val = sc.get("expected_duration_min")
-        max_val = sc.get("expected_duration_max")
-        assert max_val is not None, "regression-006 must have expected_duration_max"
-        assert isinstance(max_val, int) and max_val > 0
-        if min_val is not None:
-            assert max_val >= min_val
-
-    def test_regression_006_has_expected_conflicts(self) -> None:
-        """THEN expected_conflicts is present and non-negative."""
-        sc = _get_scenario("regression-006")
-        val = sc.get("expected_conflicts")
-        assert val is not None, "regression-006 must have expected_conflicts"
-        assert isinstance(val, int) and val >= 0
-
-    def test_regression_006_has_expected_pr_count(self) -> None:
-        """THEN expected_pr_count is present and positive."""
-        sc = _get_scenario("regression-006")
-        val = sc.get("expected_pr_count")
-        assert val is not None, "regression-006 must have expected_pr_count"
-        assert isinstance(val, int) and val > 0
 
 
 class TestRegression006BugReproCondition:
@@ -595,18 +260,11 @@ class TestRegression006BugReproCondition:
          phase-review.json が生成されないまま merge-gate に到達できる状況が記述されている
     """
 
-    def test_regression_006_templates_non_empty(self) -> None:
-        """THEN issue_templates list is not empty."""
-        sc = _get_scenario("regression-006")
-        templates = sc.get("issue_templates", [])
-        assert len(templates) > 0, "regression-006 must have at least one issue_template"
-
     def test_regression_006_body_describes_review_skip_condition(self) -> None:
         """THEN issue body describes condition that causes review phase to be skipped (Bug #439)."""
         sc = _get_scenario("regression-006")
         bodies = [t.get("body", "") for t in sc.get("issue_templates", [])]
         combined = "\n".join(bodies).lower()
-        # Body should reference review, phase-review, pr-verify, or merge-gate
         review_keywords = (
             "review", "pr-verify", "phase-review", "merge-gate", "mergegate",
             "レビュー", "skip", "スキップ"
@@ -640,27 +298,24 @@ class TestRegression006BugReproCondition:
             "Bug #439 phase-review.json absence condition"
         )
 
-    def test_regression_006_template_has_required_fields(self) -> None:
-        """THEN each issue_template has title, body, labels."""
-        sc = _get_scenario("regression-006")
-        for i, t in enumerate(sc.get("issue_templates", [])):
-            assert t.get("title"), f"regression-006 issue_templates[{i}] missing title"
-            assert t.get("body"), f"regression-006 issue_templates[{i}] missing body"
-            labels = t.get("labels")
-            assert isinstance(labels, list) and len(labels) > 0, (
-                f"regression-006 issue_templates[{i}] must have non-empty labels"
-            )
-
 
 # ===========================================================================
-# Edge cases: フォーマット不正・フィールド欠落
+# Edge cases: フォーマット準拠・フィールド欠落検出（全新規シナリオ共通）
 # ===========================================================================
 
 
 class TestCatalogEdgeCases:
-    """Edge cases: catalog format validation and field completeness."""
+    """Edge cases: catalog format validation and field completeness for regression-003〜006."""
 
     _REGRESSION_IDS = ["regression-003", "regression-004", "regression-005", "regression-006"]
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_entry_exists(self, scenario_id: str) -> None:
+        """THEN each new regression scenario key is present in the catalog."""
+        catalog = _get_catalog()
+        assert scenario_id in catalog, (
+            f"Scenario '{scenario_id}' must be defined in test-scenario-catalog.md"
+        )
 
     @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
     def test_scenario_has_description(self, scenario_id: str) -> None:
@@ -672,26 +327,25 @@ class TestCatalogEdgeCases:
         )
 
     @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
-    def test_scenario_level_is_valid(self, scenario_id: str) -> None:
-        """THEN level is one of smoke | regression | load."""
+    def test_scenario_level_is_regression(self, scenario_id: str) -> None:
+        """THEN level == 'regression' for all new scenarios."""
         sc = _get_scenario(scenario_id)
-        valid_levels = {"smoke", "regression", "load"}
-        assert sc.get("level") in valid_levels, (
-            f"{scenario_id} level must be one of {valid_levels}, got: {sc.get('level')!r}"
+        assert sc.get("level") == "regression", (
+            f"{scenario_id} level must be 'regression', got: {sc.get('level')!r}"
         )
 
     @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
-    def test_scenario_issues_count_positive_integer(self, scenario_id: str) -> None:
-        """THEN issues_count is a positive integer."""
+    def test_scenario_issues_count_is_1(self, scenario_id: str) -> None:
+        """THEN issues_count == 1 for all new Bug-repro scenarios."""
         sc = _get_scenario(scenario_id)
         val = sc.get("issues_count")
-        assert isinstance(val, int) and val >= 1, (
-            f"{scenario_id} issues_count must be >= 1, got: {val!r}"
+        assert isinstance(val, int) and val == 1, (
+            f"{scenario_id} issues_count must be 1, got: {val!r}"
         )
 
     @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
     def test_scenario_duration_range_valid(self, scenario_id: str) -> None:
-        """THEN expected_duration_max >= expected_duration_min."""
+        """THEN expected_duration_max >= expected_duration_min > 0."""
         sc = _get_scenario(scenario_id)
         min_val = sc.get("expected_duration_min")
         max_val = sc.get("expected_duration_max")
@@ -701,6 +355,26 @@ class TestCatalogEdgeCases:
         assert isinstance(max_val, int) and max_val >= min_val, (
             f"{scenario_id} expected_duration_max ({max_val}) must be >= "
             f"expected_duration_min ({min_val})"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_has_expected_conflicts(self, scenario_id: str) -> None:
+        """THEN expected_conflicts is present and is a non-negative integer."""
+        sc = _get_scenario(scenario_id)
+        val = sc.get("expected_conflicts")
+        assert val is not None, f"{scenario_id} must have expected_conflicts"
+        assert isinstance(val, int) and val >= 0, (
+            f"{scenario_id} expected_conflicts must be a non-negative int, got: {val!r}"
+        )
+
+    @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)
+    def test_scenario_has_expected_pr_count(self, scenario_id: str) -> None:
+        """THEN expected_pr_count is present and is a positive integer."""
+        sc = _get_scenario(scenario_id)
+        val = sc.get("expected_pr_count")
+        assert val is not None, f"{scenario_id} must have expected_pr_count"
+        assert isinstance(val, int) and val > 0, (
+            f"{scenario_id} expected_pr_count must be a positive int, got: {val!r}"
         )
 
     @pytest.mark.parametrize("scenario_id", _REGRESSION_IDS)

--- a/plugins/twl/refs/test-scenario-catalog.md
+++ b/plugins/twl/refs/test-scenario-catalog.md
@@ -194,6 +194,127 @@ regression-002:
       complexity: medium
 ```
 
+### regression-003: full-chain regression
+
+```yaml
+regression-003:
+  level: regression
+  description: "DeltaSpec + medium complexity Issue で setup→test-ready→pr-verify→pr-merge の full-chain 遷移を検証"
+  issues_count: 1
+  expected_duration_min: 15
+  expected_duration_max: 35
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 15
+  issue_templates:
+    - title: "[Test] add greet() function with DeltaSpec"
+      body: |
+        ## Goal
+        test-target plugin に `greet(name)` 関数を追加する。DeltaSpec を使用して実装すること。
+
+        ## AC
+        - [ ] `scripts/greet.sh` が新規作成され `echo "Hello, $1"` を実行する
+        - [ ] `deltaspec/changes/` に DeltaSpec change が存在する
+        - [ ] chmod +x が設定されている
+      labels: [test, scope/test-target, complexity-medium]
+      complexity: medium
+```
+
+### regression-004: Bug #436 再現（issue: フィールド欠落）
+
+```yaml
+regression-004:
+  level: regression
+  description: "twl spec new が .deltaspec.yaml に issue: フィールドを生成しない Bug #436 の再現シナリオ"
+  issues_count: 1
+  expected_duration_min: 10
+  expected_duration_max: 20
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 15
+  issue_templates:
+    - title: "[Test] add farewell() function with DeltaSpec (Bug436 repro)"
+      body: |
+        ## Goal
+        test-target plugin に `farewell(name)` 関数を追加する。DeltaSpec を使用して実装すること。
+
+        ## Bug 再現条件
+        この Issue は Bug #436 の再現用シナリオ。autopilot が `twl spec new` を呼び出した後、
+        生成される `.deltaspec.yaml` に `issue:` フィールドが存在するかを検証する。
+        `issue:` フィールドが欠落した場合、orchestrator の `grep "^issue:"` が 0 件ヒットし
+        archive フェーズで失敗する。
+
+        ## AC
+        - [ ] `scripts/farewell.sh` が新規作成され `echo "Goodbye, $1"` を実行する
+        - [ ] `deltaspec/changes/*.yaml` に `issue:` フィールドが存在する（Bug #436 修正検証）
+      labels: [test, scope/test-target, complexity-medium]
+      complexity: medium
+```
+
+### regression-005: Bug #438 再現（Orchestrator polling timeout）
+
+```yaml
+regression-005:
+  level: regression
+  description: "Orchestrator polling loop が Bash timeout 120秒で停止し inject_next_workflow() が呼ばれない Bug #438 の再現シナリオ"
+  issues_count: 1
+  expected_duration_min: 15
+  expected_duration_max: 30
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 10
+  issue_templates:
+    - title: "[Test] add slow-init script with heavy setup (Bug438 repro)"
+      body: |
+        ## Goal
+        test-target plugin に `scripts/slow-init.sh` を追加する。このスクリプトは初期化に
+        時間がかかる処理を含む（複数ファイルの生成とループ処理）。
+
+        ## Bug 再現条件
+        この Issue は Bug #438 の再現用シナリオ。workflow-setup フェーズで change-propose が
+        120 秒以上かかる処理を含む場合、Orchestrator の polling loop が Bash timeout で停止し、
+        `inject_next_workflow()` が呼ばれず chain 遷移が停止することを検証する。
+
+        ## AC
+        - [ ] `scripts/slow-init.sh` が新規作成されている
+        - [ ] スクリプト内に 10 個以上のファイルを生成するループが含まれている
+        - [ ] chmod +x が設定されている
+      labels: [test, scope/test-target, complexity-medium]
+      complexity: medium
+```
+
+### regression-006: Bug #439 再現（merge-gate phase-review チェック欠落）
+
+```yaml
+regression-006:
+  level: regression
+  description: "merge-gate が phase-review.json の存在を検査しない Bug #439 の再現シナリオ"
+  issues_count: 1
+  expected_duration_min: 10
+  expected_duration_max: 25
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 15
+  issue_templates:
+    - title: "[Test] add config.yaml with minimal changes (Bug439 repro)"
+      body: |
+        ## Goal
+        test-target plugin に `config.yaml` を追加し、プラグイン設定の基本構造を定義する。
+
+        ## Bug 再現条件
+        この Issue は Bug #439 の再現用シナリオ。workflow-pr-verify の review フェーズが
+        実行されないまま merge-gate に到達した場合、`phase-review.json` が不在でも
+        merge-gate が PASS してしまうことを検証する。trivial な変更で pr-verify の
+        reviewer specialist が起動されない条件を意図的に作る。
+
+        ## AC
+        - [ ] `config.yaml` が新規作成され `name: test-target` が含まれている
+        - [ ] merge-gate 到達時に `.autopilot/checkpoints/phase-review.json` の存在が
+              確認される（Bug #439 修正検証）
+      labels: [test, scope/test-target, complexity-medium]
+      complexity: medium
+```
+
 ## load level シナリオ (8-12 Issue, conflict 5+)
 
 **注意**: 本 reference では **smoke + regression のみ定義**。load level は将来別 Issue で追加する。


### PR DESCRIPTION
## 概要

Bug #436/#438/#439 を再現するためのシナリオを `plugins/twl/refs/test-scenario-catalog.md` に追加する。

## 変更内容

- `regression-003`: DeltaSpec + medium complexity Issue で full-chain 遷移（setup→test-ready→pr-verify→pr-merge）を検証するシナリオ
- `regression-004`: Bug #436 再現（`twl spec new` が `.deltaspec.yaml` に `issue:` フィールドを生成しない）
- `regression-005`: Bug #438 再現（Orchestrator polling loop が Bash timeout 120秒で停止）
- `regression-006`: Bug #439 再現（merge-gate が `phase-review.json` の存在を検査しない）

各シナリオは既存 YAML フォーマット（level/issues_count/expected_duration_min-max/expected_conflicts/expected_pr_count/observer_polling_interval/issue_templates）に準拠。

## 関連 Issue

Closes #442

## テスト

`cli/twl/tests/scenarios/test_scenario_catalog_regression.py` に BDD スタイルの pytest テストを追加（455行）。