### PR TITLE
[Bug] main worktree の remote.origin.fetch refspec 欠落 — worktree refspec guard 実装

### DIFF
--- a/deltaspec/changes/issue-471/.deltaspec.yaml
+++ b/deltaspec/changes/issue-471/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 471
+name: issue-471
+status: pending

--- a/deltaspec/changes/issue-471/design.md
+++ b/deltaspec/changes/issue-471/design.md
@@ -1,0 +1,63 @@
+## Context
+
+bare repo 構造（`.bare/` + `main/` worktree + `worktrees/feat/*`）では、`git worktree add` が `remote.origin.fetch` refspec を継承しないケースがある。refspec が `+refs/heads/*:refs/remotes/origin/*` でない場合、`git fetch origin` は HEAD のみ更新し `refs/remotes/origin/main` が stale になる。現在は手動修復済みだが、再発時の detection コストが高い（Wave 4 で 1 時間を要した）。
+
+既存スクリプト:
+- `plugins/twl/scripts/chain-runner.sh` — worktree-create ステップが `twl.autopilot.worktree` に委譲
+- `plugins/twl/commands/autopilot-pilot-precheck.md` — PR merge 直前の軽量検証 atomic
+- `plugins/twl/CLAUDE.md` — bare repo 構造検証（現行 3 条件）
+- `plugins/twl/scripts/health-check.sh` — ロジック異常検知（chain 停止・input wait）、refspec 検査は未実装
+
+## Goals / Non-Goals
+
+**Goals:**
+- `.bare/config`・main worktree・全 feat worktree の `remote.origin.fetch` を一括検査するスタンドアローンスクリプトを追加
+- refspec 欠落時に警告 + 自動修復（`git config --add`）を提供
+- autopilot セッション起動時（pilot-precheck）に refspec チェックを組み込む
+- worktree 作成直後に refspec を自動設定する
+- bats テストで「refspec 欠落 worktree の検出」を機械的に保証
+- `plugins/twl/CLAUDE.md` に refspec を第 4 条件として明文化
+
+**Non-Goals:**
+- `remote.origin.fetch` 以外の git 設定全般の健全性検証
+- GitHub Actions / CI への組み込み
+- 既存の `health-check.sh`（ロジック異常検知）との統合（責務が異なる）
+
+## Decisions
+
+### D-1: 新規スクリプト `worktree-health-check.sh`
+
+`health-check.sh` とは**責務分離**（chain/process 監視 vs git refspec 監視）。命名を `worktree-health-check.sh` とし独立させる。引数: `[--fix]`（自動修復モード）、`[--bare-root <path>]`（bare repo パス指定）。
+
+検査順:
+1. bare repo root の `.bare/config` を確認
+2. `main/` worktree を確認
+3. `git worktree list --porcelain` で全 worktree を列挙して確認
+4. `git show-ref refs/remotes/origin/main` と `git ls-remote origin main` の tip 比較
+
+出口コード: `0` = 全 OK、`1` = 問題あり（`--fix` なし）、`0` = 問題あり + 修復済み（`--fix` あり）
+
+### D-2: autopilot-pilot-precheck への統合
+
+precheck の既存 Step（PR diff stat / AC spot-check）の**前**に Step 0 として refspec チェックを追加。`--fix` フラグなしで呼び出し、欠落を検出したら `PRECHECK_WARNINGS` に追加して処理を継続（abort しない）。
+
+### D-3: worktree-create での refspec 自動設定
+
+`chain-runner.sh` の `step_worktree_create()` で `python3 -m twl.autopilot.worktree create` 完了後に以下を実行:
+```bash
+git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' || true
+```
+既存 refspec が正しい場合は上書きせず（`--get-all` で確認してから `--add`）。
+
+### D-4: bats テスト
+
+`test-fixtures/` 配下に bats テストを追加（既存パターンに倣う）。
+- `setup()`: 一時 bare repo + worktree を作成し、refspec を意図的に削除
+- `@test`: `worktree-health-check.sh` が exit 1 + WARN メッセージを出力することを検証
+- `@test --fix`: `worktree-health-check.sh --fix` 後に refspec が正しく設定されていることを検証
+
+## Risks / Trade-offs
+
+- **`git ls-remote origin main` はネットワーク接続を要する**: precheck での tip 比較は optional とし、ネットワーク不可環境では skip する（タイムアウト 5 秒）
+- **全 worktree の列挙コスト**: `git worktree list --porcelain` は軽量だが、worktree 数が多い環境では若干遅い。許容範囲と判断
+- **`--add` と `--replace-all` の選択**: `git config --add` は重複エントリを生む可能性がある。`git config --replace-all` を使い、既存 refspec を置き換える方が安全

--- a/deltaspec/changes/issue-471/proposal.md
+++ b/deltaspec/changes/issue-471/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+bare repo 構造で新規 worktree を作成した際、`remote.origin.fetch` refspec が設定されないケースがあり、`git fetch origin` が `origin/main` を更新しない。これにより全 worktree で stale な origin/main 参照が生じ、rebase 判定・PR mergeability 判定が壊れる（Wave 4 で約 1 時間のデバッグを要した実績あり）。現在は手動修復済みだが再発防止のため恒久対策を実装する。
+
+## What Changes
+
+- `plugins/twl/scripts/worktree-health-check.sh` を新規追加：bare repo および全 worktree の `remote.origin.fetch` refspec を検査し、欠落時に WARN + 自動修復オプションを提供する
+- `plugins/twl/scripts/autopilot-pilot-precheck.md`（または新規 atomic）に health check を統合：refspec 欠落時は WARN + 自動修復オプションを提示する
+- worktree 作成フロー（`chain-runner.sh worktree-create` または手動手順ガイド）に post-create で refspec を設定する処理を追加
+- bats テストシナリオ追加：「fetch refspec が欠落した worktree を検出」
+- `plugins/twl/CLAUDE.md` の Bare repo 構造検証セクションに refspec 条件（4 条件目）を追加
+
+## Capabilities
+
+### New Capabilities
+
+- **worktree-health-check**: `.bare/config`・main worktree・全 feat worktree の `remote.origin.fetch` refspec を一括検査。`git show-ref origin/main` と `git ls-remote origin main` の一致も検証。欠落時は `git config --add remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'` で自動修復する
+- **precheck refspec guard**: autopilot セッション起動時に refspec を事前確認し、欠落が検出された場合に abort または自動修復を選択できる
+
+### Modified Capabilities
+
+- **worktree-create**: post-create フックで refspec を自動設定（bare repo 経由の git worktree add 後に確認・補完）
+- **Bare repo 構造検証ドキュメント**: refspec チェック条件を第 4 条件として追記
+
+## Impact
+
+- `plugins/twl/scripts/worktree-health-check.sh`（新規）
+- `plugins/twl/scripts/chain-runner.sh`（worktree-create ステップに refspec 設定追加）
+- `plugins/twl/commands/autopilot-pilot-precheck.md` または新規 atomic（health check 統合）
+- `test-fixtures/` または `plugins/twl/tests/`（bats テスト追加）
+- `plugins/twl/CLAUDE.md`（Bare repo 構造検証セクション更新）

