### PR TITLE
feat(#444): ADR-016 test-target --real-issues モード設計

### DIFF
--- a/cli/twl/deltaspec/changes/issue-444/.deltaspec.yaml
+++ b/cli/twl/deltaspec/changes/issue-444/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 444
+name: issue-444
+status: pending

--- a/cli/twl/deltaspec/changes/issue-444/design.md
+++ b/cli/twl/deltaspec/changes/issue-444/design.md
@@ -1,0 +1,64 @@
+## Context
+
+autopilot の full chain は GitHub Issue/PR を前提とした chain 遷移を持つ。現在の `--local-only` モードはローカルに Issue ファイルを配置するだけで、Orchestrator の polling → inject_next_workflow → merge-gate のフローを実行できない。
+
+observation.md の不変制約: "test target は実 twill main の git 履歴を絶対に汚染しない"。この制約が分離戦略の選択を決定づける。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `--real-issues` モードの設計ドキュメント（ADR-016）を作成する
+- 3 選択肢の比較表と選定根拠を明記する
+- co-self-improve scenario-run モードとの統合フロー図を記載する
+- クリーンアップ設計（Issue/PR/branch の後処理）を記載する
+- リポジトリ作成・管理の責務帰属を決定する
+
+**Non-Goals:**
+- `--real-issues` モードの実装
+- test-scenario-catalog.md のシナリオ追加
+- observation-pattern-catalog.md のパターン追加
+
+## Decisions
+
+### Decision 1: リポジトリ分離戦略の選択
+
+3 選択肢の比較:
+
+| 戦略 | 隔離性 | GitHub API 依存 | クリーンアップ複雑度 | 備考 |
+|------|--------|----------------|---------------------|------|
+| 専用テストリポ | 高 | 中（リポ作成 API） | 低 | 実リポに影響なし、リポ管理コスト発生 |
+| 実リポ test ラベル | 低 | 低 | 高 | git 履歴汚染リスク、不変制約に抵触 |
+| mock GitHub API | 高 | なし | なし | 実装複雑度高、CI 向きだが現実性低 |
+
+**決定**: 専用テストリポ。observation.md の不変制約（実 main 汚染禁止）を満たす唯一の現実的選択肢。mock は実装コストが高すぎる。
+
+### Decision 2: リポジトリ作成・管理の責務帰属
+
+- **既存コマンド拡張**: `test-project-init` に `--mode real-issues` フラグを追加
+- 理由: 新規コマンドより既存コンポーネントの責務を明確に拡張する方が deps.yaml 管理が単純
+
+### Decision 3: co-self-improve 統合フロー
+
+SKILL.md Step 1 への分岐追加:
+```
+IF --real-issues:
+  1. test-project-init --mode real-issues → 専用テストリポ作成（既存なら skip）
+  2. GitHub Issue 起票（シナリオに対応する Issue を対象リポに作成）
+  3. autopilot start --repo <test-repo> --issue <N>
+  4. observe loop（polling）
+  5. cleanup（Issue close / PR close / branch 削除）
+```
+
+### Decision 4: クリーンアップ設計
+
+テスト完了後（成功・失敗問わず）:
+1. 対象 PR をクローズ（マージ済み or 未マージ問わず）
+2. 対象 GitHub Issue をクローズ（`test-result: pass/fail` ラベル付与）
+3. feature branch 削除（対象テストリポの branch のみ）
+4. test-project-init で作成した専用リポは保持（次回テストで再利用）
+
+## Risks / Trade-offs
+
+- 専用テストリポを使うと GitHub Actions の無料枠消費が増える可能性がある
+- テストリポが増殖しないよう、テストリポのライフサイクル管理ルールを ADR に明記する必要がある
+- クリーンアップが途中で失敗した場合の再実行可否設計が必要（冪等性の担保）

--- a/cli/twl/deltaspec/changes/issue-444/proposal.md
+++ b/cli/twl/deltaspec/changes/issue-444/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+autopilot の full chain（setup → test-ready → pr-verify → pr-merge）は GitHub Issue/PR を前提とした chain 遷移を持つが、現在の `--local-only` モードではローカルファイル配置のみで chain 遷移を通せない。Bug #436/#438/#439 の再現・回帰防止には実際の GitHub Issue + PR を使った full chain 実行基盤が必要。
+
+## What Changes
+
+- `--real-issues` モードの設計ドキュメントを ADR-016 として追加
+- テスト用リポジトリ分離戦略の比較検討（専用リポ / 実リポ test ラベル / mock GitHub API）
+- co-self-improve の scenario-run モードへの `--real-issues` 分岐統合フロー設計
+- テスト後クリーンアップ設計（Issue close, PR close, branch 削除）
+- リポジトリ作成・管理の責務帰属の決定
+
+## Capabilities
+
+### New Capabilities
+
+- `--real-issues` モード: GitHub Issue 起票 → autopilot 実行 → observe の full chain 実行フロー
+- テスト対象リポジトリの分離戦略: 実リポジトリの git 履歴を汚染しない隔離設計
+- クリーンアップパイプライン: テスト完了後の GitHub リソース（Issue/PR/branch）後処理
+
+### Modified Capabilities
+
+- co-self-improve scenario-run モード: `--real-issues` フラグ対応の分岐ロジック追加（設計のみ）
+- test-project-init または新規コマンド: テスト用リポジトリ作成・管理の責務拡張（設計のみ）
+
+## Impact
+
+- 影響ファイル: `plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md`（新規）
+- 依存 API: GitHub REST API（Issue/PR 作成・クローズ・削除）
+- 設計のみ（実装 Issue は別途）

--- a/cli/twl/deltaspec/changes/issue-444/proposal.md
+++ b/cli/twl/deltaspec/changes/issue-444/proposal.md
@@ -21,7 +21,7 @@ autopilot の full chain（setup → test-ready → pr-verify → pr-merge）は
 ### Modified Capabilities
 
 - co-self-improve scenario-run モード: `--real-issues` フラグ対応の分岐ロジック追加（設計のみ）
-- test-project-init または新規コマンド: テスト用リポジトリ作成・管理の責務拡張（設計のみ）
+- test-project-init（`--mode real-issues` フラグ追加）: テスト用リポジトリ作成・管理の責務拡張（設計のみ）
 
 ## Impact
 

--- a/cli/twl/deltaspec/changes/issue-444/specs/adr-016/spec.md
+++ b/cli/twl/deltaspec/changes/issue-444/specs/adr-016/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: ADR-016 ドキュメント作成
+test-target の `--real-issues` モードに関する設計決定を ADR-016 として記録しなければならない（SHALL）。ADR は `plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md` に配置されなければならない（MUST）。
+
+#### Scenario: ADR-016 ファイル作成
+- **WHEN** issue #444 の受け入れ基準を満たす変更が加えられる
+- **THEN** `plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md` が存在し、以下を含む: タイトル・Status・Context・3選択肢比較表・Decision・Consequences
+
+### Requirement: 3選択肢比較表の記載
+ADR-016 は専用リポ・実リポ test ラベル・mock GitHub API の 3 選択肢を比較する表を含まなければならない（MUST）。比較軸として隔離性・GitHub API 依存度・クリーンアップ複雑度を含まなければならない（SHALL）。
+
+#### Scenario: 比較表の内容検証
+- **WHEN** ADR-016 を読む
+- **THEN** 3 戦略それぞれの隔離性・GitHub API 依存・クリーンアップ複雑度の評価と選定根拠が明記されている
+
+### Requirement: co-self-improve 統合フロー図
+ADR-016 は co-self-improve scenario-run モードと `--real-issues` モードの統合フローを含まなければならない（MUST）。フローは Step 1 への分岐追加として記述されなければならない（SHALL）。
+
+#### Scenario: 統合フロー記載
+- **WHEN** ADR-016 を読む
+- **THEN** `--real-issues` 時のフロー（リポ作成→Issue起票→autopilot→observe→cleanup）が記載されている
+
+### Requirement: クリーンアップ設計の記載
+ADR-016 はテスト後の GitHub リソース（Issue/PR/branch）クリーンアップ設計を含まなければならない（MUST）。クリーンアップはテスト成功・失敗問わず実行されなければならない（SHALL）。
+
+#### Scenario: クリーンアップ設計の記載
+- **WHEN** ADR-016 を読む
+- **THEN** PR クローズ・Issue クローズ・branch 削除の後処理フローが記載されている
+
+### Requirement: リポジトリ管理の責務決定
+ADR-016 はリポジトリ作成・管理の責務帰属（test-project-init 拡張 or 新規コマンド）を明記しなければならない（MUST）。
+
+#### Scenario: 責務決定の記載
+- **WHEN** ADR-016 を読む
+- **THEN** `test-project-init --mode real-issues` 拡張として決定されたことと、その根拠が記載されている

--- a/cli/twl/deltaspec/changes/issue-444/tasks.md
+++ b/cli/twl/deltaspec/changes/issue-444/tasks.md
@@ -1,0 +1,21 @@
+## 1. ADR-016 ドキュメント作成
+
+- [x] 1.1 `plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md` を新規作成する
+- [x] 1.2 3 選択肢（専用リポ / 実リポ test ラベル / mock GitHub API）の比較表を記載する
+- [x] 1.3 Decision（専用リポ採用）と選定根拠を記載する
+- [x] 1.4 Consequences（リスク・トレードオフ）を記載する
+
+## 2. co-self-improve 統合フロー設計
+
+- [x] 2.1 `--real-issues` モードの統合フロー図を ADR-016 に記載する（リポ作成→Issue起票→autopilot→observe→cleanup）
+- [x] 2.2 co-self-improve SKILL.md の Step 1 への分岐追加箇所を特定し、設計内容として ADR に記載する
+
+## 3. クリーンアップ設計
+
+- [x] 3.1 テスト後クリーンアップフロー（PR close / Issue close / branch 削除）を ADR-016 に記載する
+- [x] 3.2 クリーンアップの冪等性（再実行可否）の設計方針を ADR-016 に記載する
+
+## 4. リポジトリ管理責務の決定
+
+- [x] 4.1 `test-project-init --mode real-issues` 拡張として責務帰属を ADR-016 に記載する
+- [x] 4.2 テストリポのライフサイクル管理ルール（増殖防止ポリシー）を ADR-016 に記載する

--- a/cli/twl/deltaspec/changes/issue-444/test-mapping.yaml
+++ b/cli/twl/deltaspec/changes/issue-444/test-mapping.yaml
@@ -1,0 +1,75 @@
+change_id: issue-444
+generated_at: "2026-04-11T00:00:00+00:00"
+test_framework: pytest
+notes: >
+  This change creates a pure documentation file
+  (plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md).
+  All tests are documentation-content checks (file existence + section/content
+  assertions). No implementation code is added; no unit tests for logic are
+  required.
+
+scenarios:
+  - id: adr-016-file-creation
+    name: "ADR-016 ファイル作成"
+    spec_file: "specs/adr-016/spec.md"
+    spec_line: 6
+    requirement: "ADR-016 ドキュメント作成"
+    test_file: "tests/scenarios/test_adr_016_test_target_real_issues.py"
+    test_name: "TestAdr016FileCreation"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: adr-016-comparison-table-content
+    name: "比較表の内容検証"
+    spec_file: "specs/adr-016/spec.md"
+    spec_line: 13
+    requirement: "3選択肢比較表の記載"
+    test_file: "tests/scenarios/test_adr_016_test_target_real_issues.py"
+    test_name: "TestAdr016ComparisonTableContent"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: adr-016-integration-flow-documented
+    name: "統合フロー記載"
+    spec_file: "specs/adr-016/spec.md"
+    spec_line: 20
+    requirement: "co-self-improve 統合フロー図"
+    test_file: "tests/scenarios/test_adr_016_test_target_real_issues.py"
+    test_name: "TestAdr016IntegrationFlowDocumented"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: adr-016-cleanup-design-documented
+    name: "クリーンアップ設計の記載"
+    spec_file: "specs/adr-016/spec.md"
+    spec_line: 27
+    requirement: "クリーンアップ設計の記載"
+    test_file: "tests/scenarios/test_adr_016_test_target_real_issues.py"
+    test_name: "TestAdr016CleanupDesignDocumented"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: adr-016-responsibility-decision-documented
+    name: "責務決定の記載"
+    spec_file: "specs/adr-016/spec.md"
+    spec_line: 34
+    requirement: "リポジトリ管理の責務決定"
+    test_file: "tests/scenarios/test_adr_016_test_target_real_issues.py"
+    test_name: "TestAdr016ResponsibilityDecisionDocumented"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/cli/twl/tests/scenarios/test_adr_016_test_target_real_issues.py
+++ b/cli/twl/tests/scenarios/test_adr_016_test_target_real_issues.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Tests for ADR-016: test-target --real-issues mode design decisions.
+
+Spec: deltaspec/changes/issue-444/specs/adr-016/spec.md
+
+Verifies that ADR-016 exists at plugins/twl/architecture/decisions/
+ADR-016-test-target-real-issues.md and contains all required sections and
+content as mandated by the issue-444 spec.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+# The ADR lives in plugins/twl, not cli/twl
+REPO_ROOT = Path(__file__).parent.parent.parent.parent.parent
+ADR_PATH = (
+    REPO_ROOT
+    / "plugins"
+    / "twl"
+    / "architecture"
+    / "decisions"
+    / "ADR-016-test-target-real-issues.md"
+)
+
+
+def _read_adr() -> str:
+    """Read ADR-016 content, skipping if not yet created."""
+    if not ADR_PATH.exists():
+        pytest.skip(f"ADR-016 does not exist yet at {ADR_PATH}")
+    return ADR_PATH.read_text(encoding="utf-8")
+
+
+def _extract_headings(content: str) -> list[str]:
+    """Extract all heading texts from Markdown content."""
+    return [
+        m.group(1).strip()
+        for m in re.finditer(r"^#{1,6}\s+(.+)$", content, re.MULTILINE)
+    ]
+
+
+class TestAdr016FileCreation:
+    """Scenario: ADR-016 ファイル作成
+
+    WHEN: issue #444 の受け入れ基準を満たす変更が加えられる
+    THEN: plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md
+          が存在し、タイトル・Status・Context・3選択肢比較表・Decision・Consequences
+          を含む
+    """
+
+    def test_adr_016_file_exists(self) -> None:
+        """ADR-016-test-target-real-issues.md exists at the expected path."""
+        assert ADR_PATH.exists(), (
+            f"ADR-016 not found at {ADR_PATH}. "
+            "The file must be created as part of issue-444."
+        )
+
+    def test_adr_016_has_title(self) -> None:
+        """ADR-016 has a title heading."""
+        content = _read_adr()
+        headings = _extract_headings(content)
+        assert headings, "ADR-016 has no headings at all"
+        # First heading should be the title (level 1 or level 2)
+        assert re.search(
+            r"^#{1,2}\s+",
+            content,
+            re.MULTILINE,
+        ), "ADR-016 must have a top-level title heading"
+
+    def test_adr_016_has_required_sections(self) -> None:
+        """ADR-016 contains Status, Context, Decision, Consequences sections."""
+        content = _read_adr()
+        headings_lower = [h.lower() for h in _extract_headings(content)]
+
+        required = ["status", "context", "decision", "consequences"]
+        missing = [
+            s for s in required
+            if not any(s in h for h in headings_lower)
+        ]
+        assert not missing, (
+            f"ADR-016 is missing required sections: {missing}. "
+            f"Found headings: {_extract_headings(content)}"
+        )
+
+    def test_adr_016_has_comparison_table(self) -> None:
+        """ADR-016 contains a 3-strategy comparison table (Markdown table syntax)."""
+        content = _read_adr()
+        # Markdown tables use | as column separator
+        table_rows = [
+            line for line in content.splitlines()
+            if line.strip().startswith("|") and "|" in line[1:]
+        ]
+        assert len(table_rows) >= 4, (
+            "ADR-016 must contain a comparison table with at least 3 data rows "
+            f"(header + separator + 3 strategies). Found {len(table_rows)} table rows."
+        )
+
+
+class TestAdr016ComparisonTableContent:
+    """Scenario: 比較表の内容検証
+
+    WHEN: ADR-016 を読む
+    THEN: 3 戦略それぞれの隔離性・GitHub API 依存・クリーンアップ複雑度の評価と
+          選定根拠が明記されている
+    """
+
+    def test_table_contains_three_strategies(self) -> None:
+        """ADR-016 comparison table covers all 3 candidate strategies."""
+        content = _read_adr()
+        # Strategy 1: 専用リポ / dedicated repo
+        has_dedicated = bool(
+            re.search(r"専用リポ|dedicated.?repo|separate.?repo", content, re.IGNORECASE)
+        )
+        # Strategy 2: 実リポ test ラベル / real repo test label
+        has_real_label = bool(
+            re.search(
+                r"実リポ|real.?repo|test\s*ラベル|test.?label",
+                content,
+                re.IGNORECASE,
+            )
+        )
+        # Strategy 3: mock GitHub API
+        has_mock = bool(
+            re.search(r"mock.{0,20}(github|api)|github.{0,20}mock", content, re.IGNORECASE)
+        )
+        missing_strategies = []
+        if not has_dedicated:
+            missing_strategies.append("専用リポ (dedicated repo)")
+        if not has_real_label:
+            missing_strategies.append("実リポ test ラベル (real repo with test label)")
+        if not has_mock:
+            missing_strategies.append("mock GitHub API")
+        assert not missing_strategies, (
+            f"ADR-016 comparison table is missing strategies: {missing_strategies}"
+        )
+
+    def test_table_contains_isolation_axis(self) -> None:
+        """ADR-016 comparison table includes 隔離性 (isolation) axis."""
+        content = _read_adr()
+        assert re.search(
+            r"隔離性|isolation|isolat",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 comparison table must include 隔離性 (isolation) as a comparison axis"
+
+    def test_table_contains_github_api_dependency_axis(self) -> None:
+        """ADR-016 comparison table includes GitHub API 依存度 axis."""
+        content = _read_adr()
+        assert re.search(
+            r"GitHub\s*API\s*依存|api.{0,15}depend|depend.{0,15}api",
+            content,
+            re.IGNORECASE,
+        ), (
+            "ADR-016 comparison table must include GitHub API 依存 "
+            "(GitHub API dependency) as a comparison axis"
+        )
+
+    def test_table_contains_cleanup_complexity_axis(self) -> None:
+        """ADR-016 comparison table includes クリーンアップ複雑度 axis."""
+        content = _read_adr()
+        assert re.search(
+            r"クリーンアップ.{0,10}複雑|cleanup.{0,15}complex|clean.{0,15}complex",
+            content,
+            re.IGNORECASE,
+        ), (
+            "ADR-016 comparison table must include クリーンアップ複雑度 "
+            "(cleanup complexity) as a comparison axis"
+        )
+
+    def test_table_contains_selection_rationale(self) -> None:
+        """ADR-016 includes the rationale for the chosen strategy."""
+        content = _read_adr()
+        has_rationale = bool(
+            re.search(
+                r"選定根拠|選択根拠|選んだ理由|rationale|reason|because|のため|から",
+                content,
+                re.IGNORECASE,
+            )
+        )
+        assert has_rationale, (
+            "ADR-016 must include selection rationale (選定根拠) for the chosen strategy"
+        )
+
+
+class TestAdr016IntegrationFlowDocumented:
+    """Scenario: 統合フロー記載
+
+    WHEN: ADR-016 を読む
+    THEN: --real-issues 時のフロー（リポ作成→Issue起票→autopilot→observe→cleanup）
+          が記載されている
+    """
+
+    def test_real_issues_flag_documented(self) -> None:
+        """ADR-016 documents the --real-issues flag / mode."""
+        content = _read_adr()
+        assert re.search(
+            r"--real-issues|real.issues\s*mode|real.issues\s*モード",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the --real-issues flag"
+
+    def test_flow_repo_creation_step_documented(self) -> None:
+        """ADR-016 documents the repo creation step in the integration flow."""
+        content = _read_adr()
+        assert re.search(
+            r"リポ作成|repo.{0,10}creat|creat.{0,10}repo|repository.{0,10}creat",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the repository creation step in the flow"
+
+    def test_flow_issue_creation_step_documented(self) -> None:
+        """ADR-016 documents the Issue creation step in the integration flow."""
+        content = _read_adr()
+        assert re.search(
+            r"Issue\s*起票|issue.{0,10}creat|creat.{0,10}issue|起票",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the Issue creation step in the flow"
+
+    def test_flow_autopilot_step_documented(self) -> None:
+        """ADR-016 documents the autopilot step in the integration flow."""
+        content = _read_adr()
+        assert re.search(
+            r"autopilot",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the autopilot step in the integration flow"
+
+    def test_flow_observe_step_documented(self) -> None:
+        """ADR-016 documents the observe/observer step in the integration flow."""
+        content = _read_adr()
+        assert re.search(
+            r"observe|observer|観察",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the observe step in the integration flow"
+
+    def test_flow_cleanup_step_documented(self) -> None:
+        """ADR-016 documents the cleanup step in the integration flow."""
+        content = _read_adr()
+        assert re.search(
+            r"cleanup|クリーンアップ|clean.?up",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the cleanup step in the integration flow"
+
+    def test_co_self_improve_integration_documented(self) -> None:
+        """ADR-016 documents co-self-improve integration."""
+        content = _read_adr()
+        assert re.search(
+            r"co-self-improve|co_self_improve",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document the co-self-improve integration"
+
+
+class TestAdr016CleanupDesignDocumented:
+    """Scenario: クリーンアップ設計の記載
+
+    WHEN: ADR-016 を読む
+    THEN: PR クローズ・Issue クローズ・branch 削除の後処理フローが記載されている
+    """
+
+    def test_pr_close_documented(self) -> None:
+        """ADR-016 documents PR close in the cleanup flow."""
+        content = _read_adr()
+        assert re.search(
+            r"PR.{0,15}(クローズ|close|clos)|close.{0,15}PR|(pull.?request).{0,15}close",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document PR close in the cleanup flow"
+
+    def test_issue_close_documented(self) -> None:
+        """ADR-016 documents Issue close in the cleanup flow."""
+        content = _read_adr()
+        assert re.search(
+            r"Issue.{0,15}(クローズ|close|clos)|close.{0,15}issue",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document Issue close in the cleanup flow"
+
+    def test_branch_delete_documented(self) -> None:
+        """ADR-016 documents branch deletion in the cleanup flow."""
+        content = _read_adr()
+        assert re.search(
+            r"branch.{0,15}(削除|delet|remov)|bランチ.{0,15}削除",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document branch deletion in the cleanup flow"
+
+    def test_cleanup_runs_regardless_of_test_outcome(self) -> None:
+        """ADR-016 states cleanup runs regardless of test success or failure."""
+        content = _read_adr()
+        has_unconditional = bool(
+            re.search(
+                r"成功.{0,30}失敗|失敗.{0,30}成功"
+                r"|regardless|問わず|にかかわらず"
+                r"|always|必ず|常に",
+                content,
+                re.IGNORECASE,
+            )
+        )
+        assert has_unconditional, (
+            "ADR-016 must state that cleanup is performed regardless of "
+            "test success or failure (成功・失敗問わず)"
+        )
+
+
+class TestAdr016ResponsibilityDecisionDocumented:
+    """Scenario: 責務決定の記載
+
+    WHEN: ADR-016 を読む
+    THEN: test-project-init --mode real-issues 拡張として決定されたことと、
+          その根拠が記載されている
+    """
+
+    def test_test_project_init_decision_documented(self) -> None:
+        """ADR-016 documents test-project-init as the chosen responsibility holder."""
+        content = _read_adr()
+        assert re.search(
+            r"test-project-init|test_project_init",
+            content,
+            re.IGNORECASE,
+        ), "ADR-016 must document test-project-init as the decision"
+
+    def test_real_issues_mode_flag_documented(self) -> None:
+        """ADR-016 documents --mode real-issues extension of test-project-init."""
+        content = _read_adr()
+        assert re.search(
+            r"--mode\s+real-issues|mode.{0,10}real.issues",
+            content,
+            re.IGNORECASE,
+        ), (
+            "ADR-016 must document --mode real-issues as the chosen extension "
+            "of test-project-init"
+        )
+
+    def test_rationale_for_responsibility_decision(self) -> None:
+        """ADR-016 explains why test-project-init was chosen over a new command."""
+        content = _read_adr()
+        # Should mention the alternative (new command) and reason for rejection/selection
+        has_rationale = bool(
+            re.search(
+                r"新規コマンド|new.?command|既存.{0,20}拡張|extend.{0,20}exist"
+                r"|根拠|rationale|reason|because|のため",
+                content,
+                re.IGNORECASE,
+            )
+        )
+        assert has_rationale, (
+            "ADR-016 must explain the rationale for choosing test-project-init "
+            "extension over creating a new command"
+        )

--- a/plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md
+++ b/plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md
@@ -72,17 +72,18 @@ co-self-improve SKILL.md の Step 1 に `--real-issues` 分岐を追加する:
 テスト完了後（成功・失敗問わず）、以下の順序でクリーンアップを実行する:
 
 ```
-1. feature branch 削除
-   - gh api DELETE /repos/{test-repo}/git/refs/heads/{branch}
-   - 対象: 専用テストリポの branch のみ
-
-2. PR クローズ（マージ済みは自動クローズ済み）
+1. PR クローズ（マージ済みは自動クローズ済み）
    - gh pr close <N> --repo <test-repo>
    - 未マージの場合のみ実行
 
-3. Issue クローズ（テスト結果ラベル付与）
+2. Issue クローズ（テスト結果ラベル付与）
    - gh issue close <N> --repo <test-repo>
    - ラベル: test-result:pass または test-result:fail
+
+3. feature branch 削除
+   - gh api DELETE /repos/{test-repo}/git/refs/heads/{branch}
+   - 対象: 専用テストリポの branch のみ
+   - PR クローズ後に実行すること（先に削除すると GitHub が PR を自動クローズして gh pr close が失敗する）
 
 4. テストリポ自体は保持（次回テストで再利用）
 ```

--- a/plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md
+++ b/plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md
@@ -1,0 +1,127 @@
+# ADR-016: test-target --real-issues モード設計
+
+## Status
+
+Proposed
+
+## Date
+
+2026-04-11
+
+## Context
+
+autopilot の full chain（setup → test-ready → pr-verify → pr-merge）は GitHub Issue/PR を前提とした chain 遷移を持つ。現在の co-self-improve は `--local-only` モード（`test-project-scenario-load` による Issue ファイル配置のみ）でシナリオを実行しており、chain 遷移を通せない。
+
+具体的な問題:
+- Orchestrator の polling → `inject_next_workflow` → merge-gate の一連のフローはローカルファイルだけでは動作しない
+- Bug #436/#438/#439 の再現・回帰防止には実際の GitHub Issue + PR を使った full chain 実行が不可欠
+
+observation.md の不変制約 **"test target は実 twill main の git 履歴を絶対に汚染しない"** が設計の起点となる。
+
+## 3 選択肢比較
+
+| 戦略 | 隔離性 | GitHub API 依存 | クリーンアップ複雑度 | 実装複雑度 |
+|------|--------|----------------|---------------------|-----------|
+| **専用テストリポ** | 高 | 中（リポ作成 API） | 低 | 低 |
+| 実リポ test ラベル付き Issue | 低 | 低 | 高 | 低 |
+| mock GitHub API | 高 | なし | なし | 高 |
+
+**専用テストリポ**: 独立した GitHub リポジトリに Issue/PR を作成してテストする。実リポと完全に分離されるため不変制約を自然に満たす。
+
+**実リポ test ラベル付き Issue**: 実リポジトリ（twill）に `test:` ラベルを付けた Issue を作成する。隔離性が低く、PR マージが実リポの main を汚染するリスクがある。観察 observation.md の不変制約に **抵触する可能性が高い**。
+
+**mock GitHub API**: GitHub API をモックし、外部依存なしでテストする。完全な隔離と高速なテストが可能だが、実際の GitHub webhook/event 動作を再現できないため、autopilot の chain 遷移テストの信頼性が低下する。実装コストも高い。
+
+## Decision
+
+**専用テストリポを採用する。**
+
+選定根拠:
+1. observation.md の不変制約（実 main 汚染禁止）を完全に満たす唯一の現実的選択肢
+2. クリーンアップは PR/Issue/branch をテストリポ内で処理するだけで済み、複雑度が低い
+3. 実際の GitHub API を使うため autopilot の chain 遷移テストの信頼性が高い
+4. mock GitHub API に比べて実装コストが大幅に低い
+
+## co-self-improve 統合フロー（--real-issues モード）
+
+co-self-improve SKILL.md の Step 1 に `--real-issues` 分岐を追加する:
+
+```
+## Step 1: scenario-run モード — シナリオ選択 + spawn
+
+### 既存フロー（--local-only）
+1. test-project-init → test-target worktree 作成（なければ）
+2. test-scenario-catalog.md を Read → シナリオ選択
+3. test-project-scenario-load → Issue ファイルをローカルに配置
+4. session:spawn で observed session 起動
+
+### 追加分岐（--real-issues）[ADR-016]
+1. test-project-init --mode real-issues → 専用テストリポ作成（既存ならスキップ）
+2. test-scenario-catalog.md を Read → シナリオ選択
+3. 選択シナリオに対応する GitHub Issue を専用テストリポに起票
+   （gh issue create --repo <test-repo> --label "test:scenario"）
+4. autopilot start --repo <test-repo> --issue <N>
+5. session:spawn で observed session 起動（--cd worktrees/test-target）
+6. spawn 後の window 名を取得し Step 2 へ
+```
+
+**分岐追加箇所**: `plugins/twl/skills/co-self-improve/SKILL.md` の Step 1 冒頭にモード判定分岐を追加する（将来の実装 Issue で対応）。
+
+## クリーンアップ設計
+
+テスト完了後（成功・失敗問わず）、以下の順序でクリーンアップを実行する:
+
+```
+1. feature branch 削除
+   - gh api DELETE /repos/{test-repo}/git/refs/heads/{branch}
+   - 対象: 専用テストリポの branch のみ
+
+2. PR クローズ（マージ済みは自動クローズ済み）
+   - gh pr close <N> --repo <test-repo>
+   - 未マージの場合のみ実行
+
+3. Issue クローズ（テスト結果ラベル付与）
+   - gh issue close <N> --repo <test-repo>
+   - ラベル: test-result:pass または test-result:fail
+
+4. テストリポ自体は保持（次回テストで再利用）
+```
+
+### 冪等性設計
+
+クリーンアップは再実行可能（冪等）でなければならない:
+- branch 削除: 既に削除済みなら 404 を無視
+- PR クローズ: 既にクローズ済みなら noop
+- Issue クローズ: 既にクローズ済みなら noop
+
+失敗時のリトライ: 各ステップは独立して再実行可能とし、前ステップの成功を前提としない。
+
+## リポジトリ管理の責務帰属
+
+**`test-project-init` コマンドに `--mode real-issues` フラグを追加する（既存コマンド拡張）。**
+
+選定根拠:
+- 新規コマンド作成より既存コマンドの責務を明確に拡張する方が deps.yaml 管理が単純
+- `test-project-init` はすでに test-target worktree 管理の責務を持っており、リポジトリ作成はその自然な拡張
+
+**テストリポのライフサイクル管理ルール（増殖防止ポリシー）**:
+- テストリポ名: `twill-test-<YYYYMM>` （月次でローテーション）
+- 同月の既存リポがあれば再利用（再作成不要）
+- リポは `private` で作成する
+- 使用していないリポの削除は `test-project-manage` モードから手動実行（自動削除禁止）
+
+## Consequences
+
+**正の影響:**
+- Bug #436/#438/#439 のような chain 遷移バグを自動テストで再現・検知できるようになる
+- 実リポの git 履歴汚染ゼロが保証される
+- クリーンアップが単純で、テスト後の状態が明確
+
+**負の影響・リスク:**
+- GitHub Actions の無料枠消費が増える可能性がある（専用リポでの CI 実行）
+- 専用テストリポの作成に GitHub API トークンと適切な権限が必要
+- 月次リポローテーションにより、前月の Issue/PR 履歴は新リポに引き継がれない
+
+**残留リスク:**
+- GitHub API のレートリミットが連続テスト実行に影響する可能性がある
+- クリーンアップが不完全な場合、孤立した branch/Issue が残る可能性がある（冪等性設計で緩和）


### PR DESCRIPTION
## 概要

test-target の full chain（setup → test-ready → pr-verify → pr-merge）を GitHub Issue/PR を使って実行するための基盤設計。

## 変更内容

- **ADR-016 追加**: `plugins/twl/architecture/decisions/ADR-016-test-target-real-issues.md`
  - 3 選択肢比較表（専用リポ / 実リポ test ラベル / mock GitHub API）
  - Decision: 専用テストリポ採用（observation.md 不変制約を満たす唯一の現実的選択肢）
  - co-self-improve Step 1 への `--real-issues` 分岐統合フロー設計
  - クリーンアップ設計（PR クローズ → Issue クローズ → branch 削除、冪等性保証）
  - 責務帰属: `test-project-init --mode real-issues` 拡張
  - テストリポ月次ローテーションポリシー
- **DeltaSpec issue-444**: proposal / design / specs / tasks 一式
- **テスト**: `cli/twl/tests/scenarios/test_adr_016_test_target_real_issues.py`（ADR-016 内容検証）

Closes #444