### PR TITLE
docs(architecture): supervision/observation/context-map/model の observer パターン整合 (#441)

### DIFF
--- a/cli/twl/deltaspec/changes/issue-441/.deltaspec.yaml
+++ b/cli/twl/deltaspec/changes/issue-441/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 441
+name: issue-441
+status: pending

--- a/cli/twl/deltaspec/changes/issue-441/design.md
+++ b/cli/twl/deltaspec/changes/issue-441/design.md
@@ -1,0 +1,73 @@
+## Context
+
+su-observer（ADR-014）は「全 controller を session:spawn して観察する常駐 observer パターン」として設計されているが、architecture spec 4 ファイル（supervision.md / observation.md / context-map.md / model.md）がこのパターンを不正確または不完全に記述している。
+
+対象ファイルはすべて `plugins/twl/architecture/domain/` 配下の純粋なドキュメントであり、実装コードへの影響はない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- supervision.md の常駐ループ mermaid 図に全 controller への spawn パスを追加する
+- supervision.md L226 の「委譲」を「session:spawn 経由」と明記する
+- supervision.md に co-autopilot のみ能動 observe、他は spawn 後即指示待ちであることを追記する
+- observation.md の Observe ループ mermaid の起点を「su-observer が session:spawn で co-self-improve を起動」に修正する
+- context-map.md の Supervision → Live Observation エッジラベルを「session:spawn → observe」に変更し、テーブルも更新する
+- model.md の Supervisor クラスの `type: observer` を `type: supervisor` に修正する
+
+**Non-Goals:**
+
+- su-observer SKILL.md の変更（別 Issue）
+- co-self-improve SKILL.md の変更（別 Issue）
+- deps.yaml の変更（別 Issue）
+- su-observer-skill-design.md の変更（正典のため変更しない）
+- ADR-014 の変更
+
+## Decisions
+
+### D1: supervision.md mermaid 図に spawn パスを追加
+
+**現状**: 常駐ループ図には `co-autopilot spawn` / `co-issue spawn` / `co-architect spawn` のみ記載。
+
+**変更**: co-self-improve / co-utility / co-project への spawn パスも追加する。ノード名は既存の命名規則（`spawn`サフィックス）に合わせる。
+
+**理由**: Issue スコープに明記されており、全 controller を spawn できることが su-observer の核心機能。
+
+### D2: L226 委譲文の修正
+
+**現状**: 「su-observer はテストシナリオ実行を co-self-improve に委譲する（ADR-011 継続）。」
+
+**変更**: 「su-observer は session:spawn 経由で co-self-improve を起動し、テストシナリオ実行を委譲する（ADR-011 継続）。」
+
+**理由**: spawn メカニズムが不明確だったため。
+
+### D3: co-autopilot の能動 observe 記述を追加
+
+**現状**: 全 controller が「spawn + observe」と書かれているが、co-autopilot のみ能動 observe で他は spawn 後即指示待ちという差異が未記載。
+
+**変更**: 「co-self-improve との境界」セクションまたは「Supervisor 常駐ループ」に差異を追記する。
+
+### D4: observation.md の起点修正
+
+**現状**: `A[co-self-improve 起動]` がフローの最初のノード（su-observer との関係が未記載）。
+
+**変更**: `A[su-observer: session:spawn で co-self-improve を起動]` に変更し、spawn 関係を明示。
+
+### D5: context-map.md の SOBS→OBS エッジ変更
+
+**現状**: `SOBS -->|"Customer-Supplier<br/>co-self-improve テスト委譲"| OBS`
+
+**変更**: `SOBS -->|"Customer-Supplier<br/>session:spawn → observe"| OBS`
+
+関係テーブルも「co-self-improve へのテスト委譲（Upstream、ADR-014）」 → 「session:spawn で co-self-improve を起動し observe（ADR-014）」に更新。
+
+### D6: model.md の type 修正
+
+**現状**: `type: observer`（タイポ）
+
+**変更**: `type: supervisor`（正しい型定義）
+
+## Risks / Trade-offs
+
+- **リスク**: mermaid 図の変更は既存ドキュメント参照に影響しない（IDではなくビジュアルなので）。変更後は必ず mermaid 記法が正しいことを確認する。
+- **トレードオフ**: 最小限の変更（文書修正のみ）のため影響範囲は極小。実装コードは変更しない。

--- a/cli/twl/deltaspec/changes/issue-441/proposal.md
+++ b/cli/twl/deltaspec/changes/issue-441/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+su-observer の設計意図（ADR-014）は「常駐 + 全 controller を session:spawn → observe」だが、architecture spec（supervision.md / observation.md / context-map.md / model.md）がこのパターンを正確に反映しておらず、仕様と実装の乖離が生じている。
+
+## What Changes
+
+- **supervision.md**: 常駐ループ mermaid 図に co-self-improve / co-utility / co-project への spawn パスを追加。「委譲」が session:spawn メカニズムであることを明記。co-autopilot のみ能動 observe、他は spawn 後即指示待ちという差異を明記
+- **observation.md**: Observe ループ mermaid の開始ノードを「su-observer が session:spawn で co-self-improve を起動」に変更し、spawn 関係を明示
+- **context-map.md**: Supervision → Live Observation の関係を「session:spawn → observe」と具体化し、`SOBS -->|"Customer-Supplier session:spawn → observe"| OBS` に更新
+- **model.md**: Supervisor コンポーネントの `type: observer` を `type: supervisor` に修正（タイポ修正）
+
+## Capabilities
+
+### New Capabilities
+
+なし（既存設計の文書化修正）
+
+### Modified Capabilities
+
+- **Supervision Context 文書**: 常駐 observer パターンの全 controller spawn パスが可視化される
+- **Observation Context 文書**: su-observer → session:spawn → co-self-improve の起動関係が明示される
+- **Context Map 文書**: Supervision と Live Observation の具体的な通信メカニズムが明記される
+- **Domain Model 文書**: Supervisor の type フィールドが正確になる
+
+## Impact
+
+影響ファイル（文書のみ、実装コードなし）:
+- `plugins/twl/architecture/domain/contexts/supervision.md`
+- `plugins/twl/architecture/domain/contexts/observation.md`
+- `plugins/twl/architecture/domain/context-map.md`
+- `plugins/twl/architecture/domain/model.md`

--- a/cli/twl/deltaspec/changes/issue-441/specs/architecture-spec-alignment/spec.md
+++ b/cli/twl/deltaspec/changes/issue-441/specs/architecture-spec-alignment/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: supervision-mermaid-full-spawn-paths
+
+supervision.md の Supervisor 常駐ループ mermaid 図は、全 controller（co-self-improve / co-utility / co-project を含む）への spawn パスを持たなければならない（SHALL）。
+
+#### Scenario: 常駐ループ図に全 controller spawn が表示される
+- **WHEN** supervision.md の「Supervisor 常駐ループ」mermaid 図を参照する
+- **THEN** co-autopilot / co-issue / co-architect / co-self-improve / co-utility / co-project の 6 つ全ての controller への spawn パスノードが存在する
+
+### Requirement: supervision-spawn-mechanism-explicit
+
+supervision.md は su-observer が co-self-improve を session:spawn 経由で起動することを明記しなければならない（SHALL）。
+
+#### Scenario: 委譲関係に spawn メカニズムが明記される
+- **WHEN** supervision.md の「co-self-improve との境界」セクションを参照する
+- **THEN** 「session:spawn 経由」という記述が委譲関係の説明に含まれている
+
+### Requirement: supervision-co-autopilot-active-observe
+
+supervision.md は co-autopilot のみが能動 observe の対象であり、他の controller は spawn 後即指示待ちであることを記述しなければならない（SHALL）。
+
+#### Scenario: co-autopilot と他 controller の observe 差異が明記される
+- **WHEN** supervision.md の常駐ループまたは境界説明を参照する
+- **THEN** co-autopilot のみが能動 observe 対象で、他は spawn 後即指示待ちという差異が記載されている
+
+### Requirement: observation-spawn-origin-explicit
+
+observation.md の Observe ループ mermaid 図は、co-self-improve が su-observer から session:spawn で起動される関係を明示しなければならない（SHALL）。
+
+#### Scenario: Observe ループの起点に su-observer spawn が表示される
+- **WHEN** observation.md の「Observe ループ」mermaid 図を参照する
+- **THEN** 最初のノードが「su-observer: session:spawn で co-self-improve を起動」または等価の記述である
+
+### Requirement: context-map-spawn-observe-explicit
+
+context-map.md の Supervision → Live Observation エッジは「session:spawn → observe」の具体的なメカニズムを示さなければならない（SHALL）。
+
+#### Scenario: Context Map 図にセッション spawn 関係が表示される
+- **WHEN** context-map.md の依存関係 mermaid 図を参照する
+- **THEN** SOBS から OBS へのエッジラベルに「session:spawn → observe」が含まれている
+
+#### Scenario: Context Map テーブルに spawn 関係が記載される
+- **WHEN** context-map.md の「関係の詳細」テーブルを参照する
+- **THEN** Supervision → Live Observation の行のインターフェース列に「session:spawn」が含まれている
+
+### Requirement: model-supervisor-type-correct
+
+model.md の Supervisor クラスの type フィールドは `supervisor` でなければならない（SHALL）。
+
+#### Scenario: model.md の Supervisor type が supervisor である
+- **WHEN** model.md のクラス図を参照する
+- **THEN** Supervisor クラスの `type` フィールドの値が `supervisor` である（`observer` ではない）

--- a/cli/twl/deltaspec/changes/issue-441/tasks.md
+++ b/cli/twl/deltaspec/changes/issue-441/tasks.md
@@ -1,0 +1,23 @@
+## 1. supervision.md 修正
+
+- [ ] 1.1 常駐ループ mermaid 図に co-self-improve / co-utility / co-project への spawn パスを追加
+- [ ] 1.2 L226 の委譲記述に「session:spawn 経由」を追加
+- [ ] 1.3 co-autopilot のみ能動 observe、他は spawn 後即指示待ちであることを追記
+
+## 2. observation.md 修正
+
+- [ ] 2.1 Observe ループ mermaid の最初のノードを「su-observer: session:spawn で co-self-improve を起動」に変更
+
+## 3. context-map.md 修正
+
+- [ ] 3.1 mermaid 図の SOBS → OBS エッジラベルを「session:spawn → observe」に変更
+- [ ] 3.2 「関係の詳細」テーブルの Supervision → Live Observation 行を更新
+
+## 4. model.md 修正
+
+- [ ] 4.1 Supervisor クラスの `type: observer` を `type: supervisor` に修正
+
+## 5. 検証
+
+- [ ] 5.1 変更した mermaid 記法の構文確認（必要なら `mmdc` で確認）
+- [ ] 5.2 受け入れ基準 6 件の全充足を確認

--- a/cli/twl/deltaspec/changes/issue-441/tasks.md
+++ b/cli/twl/deltaspec/changes/issue-441/tasks.md
@@ -1,23 +1,23 @@
 ## 1. supervision.md 修正
 
-- [ ] 1.1 常駐ループ mermaid 図に co-self-improve / co-utility / co-project への spawn パスを追加
-- [ ] 1.2 L226 の委譲記述に「session:spawn 経由」を追加
-- [ ] 1.3 co-autopilot のみ能動 observe、他は spawn 後即指示待ちであることを追記
+- [x] 1.1 常駐ループ mermaid 図に co-self-improve / co-utility / co-project への spawn パスを追加
+- [x] 1.2 L226 の委譲記述に「session:spawn 経由」を追加
+- [x] 1.3 co-autopilot のみ能動 observe、他は spawn 後即指示待ちであることを追記
 
 ## 2. observation.md 修正
 
-- [ ] 2.1 Observe ループ mermaid の最初のノードを「su-observer: session:spawn で co-self-improve を起動」に変更
+- [x] 2.1 Observe ループ mermaid の最初のノードを「su-observer: session:spawn で co-self-improve を起動」に変更
 
 ## 3. context-map.md 修正
 
-- [ ] 3.1 mermaid 図の SOBS → OBS エッジラベルを「session:spawn → observe」に変更
-- [ ] 3.2 「関係の詳細」テーブルの Supervision → Live Observation 行を更新
+- [x] 3.1 mermaid 図の SOBS → OBS エッジラベルを「session:spawn → observe」に変更
+- [x] 3.2 「関係の詳細」テーブルの Supervision → Live Observation 行を更新
 
 ## 4. model.md 修正
 
-- [ ] 4.1 Supervisor クラスの `type: observer` を `type: supervisor` に修正
+- [x] 4.1 Supervisor クラスの `type: observer` を `type: supervisor` に修正
 
 ## 5. 検証
 
-- [ ] 5.1 変更した mermaid 記法の構文確認（必要なら `mmdc` で確認）
-- [ ] 5.2 受け入れ基準 6 件の全充足を確認
+- [x] 5.1 変更した mermaid 記法の構文確認（必要なら `mmdc` で確認）
+- [x] 5.2 受け入れ基準 6 件の全充足を確認

--- a/plugins/twl/architecture/domain/context-map.md
+++ b/plugins/twl/architecture/domain/context-map.md
@@ -68,7 +68,7 @@ graph TD
 
     SOBS -->|"Customer-Supplier<br/>Autopilot状態取得<br/>+ 介入時 state-write 可"| AP
     SOBS -->|"Customer-Supplier<br/>Issue 起票要求"| IM
-    SOBS -->|"Customer-Supplier<br/>co-self-improve テスト委譲"| OBS
+    SOBS -->|"Customer-Supplier<br/>session:spawn → observe"| OBS
 
     AS -.->|"DCI 注入"| IM
     IM -.->|"drift detection<br/>(INFO)"| AS
@@ -97,7 +97,7 @@ graph TD
 | Self-Improve | Live Observation | 並存 | 受動 retrospective と能動 observation の補完関係（ADR-011） |
 | Supervision | Autopilot | Customer-Supplier | Autopilot 状態取得（Downstream）、介入時 state-write 可（ADR-014） |
 | Supervision | Issue Mgmt | Customer-Supplier | フロー逸脱検知時の Issue 起票要求（Upstream） |
-| Supervision | Live Observation | Customer-Supplier | co-self-improve へのテスト委譲（Upstream、ADR-014） |
+| Supervision | Live Observation | Customer-Supplier | session:spawn で co-self-improve を起動し observe（ADR-014） |
 
 ## Architecture Spec の DCI フロー
 

--- a/plugins/twl/architecture/domain/contexts/observation.md
+++ b/plugins/twl/architecture/domain/contexts/observation.md
@@ -80,7 +80,7 @@ Observer 介入ログの単位。
 
 ```mermaid
 flowchart TD
-    A[co-self-improve 起動] --> B[ObservationSession 作成]
+    A[su-observer: session:spawn で co-self-improve を起動] --> B[ObservationSession 作成]
     B --> C[observed target 選択]
     C --> D[capture: tmux 出力取得]
     D --> E[problem-detect: rule-based 検出]

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -105,14 +105,20 @@ Observer 介入ログの単位（ADR-013 から継承）。
 flowchart TD
     A[su-observer 起動] --> B[SupervisorSession 作成]
     B --> C{ユーザー指示待ち}
-    C -->|autopilot 指示| D[co-autopilot spawn]
-    C -->|issue 指示| E[co-issue spawn]
-    C -->|architect 指示| F[co-architect spawn]
+    C -->|autopilot 指示| D[co-autopilot session:spawn]
+    C -->|issue 指示| E[co-issue session:spawn]
+    C -->|architect 指示| F[co-architect session:spawn]
+    C -->|self-improve 指示| SI[co-self-improve session:spawn]
+    C -->|utility 指示| UT[co-utility session:spawn]
+    C -->|project 指示| PR[co-project session:spawn]
     C -->|compact 指示| G[su-compact 実行]
     C -->|observe 指示| H[observe-once 実行]
-    D --> I[observe ループ]
-    E --> I
-    F --> I
+    D --> I[observe ループ（能動）]
+    E --> I2[指示待ち]
+    F --> I2
+    SI --> I2
+    UT --> I2
+    PR --> I2
     I --> J{問題検出?}
     J -->|Yes| K[intervention-catalog 照合]
     K --> L[Auto/Confirm/Escalate]
@@ -124,6 +130,7 @@ flowchart TD
     P --> C
     O -->|No| C
     M -->|No| I
+    I2 --> C
     G --> C
     H --> C
 ```
@@ -223,8 +230,11 @@ su-observer と co-self-improve は異なるレイヤーで補完関係にある
 | 直接実装 | 禁止（SU-3） | 禁止（不変条件 K） |
 | compaction | su-compact で自律的に知識外部化 | chain-driven でテンプレート的に外部化 |
 
-**委譲関係**: su-observer はテストシナリオ実行を co-self-improve に委譲する（ADR-011 継続）。
+**委譲関係**: su-observer は session:spawn 経由で co-self-improve を起動し、テストシナリオ実行を委譲する（ADR-011 継続）。
 co-self-improve の観察結果は su-observer に報告され、su-observer が介入判断を行う。
+
+**spawn 後の observe 差異**: co-autopilot のみ能動 observe（observe ループで継続監視）の対象とする。
+co-issue / co-architect / co-self-improve / co-utility / co-project は session:spawn 後即指示待ち（I/O 待機）となり、完了報告を受け取るまで su-observer は別タスクを継続できる。
 
 **observation.md の OB-* 制約との関係**:
 - OB-1〜OB-5 は co-self-improve にのみ適用される

--- a/plugins/twl/architecture/domain/model.md
+++ b/plugins/twl/architecture/domain/model.md
@@ -72,7 +72,7 @@ classDiagram
     }
     class Supervisor {
         name: su-*
-        type: observer
+        type: supervisor
         supervised: Controller[]
     }
     class InterventionRecord {


### PR DESCRIPTION
## 概要

su-observer の常駐 observer パターン（全 controller を session:spawn → observe）を architecture spec に正確に反映するドキュメント修正。

## 変更内容

- **supervision.md**: 常駐ループ mermaid 図に全 6 controller spawn パス追加、`session:spawn` 明記、co-autopilot 能動 observe と他 controller の spawn 後指示待ちの差異追記
- **observation.md**: Observe ループ起点を「su-observer: session:spawn で co-self-improve を起動」に修正
- **context-map.md**: SOBS→OBS エッジを「session:spawn → observe」に変更、関係テーブルも更新
- **model.md**: Supervisor `type: observer` → `type: supervisor` 修正（タイポ修正）

## 受け入れ基準

- [x] supervision.md の常駐ループ図に全 controller への spawn パスがある
- [x] supervision.md の「委譲」が session:spawn であることが明記されている
- [x] supervision.md に co-autopilot のみ能動 observe、他は spawn 後即指示待ちが明記されている
- [x] observation.md に co-self-improve が su-observer から spawn される前提が反映されている
- [x] context-map.md が「session:spawn → observe」と具体化されている
- [x] model.md の Supervisor type が supervisor になっている

Closes #441