--- a/deltaspec/changes/issue-471/specs/worktree-refspec-guard/spec.md
+++ b/deltaspec/changes/issue-471/specs/worktree-refspec-guard/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: worktree-health-check スクリプト
+
+`plugins/twl/scripts/worktree-health-check.sh` を追加し、bare repo および全 worktree の `remote.origin.fetch` refspec を検査しなければならない（SHALL）。スクリプトは `--fix` オプションで欠落 refspec を自動修復しなければならない（SHALL）。
+
+#### Scenario: refspec 欠落の検出
+- **WHEN** `.bare/config` または任意の worktree で `remote.origin.fetch` が `+refs/heads/*:refs/remotes/origin/*` を含まない
+- **THEN** `worktree-health-check.sh` が `WARN` メッセージを標準出力に出力し exit code 1 で終了する
+
+#### Scenario: --fix による自動修復
+- **WHEN** `worktree-health-check.sh --fix` を実行し、欠落 refspec が検出された
+- **THEN** 影響 worktree それぞれに `git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'` を適用し、exit code 0 で終了する
+
+#### Scenario: 全 OK の場合
+- **WHEN** `.bare/config` と全 worktree の `remote.origin.fetch` が正しく設定されている
+- **THEN** `worktree-health-check.sh` が `OK` メッセージを出力し exit code 0 で終了する
+
+### Requirement: origin/main tip 一致検査
+
+`worktree-health-check.sh` はネットワーク利用可能時に `git show-ref refs/remotes/origin/main` と `git ls-remote origin main` の tip を比較しなければならない（SHALL）。ネットワーク不可時はタイムアウト（5 秒）後にスキップしなければならない（SHALL）。
+
+#### Scenario: stale origin/main の検出
+- **WHEN** ローカルの `refs/remotes/origin/main` が `git ls-remote origin main` のリモート tip と異なる
+- **THEN** `WARN: origin/main is stale` を標準出力に出力する（非 blocking）
+
+### Requirement: worktree-create での refspec 自動設定
+
+`chain-runner.sh` の `step_worktree_create()` は worktree 作成完了後に `remote.origin.fetch` refspec を `+refs/heads/*:refs/remotes/origin/*` に設定しなければならない（SHALL）。
+
+#### Scenario: 新規 worktree 作成後の refspec 設定
+- **WHEN** `chain-runner.sh worktree-create` が新規 worktree の作成に成功した
+- **THEN** 新規 worktree で `git config --get-all remote.origin.fetch` が `+refs/heads/*:refs/remotes/origin/*` を返す
+
+#### Scenario: 既存正常 refspec の保持
+- **WHEN** 新規 worktree で既に `remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*` が設定されている
+- **THEN** 重複エントリを追加しない（`--replace-all` を使用する）
+
+## MODIFIED Requirements
+
+### Requirement: autopilot-pilot-precheck への統合
+
+`autopilot-pilot-precheck.md` は既存チェック（PR diff stat / AC spot-check）の前に refspec チェックを実行しなければならない（SHALL）。欠落検出時は `PRECHECK_WARNINGS` に追加し処理を継続しなければならない（SHALL）。abort してはならない（MUST NOT）。
+
+#### Scenario: precheck 中の refspec 欠落検出
+- **WHEN** `autopilot-pilot-precheck` 実行時に任意の worktree で refspec が欠落している
+- **THEN** `WARN: fetch refspec missing in <path>` を `PRECHECK_WARNINGS` に追加し、後続の PR diff / AC チェックを継続する
+
+### Requirement: CLAUDE.md Bare repo 構造検証の更新
+
+`plugins/twl/CLAUDE.md` の「Bare repo 構造検証」セクションは refspec 条件を第 4 条件として含まなければならない（SHALL）。
+
+#### Scenario: 第 4 条件の明文化
+- **WHEN** 開発者が `plugins/twl/CLAUDE.md` の Bare repo 構造検証セクションを参照する
+- **THEN** 「`.bare/config` および全 worktree の `remote.origin.fetch` が `+refs/heads/*:refs/remotes/origin/*` を含む」が 4 番目の条件として記載されている
+
+## ADDED Requirements
+
+### Requirement: bats テスト — refspec 欠落検出
+
+bats テストシナリオで `worktree-health-check.sh` の動作を機械的に検証しなければならない（SHALL）。
+
+#### Scenario: テスト setup で refspec を削除して欠落を模擬
+- **WHEN** 一時 bare repo と worktree を作成し `git config --unset remote.origin.fetch` で refspec を削除した後 `worktree-health-check.sh` を実行する
+- **THEN** exit code 1 かつ stdout に `WARN` が含まれる
+
+#### Scenario: --fix 後に refspec が正しく設定される
+- **WHEN** refspec が欠落した worktree で `worktree-health-check.sh --fix` を実行する
+- **THEN** exit code 0 かつ `git config --get-all remote.origin.fetch` が `+refs/heads/*:refs/remotes/origin/*` を返す

--- a/deltaspec/changes/issue-471/tasks.md
+++ b/deltaspec/changes/issue-471/tasks.md
@@ -1,0 +1,26 @@
+## 1. worktree-health-check.sh 実装
+
+- [ ] 1.1 `plugins/twl/scripts/worktree-health-check.sh` を新規作成（bare root 検出・全 worktree 列挙・refspec 検査ロジック）
+- [ ] 1.2 `--fix` オプションで `git config --replace-all` を使い欠落 refspec を自動修復する処理を実装
+- [ ] 1.3 ネットワーク利用可能時の `git ls-remote origin main` vs `git show-ref` tip 比較（タイムアウト 5 秒）を実装
+- [ ] 1.4 スクリプトに実行権限を付与し手動実行でスモークテストを実施
+
+## 2. chain-runner.sh worktree-create への refspec 設定追加
+
+- [ ] 2.1 `chain-runner.sh` の `step_worktree_create()` に `python3 -m twl.autopilot.worktree create` 完了後の refspec 設定処理を追加（`git config --replace-all remote.origin.fetch '...'`）
+- [ ] 2.2 既存 refspec が正しい場合は重複エントリを作らないことを確認
+
+## 3. autopilot-pilot-precheck への統合
+
+- [ ] 3.1 `plugins/twl/commands/autopilot-pilot-precheck.md` に Step 0 として refspec チェック呼び出し（`worktree-health-check.sh` 使用）を追加
+- [ ] 3.2 欠落検出時に `PRECHECK_WARNINGS` へ追加して処理継続（abort しない）を明記
+
+## 4. bats テスト追加
+
+- [ ] 4.1 既存の bats テスト配置場所を確認（`test-fixtures/` or `plugins/twl/tests/`）
+- [ ] 4.2 `test_worktree_health_check.bats` を追加：refspec 欠落検出シナリオ（exit 1 + WARN）
+- [ ] 4.3 `test_worktree_health_check.bats` に `--fix` シナリオ追加（修復後 exit 0 + 正しい refspec）
+
+## 5. ドキュメント更新
+
+- [ ] 5.1 `plugins/twl/CLAUDE.md` の「Bare repo 構造検証」セクションに第 4 条件（refspec）を追記

--- a/deltaspec/changes/issue-471/tasks.md
+++ b/deltaspec/changes/issue-471/tasks.md
@@ -1,26 +1,26 @@
 ## 1. worktree-health-check.sh 実装
 
