### PR TITLE
fix(#470): Pilot state file path 誤認識 + pr フィールド書き込み権限修正

### DIFF
--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -31,7 +31,7 @@ _TRANSITIONS: dict[str, set[str]] = {
     "conflict": {"merge-ready", "failed"},
 }
 
-_PILOT_ISSUE_ALLOWED_KEYS = {"status", "merged_at", "failure", "manual_override", "workflow_done"}
+_PILOT_ISSUE_ALLOWED_KEYS = {"status", "merged_at", "failure", "manual_override", "workflow_done", "pr"}
 
 
 def _autopilot_dir() -> Path:
@@ -39,8 +39,11 @@ def _autopilot_dir() -> Path:
 
     Fallback uses ``git worktree list --porcelain`` to find the main
     worktree (the entry on ``branch refs/heads/main``) and appends
-    ``.autopilot``.  In bare-repo setups the first entry is the bare
-    root, so we skip it and look for the ``main`` branch entry.
+    ``.autopilot``.  In bare-repo setups the ``.autopilot`` directory
+    typically lives as a sibling of the main worktree (e.g.
+    ``twill/.autopilot/`` next to ``twill/main/``), so we check the
+    parent of the main worktree first before falling back to the
+    worktree-local path.
     """
     env = os.environ.get("AUTOPILOT_DIR", "")
     if env:
@@ -83,9 +86,16 @@ def _autopilot_dir() -> Path:
             if first_real_wt is None:
                 first_real_wt = wt_path
             if is_main_branch:
+                # Prefer bare sibling: <main_wt>/../.autopilot
+                bare_sibling = Path(wt_path).parent / ".autopilot"
+                if bare_sibling.exists():
+                    return bare_sibling
                 return Path(wt_path) / ".autopilot"
         # No main branch found — use first real worktree
         if first_real_wt:
+            bare_sibling = Path(first_real_wt).parent / ".autopilot"
+            if bare_sibling.exists():
+                return bare_sibling
             return Path(first_real_wt) / ".autopilot"
     except Exception:
         pass
@@ -198,7 +208,14 @@ class StateManager:
             return self._init_issue(file, issue)  # type: ignore[arg-type]
 
         if not file.is_file():
-            raise StateError(f"ファイルが存在しません: {file}")
+            bare_sibling_dir = self.autopilot_dir.parent.parent / ".autopilot"
+            bare_sibling = bare_sibling_dir / file.relative_to(self.autopilot_dir)
+            hint = (
+                f"\n  試したパス: {file}"
+                f"\n  bare sibling 候補: {bare_sibling}"
+                "\n  解決策: export AUTOPILOT_DIR=<.autopilot への絶対パス>"
+            )
+            raise StateError(f"ファイルが存在しません: {file}{hint}")
         if not sets:
             raise StateArgError("--set が指定されていません")
 

--- a/cli/twl/tests/autopilot/test_state.py
+++ b/cli/twl/tests/autopilot/test_state.py
@@ -1,0 +1,175 @@
+"""Tests for state.py autopilot dir resolution and RBAC fixes (Issue #470).
+
+Covers:
+  - _autopilot_dir() bare sibling detection
+  - _autopilot_dir() fallback to main worktree
+  - Pilot role is allowed to write the `pr` field
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from twl.autopilot.state import StateError, StateManager, _autopilot_dir
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PORCELAIN_TEMPLATE = """\
+worktree {main_wt}
+HEAD abc1234def5678901234567890123456789012ab
+branch refs/heads/main
+
+worktree {feature_wt}
+HEAD def5678901234567890123456789012abcdef12
+branch refs/heads/fix/some-issue
+
+"""
+
+
+def _make_porcelain(main_wt: str, feature_wt: str) -> str:
+    return _PORCELAIN_TEMPLATE.format(main_wt=main_wt, feature_wt=feature_wt)
+
+
+# ---------------------------------------------------------------------------
+# _autopilot_dir(): bare sibling detection
+# ---------------------------------------------------------------------------
+
+
+class TestAutopilotDirResolution:
+    def test_env_var_takes_priority(self, tmp_path: Path) -> None:
+        """AUTOPILOT_DIR env var always wins regardless of filesystem layout."""
+        custom = tmp_path / "custom" / ".autopilot"
+        custom.mkdir(parents=True)
+        with patch.dict("os.environ", {"AUTOPILOT_DIR": str(custom)}):
+            result = _autopilot_dir()
+        assert result == custom
+
+    def test_bare_sibling_preferred_when_exists(self, tmp_path: Path) -> None:
+        """bare sibling (<main_wt>/../.autopilot) is returned when it exists."""
+        # Simulate: tmp_path/main/  (main worktree)
+        #           tmp_path/.autopilot/  (bare sibling — actual state dir)
+        main_wt = tmp_path / "main"
+        main_wt.mkdir()
+        bare_sibling = tmp_path / ".autopilot"
+        bare_sibling.mkdir()
+
+        porcelain = _make_porcelain(str(main_wt), str(tmp_path / "feature"))
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "subprocess.check_output",
+                return_value=porcelain,
+            ),
+        ):
+            result = _autopilot_dir()
+
+        assert result == bare_sibling
+
+    def test_main_worktree_fallback_when_no_bare_sibling(self, tmp_path: Path) -> None:
+        """Falls back to <main_wt>/.autopilot when bare sibling does not exist."""
+        main_wt = tmp_path / "main"
+        main_wt.mkdir()
+        # bare sibling NOT created intentionally
+
+        porcelain = _make_porcelain(str(main_wt), str(tmp_path / "feature"))
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch(
+                "subprocess.check_output",
+                return_value=porcelain,
+            ),
+        ):
+            result = _autopilot_dir()
+
+        assert result == main_wt / ".autopilot"
+
+    def test_cwd_fallback_on_subprocess_error(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Falls back to cwd/.autopilot when git command fails."""
+        monkeypatch.chdir(tmp_path)
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("subprocess.check_output", side_effect=Exception("git not found")),
+        ):
+            result = _autopilot_dir()
+
+        assert result == tmp_path / ".autopilot"
+
+
+# ---------------------------------------------------------------------------
+# Pilot RBAC: `pr` フィールド書き込み許可
+# ---------------------------------------------------------------------------
+
+
+class TestPilotPrWriteAllowed:
+    def _make_issue_file(self, autopilot_dir: Path, issue_num: str) -> Path:
+        issues = autopilot_dir / "issues"
+        issues.mkdir(parents=True, exist_ok=True)
+        f = issues / f"issue-{issue_num}.json"
+        f.write_text(
+            json.dumps(
+                {
+                    "issue": int(issue_num),
+                    "status": "running",
+                    "branch": "fix/test",
+                    "pr": None,
+                    "window": "",
+                    "started_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-01T00:00:00Z",
+                    "current_step": "init",
+                    "retry_count": 0,
+                    "fix_instructions": None,
+                    "merged_at": None,
+                    "files_changed": [],
+                    "failure": None,
+                    "workflow_done": None,
+                    "implementation_pr": None,
+                    "deltaspec_mode": None,
+                    "is_quick": False,
+                    "is_direct": False,
+                    "mode": "propose",
+                    "llm_delegated_at": None,
+                    "llm_completed_at": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+        return f
+
+    def test_pilot_pr_write_allowed(self, tmp_path: Path) -> None:
+        """Pilot role can write the `pr` field (Issue #470 AC-2)."""
+        autopilot_dir = tmp_path / ".autopilot"
+        self._make_issue_file(autopilot_dir, "470")
+
+        mgr = StateManager(autopilot_dir=autopilot_dir)
+        # Should not raise StateError
+        result = mgr.write(
+            role="pilot",
+            type_="issue",
+            issue="470",
+            sets=["pr=509"],
+        )
+        assert "OK" in result
+
+        data = json.loads((autopilot_dir / "issues" / "issue-470.json").read_text())
+        assert data["pr"] == 509 or data["pr"] == "509"
+
+    def test_pilot_cannot_write_current_step(self, tmp_path: Path) -> None:
+        """Pilot role still cannot write fields not in _PILOT_ISSUE_ALLOWED_KEYS."""
+        autopilot_dir = tmp_path / ".autopilot"
+        self._make_issue_file(autopilot_dir, "470")
+
+        mgr = StateManager(autopilot_dir=autopilot_dir)
+        with pytest.raises(StateError):
+            mgr.write(
+                role="pilot",
+                type_="issue",
+                issue="470",
+                sets=["current_step=evil"],
+            )

--- a/deltaspec/changes/issue-470/.deltaspec.yaml
+++ b/deltaspec/changes/issue-470/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-11
+issue: 470
+name: issue-470
+status: pending

--- a/deltaspec/changes/issue-470/design.md
+++ b/deltaspec/changes/issue-470/design.md
@@ -1,0 +1,47 @@
+## Context
+
+bare repo 構成（`twill/.bare`, `twill/main/`, `twill/.autopilot/`）において、state CLI の `_autopilot_dir()` fallback は `git worktree list` で main worktree path を取得し `<main_wt>/.autopilot` を返す。しかし実際の state file は bare sibling（`<main_wt>/../.autopilot`）に配置されており、Pilot が `AUTOPILOT_DIR` 未設定で実行すると存在しないパスを参照してしまう。
+
+また `_PILOT_ISSUE_ALLOWED_KEYS` に `pr` が含まれないため、Worker が `pr` を書き残さなかったケースで Pilot による recovery（Emergency Bypass など）が不能になる。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `_autopilot_dir()` fallback で bare sibling（`<main_wt>/../.autopilot`）を優先的に試す
+- `_PILOT_ISSUE_ALLOWED_KEYS` に `pr` を追加する
+- ファイル不在時エラーメッセージに試したパスと `AUTOPILOT_DIR` export 推奨を追加する
+- `autopilot-orchestrator.sh` で `AUTOPILOT_DIR` 未設定時 warning を出す
+- `co-autopilot/SKILL.md` に `AUTOPILOT_DIR` export 必須を明示する
+- pytest で bare sibling / main worktree 両パターンのテストを追加する
+
+**Non-Goals:**
+- `AUTOPILOT_DIR` の自動 export（env propagation の根本的な変更）
+- state.py 内部からの gh API 呼び出し（PR 実在検証は呼び出し元の責務）
+- bare repo でない環境（standard git repo）の動作変更
+
+## Decisions
+
+### `_autopilot_dir()` の fallback 順序
+
+現在: env var → main worktree 配下 → first real worktree 配下 → cwd
+
+変更後: env var → bare sibling（`<main_wt>/../.autopilot`が存在する場合） → main worktree 配下（`<main_wt>/.autopilot`が存在する場合）→ first real worktree 配下 → cwd
+
+bare sibling を main worktree 配下より先に試す根拠: `twill/.autopilot/` が実際の配置場所であることを本機で確認済み。存在確認（`Path.exists()`）で判定するため、bare sibling が存在しない環境では既存動作にフォールバックする。
+
+### `pr` フィールド許可の設計
+
+state.py 内部では RBAC チェックのみ担う。`pr` の値が実在する GitHub PR 番号かどうかの検証は呼び出し元（orchestrator.sh や Pilot コマンド）の責務とする。これにより state.py が外部 API 依存を持たない純粋な状態管理モジュールになる。
+
+### エラーメッセージ設計
+
+`StateError` の文字列に以下を追加する:
+- 実際に試したパス一覧（`tried: [...]`）
+- `AUTOPILOT_DIR` env var の export 方法（`export AUTOPILOT_DIR=<path>`）
+
+`_resolve_file()` がエラーを raise する箇所（FileNotFoundError / StateError）でこの情報を付与する。
+
+## Risks / Trade-offs
+
+- bare sibling の存在確認を `Path.exists()` で行うため、存在しない環境では extra filesystem stat が 1 回増加するが無視できるコスト
+- `_PILOT_ISSUE_ALLOWED_KEYS` への `pr` 追加は Pilot の書き込み権限拡張。誤用リスクは呼び出し元の検証で緩和する

--- a/deltaspec/changes/issue-470/proposal.md
+++ b/deltaspec/changes/issue-470/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Pilot が `AUTOPILOT_DIR` 未設定のまま実行すると `_autopilot_dir()` が main worktree 配下（`twill/main/.autopilot/`）を返すが、実際の state file は bare sibling（`twill/.autopilot/`）にある。また `_PILOT_ISSUE_ALLOWED_KEYS` に `pr` が含まれないため、Worker が `pr` を書き残さなかった場合の Pilot による recovery が不能になる。
+
+## What Changes
+
+- `cli/twl/src/twl/autopilot/state.py`: `_autopilot_dir()` の fallback に bare sibling 探索ロジックを追加（main worktree path から `../` を試す）
+- `cli/twl/src/twl/autopilot/state.py`: `_PILOT_ISSUE_ALLOWED_KEYS` に `pr` を追加（1 行変更）
+- `cli/twl/src/twl/autopilot/state.py`: `_autopilot_dir()` のエラーメッセージ改善（試したパス一覧 + `AUTOPILOT_DIR` export 推奨）
+- `plugins/twl/scripts/autopilot-orchestrator.sh`: `AUTOPILOT_DIR` の export 必須化、未設定時 warning
+- `plugins/twl/skills/co-autopilot/SKILL.md`: `AUTOPILOT_DIR` export 前提を明示
+- `cli/twl/tests/autopilot/test_state.py`: bare sibling + main worktree 両配置パターンのテスト追加
+
+## Capabilities
+
+### New Capabilities
+
+- **bare sibling 自動解決**: `_autopilot_dir()` が main worktree path から `../` を確認し bare sibling の `.autopilot/` を優先的に返す（`twill/main/../.autopilot` = `twill/.autopilot`）
+- **Pilot `pr` 書き込み**: Emergency Bypass や recovery フローで Pilot が issue-{N}.json の `pr` フィールドを更新可能になる
+
+### Modified Capabilities
+
+- **`_autopilot_dir()` fallback 順序**: env var → main worktree 配下 → bare sibling → first real worktree → cwd の順に変更
+- **エラーメッセージ**: ファイル不在時に試したパス一覧と `AUTOPILOT_DIR` export 手順を併記
+
+## Impact
+
+- 対象モジュール: `cli/twl/src/twl/autopilot/state.py`（RBAC + パス解決）
+- 対象スクリプト: `plugins/twl/scripts/autopilot-orchestrator.sh`
+- 対象ドキュメント: `plugins/twl/skills/co-autopilot/SKILL.md`
+- 既存の `AUTOPILOT_DIR` 設定済み環境には影響なし（env var が最優先）
+- Wave 4 以降の Pilot recovery フローが安定化する

--- a/deltaspec/changes/issue-470/specs/autopilot-state-fixes/spec.md
+++ b/deltaspec/changes/issue-470/specs/autopilot-state-fixes/spec.md
@@ -1,0 +1,56 @@
+## MODIFIED Requirements
+
+### Requirement: bare sibling 優先解決
+
+`_autopilot_dir()` の fallback は env var → bare sibling → main worktree 配下 → first real worktree → cwd の順で試さなければならない（SHALL）。bare sibling とは main worktree path の親ディレクトリに `.autopilot/` が存在する場合（`Path(<main_wt>).parent / ".autopilot"`）を指す。
+
+#### Scenario: bare sibling が存在するとき
+
+- **WHEN** `AUTOPILOT_DIR` 未設定、かつ `git worktree list` で main worktree が `twill/main/` と判定され、`twill/.autopilot/` が存在する
+- **THEN** `_autopilot_dir()` は `twill/.autopilot/` を返さなければならない（SHALL）
+
+#### Scenario: bare sibling が存在せず main worktree 配下が存在するとき
+
+- **WHEN** `AUTOPILOT_DIR` 未設定、かつ `twill/.autopilot/` が存在せず `twill/main/.autopilot/` が存在する
+- **THEN** `_autopilot_dir()` は `twill/main/.autopilot/` を返さなければならない（SHALL）
+
+#### Scenario: env var が設定されているとき
+
+- **WHEN** `AUTOPILOT_DIR=/custom/path` が設定されている
+- **THEN** `_autopilot_dir()` は常に `/custom/path` を返さなければならない（SHALL、既存動作維持）
+
+### Requirement: エラーメッセージに試行パスと AUTOPILOT_DIR 案内を含める
+
+ファイル不在時の `StateError` メッセージは、実際に試したパス一覧と `AUTOPILOT_DIR` export 方法を含まなければならない（SHALL）。
+
+#### Scenario: state file が見つからないとき
+
+- **WHEN** `python3 -m twl.autopilot.state read --type issue --issue 443` を実行し、対象ファイルが存在しない
+- **THEN** エラーメッセージに「試したパス」と「`export AUTOPILOT_DIR=<path>`」の文字列が含まれなければならない（SHALL）
+
+## MODIFIED Requirements
+
+### Requirement: Pilot が `pr` フィールドを書き込み可能
+
+`_PILOT_ISSUE_ALLOWED_KEYS` に `"pr"` を追加し、Pilot role が issue-{N}.json の `pr` フィールドを更新できなければならない（SHALL）。
+
+#### Scenario: Pilot が pr フィールドを設定するとき
+
+- **WHEN** `python3 -m twl.autopilot.state write --role pilot --type issue --issue N --set "pr=467"` を実行する
+- **THEN** `StateError` を raise せずに正常終了しなければならない（SHALL）
+
+#### Scenario: Pilot が許可されていないフィールドを設定しようとするとき
+
+- **WHEN** `python3 -m twl.autopilot.state write --role pilot --type issue --issue N --set "current_step=foo"` を実行する
+- **THEN** `StateError` を raise しなければならない（SHALL、既存動作維持）
+
+## ADDED Requirements
+
+### Requirement: orchestrator.sh が AUTOPILOT_DIR 未設定時に警告する
+
+`autopilot-orchestrator.sh` は起動時に `AUTOPILOT_DIR` が空の場合、stderr に警告を出力しなければならない（SHALL）。
+
+#### Scenario: AUTOPILOT_DIR 未設定で orchestrator が起動するとき
+
+- **WHEN** `AUTOPILOT_DIR` 未設定のまま `autopilot-orchestrator.sh` を起動する
+- **THEN** stderr に `WARN: AUTOPILOT_DIR` を含む警告メッセージが出力されなければならない（SHALL）

--- a/deltaspec/changes/issue-470/tasks.md
+++ b/deltaspec/changes/issue-470/tasks.md
@@ -1,0 +1,27 @@
+## 1. state.py: RBAC 修正（pr フィールド追加）
+
+- [x] 1.1 `cli/twl/src/twl/autopilot/state.py:34` の `_PILOT_ISSUE_ALLOWED_KEYS` に `"pr"` を追加する
+
+## 2. state.py: `_autopilot_dir()` bare sibling 対応
+
+- [x] 2.1 main worktree path が判明した時点で `Path(main_wt).parent / ".autopilot"` が存在するか確認し、存在すれば即 return するロジックを追加する
+- [x] 2.2 bare sibling が存在しない場合は従来通り `Path(main_wt) / ".autopilot"` を返すよう fallback を維持する
+
+## 3. state.py: エラーメッセージ改善
+
+- [x] 3.1 `_resolve_file()` のファイル不在時エラーメッセージに「試したパス一覧」と「`export AUTOPILOT_DIR=<path>` 推奨」を追加する
+
+## 4. autopilot-orchestrator.sh: AUTOPILOT_DIR 未設定 warning
+
+- [x] 4.1 `autopilot-orchestrator.sh` の引数パース後（`export AUTOPILOT_DIR` の直後）で `AUTOPILOT_DIR` が空の場合に stderr へ warning を出力する
+
+## 5. co-autopilot/SKILL.md: AUTOPILOT_DIR export 必須化明示
+
+- [x] 5.1 `plugins/twl/skills/co-autopilot/SKILL.md` の orchestrator 起動セクションに「`AUTOPILOT_DIR` は必ず export すること（未設定時は fallback が bare sibling を自動解決するが保証されない）」を追記する
+
+## 6. テスト追加
+
+- [x] 6.1 `cli/twl/tests/autopilot/test_state.py` に `test_autopilot_dir_bare_sibling` を追加（bare sibling が存在する場合に bare sibling を返すことを検証）
+- [x] 6.2 `cli/twl/tests/autopilot/test_state.py` に `test_autopilot_dir_main_worktree_fallback` を追加（bare sibling が存在しない場合に main worktree 配下を返すことを検証）
+- [x] 6.3 `cli/twl/tests/autopilot/test_state.py` に `test_pilot_pr_write_allowed` を追加（Pilot role で `pr` フィールドの書き込みが許可されることを検証）
+- [x] 6.4 `pytest cli/twl/tests/autopilot/test_state.py -v` で全テスト通過を確認する（6/6 PASS）

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -86,6 +86,11 @@ done
 
 export AUTOPILOT_DIR
 
+# AUTOPILOT_DIR 未設定 warning
+if [[ -z "$AUTOPILOT_DIR" ]]; then
+  echo "WARN: AUTOPILOT_DIR が未設定です。state.py の fallback で自動解決を試みますが、bare sibling 構成では誤ったパスを参照する可能性があります。export AUTOPILOT_DIR=<.autopilot への絶対パス> を設定してください。" >&2
+fi
+
 # --- model 解決: CLI arg > plan.yaml > デフォルト（sonnet） ---
 # plan.yaml の model フィールドは Phase 実行モードで PLAN_FILE が確定後に読み込む
 # （SUMMARY_MODE では不要）

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -188,6 +188,8 @@ issue-{N}.json の status から自動判定:
 
 **デフォルト値**: `$PROJECT_ROOT/.autopilot/`（`autopilot-init.sh` L9 で確立: `AUTOPILOT_DIR="${AUTOPILOT_DIR:-$PROJECT_ROOT/.autopilot}"`）
 
+**MUST**: `AUTOPILOT_DIR` は orchestrator 起動前に必ず `export` すること。未設定のまま Pilot や Worker が `python3 -m twl.autopilot.state` を実行すると、bare sibling 構成（`twill/.autopilot/`）で main worktree 配下（`twill/main/.autopilot/`）を参照してしまい state file が見つからないエラーになる場合がある（Issue #470）。
+
 **override 方法**: 起動前に `export AUTOPILOT_DIR=/custom/path` を設定する。test-target worktree での隔離実行（`AUTOPILOT_DIR=/tmp/test-autopilot`）など、main worktree の `.autopilot/` を汚染しない実行に使用する。
 
 **Pilot→Worker env 継承経路**: `autopilot-launch.sh` が `--autopilot-dir DIR` を受け取り（L84）、`AUTOPILOT_ENV="AUTOPILOT_DIR=${QUOTED_AUTOPILOT_DIR}"`（L309）を構築して `env AUTOPILOT_DIR=... cld ...`（L365-366）として Worker プロセスに渡す。Worker は `AUTOPILOT_DIR` を直接 export された状態で起動するため、`state read/write` が同一ディレクトリを参照する。


### PR DESCRIPTION
## 概要

Closes #470

## 変更内容

- `state.py`: `_autopilot_dir()` fallback に bare sibling 探索を追加（bare repo 構成で `twill/.autopilot/` を優先解決）
- `state.py`: `_PILOT_ISSUE_ALLOWED_KEYS` に `pr` を追加（Emergency Bypass / recovery で Pilot が `pr` フィールドを更新可能）
- `state.py`: ファイル不在時エラーメッセージに試行パスと `AUTOPILOT_DIR` export 案内を追加
- `autopilot-orchestrator.sh`: `AUTOPILOT_DIR` 未設定時に stderr へ warning を出力
- `co-autopilot/SKILL.md`: `AUTOPILOT_DIR` export 必須を MUST として明示
- `tests/autopilot/test_state.py`: bare sibling / fallback / RBAC の pytest 追加（6 PASS）

## DeltaSpec

change: `issue-470`