### PR TITLE
feat(#482): test-target real-issues クリーンアップスクリプト

### DIFF
--- a/cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py
+++ b/cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py
@@ -1,0 +1,535 @@
+#!/usr/bin/env python3
+"""Tests for test-project-reset --real-issues cleanup requirements.
+
+Spec: deltaspec/changes/issue-482/specs/real-issues-cleanup/spec.md
+
+Coverage:
+  Requirement: real-issues クリーンアップフラグ
+    Scenario: real-issues フラグで全リソース削除
+    Scenario: loaded-issues.json が存在しない
+
+  Requirement: older-than フィルタリング
+    Scenario: older-than で古いエントリのみ削除
+    Scenario: 無効な duration 指定
+
+  Requirement: ドライランモード
+    Scenario: dry-run で削除予定リストのみ出力
+
+  Requirement: local モードと real-issues の相互排他
+    Scenario: 両フラグ同時指定時エラー
+
+  Requirement: local モード分岐整理
+    Scenario: local モードで既存動作を維持
+
+TDD: これらのテストは実装前に書かれており、実装完了後に passing になる。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+COMMAND_MD = (
+    REPO_ROOT
+    / "plugins"
+    / "twl"
+    / "commands"
+    / "test-project-reset.md"
+)
+
+
+def _read_command() -> str:
+    """Read test-project-reset.md, skip if not found."""
+    if not COMMAND_MD.exists():
+        pytest.skip(f"test-project-reset.md not found at {COMMAND_MD}")
+    return COMMAND_MD.read_text(encoding="utf-8")
+
+
+def _extract_headings(content: str) -> list[str]:
+    return [
+        m.group(1).strip()
+        for m in re.finditer(r"^#{1,6}\s+(.+)$", content, re.MULTILINE)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Requirement: real-issues クリーンアップフラグ
+# ---------------------------------------------------------------------------
+
+
+class TestRealIssuesFlagDeleteAll:
+    """Scenario: real-issues フラグで全リソース削除
+
+    WHEN --real-issues フラグ付きで実行し、loaded-issues.json が存在する
+    THEN 各エントリの PR close → Issue close → branch 削除が順次実行される
+    """
+
+    def test_command_md_exists(self) -> None:
+        """test-project-reset.md が存在する。"""
+        assert COMMAND_MD.exists(), (
+            f"test-project-reset.md not found at {COMMAND_MD}. "
+            "Issue #482 の実装が必要。"
+        )
+
+    def test_real_issues_flag_accepted(self) -> None:
+        """--real-issues フラグが定義またはドキュメントされている。"""
+        content = _read_command()
+        assert re.search(
+            r"--real-issues|real.issues",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に --real-issues フラグの記述がない。"
+        )
+
+    def test_loaded_issues_json_referenced(self) -> None:
+        """loaded-issues.json への参照がある。"""
+        content = _read_command()
+        assert re.search(
+            r"loaded.issues\.json|loaded_issues",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に loaded-issues.json への参照がない。"
+        )
+
+    def test_pr_close_step_defined(self) -> None:
+        """PR close の処理ステップが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"pr\s+close|gh\s+pr\s+close|PR.{0,20}clos",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に PR close のステップが定義されていない。"
+        )
+
+    def test_issue_close_step_defined(self) -> None:
+        """Issue close の処理ステップが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"issue\s+close|gh\s+issue\s+close|Issue.{0,20}clos",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に Issue close のステップが定義されていない。"
+        )
+
+    def test_branch_delete_step_defined(self) -> None:
+        """branch 削除の処理ステップが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"branch.{0,20}delet|gh\s+api.{0,40}branch|git\s+branch\s+-[dD]",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に branch 削除のステップが定義されていない。"
+        )
+
+    def test_sequential_order_pr_then_issue_then_branch(self) -> None:
+        """PR close → Issue close → branch 削除の順序が明示されている。"""
+        content = _read_command()
+        pr_pos = re.search(r"pr\s+close|gh\s+pr\s+close", content, re.IGNORECASE)
+        issue_pos = re.search(r"issue\s+close|gh\s+issue\s+close", content, re.IGNORECASE)
+        branch_pos = re.search(
+            r"branch.{0,20}delet|gh\s+api.{0,40}branch|git\s+branch\s+-[dD]",
+            content,
+            re.IGNORECASE,
+        )
+        if not (pr_pos and issue_pos and branch_pos):
+            pytest.skip("PR/Issue/branch 操作のいずれかが未実装のためスキップ")
+        assert pr_pos.start() < issue_pos.start() < branch_pos.start(), (
+            "PR close → Issue close → branch 削除の順序が正しくない。"
+            f"PR位置={pr_pos.start()}, Issue位置={issue_pos.start()}, "
+            f"branch位置={branch_pos.start()}"
+        )
+
+
+class TestLoadedIssuesJsonNotFound:
+    """Scenario: loaded-issues.json が存在しない
+
+    WHEN --real-issues フラグ付きで実行し、.test-target/loaded-issues.json が存在しない
+    THEN エラーメッセージを出力して終了する（実操作なし）
+    """
+
+    def test_file_not_found_error_handling_defined(self) -> None:
+        """loaded-issues.json が存在しない場合のエラー処理が定義されている。"""
+        content = _read_command()
+        # ファイル存在チェック + エラー処理のパターン
+        assert re.search(
+            r"\[\[\s*-[ef]\s+[^]]+loaded.issues|"
+            r"loaded.issues.*exist|"
+            r"FileNotFoundError|"
+            r"loaded.issues.*not\s+found|"
+            r"loaded.issues.*存在しない",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に loaded-issues.json が存在しない場合の"
+            "エラー処理が定義されていない。"
+        )
+
+    def test_error_exit_on_missing_json(self) -> None:
+        """ファイルが存在しない場合に exit 1 またはエラー出力が定義されている。"""
+        content = _read_command()
+        # exit 1 か エラー JSON か
+        has_exit = bool(re.search(r"exit\s+1", content))
+        has_error_json = bool(re.search(r'"error"', content))
+        assert has_exit or has_error_json, (
+            "test-project-reset.md にエラー終了（exit 1 または JSON error）が定義されていない。"
+        )
+
+    def test_no_real_operations_on_missing_json(self) -> None:
+        """loaded-issues.json が存在しない場合は実操作を行わない旨が明示されている。"""
+        content = _read_command()
+        # 「実操作なし」または MUST NOT 系の記述
+        assert re.search(
+            r"実操作.{0,20}(なし|行わない|しない)|"
+            r"no.{0,20}operation|"
+            r"MUST NOT.{0,50}execut|"
+            r"without.{0,30}operat",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に loaded-issues.json 不在時の"
+            "「実操作なし」の明示がない。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: older-than フィルタリング
+# ---------------------------------------------------------------------------
+
+
+class TestOlderThanFilterDeleteOldOnly:
+    """Scenario: older-than で古いエントリのみ削除
+
+    WHEN --real-issues --older-than 30d で実行する
+    THEN loaded_at が 30 日以上前のエントリのみが削除対象となる
+    """
+
+    def test_older_than_option_defined(self) -> None:
+        """--older-than オプションが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"--older.than|older_than",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に --older-than オプションの記述がない。"
+        )
+
+    def test_loaded_at_field_referenced(self) -> None:
+        """loaded_at フィールドが参照されている。"""
+        content = _read_command()
+        assert re.search(
+            r"loaded_at|loaded.at",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に loaded_at フィールドへの参照がない。"
+        )
+
+    def test_day_unit_supported(self) -> None:
+        """d（日）単位がサポートされている。"""
+        content = _read_command()
+        assert re.search(
+            r"\bd\b.{0,20}(日|day)|day.{0,10}unit|\dd\b|30d",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に d（日）単位のサポートが明示されていない。"
+        )
+
+    def test_week_unit_supported(self) -> None:
+        """w（週）単位がサポートされている。"""
+        content = _read_command()
+        assert re.search(
+            r"\bw\b.{0,20}(週|week)|week.{0,10}unit|\dw\b",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に w（週）単位のサポートが明示されていない。"
+        )
+
+    def test_month_unit_supported(self) -> None:
+        """m（月）単位がサポートされている。"""
+        content = _read_command()
+        assert re.search(
+            r"\bm\b.{0,20}(月|month)|month.{0,10}unit|\dm\b",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に m（月）単位のサポートが明示されていない。"
+        )
+
+    def test_filter_logic_described(self) -> None:
+        """フィルタリングロジック（指定期間より古いもののみ対象）が記述されている。"""
+        content = _read_command()
+        assert re.search(
+            r"古い.{0,30}エントリ|"
+            r"older\s+than|"
+            r"期間.{0,20}前|"
+            r"loaded_at.{0,50}前|"
+            r"filter.{0,30}date|"
+            r"date.{0,30}filter",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に older-than フィルタリングロジックの記述がない。"
+        )
+
+
+class TestInvalidDurationSpec:
+    """Scenario: 無効な duration 指定
+
+    WHEN --older-than 2x のような無効な単位を指定する
+    THEN エラーメッセージを出力して終了する（実操作なし）
+    """
+
+    def test_invalid_duration_error_handling_defined(self) -> None:
+        """無効な duration 指定のエラー処理が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"(invalid|無効).{0,30}(duration|単位|format)|"
+            r"(duration|単位).{0,30}(invalid|無効|error)|"
+            r"unknown.{0,20}unit|"
+            r"サポート.{0,20}(外|しない|されない)",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に無効な duration 指定のエラー処理が定義されていない。"
+        )
+
+    def test_exit_on_invalid_duration(self) -> None:
+        """無効な duration 指定時に終了する記述がある。"""
+        content = _read_command()
+        # exit 1 + 無効unit周辺に記述があるか、またはエラーJSON
+        has_exit = bool(re.search(r"exit\s+1", content))
+        has_error_json = bool(re.search(r'"error"', content))
+        assert has_exit or has_error_json, (
+            "test-project-reset.md にエラー終了（exit 1 または JSON error）が定義されていない。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: ドライランモード
+# ---------------------------------------------------------------------------
+
+
+class TestDryRunOutputOnly:
+    """Scenario: dry-run で削除予定リストのみ出力
+
+    WHEN --real-issues --dry-run で実行する
+    THEN 削除予定の PR#/Issue#/branch のリストが出力され、
+         gh CLI による実操作は行われない
+    """
+
+    def test_dry_run_flag_defined(self) -> None:
+        """--dry-run フラグが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"--dry.run|dry_run",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に --dry-run フラグの記述がない。"
+        )
+
+    def test_dry_run_outputs_list(self) -> None:
+        """dry-run 時に削除予定リストの出力が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"dry.run.{0,100}(list|リスト|output|出力)|"
+            r"(list|リスト|output|出力).{0,100}dry.run|"
+            r"削除予定.{0,30}(出力|リスト)|"
+            r"would.{0,30}(delete|remove)",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に dry-run 時の出力リスト定義がない。"
+        )
+
+    def test_dry_run_no_real_operations(self) -> None:
+        """dry-run 時に実操作を行わない旨が定義されている（MUST NOT）。"""
+        content = _read_command()
+        assert re.search(
+            r"dry.run.{0,100}(実操作.*行わない|MUST NOT|no.{0,20}operat|操作.*しない)|"
+            r"(実操作.*行わない|MUST NOT|no.{0,20}operat|操作.*しない).{0,100}dry.run",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に dry-run 時の「実操作なし（MUST NOT）」定義がない。"
+        )
+
+    def test_dry_run_shows_pr_numbers(self) -> None:
+        """dry-run 出力に PR# が含まれることが明示されている。"""
+        content = _read_command()
+        assert re.search(
+            r"PR#|PR\s+number|#\d+|pr_number|PR.{0,10}番号",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に dry-run 出力が PR# を含む定義がない。"
+        )
+
+    def test_dry_run_shows_issue_numbers(self) -> None:
+        """dry-run 出力に Issue# が含まれることが明示されている。"""
+        content = _read_command()
+        assert re.search(
+            r"Issue#|issue\s+number|issue_number|Issue.{0,10}番号",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に dry-run 出力が Issue# を含む定義がない。"
+        )
+
+    def test_dry_run_shows_branch_names(self) -> None:
+        """dry-run 出力に branch 名が含まれることが明示されている。"""
+        content = _read_command()
+        assert re.search(
+            r"branch.{0,20}name|branch.{0,20}名|branch_name",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に dry-run 出力が branch 名を含む定義がない。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: local モードと real-issues の相互排他
+# ---------------------------------------------------------------------------
+
+
+class TestMutualExclusionLocalAndRealIssues:
+    """Scenario: 両フラグ同時指定時エラー
+
+    WHEN --mode local --real-issues を同時に指定する
+    THEN エラーメッセージを出力して終了する（いずれの操作も実行しない）
+    """
+
+    def test_mutual_exclusion_defined(self) -> None:
+        """--mode local と --real-issues の相互排他が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"(local|mode.{0,10}local).{0,100}real.issues|"
+            r"real.issues.{0,100}(local|mode.{0,10}local)|"
+            r"相互排他|mutually.exclusive|mutex|cannot.{0,30}together|"
+            r"同時.{0,20}(指定|使用).{0,20}(エラー|できない|不可)|"
+            r"exclusive|排他",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に --mode local と --real-issues の"
+            "相互排他の定義がない。"
+        )
+
+    def test_error_output_on_mutual_exclusion(self) -> None:
+        """相互排他違反時にエラーが出力される定義がある。"""
+        content = _read_command()
+        has_exit = bool(re.search(r"exit\s+1", content))
+        has_error_json = bool(re.search(r'"error"', content))
+        assert has_exit or has_error_json, (
+            "test-project-reset.md に相互排他違反時のエラー出力定義がない。"
+        )
+
+    def test_no_operations_on_mutual_exclusion(self) -> None:
+        """相互排他違反時にいずれの操作も実行しない旨が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"(いずれ|どちら).{0,30}(実行|操作).{0,30}(しない|なし)|"
+            r"no.{0,30}operation.{0,30}execut|"
+            r"SHALL.{0,30}(exit|error)|"
+            r"操作.{0,30}(行わない|しない|なし)",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に相互排他違反時の「いずれの操作も実行しない」定義がない。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Requirement: local モード分岐整理
+# ---------------------------------------------------------------------------
+
+
+class TestLocalModePreservesExistingFlow:
+    """Scenario: local モードで既存動作を維持
+
+    WHEN フラグなしまたは --mode local で実行する
+    THEN Step 4（ユーザー確認）→ Step 5（git reset --hard）の既存フローが維持される
+    """
+
+    def test_step4_user_confirmation_exists(self) -> None:
+        """Step 4 ユーザー確認ステップが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"Step\s+4|ユーザー確認|AskUserQuestion|確認.*続行",
+            content,
+        ), (
+            "test-project-reset.md に Step 4（ユーザー確認）の定義がない。"
+        )
+
+    def test_step5_git_reset_hard_exists(self) -> None:
+        """Step 5 git reset --hard ステップが定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"git\s+reset\s+--hard",
+            content,
+        ), (
+            "test-project-reset.md に Step 5（git reset --hard）の定義がない。"
+        )
+
+    def test_local_mode_scope_defined(self) -> None:
+        """Step 4/5 が local モード（またはフラグなし）時のみ実行される条件が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"(--mode\s+local|mode\s+local|local\s+mode|フラグなし|no.{0,10}flag).{0,200}"
+            r"(Step\s+4|Step\s+5|git\s+reset|ユーザー確認)|"
+            r"(Step\s+4|Step\s+5|git\s+reset|ユーザー確認).{0,200}"
+            r"(--mode\s+local|mode\s+local|local\s+mode|フラグなし|no.{0,10}flag)|"
+            r"mode.{0,10}local.*のみ|local.*only",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に Step 4/5 が local モード時のみ実行される条件定義がない。"
+        )
+
+    def test_real_issues_does_not_execute_steps_4_5(self) -> None:
+        """--real-issues 時に Step 4/5 を実行しない旨が定義されている。"""
+        content = _read_command()
+        assert re.search(
+            r"real.issues.{0,200}(Step\s+4|Step\s+5|ユーザー確認|git\s+reset).{0,200}"
+            r"(しない|行わない|MUST NOT|skip|除外)|"
+            r"(Step\s+4|Step\s+5|ユーザー確認|git\s+reset).{0,200}"
+            r"real.issues.{0,200}(しない|行わない|MUST NOT|skip)|"
+            r"MUST NOT.{0,100}(Step\s+4|Step\s+5|ユーザー確認|git\s+reset)|"
+            r"--real-issues.{0,100}(実行.*しない|実行.*してはならない|除外)",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md に --real-issues 時の Step 4/5 除外定義がない。"
+        )
+
+    def test_default_behavior_unchanged(self) -> None:
+        """デフォルト（フラグなし）の動作が変更されていないことが明示されている。"""
+        content = _read_command()
+        # 既存フロー維持 or デフォルト動作 の記述
+        assert re.search(
+            r"既存.{0,30}(動作|フロー|維持)|"
+            r"default.{0,30}behavior|"
+            r"(フラグなし|without\s+flag|no.{0,10}flag).{0,50}"
+            r"(維持|変わらない|unchanged|same)|"
+            r"backward.{0,20}compat",
+            content,
+            re.IGNORECASE,
+        ), (
+            "test-project-reset.md にデフォルト動作が維持される旨の記述がない。"
+        )

--- a/cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py
+++ b/cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py
@@ -52,12 +52,6 @@ def _read_command() -> str:
     return COMMAND_MD.read_text(encoding="utf-8")
 
 
-def _extract_headings(content: str) -> list[str]:
-    return [
-        m.group(1).strip()
-        for m in re.finditer(r"^#{1,6}\s+(.+)$", content, re.MULTILINE)
-    ]
-
 
 # ---------------------------------------------------------------------------
 # Requirement: real-issues クリーンアップフラグ

--- a/deltaspec/changes/issue-482/.deltaspec.yaml
+++ b/deltaspec/changes/issue-482/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 482
+name: issue-482
+status: pending

--- a/deltaspec/changes/issue-482/design.md
+++ b/deltaspec/changes/issue-482/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`test-project-reset.md` は現在 `--mode local` 相当の動作（worktree を initial タグに git reset）のみを持つ。real-issues モードでは GitHub 上のリソース（PR/Issue/branch）が専用リポに作成されるため、git reset では対応できない。クリーンアップには GitHub API（`gh` CLI）を使用して PR close → Issue close → remote branch 削除を行う必要がある。
+
+クリーンアップ対象は `.test-target/loaded-issues.json`（Issue #480 が生成）に記録されたエントリで確定する。専用リポの特定は `.test-target/config.json`（Issue #479）の `repo` フィールドから行う。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `test-project-reset --real-issues` で loaded-issues.json の全 PR/Issue/branch を削除
+- `--older-than <duration>` で `loaded_at` フィールドによる経過時間フィルタリング
+- `--dry-run` でドライランモード（実操作なし、削除予定リスト出力のみ）
+- `--mode local` と `--real-issues` の相互排他チェック
+- 既存 `--mode local` 動作の維持（Step 4: ユーザー確認、Step 5: git reset）
+
+**Non-Goals:**
+- 専用リポ自体の削除
+- local モードのリセットロジック変更
+
+## Decisions
+
+**D1: コマンド引数の拡張方針**
+既存フローを `--mode local`（または引数なし）として維持し、`--real-issues` フラグを新規追加。両フラグが同時指定された場合はエラー終了する。
+
+**D2: `--older-than` パース方式**
+`date -d "-<value><unit>" +%s` コマンドで Epoch 変換を行う。単位: `d`（日）, `w`（週）, `m`（月）。パース失敗時はエラー出力して終了。
+
+**D3: 削除順序**
+PR close → Issue close → branch 削除の順で実行。PR が null の場合は PR close をスキップ。
+
+**D4: loaded-issues.json のフィルタリング**
+`--older-than` 指定時は `loaded_at` フィールドと比較して Epoch 以前のエントリのみを対象とする。
+
+## Risks / Trade-offs
+
+- `gh pr close` / `gh issue close` の失敗時は警告を出力して続行（既に close 済みの場合などに対応）
+- `loaded-issues.json` が存在しない場合は `"loaded-issues.json が見つかりません"` エラーで終了
+- `--older-than` の `m`（月）は GNU date 依存。非 GNU 環境では動作しない可能性あり（Linux 環境を前提）

--- a/deltaspec/changes/issue-482/proposal.md
+++ b/deltaspec/changes/issue-482/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+real-issues モードで作成された test Issue/PR/branch が積み上がると専用リポが肥大化する。定期的なクリーンアップ機構がないため、ADR-016 で懸念された「専用リポ案のクリーンアップ複雑度」が実運用上の障害となっている。
+
+## What Changes
+
+- `plugins/twl/commands/test-project-reset.md` に `--real-issues` フラグ分岐を追加
+- `.test-target/loaded-issues.json` を参照した PR close → Issue close → test ブランチ削除フローを実装
+- `--older-than <duration>` オプション追加（`d`/`w`/`m` 単位）
+- `--dry-run` オプションで削除予定リストのみ出力
+- `--mode local` と `--real-issues` の相互排他チェックを追加
+- `plugins/twl/deps.yaml` の effort を low → medium に更新
+
+## Capabilities
+
+### New Capabilities
+
+- `test-project-reset --real-issues` による real-issues モードリソース一括クリーンアップ
+- `--older-than` による経過時間フィルタリング（`d`/`w`/`m` 単位対応）
+- `--dry-run` によるドライランモード（削除予定リスト出力のみ）
+
+### Modified Capabilities
+
+- `test-project-reset` コマンドが `--mode local` と `--real-issues` の 2 系統を持つよう拡張
+- 既存 Step 4（ユーザー確認）・Step 5（`git reset --hard`）を `--mode local` 時のみ実行するよう分岐整理
+
+## Impact
+
+- 影響ファイル: `plugins/twl/commands/test-project-reset.md`, `plugins/twl/deps.yaml`
+- 依存: `#479`（`.test-target/config.json` の `repo` フィールド）、`#480`（`.test-target/loaded-issues.json` スキーマ）
+- API: `gh pr close`, `gh issue close`, `git push origin --delete <branch>` を順次呼び出す
+- 既存の `--mode local` 動作には変更なし

--- a/deltaspec/changes/issue-482/specs/real-issues-cleanup/spec.md
+++ b/deltaspec/changes/issue-482/specs/real-issues-cleanup/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: real-issues クリーンアップフラグ
+
+`test-project-reset` コマンドは `--real-issues` フラグを受け付け、`.test-target/loaded-issues.json` に記録された PR/Issue/branch を一括削除しなければならない（SHALL）。
+
+#### Scenario: real-issues フラグで全リソース削除
+
+- **WHEN** `--real-issues` フラグ付きで実行し、loaded-issues.json が存在する
+- **THEN** 各エントリの PR close → Issue close → branch 削除が順次実行される
+
+#### Scenario: loaded-issues.json が存在しない
+
+- **WHEN** `--real-issues` フラグ付きで実行し、`.test-target/loaded-issues.json` が存在しない
+- **THEN** エラーメッセージを出力して終了する（実操作なし）
+
+### Requirement: older-than フィルタリング
+
+`--older-than <duration>` オプションを指定した場合、`loaded_at` が指定期間より古いエントリのみを対象としなければならない（SHALL）。`duration` は `d`（日）、`w`（週）、`m`（月）の単位をサポートする。
+
+#### Scenario: older-than で古いエントリのみ削除
+
+- **WHEN** `--real-issues --older-than 30d` で実行する
+- **THEN** `loaded_at` が 30 日以上前のエントリのみが削除対象となる
+
+#### Scenario: 無効な duration 指定
+
+- **WHEN** `--older-than 2x` のような無効な単位を指定する
+- **THEN** エラーメッセージを出力して終了する（実操作なし）
+
+### Requirement: ドライランモード
+
+`--dry-run` フラグを指定した場合、削除予定の PR#/Issue#/branch 名のリストのみを出力し、実操作を行ってはならない（MUST NOT）。
+
+#### Scenario: dry-run で削除予定リストのみ出力
+
+- **WHEN** `--real-issues --dry-run` で実行する
+- **THEN** 削除予定の PR#/Issue#/branch のリストが出力され、`gh` CLI による実操作は行われない
+
+## MODIFIED Requirements
+
+### Requirement: local モードと real-issues の相互排他
+
+`--mode local` と `--real-issues` を同時に指定した場合、エラーを出力して終了しなければならない（SHALL）。
+
+#### Scenario: 両フラグ同時指定時エラー
+
+- **WHEN** `--mode local --real-issues` を同時に指定する
+- **THEN** エラーメッセージを出力して終了する（いずれの操作も実行しない）
+
+### Requirement: local モード分岐整理
+
+既存の Step 4（ユーザー確認）と Step 5（`git reset --hard`）は `--mode local`（またはフラグなし）の場合のみ実行しなければならない（SHALL）。`--real-issues` 時には実行してはならない（MUST NOT）。
+
+#### Scenario: local モードで既存動作を維持
+
+- **WHEN** フラグなしまたは `--mode local` で実行する
+- **THEN** Step 4（ユーザー確認）→ Step 5（git reset --hard）の既存フローが維持される

--- a/deltaspec/changes/issue-482/tasks.md
+++ b/deltaspec/changes/issue-482/tasks.md
@@ -1,0 +1,21 @@
+## 1. コマンド引数拡張
+
+- [ ] 1.1 `test-project-reset.md` に `--real-issues` フラグの引数定義を追加
+- [ ] 1.2 `--mode local` と `--real-issues` の相互排他チェックを実装
+- [ ] 1.3 `--older-than <duration>` オプションの引数解析と date コマンドによる Epoch 変換を実装
+
+## 2. real-issues クリーンアップフロー実装
+
+- [ ] 2.1 `.test-target/config.json` から専用リポの `repo` フィールドを読み込む処理を追加
+- [ ] 2.2 `.test-target/loaded-issues.json` の読み込みと `--older-than` フィルタリング処理を実装
+- [ ] 2.3 `--dry-run` 時の削除予定リスト出力ロジックを実装
+- [ ] 2.4 PR close（`gh pr close`）→ Issue close（`gh issue close`）→ branch 削除（`git push origin --delete`）の順次実行フローを実装
+
+## 3. local モード分岐整理
+
+- [ ] 3.1 Step 4（ユーザー確認）を `--mode local` 時のみ実行するよう分岐整理
+- [ ] 3.2 Step 5（`git reset --hard`）を `--mode local` 時のみ実行するよう分岐整理
+
+## 4. deps.yaml 更新
+
+- [ ] 4.1 `plugins/twl/deps.yaml` の `test-project-reset` エントリの `effort` を `low` → `medium` に更新

--- a/deltaspec/changes/issue-482/tasks.md
+++ b/deltaspec/changes/issue-482/tasks.md
@@ -1,21 +1,21 @@
 ## 1. コマンド引数拡張
 
-- [ ] 1.1 `test-project-reset.md` に `--real-issues` フラグの引数定義を追加
-- [ ] 1.2 `--mode local` と `--real-issues` の相互排他チェックを実装
-- [ ] 1.3 `--older-than <duration>` オプションの引数解析と date コマンドによる Epoch 変換を実装
+- [x] 1.1 `test-project-reset.md` に `--real-issues` フラグの引数定義を追加
+- [x] 1.2 `--mode local` と `--real-issues` の相互排他チェックを実装
+- [x] 1.3 `--older-than <duration>` オプションの引数解析と date コマンドによる Epoch 変換を実装
 
 ## 2. real-issues クリーンアップフロー実装
 
-- [ ] 2.1 `.test-target/config.json` から専用リポの `repo` フィールドを読み込む処理を追加
-- [ ] 2.2 `.test-target/loaded-issues.json` の読み込みと `--older-than` フィルタリング処理を実装
-- [ ] 2.3 `--dry-run` 時の削除予定リスト出力ロジックを実装
-- [ ] 2.4 PR close（`gh pr close`）→ Issue close（`gh issue close`）→ branch 削除（`git push origin --delete`）の順次実行フローを実装
+- [x] 2.1 `.test-target/config.json` から専用リポの `repo` フィールドを読み込む処理を追加
+- [x] 2.2 `.test-target/loaded-issues.json` の読み込みと `--older-than` フィルタリング処理を実装
+- [x] 2.3 `--dry-run` 時の削除予定リスト出力ロジックを実装
+- [x] 2.4 PR close（`gh pr close`）→ Issue close（`gh issue close`）→ branch 削除（`git push origin --delete`）の順次実行フローを実装
 
 ## 3. local モード分岐整理
 
-- [ ] 3.1 Step 4（ユーザー確認）を `--mode local` 時のみ実行するよう分岐整理
-- [ ] 3.2 Step 5（`git reset --hard`）を `--mode local` 時のみ実行するよう分岐整理
+- [x] 3.1 Step 4（ユーザー確認）を `--mode local` 時のみ実行するよう分岐整理
+- [x] 3.2 Step 5（`git reset --hard`）を `--mode local` 時のみ実行するよう分岐整理
 
 ## 4. deps.yaml 更新
 
-- [ ] 4.1 `plugins/twl/deps.yaml` の `test-project-reset` エントリの `effort` を `low` → `medium` に更新
+- [x] 4.1 `plugins/twl/deps.yaml` の `test-project-reset` エントリの `effort` を `low` → `medium` に更新

--- a/deltaspec/changes/issue-482/test-mapping.yaml
+++ b/deltaspec/changes/issue-482/test-mapping.yaml
@@ -1,0 +1,131 @@
+change_id: issue-482
+generated_at: "2026-04-12T00:00:00Z"
+test_framework: pytest
+scenarios:
+  # --------------------------------------------------------------------------
+  # Requirement: real-issues クリーンアップフラグ
+  # --------------------------------------------------------------------------
+
+  - id: "real-issues-flag-delete-all"
+    name: "real-issues フラグで全リソース削除"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 7
+    requirement: "real-issues クリーンアップフラグ"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestRealIssuesFlagDeleteAll"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      test-project-reset.md に --real-issues フラグ、loaded-issues.json 参照、
+      PR close / Issue close / branch 削除のステップが未実装。
+      Issue #482 の実装完了後に passing に更新すること。
+
+  - id: "loaded-issues-json-not-found"
+    name: "loaded-issues.json が存在しない"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 13
+    requirement: "real-issues クリーンアップフラグ"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestLoadedIssuesJsonNotFound"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      loaded-issues.json が存在しない場合のエラー処理（exit 1 または JSON error）
+      および実操作なしの明示が test-project-reset.md に未実装。
+
+  # --------------------------------------------------------------------------
+  # Requirement: older-than フィルタリング
+  # --------------------------------------------------------------------------
+
+  - id: "older-than-filter-delete-old-only"
+    name: "older-than で古いエントリのみ削除"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 21
+    requirement: "older-than フィルタリング"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestOlderThanFilterDeleteOldOnly"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      --older-than オプション、loaded_at フィールド参照、d/w/m 単位サポート、
+      フィルタリングロジックが test-project-reset.md に未実装。
+
+  - id: "invalid-duration-spec"
+    name: "無効な duration 指定"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 27
+    requirement: "older-than フィルタリング"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestInvalidDurationSpec"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      無効な duration 指定（例: 2x）のエラー処理が test-project-reset.md に未実装。
+
+  # --------------------------------------------------------------------------
+  # Requirement: ドライランモード
+  # --------------------------------------------------------------------------
+
+  - id: "dry-run-output-only"
+    name: "dry-run で削除予定リストのみ出力"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 35
+    requirement: "ドライランモード"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestDryRunOutputOnly"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      --dry-run フラグ、削除予定リスト出力（PR#/Issue#/branch名）、
+      実操作なし（MUST NOT）が test-project-reset.md に未実装。
+
+  # --------------------------------------------------------------------------
+  # Requirement: local モードと real-issues の相互排他
+  # --------------------------------------------------------------------------
+
+  - id: "mutual-exclusion-local-and-real-issues"
+    name: "両フラグ同時指定時エラー"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 46
+    requirement: "local モードと real-issues の相互排他"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestMutualExclusionLocalAndRealIssues"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      --mode local と --real-issues の相互排他定義、エラー出力、
+      いずれの操作も実行しない旨が test-project-reset.md に未実装。
+
+  # --------------------------------------------------------------------------
+  # Requirement: local モード分岐整理
+  # --------------------------------------------------------------------------
+
+  - id: "local-mode-preserves-existing-flow"
+    name: "local モードで既存動作を維持"
+    spec_file: "specs/real-issues-cleanup/spec.md"
+    spec_line: 55
+    requirement: "local モード分岐整理"
+    test_file: "cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py"
+    test_name: "TestLocalModePreservesExistingFlow"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: >
+      Step 4/5 が local モード時のみ実行されること、
+      --real-issues 時に Step 4/5 を除外する記述、
+      デフォルト動作維持の明示が test-project-reset.md に必要。
+      既存の Step 4/5 自体は存在するため、test_step4_user_confirmation_exists
+      と test_step5_git_reset_hard_exists は passing になる可能性がある。

--- a/plugins/twl/commands/test-project-reset.md
+++ b/plugins/twl/commands/test-project-reset.md
@@ -2,7 +2,6 @@
 type: atomic
 tools: [AskUserQuestion, Bash]
 effort: medium
-maxTurns: 10
 ---
 # test-target リセット
 
@@ -27,7 +26,7 @@ DRY_RUN=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode) MODE_LOCAL=true; shift 2 ;;
+    --mode) [[ "$2" == "local" ]] && MODE_LOCAL=true; shift 2 ;;
     --real-issues) REAL_ISSUES=true; shift ;;
     --older-than) OLDER_THAN="$2"; shift 2 ;;
     --dry-run) DRY_RUN=true; shift ;;
@@ -55,9 +54,15 @@ if [[ -n "$OLDER_THAN" ]]; then
     echo "{\"error\": \"--older-than の形式が無効です: $OLDER_THAN （例: 30d, 2w, 1m）\"}"
     exit 1
   fi
-  CUTOFF_EPOCH=$(date -d "-${VALUE} ${UNIT/d/days}" +%s 2>/dev/null || \
-                 date -d "-${VALUE} ${UNIT/w/weeks}" +%s 2>/dev/null || \
-                 date -d "-${VALUE} month" +%s 2>/dev/null)
+  case "$UNIT" in
+    d) CUTOFF_EPOCH=$(date -d "-${VALUE} days" +%s 2>/dev/null) ;;
+    w) CUTOFF_EPOCH=$(date -d "-${VALUE} weeks" +%s 2>/dev/null) ;;
+    m) CUTOFF_EPOCH=$(date -d "-${VALUE} months" +%s 2>/dev/null) ;;
+  esac
+  if [[ -z "$CUTOFF_EPOCH" ]]; then
+    echo "{\"error\": \"--older-than の日付計算に失敗しました: $OLDER_THAN\"}"
+    exit 1
+  fi
 fi
 ```
 
@@ -84,6 +89,11 @@ TEST_TARGET="$BARE_ROOT/worktrees/test-target"
 CONFIG_JSON="$PROJECT_DIR/.test-target/config.json"
 [[ -f "$CONFIG_JSON" ]] || { echo '{"error": ".test-target/config.json が見つかりません"}'; exit 1; }
 REPO=$(jq -r '.repo' "$CONFIG_JSON")
+# REPO の形式を owner/repo に限定（インジェクション防止）
+if ! [[ "$REPO" =~ ^[a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+$ ]]; then
+  echo "{\"error\": \"config.json の repo フィールドが不正です: $REPO （期待形式: owner/repo）\"}"
+  exit 1
+fi
 ```
 
 **Step 3-R-2: loaded-issues.json 読み込み**
@@ -127,6 +137,20 @@ echo "$ENTRIES" | jq -c '.' | while IFS= read -r entry; do
   issue_num=$(echo "$entry" | jq -r '.github_number')
   branch=$(echo "$entry" | jq -r '.branch')
 
+  # 入力値バリデーション（インジェクション防止）
+  if [[ -n "$pr_num" ]] && ! [[ "$pr_num" =~ ^[0-9]+$ ]]; then
+    echo "⚠️ pr_number が数値でないためスキップ: $pr_num"
+    continue
+  fi
+  if ! [[ "$issue_num" =~ ^[0-9]+$ ]]; then
+    echo "⚠️ github_number が数値でないためスキップ: $issue_num"
+    continue
+  fi
+  if ! [[ "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]] || [[ "$branch" == -* ]]; then
+    echo "⚠️ branch 名が不正なためスキップ: $branch"
+    continue
+  fi
+
   # PR close（pr_number が存在する場合のみ）
   if [[ -n "$pr_num" ]]; then
     gh pr close "$pr_num" --repo "$REPO" 2>/dev/null \
@@ -139,8 +163,8 @@ echo "$ENTRIES" | jq -c '.' | while IFS= read -r entry; do
     && echo "✓ Issue#$issue_num close" \
     || echo "⚠️ Issue#$issue_num close 失敗（既に closed の可能性）"
 
-  # branch 削除
-  git push "$REPO" --delete "$branch" 2>/dev/null \
+  # branch 削除（gh api 経由で専用リポの remote branch を削除）
+  gh api "repos/${REPO}/git/refs/heads/${branch}" --method DELETE 2>/dev/null \
     && echo "✓ branch $branch 削除" \
     || echo "⚠️ branch $branch 削除失敗（既に削除済みの可能性）"
 done

--- a/plugins/twl/commands/test-project-reset.md
+++ b/plugins/twl/commands/test-project-reset.md
@@ -146,7 +146,7 @@ echo "$ENTRIES" | jq -c '.' | while IFS= read -r entry; do
     echo "⚠️ github_number が数値でないためスキップ: $issue_num"
     continue
   fi
-  if ! [[ "$branch" =~ ^[a-zA-Z0-9/_.-]+$ ]] || [[ "$branch" == -* ]]; then
+  if [[ "$branch" == -* ]] || ! [[ "$branch" =~ ^[a-zA-Z0-9/_.\-]+$ ]]; then
     echo "⚠️ branch 名が不正なためスキップ: $branch"
     continue
   fi

--- a/plugins/twl/commands/test-project-reset.md
+++ b/plugins/twl/commands/test-project-reset.md
@@ -1,16 +1,67 @@
 ---
 type: atomic
-tools: [Bash]
-effort: low
+tools: [AskUserQuestion, Bash]
+effort: medium
 maxTurns: 10
 ---
 # test-target リセット
 
-test-target worktree を初期状態（`test-target/initial` tag）に戻す。
+test-target worktree を初期状態（`test-target/initial` tag）に戻す（`--mode local`）、または real-issues モードで作成されたリソースをクリーンアップする（`--real-issues`）。
+
+## 引数
+
+- `--mode local`: local worktree を初期状態に git reset（デフォルト動作）
+- `--real-issues`: `.test-target/loaded-issues.json` に記録された PR/Issue/branch を一括削除
+- `--older-than <duration>`: `loaded_at` が指定期間より古いエントリのみを対象（`d`=日, `w`=週, `m`=月）
+- `--dry-run`: 削除予定リストのみ出力、実操作なし
 
 ## 処理フロー（MUST）
 
-### Step 1: プロジェクトルート解決
+### Step 1: 引数解析と排他チェック
+
+```bash
+MODE_LOCAL=false
+REAL_ISSUES=false
+OLDER_THAN=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode) MODE_LOCAL=true; shift 2 ;;
+    --real-issues) REAL_ISSUES=true; shift ;;
+    --older-than) OLDER_THAN="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) shift ;;
+  esac
+done
+```
+
+`--mode local` と `--real-issues` が同時に指定された場合はエラー終了:
+
+```bash
+if $MODE_LOCAL && $REAL_ISSUES; then
+  echo '{"error": "--mode local と --real-issues は同時に指定できません"}'
+  exit 1
+fi
+```
+
+`--older-than` が指定された場合、単位を検証して Epoch 変換:
+
+```bash
+if [[ -n "$OLDER_THAN" ]]; then
+  VALUE="${OLDER_THAN%[dwm]}"
+  UNIT="${OLDER_THAN: -1}"
+  if ! [[ "$VALUE" =~ ^[0-9]+$ ]] || ! [[ "$UNIT" =~ ^[dwm]$ ]]; then
+    echo "{\"error\": \"--older-than の形式が無効です: $OLDER_THAN （例: 30d, 2w, 1m）\"}"
+    exit 1
+  fi
+  CUTOFF_EPOCH=$(date -d "-${VALUE} ${UNIT/d/days}" +%s 2>/dev/null || \
+                 date -d "-${VALUE} ${UNIT/w/weeks}" +%s 2>/dev/null || \
+                 date -d "-${VALUE} month" +%s 2>/dev/null)
+fi
+```
+
+### Step 2: プロジェクトルート解決
 
 ```bash
 PROJECT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
@@ -18,13 +69,104 @@ BARE_ROOT="$(cd "$PROJECT_DIR/.." && pwd)"
 TEST_TARGET="$BARE_ROOT/worktrees/test-target"
 ```
 
-### Step 2: 存在チェック
+### Step 3: モード分岐
+
+`$REAL_ISSUES == true` → Step 3-R（real-issues クリーンアップ）へ
+それ以外 → Step 3-L（local モード）へ
+
+---
+
+#### Step 3-R: real-issues クリーンアップ
+
+**Step 3-R-1: config.json から専用リポ取得**
+
+```bash
+CONFIG_JSON="$PROJECT_DIR/.test-target/config.json"
+[[ -f "$CONFIG_JSON" ]] || { echo '{"error": ".test-target/config.json が見つかりません"}'; exit 1; }
+REPO=$(jq -r '.repo' "$CONFIG_JSON")
+```
+
+**Step 3-R-2: loaded-issues.json 読み込み**
+
+```bash
+LOADED_JSON="$PROJECT_DIR/.test-target/loaded-issues.json"
+[[ -f "$LOADED_JSON" ]] || { echo '{"error": ".test-target/loaded-issues.json が見つかりません"}'; exit 1; }
+```
+
+**Step 3-R-3: `--older-than` フィルタリング**
+
+`$OLDER_THAN` が指定されている場合、`loaded_at` を Epoch 変換して `$CUTOFF_EPOCH` 以前のエントリのみを対象とする:
+
+```bash
+# jq で loaded_at をフィルタ（CUTOFF_EPOCH より古いもの）
+ENTRIES=$(jq --argjson cutoff "${CUTOFF_EPOCH:-0}" '
+  .issues[] | select(
+    ($cutoff == 0) or
+    ((.loaded_at // "") | if . == "" then false else (gsub("Z$";"") | strptime("%Y-%m-%dT%H:%M:%S") | mktime) < $cutoff end)
+  )
+' "$LOADED_JSON")
+```
+
+**Step 3-R-4: `--dry-run` 出力**
+
+```bash
+if $DRY_RUN; then
+  echo "=== 削除予定リスト (dry-run) ==="
+  echo "$ENTRIES" | jq -r '"PR#\(.pr_number // "なし") | Issue#\(.github_number) | branch: \(.branch)"'
+  exit 0
+fi
+```
+
+**Step 3-R-5: PR close → Issue close → branch 削除**
+
+各エントリに対して順次実行:
+
+```bash
+echo "$ENTRIES" | jq -c '.' | while IFS= read -r entry; do
+  pr_num=$(echo "$entry" | jq -r '.pr_number // empty')
+  issue_num=$(echo "$entry" | jq -r '.github_number')
+  branch=$(echo "$entry" | jq -r '.branch')
+
+  # PR close（pr_number が存在する場合のみ）
+  if [[ -n "$pr_num" ]]; then
+    gh pr close "$pr_num" --repo "$REPO" 2>/dev/null \
+      && echo "✓ PR#$pr_num close" \
+      || echo "⚠️ PR#$pr_num close 失敗（既に closed の可能性）"
+  fi
+
+  # Issue close
+  gh issue close "$issue_num" --repo "$REPO" 2>/dev/null \
+    && echo "✓ Issue#$issue_num close" \
+    || echo "⚠️ Issue#$issue_num close 失敗（既に closed の可能性）"
+
+  # branch 削除
+  git push "$REPO" --delete "$branch" 2>/dev/null \
+    && echo "✓ branch $branch 削除" \
+    || echo "⚠️ branch $branch 削除失敗（既に削除済みの可能性）"
+done
+```
+
+**Step 3-R-6: JSON 出力**
+
+```json
+{
+  "status": "cleaned",
+  "repo": "<専用リポ>",
+  "cleaned_count": <削除したエントリ数>
+}
+```
+
+---
+
+#### Step 3-L: local モード
+
+**Step 3-L-1: test-target worktree 存在チェック**
 
 ```bash
 [[ -d "$TEST_TARGET" ]] || { echo '{"error": "test-target worktree が存在しません。先に /twl:test-project-init を実行してください"}'; exit 1; }
 ```
 
-### Step 3: cwd 安全確認（MUST）
+**Step 3-L-2: cwd 安全確認（MUST）**
 
 ```bash
 CURRENT_DIR="$(pwd)"
@@ -34,14 +176,14 @@ if [[ "$CURRENT_DIR" == "$TEST_TARGET"* ]]; then
 fi
 ```
 
-### Step 4: ユーザー確認（MUST）
+### Step 4: ユーザー確認（MUST — `--mode local` 時のみ）
 
 AskUserQuestion: 「test-target を初期状態に reset します。未 push の変更は失われます。続行しますか?」
 
 - No → no-op で終了
 - Yes → Step 5 へ
 
-### Step 5: reset 実行
+### Step 5: reset 実行（`--mode local` 時のみ）
 
 ```bash
 cd "$TEST_TARGET"
@@ -49,7 +191,7 @@ git reset --hard test-target/initial
 git clean -fdx
 ```
 
-### Step 6: JSON 出力
+### Step 6: JSON 出力（`--mode local` 時）
 
 ```json
 {
@@ -62,5 +204,8 @@ git clean -fdx
 
 ## 禁止事項（MUST NOT）
 
-- cwd が test-target 内の場合に reset を実行してはならない
-- ユーザー確認なしに reset を実行してはならない
+- cwd が test-target 内の場合に local reset を実行してはならない
+- `--mode local` 時はユーザー確認なしに reset を実行してはならない
+- `--real-issues` 時に Step 4（ユーザー確認）および Step 5（git reset）を実行してはならない
+- `--mode local` と `--real-issues` を同時に受け入れてはならない
+- 正規表現マッチで削除対象 branch を決定してはならない（`loaded-issues.json` の明示リストを使うこと）

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1716,6 +1716,7 @@ commands:
     refined_at: "2026-04-08"
     path: commands/test-project-reset.md
     effort: medium
+    tools: [AskUserQuestion, Bash]
     spawnable_by: [controller, workflow]
     can_spawn: []
     description: "test-target を初期状態に reset"

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1715,7 +1715,7 @@ commands:
     refined_by: "ref-prompt-guide@2c7a62f2"
     refined_at: "2026-04-08"
     path: commands/test-project-reset.md
-    effort: low
+    effort: medium
     spawnable_by: [controller, workflow]
     can_spawn: []
     description: "test-target を初期状態に reset"


### PR DESCRIPTION
## 概要

`test-project-reset` コマンドに `--real-issues` フラグを追加し、real-issues モードで作成された PR/Issue/branch の一括クリーンアップ機能を実装する。

## 変更内容

- `plugins/twl/commands/test-project-reset.md`: `--real-issues` / `--older-than` / `--dry-run` フラグ追加
- `plugins/twl/deps.yaml`: effort `low` → `medium`
- `cli/twl/tests/scenarios/test_issue_482_real_issues_cleanup.py`: シナリオテスト追加

## セキュリティ修正

- `$REPO` / `$branch` / `$issue_num` / `$pr_num` の入力バリデーション追加
- `git push $REPO --delete` → `gh api DELETE` に変更

Closes #482