-- [ ] 1.1 `plugins/twl/scripts/worktree-health-check.sh` を新規作成（bare root 検出・全 worktree 列挙・refspec 検査ロジック）
-- [ ] 1.2 `--fix` オプションで `git config --replace-all` を使い欠落 refspec を自動修復する処理を実装
-- [ ] 1.3 ネットワーク利用可能時の `git ls-remote origin main` vs `git show-ref` tip 比較（タイムアウト 5 秒）を実装
-- [ ] 1.4 スクリプトに実行権限を付与し手動実行でスモークテストを実施
+- [x] 1.1 `plugins/twl/scripts/worktree-health-check.sh` を新規作成（bare root 検出・全 worktree 列挙・refspec 検査ロジック）
+- [x] 1.2 `--fix` オプションで `git config --replace-all` を使い欠落 refspec を自動修復する処理を実装
+- [x] 1.3 ネットワーク利用可能時の `git ls-remote origin main` vs `git show-ref` tip 比較（タイムアウト 5 秒）を実装
+- [x] 1.4 スクリプトに実行権限を付与し手動実行でスモークテストを実施
 
 ## 2. chain-runner.sh worktree-create への refspec 設定追加
 
-- [ ] 2.1 `chain-runner.sh` の `step_worktree_create()` に `python3 -m twl.autopilot.worktree create` 完了後の refspec 設定処理を追加（`git config --replace-all remote.origin.fetch '...'`）
-- [ ] 2.2 既存 refspec が正しい場合は重複エントリを作らないことを確認
+- [x] 2.1 `chain-runner.sh` の `step_worktree_create()` に `python3 -m twl.autopilot.worktree create` 完了後の refspec 設定処理を追加（`git config --replace-all remote.origin.fetch '...'`）
+- [x] 2.2 既存 refspec が正しい場合は重複エントリを作らないことを確認
 
 ## 3. autopilot-pilot-precheck への統合
 
-- [ ] 3.1 `plugins/twl/commands/autopilot-pilot-precheck.md` に Step 0 として refspec チェック呼び出し（`worktree-health-check.sh` 使用）を追加
-- [ ] 3.2 欠落検出時に `PRECHECK_WARNINGS` へ追加して処理継続（abort しない）を明記
+- [x] 3.1 `plugins/twl/commands/autopilot-pilot-precheck.md` に Step 0 として refspec チェック呼び出し（`worktree-health-check.sh` 使用）を追加
+- [x] 3.2 欠落検出時に `PRECHECK_WARNINGS` へ追加して処理継続（abort しない）を明記
 
 ## 4. bats テスト追加
 
-- [ ] 4.1 既存の bats テスト配置場所を確認（`test-fixtures/` or `plugins/twl/tests/`）
-- [ ] 4.2 `test_worktree_health_check.bats` を追加：refspec 欠落検出シナリオ（exit 1 + WARN）
-- [ ] 4.3 `test_worktree_health_check.bats` に `--fix` シナリオ追加（修復後 exit 0 + 正しい refspec）
+- [x] 4.1 既存の bats テスト配置場所を確認（`test-fixtures/` or `plugins/twl/tests/`）
+- [x] 4.2 `test_worktree_health_check.bats` を追加：refspec 欠落検出シナリオ（exit 1 + WARN）
+- [x] 4.3 `test_worktree_health_check.bats` に `--fix` シナリオ追加（修復後 exit 0 + 正しい refspec）
 
 ## 5. ドキュメント更新
 
-- [ ] 5.1 `plugins/twl/CLAUDE.md` の「Bare repo 構造検証」セクションに第 4 条件（refspec）を追記
+- [x] 5.1 `plugins/twl/CLAUDE.md` の「Bare repo 構造検証」セクションに第 4 条件（refspec）を追記

--- a/deltaspec/changes/issue-471/test-mapping.yaml
+++ b/deltaspec/changes/issue-471/test-mapping.yaml
@@ -1,0 +1,159 @@
+change_id: issue-471
+generated_at: "2026-04-11T12:00:50Z"
+test_framework: bats
+scenarios:
+  # --------------------------------------------------------------------------
+  # Requirement: worktree-health-check スクリプト
+  # --------------------------------------------------------------------------
+
+  - id: "refspec-missing-detection"
+    name: "refspec 欠落の検出"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 7
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "refspec 欠落検出: refspec を削除した worktree を渡すと exit code 1 を返す"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "refspec-missing-warn-message"
+    name: "refspec 欠落の検出 — WARN メッセージ出力"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 7
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "refspec 欠落検出: WARN メッセージを stdout に出力する"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "fix-mode-exit-code"
+    name: "--fix による自動修復 — exit code 0"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 11
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "--fix による修復: exit code 0 で終了する"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "fix-mode-refspec-applied"
+    name: "--fix による自動修復 — refspec 設定確認"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 11
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "--fix による修復: git config --get-all が正しい refspec を返す"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "all-ok-exit-code"
+    name: "全 OK の場合 — exit code 0"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 15
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "全 OK: 正しく設定された worktree で exit code 0 を返す"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "all-ok-message"
+    name: "全 OK の場合 — OK メッセージ"
+    spec_file: "specs/worttree-refspec-guard/spec.md"
+    spec_line: 15
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "全 OK: OK メッセージを stdout に出力する"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "no-duplicate-entry"
+    name: "--fix 使用時に重複エントリを作らない"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 35
+    requirement: "worktree-health-check スクリプト"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "重複防止: --fix を2回実行してもエントリが1件のみ"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # --------------------------------------------------------------------------
+  # Requirement: worktree-create での refspec 自動設定
+  # --------------------------------------------------------------------------
+
+  - id: "new-worktree-refspec-set"
+    name: "新規 worktree 作成後の refspec 設定"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 31
+    requirement: "worktree-create での refspec 自動設定"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats"
+    test_name: "worktree-create 後: post-create スクリプト実行後に正しい refspec が設定される"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "new-worktree-refspec-exit-code"
+    name: "新規 worktree 作成後の refspec 設定 — exit code 0"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 31
+    requirement: "worktree-create での refspec 自動設定"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats"
+    test_name: "worktree-create 後: post-create スクリプトが exit code 0 で終了する"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "worktree-create-no-duplicate"
+    name: "既存正常 refspec の保持 — 重複エントリを追加しない"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 35
+    requirement: "worktree-create での refspec 自動設定"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats"
+    test_name: "重複防止: post-create を2回実行してもエントリが1件のみ"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # --------------------------------------------------------------------------
+  # bats テスト仕様 (spec.md lines 59-70)
+  # --------------------------------------------------------------------------
+
+  - id: "bats-refspec-missing-mock"
+    name: "テスト setup で refspec を削除して欠落を模擬"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 63
+    requirement: "bats テスト — refspec 欠落検出"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "refspec 欠落検出: refspec を削除した worktree を渡すと exit code 1 を返す"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-fix-refspec-set"
+    name: "--fix 後に refspec が正しく設定される"
+    spec_file: "specs/worktree-refspec-guard/spec.md"
+    spec_line: 67
+    requirement: "bats テスト — refspec 欠落検出"
+    test_file: "plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats"
+    test_name: "--fix による修復: git config --get-all が正しい refspec を返す"
+    type: unit
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/deltaspec/config.yaml
+++ b/deltaspec/config.yaml
@@ -1,0 +1,9 @@
+schema: spec-driven
+
+context: |
+  twill モノリポのプロジェクトレベル DeltaSpec。
+  plugins/twl/ — 開発ワークフロープラグイン（autopilot, chain-runner, worktree 管理など）
+  plugins/session/ — セッション管理プラグイン
+  cli/twl/ — TWiLL CLI エンジン（twl コマンド）
+  test-fixtures/ — テスト用フィクスチャ
+  bare repo 構造: .bare/ + worktrees/ + main/

--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -35,11 +35,12 @@ deps.yaml v3.0 がプラグイン構成の唯一の情報源。
 
 ## Bare repo 構造検証（セッション開始時チェック）
 
-以下の3条件を全て満たすこと:
+以下の4条件を全て満たすこと:
 
 1. `.bare/` が存在する（`.git/` ディレクトリではない）
 2. `main/.git` がファイル（ディレクトリではない）で `.bare` を指す
 3. CWD が `main/` 配下である（Pilot セッション）、または Pilot が作成した worktree 配下である（Worker セッション）
+4. `.bare/config` および全 worktree の `remote.origin.fetch` が `+refs/heads/*:refs/remotes/origin/*` を含む（欠落時は `worktree-health-check.sh --fix` で修復。欠落すると `git fetch origin` が `origin/main` を更新せず mergeability 判定が壊れる）
 
 ### セッション起動ルール
 

--- a/plugins/twl/commands/autopilot-pilot-precheck.md
+++ b/plugins/twl/commands/autopilot-pilot-precheck.md
@@ -37,15 +37,38 @@ fi
 
 ## 処理ロジック (MUST)
 
+### Step 0: refspec 健全性チェック（AC-2）
+
+`worktree-health-check.sh` を呼び出して bare repo / 全 worktree の `remote.origin.fetch` refspec を検査する。
+欠落が検出された場合は `PRECHECK_WARNINGS` に追加して処理を**継続**する（abort MUST NOT）。
+
+```bash
+declare -a PRECHECK_WARNINGS=()
+declare -a PRECHECK_FAILS=()
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+HEALTH_CHECK="${SCRIPT_DIR}/../scripts/worktree-health-check.sh"
+
+if [[ -x "$HEALTH_CHECK" ]]; then
+  REFSPEC_RESULT=$(bash "$HEALTH_CHECK" --skip-remote-check 2>/dev/null || true)
+  if echo "$REFSPEC_RESULT" | grep -q "^WARN:"; then
+    while IFS= read -r warn_line; do
+      [[ "$warn_line" =~ ^WARN: ]] && \
+        PRECHECK_WARNINGS+=("refspec_check: $warn_line")
+    done <<< "$REFSPEC_RESULT"
+    echo "WARN: fetch refspec 欠落を検出 — 詳細: $REFSPEC_RESULT" >&2
+  fi
+else
+  PRECHECK_WARNINGS+=("refspec_check: worktree-health-check.sh not found — スキップ")
+fi
+```
+
 ### Step 1: done Issue リスト取得
 
 ```bash
 DONE_LIST=$(jq -r '.done[]' "$PHASE_RESULTS_JSON" 2>/dev/null || true)
 VERIFY_COUNT=0
 MAX_VERIFY=3
-
-declare -a PRECHECK_WARNINGS=()
-declare -a PRECHECK_FAILS=()
 ```
 
 ### Step 2: 各 done Issue を verify (最大 3 件)

--- a/plugins/twl/commands/autopilot-pilot-precheck.md
+++ b/plugins/twl/commands/autopilot-pilot-precheck.md
@@ -50,7 +50,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 HEALTH_CHECK="${SCRIPT_DIR}/../scripts/worktree-health-check.sh"
 
 if [[ -x "$HEALTH_CHECK" ]]; then
-  REFSPEC_RESULT=$(bash "$HEALTH_CHECK" --skip-remote-check 2>/dev/null || true)
+  REFSPEC_RESULT=$(bash "$HEALTH_CHECK" --skip-remote-check 2>&1 || true)
   if echo "$REFSPEC_RESULT" | grep -q "^WARN:"; then
     while IFS= read -r warn_line; do
       [[ "$warn_line" =~ ^WARN: ]] && \

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -387,12 +387,14 @@ step_worktree_create() {
     ok "worktree-create" "既に worktree 内（branch=$branch）— スキップ"
     return 0
   fi
-  python3 -m twl.autopilot.worktree create "$@"
   # AC-3: post-create refspec 自動設定（重複防止のため --replace-all を使用）
-  local new_branch
-  new_branch="$(git branch --show-current 2>/dev/null || echo "")"
-  if [[ -n "$new_branch" && "$new_branch" != "main" && "$new_branch" != "master" ]]; then
-    git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || true
+  # twl.autopilot.worktree create は "パス: <path>" を stdout に出力するためキャプチャする
+  local create_output new_wt_path
+  create_output=$(python3 -m twl.autopilot.worktree create "$@")
+  echo "$create_output"
+  new_wt_path=$(echo "$create_output" | grep "^パス: " | sed 's/^パス: //')
+  if [[ -n "$new_wt_path" && -d "$new_wt_path" ]]; then
+    git -C "$new_wt_path" config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || true
   fi
   ok "worktree-create" "完了"
 }

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -388,6 +388,12 @@ step_worktree_create() {
     return 0
   fi
   python3 -m twl.autopilot.worktree create "$@"
+  # AC-3: post-create refspec 自動設定（重複防止のため --replace-all を使用）
+  local new_branch
+  new_branch="$(git branch --show-current 2>/dev/null || echo "")"
+  if [[ -n "$new_branch" && "$new_branch" != "main" && "$new_branch" != "master" ]]; then
+    git config --replace-all remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*' 2>/dev/null || true
+  fi
   ok "worktree-create" "完了"
 }
 

--- a/plugins/twl/scripts/worktree-health-check.sh
+++ b/plugins/twl/scripts/worktree-health-check.sh
@@ -64,13 +64,15 @@ _find_bare_root() {
     # worktree の .git ファイルが bare repo を指している場合
     if [[ -f "$current/.git" ]]; then
       local gitdir
-      gitdir=$(cat "$current/.git" | sed 's/gitdir: //')
-      # .bare/ 構造: gitdir は ../.bare または絶対パス
+      local gitdir
+      gitdir=$(sed 's/^gitdir: //' "$current/.git" | tr -d '[:space:]')
+      # .bare/ 構造: gitdir は絶対パスまたは $current 基準の相対パス
       local bare_candidate
       if [[ "$gitdir" = /* ]]; then
         bare_candidate="$gitdir"
       else
-        bare_candidate="$(dirname "$current")/$gitdir"
+        # 相対パスは .git ファイルが存在する $current を基準に解決する
+        bare_candidate="$(cd "$current" && realpath "$gitdir" 2>/dev/null || echo "")"
       fi
       # worktrees/ サブディレクトリを除いた bare root
       bare_candidate="${bare_candidate%/worktrees/*}"
@@ -110,7 +112,7 @@ _check_refspec() {
   fi
 
   if [[ "$FIX_MODE" -eq 1 ]]; then
-    git -C "$dir" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC" 2>/dev/null
+    git -C "$dir" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC" 2>/dev/null || true
     echo "FIXED: $dir — remote.origin.fetch set to $REQUIRED_REFSPEC"
     return 0
   else

--- a/plugins/twl/scripts/worktree-health-check.sh
+++ b/plugins/twl/scripts/worktree-health-check.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# worktree-health-check.sh — bare repo / worktree の remote.origin.fetch refspec 検査
+#
+# 責務: refspec 欠落の検出と自動修復（chain停止検知の health-check.sh とは別責務）
+#
+# Usage:
+#   worktree-health-check.sh [--fix] [--bare-root <path>] [--skip-remote-check]
+#
+# Options:
+#   --fix               欠落 refspec を自動修復（git config --replace-all）
+#   --bare-root <path>  bare repo パスを明示指定（省略時は自動検出）
+#   --skip-remote-check git ls-remote によるリモート tip 比較をスキップ
+#
+# Exit codes:
+#   0  全 OK（または --fix で修復完了）
+#   1  refspec 欠落が検出された（--fix なし）
+
+set -uo pipefail
+
+REQUIRED_REFSPEC='+refs/heads/*:refs/remotes/origin/*'
+FIX_MODE=0
+BARE_ROOT_OVERRIDE=""
+SKIP_REMOTE_CHECK=0
+WARN_COUNT=0
+
+# ---------------------------------------------------------------------------
+# 引数パース
+# ---------------------------------------------------------------------------
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)                FIX_MODE=1; shift ;;
+    --bare-root)          BARE_ROOT_OVERRIDE="$2"; shift 2 ;;
+    --skip-remote-check)  SKIP_REMOTE_CHECK=1; shift ;;
+    -h|--help)
+      cat <<EOF
+Usage: $(basename "$0") [--fix] [--bare-root <path>] [--skip-remote-check]
+
+Checks remote.origin.fetch refspec for bare repo and all worktrees.
+
+Options:
+  --fix               Auto-repair missing refspecs (git config --replace-all)
+  --bare-root <path>  Override bare repo path (default: auto-detect)
+  --skip-remote-check Skip git ls-remote tip comparison
+EOF
+      exit 0
+      ;;
+    *) shift ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# bare root 検出
+# ---------------------------------------------------------------------------
+_find_bare_root() {
+  # 1. 明示指定があればそれを使う
+  if [[ -n "$BARE_ROOT_OVERRIDE" ]]; then
+    echo "$BARE_ROOT_OVERRIDE"
+    return 0
+  fi
+
+  # 2. CWD から .git を辿り bare repo を検出
+  local current="$PWD"
+  while [[ "$current" != "/" ]]; do
+    # worktree の .git ファイルが bare repo を指している場合
+    if [[ -f "$current/.git" ]]; then
+      local gitdir
+      gitdir=$(cat "$current/.git" | sed 's/gitdir: //')
+      # .bare/ 構造: gitdir は ../.bare または絶対パス
+      local bare_candidate
+      if [[ "$gitdir" = /* ]]; then
+        bare_candidate="$gitdir"
+      else
+        bare_candidate="$(dirname "$current")/$gitdir"
+      fi
+      # worktrees/ サブディレクトリを除いた bare root
+      bare_candidate="${bare_candidate%/worktrees/*}"
+      if [[ -d "$bare_candidate" ]]; then
+        echo "$bare_candidate"
+        return 0
+      fi
+    fi
+    current="$(dirname "$current")"
+  done
+
+  # 3. フォールバック: CWD 自体が bare repo
+  if git -C "$PWD" rev-parse --is-bare-repository 2>/dev/null | grep -q "^true$"; then
+    echo "$PWD"
+    return 0
+  fi
+
+  echo ""
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# 単一ディレクトリの refspec チェック
+# ---------------------------------------------------------------------------
+_check_refspec() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+
+  local current_fetch
+  current_fetch=$(git -C "$dir" config --get-all remote.origin.fetch 2>/dev/null || true)
+
+  if echo "$current_fetch" | grep -qF "$REQUIRED_REFSPEC"; then
+    echo "OK: $dir — remote.origin.fetch OK"
+    return 0
+  fi
+
+  if [[ "$FIX_MODE" -eq 1 ]]; then
+    git -C "$dir" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC" 2>/dev/null
+    echo "FIXED: $dir — remote.origin.fetch set to $REQUIRED_REFSPEC"
+    return 0
+  else
+    echo "WARN: $dir — remote.origin.fetch missing required refspec ($REQUIRED_REFSPEC)"
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return 0
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# メイン: bare root 検出 → 全 worktree 列挙 → チェック
+# ---------------------------------------------------------------------------
+BARE_ROOT=$(_find_bare_root || true)
+
+if [[ -z "$BARE_ROOT" ]]; then
+  echo "WARN: bare repo root を自動検出できませんでした。CWD のみをチェックします。" >&2
+  _check_refspec "$PWD"
+else
+  # bare repo 本体の config をチェック
+  _check_refspec "$BARE_ROOT"
+
+  # git worktree list --porcelain で全 worktree を列挙
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^worktree\ (.+)$ ]]; then
+      local_wt="${BASH_REMATCH[1]}"
+      # bare root 自体は既にチェック済みなのでスキップ
+      [[ "$local_wt" == "$BARE_ROOT" ]] && continue
+      _check_refspec "$local_wt"
+    fi
+  done < <(git -C "$BARE_ROOT" worktree list --porcelain 2>/dev/null || true)
+fi
+
+# ---------------------------------------------------------------------------
+# オプション: remote tip との比較（ネットワーク利用可能時のみ）
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_REMOTE_CHECK" -eq 0 ]]; then
+  LOCAL_TIP=$(git -C "${BARE_ROOT:-$PWD}" show-ref refs/remotes/origin/main 2>/dev/null | awk '{print $1}' || true)
+  if [[ -n "$LOCAL_TIP" ]]; then
+    REMOTE_TIP=$(timeout 5 git -C "${BARE_ROOT:-$PWD}" ls-remote origin main 2>/dev/null | awk '{print $1}' || true)
+    if [[ -n "$REMOTE_TIP" && "$LOCAL_TIP" != "$REMOTE_TIP" ]]; then
+      echo "WARN: origin/main is stale (local=$LOCAL_TIP remote=$REMOTE_TIP) — run: git fetch origin"
+    fi
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# 結果
+# ---------------------------------------------------------------------------
+if [[ "$WARN_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats
+++ b/plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats
@@ -1,0 +1,305 @@
+#!/usr/bin/env bats
+# worktree-create-refspec.bats
+# Requirement: worktree-create での refspec 自動設定
+# Spec: deltaspec/changes/issue-471/specs/worktree-refspec-guard/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# chain-runner.sh の step_worktree_create() が worktree 作成後に
+# remote.origin.fetch refspec を自動設定することを検証する。
+#
+# テスト double 方針:
+#   - python3 -m twl.autopilot.worktree は stub で代替
+#   - git worktree add は実際に実行（一時 bare repo 経由）
+#   - refspec 設定ロジックを dispatch script として切り出してテスト
+
+load '../../bats/helpers/common.bash'
+
+REQUIRED_REFSPEC='+refs/heads/*:refs/remotes/origin/*'
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  # ---- 一時 bare repo を作成（worktree の起点） ----
+  BARE_REPO="$(mktemp -d)"
+  export BARE_REPO
+
+  (
+    cd "$BARE_REPO"
+    git init --bare -q
+    git config remote.origin.url "https://example.com/repo.git"
+    git config remote.origin.fetch "$REQUIRED_REFSPEC"
+  )
+
+  # ---- main worktree 相当のディレクトリを作成 ----
+  MAIN_WT="$(mktemp -d)"
+  export MAIN_WT
+
+  (
+    cd "$MAIN_WT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit --allow-empty -m "initial" -q
+    git config remote.origin.url "https://example.com/repo.git"
+    git config remote.origin.fetch "$REQUIRED_REFSPEC"
+  )
+
+  # ---- post-worktree-create refspec 設定スクリプトを SANDBOX に配置 ----
+  _write_post_create_script
+
+  # ---- worktree-health-check.sh も SANDBOX に配置 ----
+  _write_health_check_script
+}
+
+teardown() {
+  common_teardown
+  if [[ -n "${BARE_REPO:-}" && -d "$BARE_REPO" ]]; then
+    rm -rf "$BARE_REPO"
+  fi
+  if [[ -n "${MAIN_WT:-}" && -d "$MAIN_WT" ]]; then
+    rm -rf "$MAIN_WT"
+  fi
+  if [[ -n "${NEW_WT:-}" && -d "$NEW_WT" ]]; then
+    rm -rf "$NEW_WT"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# post-worktree-create refspec 設定スクリプト
+# (chain-runner.sh の step_worktree_create() 後処理を模倣)
+# ---------------------------------------------------------------------------
+
+_write_post_create_script() {
+  cat > "$SANDBOX/scripts/post-worktree-create-refspec.sh" << 'SCRIPT_EOF'
+#!/usr/bin/env bash
+# post-worktree-create-refspec.sh
+# step_worktree_create() 完了後の refspec 自動設定処理
+# Usage: post-worktree-create-refspec.sh <worktree-path>
+#
+# 新規 worktree の remote.origin.fetch を +refs/heads/*:refs/remotes/origin/*
+# に --replace-all で設定する。
+
+set -uo pipefail
+
+REQUIRED_REFSPEC='+refs/heads/*:refs/remotes/origin/*'
+WORKTREE_PATH="${1:-}"
+
+if [[ -z "$WORKTREE_PATH" || ! -d "$WORKTREE_PATH" ]]; then
+  echo "ERROR: worktree path required" >&2
+  exit 1
+fi
+
+# --replace-all で既存エントリを置換（重複防止）
+git -C "$WORKTREE_PATH" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC"
+echo "OK: refspec set for $WORKTREE_PATH"
+exit 0
+SCRIPT_EOF
+  chmod +x "$SANDBOX/scripts/post-worktree-create-refspec.sh"
+}
+
+_write_health_check_script() {
+  cat > "$SANDBOX/scripts/worktree-health-check.sh" << 'SCRIPT_EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+
+REQUIRED_REFSPEC='+refs/heads/*:refs/remotes/origin/*'
+FIX_MODE=0
+DIRS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)   FIX_MODE=1; shift ;;
+    --dirs)
+      shift
+      while [[ $# -gt 0 && "$1" != --* ]]; do
+        DIRS+=("$1"); shift
+      done
+      ;;
+    *) shift ;;
+  esac
+done
+
+if [[ ${#DIRS[@]} -eq 0 && -n "${CHECK_DIRS:-}" ]]; then
+  read -ra DIRS <<< "$CHECK_DIRS"
+fi
+
+if [[ ${#DIRS[@]} -eq 0 ]]; then
+  DIRS=("$(pwd)")
+fi
+
+WARN_COUNT=0
+
+_check_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+
+  local current_fetch
+  current_fetch=$(git -C "$dir" config --get-all remote.origin.fetch 2>/dev/null || true)
+
+  if echo "$current_fetch" | grep -qF "$REQUIRED_REFSPEC"; then
+    echo "OK: $dir — remote.origin.fetch contains required refspec"
+    return 0
+  fi
+
+  if [[ "$FIX_MODE" -eq 1 ]]; then
+    git -C "$dir" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC"
+    echo "FIXED: $dir — remote.origin.fetch set to $REQUIRED_REFSPEC"
+    return 0
+  else
+    echo "WARN: $dir — remote.origin.fetch missing required refspec"
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return 0
+  fi
+}
+
+for d in "${DIRS[@]}"; do
+  _check_dir "$d"
+done
+
+[[ "$WARN_COUNT" -gt 0 ]] && exit 1
+exit 0
+SCRIPT_EOF
+  chmod +x "$SANDBOX/scripts/worktree-health-check.sh"
+}
+
+# ヘルパー: 新規 worktree ディレクトリを作成して git init
+_make_new_worktree() {
+  NEW_WT="$(mktemp -d)"
+  export NEW_WT
+  (
+    cd "$NEW_WT"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit --allow-empty -m "initial" -q
+    git config remote.origin.url "https://example.com/repo.git"
+    # fetch refspec は意図的に設定しない（worktree 作成直後の状態を模擬）
+  )
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 新規 worktree 作成後の refspec 設定
+# WHEN chain-runner.sh worktree-create が新規 worktree の作成に成功した
+# THEN 新規 worktree で git config --get-all remote.origin.fetch が
+#      +refs/heads/*:refs/remotes/origin/* を返す
+# ---------------------------------------------------------------------------
+
+@test "worktree-create 後: post-create スクリプト実行後に正しい refspec が設定される" {
+  _make_new_worktree
+
+  bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+
+  run git -C "$NEW_WT" config --get-all remote.origin.fetch
+  assert_success
+  assert_output '+refs/heads/*:refs/remotes/origin/*'
+}
+
+@test "worktree-create 後: post-create スクリプトが exit code 0 で終了する" {
+  _make_new_worktree
+
+  run bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+  assert_success
+}
+
+@test "worktree-create 後: worktree-health-check が新規 worktree を OK と判定する" {
+  _make_new_worktree
+
+  bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" --dirs "$NEW_WT"
+  assert_success
+  assert_output --partial "OK"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 既存正常 refspec の保持（重複エントリを追加しない）
+# WHEN 新規 worktree で既に remote.origin.fetch = +refs/heads/*:refs/remotes/origin/*
+#      が設定されている
+# THEN 重複エントリを追加しない（--replace-all を使用する）
+# ---------------------------------------------------------------------------
+
+@test "重複防止: post-create を2回実行してもエントリが1件のみ" {
+  _make_new_worktree
+
+  bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+  bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+
+  run git -C "$NEW_WT" config --get-all remote.origin.fetch
+  assert_success
+  [[ "$(echo "$output" | wc -l)" -eq 1 ]]
+}
+
+@test "重複防止: post-create 後の refspec が正確に1行である" {
+  _make_new_worktree
+  # 事前に2つの fetch refspec を追加
+  git -C "$NEW_WT" config --add remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+  git -C "$NEW_WT" config --add remote.origin.fetch '+refs/heads/dev:refs/remotes/origin/dev'
+
+  bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+
+  run git -C "$NEW_WT" config --get-all remote.origin.fetch
+  assert_success
+  assert_output '+refs/heads/*:refs/remotes/origin/*'
+}
+
+@test "重複防止: 既に正しい refspec が設定済みの場合も exit code 0 を返す" {
+  _make_new_worktree
+  git -C "$NEW_WT" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+
+  run bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "$NEW_WT"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: worktree パスが指定されなかった場合
+# ---------------------------------------------------------------------------
+
+@test "エッジケース: 引数なしで post-create スクリプトを実行すると exit code 1" {
+  run bash "$SANDBOX/scripts/post-worktree-create-refspec.sh"
+  assert_failure
+}
+
+@test "エッジケース: 存在しないパスを渡すと exit code 1 で ERROR を出力する" {
+  run bash "$SANDBOX/scripts/post-worktree-create-refspec.sh" "/nonexistent/worktree/$$"
+  assert_failure
+  assert_output --partial "ERROR"
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 複数 worktree への適用
+# ---------------------------------------------------------------------------
+
+@test "エッジケース: worktree-health-check --fix で複数 worktree を一括設定できる" {
+  local wt2
+  wt2="$(mktemp -d)"
+  (
+    cd "$wt2"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit --allow-empty -m "initial" -q
+    git config remote.origin.url "https://example.com/repo.git"
+    # fetch refspec 未設定
+  )
+
+  _make_new_worktree
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$NEW_WT" "$wt2"
+
+  rm -rf "$wt2"
+  assert_success
+}
+
+@test "エッジケース: main worktree に正しい refspec がある場合 OK を返す" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$MAIN_WT"
+  assert_success
+  assert_output --partial "OK"
+}

--- a/plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats
+++ b/plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats
@@ -54,10 +54,6 @@ setup() {
   # ---- テスト対象スクリプトを SANDBOX に配置 ----
   mkdir -p "$SANDBOX/scripts"
   _write_health_check_script
-
-  # ---- git ls-remote スタブ（ネットワーク不要） ----
-  # デフォルト: local と remote が一致（stale なし）
-  stub_command "git_ls_remote_stub" 'echo "abc123\trefs/heads/main"'
 }
 
 teardown() {

--- a/plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats
+++ b/plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats
@@ -1,0 +1,414 @@
+#!/usr/bin/env bats
+# worktree-refspec-guard.bats
+# Requirement: worktree-health-check スクリプト
+# Spec: deltaspec/changes/issue-471/specs/worktree-refspec-guard/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# worktree-health-check.sh は bare repo および全 worktree の
+# remote.origin.fetch refspec を検査・修復するスクリプト。
+#
+# テスト構造:
+#   - setup()    : 一時 bare repo + worktree を作成し refspec を設定
+#   - teardown() : 一時ディレクトリを全削除
+#
+# テスト double 方針:
+#   - git ls-remote (ネットワーク呼び出し) はスタブで差し替える
+#   - スクリプト本体は SANDBOX/scripts/worktree-health-check.sh を使用
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  # ---- 一時 bare repo を作成 ----
+  BARE_DIR="$(mktemp -d)"
+  export BARE_DIR
+
+  (
+    cd "$BARE_DIR"
+    git init --bare -q
+    # bare repo に remote.origin.fetch を正しく設定
+    git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+    git config remote.origin.url "https://example.com/repo.git"
+  )
+
+  # ---- 通常リポジトリを作成して worktree の代替とする ----
+  WORKTREE_DIR="$(mktemp -d)"
+  export WORKTREE_DIR
+
+  (
+    cd "$WORKTREE_DIR"
+    git init -q
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    git commit --allow-empty -m "initial" -q
+    # worktree に remote.origin.fetch を正しく設定
+    git config remote.origin.url "https://example.com/repo.git"
+    git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+  )
+
+  # ---- テスト対象スクリプトを SANDBOX に配置 ----
+  mkdir -p "$SANDBOX/scripts"
+  _write_health_check_script
+
+  # ---- git ls-remote スタブ（ネットワーク不要） ----
+  # デフォルト: local と remote が一致（stale なし）
+  stub_command "git_ls_remote_stub" 'echo "abc123\trefs/heads/main"'
+}
+
+teardown() {
+  common_teardown
+  if [[ -n "${BARE_DIR:-}" && -d "$BARE_DIR" ]]; then
+    rm -rf "$BARE_DIR"
+  fi
+  if [[ -n "${WORKTREE_DIR:-}" && -d "$WORKTREE_DIR" ]]; then
+    rm -rf "$WORKTREE_DIR"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# worktree-health-check.sh 本体をサンドボックスに書き出すヘルパー
+# ---------------------------------------------------------------------------
+
+_write_health_check_script() {
+  cat > "$SANDBOX/scripts/worktree-health-check.sh" << 'SCRIPT_EOF'
+#!/usr/bin/env bash
+# worktree-health-check.sh
+# Usage: worktree-health-check.sh [--fix] [--dirs <dir1> <dir2> ...]
+#
+# bare repo および worktree の remote.origin.fetch refspec を検査する。
+# --fix  : 欠落 refspec を +refs/heads/*:refs/remotes/origin/* に修復
+# --dirs : チェック対象ディレクトリを明示指定（未指定時は自動検出）
+#
+# Exit codes:
+#   0  : 全 OK（または --fix で修復完了）
+#   1  : refspec 欠落が検出され --fix なし
+
+set -uo pipefail
+
+REQUIRED_REFSPEC='+refs/heads/*:refs/remotes/origin/*'
+FIX_MODE=0
+DIRS=()
+
+# 引数パース
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --fix)   FIX_MODE=1; shift ;;
+    --dirs)
+      shift
+      while [[ $# -gt 0 && "$1" != --* ]]; do
+        DIRS+=("$1"); shift
+      done
+      ;;
+    *) shift ;;
+  esac
+done
+
+# 対象ディレクトリが指定されていない場合は環境変数 CHECK_DIRS を使用
+if [[ ${#DIRS[@]} -eq 0 && -n "${CHECK_DIRS:-}" ]]; then
+  read -ra DIRS <<< "$CHECK_DIRS"
+fi
+
+# チェック対象が空の場合は自分の CWD を使用
+if [[ ${#DIRS[@]} -eq 0 ]]; then
+  DIRS=("$(pwd)")
+fi
+
+WARN_COUNT=0
+
+_check_dir() {
+  local dir="$1"
+  if [[ ! -d "$dir" ]]; then
+    return 0
+  fi
+
+  local current_fetch
+  current_fetch=$(git -C "$dir" config --get-all remote.origin.fetch 2>/dev/null || true)
+
+  if echo "$current_fetch" | grep -qF "$REQUIRED_REFSPEC"; then
+    echo "OK: $dir — remote.origin.fetch contains required refspec"
+    return 0
+  fi
+
+  if [[ "$FIX_MODE" -eq 1 ]]; then
+    git -C "$dir" config --replace-all remote.origin.fetch "$REQUIRED_REFSPEC"
+    echo "FIXED: $dir — remote.origin.fetch set to $REQUIRED_REFSPEC"
+    return 0
+  else
+    echo "WARN: $dir — remote.origin.fetch missing required refspec"
+    WARN_COUNT=$((WARN_COUNT + 1))
+    return 0
+  fi
+}
+
+for d in "${DIRS[@]}"; do
+  _check_dir "$d"
+done
+
+if [[ "$WARN_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+
+exit 0
+SCRIPT_EOF
+  chmod +x "$SANDBOX/scripts/worktree-health-check.sh"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: refspec 欠落の検出
+# WHEN .bare/config または任意の worktree で remote.origin.fetch が
+#      +refs/heads/*:refs/remotes/origin/* を含まない
+# THEN WARN メッセージを標準出力に出力し exit code 1 で終了する
+# ---------------------------------------------------------------------------
+
+@test "refspec 欠落検出: refspec を削除した worktree を渡すと exit code 1 を返す" {
+  # refspec を削除して欠落を模擬
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_failure
+}
+
+@test "refspec 欠落検出: WARN メッセージを stdout に出力する" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_output --partial "WARN"
+}
+
+@test "refspec 欠落検出: WARN 出力に対象ディレクトリのパスを含む" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_output --partial "$WORKTREE_DIR"
+}
+
+@test "refspec 欠落検出: bare repo の refspec を削除すると exit code 1 を返す" {
+  git -C "$BARE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$BARE_DIR"
+
+  assert_failure
+}
+
+@test "refspec 欠落検出: 複数ディレクトリのうち1つが欠落でも exit code 1 を返す" {
+  local ok_dir
+  ok_dir="$(mktemp -d)"
+  git -C "$ok_dir" init -q
+  git -C "$ok_dir" config remote.origin.url "https://example.com/repo.git"
+  git -C "$ok_dir" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$ok_dir" "$WORKTREE_DIR"
+
+  rm -rf "$ok_dir"
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --fix による自動修復
+# WHEN worktree-health-check.sh --fix を実行し欠落 refspec が検出された
+# THEN git config --replace-all remote.origin.fetch を適用し exit code 0 で終了する
+# ---------------------------------------------------------------------------
+
+@test "--fix による修復: exit code 0 で終了する" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  assert_success
+}
+
+@test "--fix による修復: git config --get-all が正しい refspec を返す" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  run git -C "$WORKTREE_DIR" config --get-all remote.origin.fetch
+  assert_success
+  assert_output '+refs/heads/*:refs/remotes/origin/*'
+}
+
+@test "--fix による修復: FIXED メッセージを stdout に出力する" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  assert_output --partial "FIXED"
+}
+
+@test "--fix による修復: bare repo の欠落 refspec も修復する" {
+  git -C "$BARE_DIR" config --unset remote.origin.fetch
+
+  bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$BARE_DIR"
+
+  run git -C "$BARE_DIR" config --get-all remote.origin.fetch
+  assert_success
+  assert_output '+refs/heads/*:refs/remotes/origin/*'
+}
+
+@test "--fix による修復: 複数ディレクトリを一括修復して exit code 0 を返す" {
+  local extra_dir
+  extra_dir="$(mktemp -d)"
+  git -C "$extra_dir" init -q
+  git -C "$extra_dir" config remote.origin.url "https://example.com/repo.git"
+
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR" "$extra_dir"
+
+  rm -rf "$extra_dir"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 全 OK の場合
+# WHEN .bare/config と全 worktree の remote.origin.fetch が正しく設定されている
+# THEN OK メッセージを出力し exit code 0 で終了する
+# ---------------------------------------------------------------------------
+
+@test "全 OK: 正しく設定された worktree で exit code 0 を返す" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_success
+}
+
+@test "全 OK: OK メッセージを stdout に出力する" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_output --partial "OK"
+}
+
+@test "全 OK: bare repo が正しく設定されている場合も exit code 0 を返す" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$BARE_DIR"
+
+  assert_success
+}
+
+@test "全 OK: 複数ディレクトリが全て正常な場合 exit code 0 を返す" {
+  local extra_dir
+  extra_dir="$(mktemp -d)"
+  git -C "$extra_dir" init -q
+  git -C "$extra_dir" config remote.origin.url "https://example.com/repo.git"
+  git -C "$extra_dir" config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR" "$extra_dir"
+
+  rm -rf "$extra_dir"
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --fix 使用時に重複エントリを作らない（--replace-all 使用）
+# WHEN 新規 worktree で既に remote.origin.fetch = +refs/heads/*:refs/remotes/origin/* が設定されている
+# THEN 重複エントリを追加しない（--replace-all を使用する）
+# ---------------------------------------------------------------------------
+
+@test "重複防止: --fix を2回実行してもエントリが1件のみ" {
+  bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+  bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  run git -C "$WORKTREE_DIR" config --get-all remote.origin.fetch
+  assert_success
+  # 出力は正確に1行（重複なし）
+  [[ "$(echo "$output" | wc -l)" -eq 1 ]]
+}
+
+@test "重複防止: 既存の正常 refspec がある状態で --fix を実行しても OK を返す" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  assert_success
+  assert_output --partial "OK"
+}
+
+@test "重複防止: --fix 後の refspec が +refs/heads/*:refs/remotes/origin/* のみ" {
+  # 先に別の fetch refspec を追加
+  git -C "$WORKTREE_DIR" config --add remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+
+  bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --fix --dirs "$WORKTREE_DIR"
+
+  # --replace-all により required refspec に置き換わっていることを確認
+  run git -C "$WORKTREE_DIR" config --get-all remote.origin.fetch
+  assert_output '+refs/heads/*:refs/remotes/origin/*'
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: 存在しないディレクトリを渡してもクラッシュしない
+# ---------------------------------------------------------------------------
+
+@test "エッジケース: 存在しないディレクトリを渡してもスクリプトが終了する" {
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "/nonexistent/path/$$"
+
+  # exit code 0 または 1 のどちらかで終了し、クラッシュしないことを検証
+  [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "エッジケース: git 管理外ディレクトリを渡しても exit code 1 にならない" {
+  local non_git_dir
+  non_git_dir="$(mktemp -d)"
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$non_git_dir"
+
+  rm -rf "$non_git_dir"
+  # git config が失敗しても OK 扱い（不在 = チェック不要）または 1 のどちらか
+  [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+@test "エッジケース: --dirs なしでも引数なし実行でクラッシュしない" {
+  # CWD を非 git ディレクトリに変更して実行
+  run bash -c "cd /tmp && bash '$SANDBOX/scripts/worktree-health-check.sh'"
+  [[ "$status" -eq 0 || "$status" -eq 1 ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case: refspec が部分一致でも不一致扱いになること
+# ---------------------------------------------------------------------------
+
+@test "エッジケース: refs/heads/main のみ設定された場合は WARN を出力する" {
+  git -C "$WORKTREE_DIR" config remote.origin.fetch '+refs/heads/main:refs/remotes/origin/main'
+
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_failure
+  assert_output --partial "WARN"
+}
+
+@test "エッジケース: refspec が空文字列の場合は WARN を出力する" {
+  git -C "$WORKTREE_DIR" config --unset remote.origin.fetch 2>/dev/null || true
+  # 空の fetch refspec を設定しようとすると git config が拒否するため
+  # --unset で削除した状態 (空) をテスト
+  run bash "$SANDBOX/scripts/worktree-health-check.sh" \
+    --dirs "$WORKTREE_DIR"
+
+  assert_failure
+  assert_output --partial "WARN"
+}


### PR DESCRIPTION
## 概要

Issue #471 の恒久対策実装。bare repo / worktree の `remote.origin.fetch` refspec 欠落を検出・修復する仕組みを追加。

## 変更内容

### AC-1: worktree-health-check.sh 新規追加
- `plugins/twl/scripts/worktree-health-check.sh`
- bare root 自動検出（.git ファイル traversal）
- `git worktree list --porcelain` で全 worktree を列挙
- `--fix`: `git config --replace-all` で欠落 refspec を自動修復
- `--skip-remote-check`: ネットワークチェックをスキップ
- origin/main stale 検出（タイムアウト 5 秒）

### AC-2: autopilot-pilot-precheck.md に Step 0 追加
- refspec チェックを PR merge 直前の precheck に統合
- 欠落検出時は `PRECHECK_WARNINGS` に追加して継続（abort しない）

### AC-3: chain-runner.sh worktree-create post-create hook
- worktree 作成後に `git config --replace-all remote.origin.fetch` を自動設定

### AC-4: bats テスト追加
- `plugins/twl/tests/unit/worktree-refspec-guard/worktree-refspec-guard.bats`
- `plugins/twl/tests/unit/worktree-refspec-guard/worktree-create-refspec.bats`

### AC-5: plugins/twl/CLAUDE.md 更新
- Bare repo 構造検証セクションに第 4 条件（refspec）を追加

Closes #471