### PR TITLE
feat(#481): co-self-improve scenario-run に --real-issues 分岐を追加

### DIFF
--- a/deltaspec/changes/issue-481/.deltaspec.yaml
+++ b/deltaspec/changes/issue-481/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 481
+name: issue-481
+status: pending

--- a/deltaspec/changes/issue-481/design.md
+++ b/deltaspec/changes/issue-481/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`co-self-improve` SKILL.md Step 1（scenario-run）は test-project-init → scenario-load → session:spawn の 3 ステップで構成される。#479 と #480 で各 atomic がそれぞれ `--mode real-issues` / `--real-issues` フラグを受け取れるようになったが、SKILL.md には引数解析と委譲ロジックが存在しない。また、spawn 後に co-autopilot が test-target worktree で起動される経路が SKILL.md に明文化されていない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `--real-issues --repo <owner>/<name>` フラグを co-self-improve が受け取り、各 atomic に適切に委譲する
+- 引数なし / local 指定の場合はローカルモード（従来の動作）を維持する
+- 引数が ambiguous な場合に AskUserQuestion で明示的にモードを選択させる
+- Step 5 の session:spawn で co-autopilot を明示的に起動する経路を SKILL.md に記述する
+
+**Non-Goals:**
+
+- test-project-init.md / test-project-scenario-load.md の実装変更（#479, #480 で完了）
+- observe ループの改修
+- session:spawn の内部実装変更
+
+## Decisions
+
+### フラグ解析の位置
+
+SKILL.md Step 1 の冒頭（init 実行前）に `--real-issues` フラグと `--repo` 引数を解析するステップを追加する。
+
+- `--real-issues` フラグあり + `--repo <owner>/<name>` あり → real-issues モード
+- `--real-issues` フラグあり + `--repo` なし → AskUserQuestion で `--repo` を質問
+- フラグなし（`--local` も含む）→ local モード（従来通り）
+- 引数が曖昧（scenario 名だけ等）→ AskUserQuestion で「local / real-issues どちらですか?」
+
+### co-autopilot の明示
+
+Step 5 の `Skill(session:spawn)` 呼び出しに `-- /twl:co-autopilot` を prompt として渡し、test-target worktree で co-autopilot が起動される経路を明文化する。
+
+### 引数フォーマット
+
+`/twl:co-self-improve scenario-run <scenario-name> --real-issues --repo <owner>/<name>` を canonical 呼び出し形式とする。
+
+## Risks / Trade-offs
+
+- **既存動作への影響**: フラグなしは従来の local モードにフォールバックするため、既存の動作は変化しない
+- **AskUserQuestion の追加**: 引数が不足する場合にのみ質問するため、明示的な呼び出しでは質問が発生しない

--- a/deltaspec/changes/issue-481/proposal.md
+++ b/deltaspec/changes/issue-481/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`co-self-improve` SKILL.md の scenario-run モード Step 1 は、test-project-init と test-project-scenario-load を常にローカルモードで呼び出す。Issue C (#479) と Issue D (#480) で `--mode real-issues` / `--real-issues` フラグが実装されたが、co-self-improve からそれらを起動する経路がなく、実 GitHub Issue を使った end-to-end シナリオ実行が不可能な状態にある。
+
+## What Changes
+
+- `plugins/twl/skills/co-self-improve/SKILL.md` Step 1 に `--real-issues` フラグ受け入れロジックを追加
+- 引数なし / ambiguous 時に AskUserQuestion（local vs real-issues）を挿入
+- `--real-issues` 時に `test-project-init.md` へ `--mode real-issues --repo <owner>/<name>` を委譲
+- `--real-issues` 時に `test-project-scenario-load.md` へ `--real-issues` フラグを委譲
+- Step 5 の `session:spawn` で co-autopilot を test-target worktree で起動する経路を明文化
+
+## Capabilities
+
+### New Capabilities
+
+- **real-issues モード**: `/twl:co-self-improve scenario-run <scenario> --real-issues --repo <owner>/<name>` で end-to-end 実行が可能になる
+- **モード選択 UX**: 引数が ambiguous な場合に AskUserQuestion で local / real-issues を選択させる
+
+### Modified Capabilities
+
+- **scenario-run Step 1**: フラグを受け取り、init と scenario-load の呼び出しに適切な引数を渡すよう拡張
+
+## Impact
+
+- `plugins/twl/skills/co-self-improve/SKILL.md` — Step 1 を拡張（約 20 行追加）
+- 他ファイルへの変更なし（atomic は #479, #480 で実装済み）

--- a/deltaspec/changes/issue-481/specs/real-issues-routing/spec.md
+++ b/deltaspec/changes/issue-481/specs/real-issues-routing/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: scenario-run モードの --real-issues フラグ受け入れ
+
+co-self-improve の scenario-run モードは `--real-issues --repo <owner>/<name>` フラグを受け取り、適切なモードで test-project-init と test-project-scenario-load を呼び出さなければならない（SHALL）。
+
+#### Scenario: real-issues モードでの end-to-end 実行
+- **WHEN** ユーザーが `/twl:co-self-improve scenario-run smoke-001 --real-issues --repo shuu5/test-repo` を実行する
+- **THEN** `test-project-init.md` が `--mode real-issues --repo shuu5/test-repo` で呼び出される
+- **THEN** `test-project-scenario-load.md` が `--scenario smoke-001 --real-issues` で呼び出される
+- **THEN** `session:spawn` が `--cd worktrees/test-target` と co-autopilot 起動 prompt で実行される
+
+#### Scenario: local モードのデフォルト動作維持
+- **WHEN** ユーザーが `--real-issues` フラグなしで scenario-run を実行する
+- **THEN** `test-project-init.md` がフラグなし（local モード）で呼び出される
+- **THEN** 既存の動作が変わらない（SHALL）
+
+## ADDED Requirements
+
+### Requirement: ambiguous 入力時の明示的モード選択
+
+co-self-improve は引数から `--real-issues` / local モードが判断できない場合、ユーザーに AskUserQuestion でモードを選択させなければならない（MUST）。
+
+#### Scenario: --repo なしで --real-issues が指定された場合
+- **WHEN** `--real-issues` フラグはあるが `--repo` が省略されている
+- **THEN** AskUserQuestion で「専用テストリポのオーナー/リポ名を入力してください（例: shuu5/twill-test）」と質問する
+
+#### Scenario: フラグなしで ambiguous な場合
+- **WHEN** scenario 名のみで local / real-issues が不明な場合
+- **THEN** AskUserQuestion で「ローカルモードと real-issues モードのどちらで実行しますか？」と選択させる
+
+### Requirement: co-autopilot の test-target worktree 起動
+
+session:spawn は co-autopilot を test-target worktree で起動する経路を明文化しなければならない（SHALL）。
+
+#### Scenario: co-autopilot が test-target で起動される
+- **WHEN** Step 1 Step 5 で session:spawn が呼ばれる
+- **THEN** `--cd worktrees/test-target` が指定され co-autopilot が test-target 内で起動する
+- **THEN** spawn 後の window 名が Step 2 に渡される

--- a/deltaspec/changes/issue-481/tasks.md
+++ b/deltaspec/changes/issue-481/tasks.md
@@ -1,0 +1,14 @@
+## 1. SKILL.md Step 1 拡張
+
+- [x] 1.1 `plugins/twl/skills/co-self-improve/SKILL.md` Step 1 冒頭にフラグ解析ステップを追加（`--real-issues` / `--repo` / `--local` の解析）
+- [x] 1.2 `--real-issues` + `--repo` あり時のフロー分岐を記述（test-project-init に `--mode real-issues --repo` を委譲）
+- [x] 1.3 `--real-issues` + `--repo` なし時の AskUserQuestion ステップを追加
+- [x] 1.4 フラグなし / ambiguous 時の AskUserQuestion ステップを追加（local vs real-issues 選択）
+- [x] 1.5 local モード時は従来の init 呼び出し（フラグなし）を継続することを明記
+- [x] 1.6 Step 4 の scenario-load 呼び出しに `--real-issues` フラグ委譲を追記
+- [x] 1.7 Step 5 の session:spawn に `-- /twl:co-autopilot` 起動の明文化を追記
+
+## 2. 動作検証
+
+- [x] 2.1 `--real-issues --repo` フラグなしでの実行が従来通り local モードで動作することを確認
+- [x] 2.2 `--real-issues --repo <owner>/<name>` フラグありでの呼び出しが init / scenario-load に正しく委譲されることを確認（SKILL.md レビューレベル）

--- a/deltaspec/changes/issue-481/test-mapping.yaml
+++ b/deltaspec/changes/issue-481/test-mapping.yaml
@@ -1,0 +1,103 @@
+change_id: issue-481
+generated_at: "2026-04-12T00:00:00Z"
+test_framework: bats
+scenarios:
+  # -------------------------------------------------------------------------
+  # Requirement: scenario-run モードの --real-issues フラグ受け入れ
+  # -------------------------------------------------------------------------
+  - id: "real-issues-flag-present"
+    name: "--real-issues フラグの存在確認"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 3
+    requirement: "scenario-run モードの --real-issues フラグ受け入れ"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md mentions --real-issues flag"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "repo-flag-present"
+    name: "--repo フラグの存在確認"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 3
+    requirement: "scenario-run モードの --real-issues フラグ受け入れ"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md mentions --repo flag for real-issues mode"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "init-mode-real-issues-delegation"
+    name: "test-project-init への --mode real-issues 委譲"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 6
+    requirement: "scenario-run モードの --real-issues フラグ受け入れ"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md Step 1 delegates --mode real-issues to test-project-init"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "scenario-load-real-issues-delegation"
+    name: "test-project-scenario-load への --real-issues 委譲"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 8
+    requirement: "scenario-run モードの --real-issues フラグ受け入れ"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md Step 1 delegates --real-issues to test-project-scenario-load"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "local-mode-preserved"
+    name: "local モードのデフォルト動作維持"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 13
+    requirement: "scenario-run モードの --real-issues フラグ受け入れ"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md retains local mode reference"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: ambiguous 入力時の明示的モード選択
+  # -------------------------------------------------------------------------
+  - id: "ask-user-question-mode-select"
+    name: "AskUserQuestion によるモード選択"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 21
+    requirement: "ambiguous 入力時の明示的モード選択"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md contains AskUserQuestion for mode selection"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # Requirement: co-autopilot の test-target worktree 起動
+  # -------------------------------------------------------------------------
+  - id: "co-autopilot-spawn"
+    name: "co-autopilot spawn 経路の明文化"
+    spec_file: "specs/real-issues-routing/spec.md"
+    spec_line: 35
+    requirement: "co-autopilot の test-target worktree 起動"
+    test_file: "plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats"
+    test_name: "co-self-improve: SKILL.md Step 1 mentions co-autopilot spawn"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/skills/co-self-improve/SKILL.md
+++ b/plugins/twl/skills/co-self-improve/SKILL.md
@@ -58,11 +58,29 @@ spawn 時プロンプトに情報が含まれない場合のみ AskUserQuestion 
 
 ## Step 1: scenario-run モード — シナリオ選択 + spawn
 
+### Step 1a: フラグ解析（実行モード決定）
+
+引数から `--real-issues` / `--repo <owner>/<name>` / `--local` を解析し、実行モードを確定する。
+
+| 条件 | モード | 処理 |
+|------|--------|------|
+| `--real-issues` + `--repo <owner>/<name>` | **real-issues** | test-project-init に `--mode real-issues --repo <owner>/<name>` を委譲 |
+| `--real-issues` のみ（`--repo` なし） | — | AskUserQuestion で「専用テストリポのオーナー/リポ名を入力してください（例: shuu5/twill-test）」と質問し、取得後 real-issues モードへ |
+| `--local` 明示 or フラグなしで scenario 名のみ | **local** | test-project-init をフラグなしで呼び出す（従来動作） |
+| フラグなしかつモードが曖昧 | — | AskUserQuestion で「ローカルモードと real-issues モードのどちらで実行しますか？」と選択させる |
+
+### Step 1b: 実行
+
 1. `commands/test-project-init.md` を Read → 実行（test-target worktree が無ければ作成）
+   - **local モード**: フラグなし（`--mode local` はデフォルト）
+   - **real-issues モード**: `--mode real-issues --repo <owner>/<name>` を渡す
 2. `refs/test-scenario-catalog.md` を Read してシナリオ一覧表示
-3. ユーザーがシナリオ選択
+3. ユーザーがシナリオ選択（引数でシナリオ名が指定済みの場合はスキップ）
 4. `commands/test-project-scenario-load.md` を Read → 実行（シナリオの Issue 群を test-target にロード）
-5. `Skill(session:spawn)` で `--cd worktrees/test-target` を指定し observed session を起動
+   - **local モード**: `--scenario <name>` のみ
+   - **real-issues モード**: `--scenario <name> --real-issues` を渡す
+5. `Skill(session:spawn)` で `--cd worktrees/test-target` を指定し co-autopilot を起動
+   - spawn プロンプト: `/twl:co-autopilot`（test-target worktree で Issue を自律実行）
 6. spawn 後の window 名を取得し Step 2 へ
 
 ## Step 2: scenario 実行中の observation loop 起動

--- a/plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats
+++ b/plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+# co-self-improve-real-issues.bats
+# Structural tests for --real-issues routing in co-self-improve SKILL.md (Issue #481)
+#
+# Verifies that SKILL.md Step 1 contains correct flag routing logic for
+# --real-issues mode introduced in Issue C (#479) and Issue D (#480).
+#
+# Run: bats plugins/twl/tests/bats/skills/co-self-improve-real-issues.bats
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+SKILL_FILE="$REPO_ROOT/skills/co-self-improve/SKILL.md"
+
+# ---------------------------------------------------------------------------
+# Case 1: --real-issues フラグ受け入れ
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md mentions --real-issues flag" {
+  grep -q '\-\-real-issues' "$SKILL_FILE"
+}
+
+@test "co-self-improve: SKILL.md mentions --repo flag for real-issues mode" {
+  grep -q '\-\-repo' "$SKILL_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: test-project-init への --mode real-issues 委譲
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md Step 1 delegates --mode real-issues to test-project-init" {
+  grep -q '\-\-mode real-issues' "$SKILL_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: test-project-scenario-load への --real-issues 委譲
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md Step 1 delegates --real-issues to test-project-scenario-load" {
+  # The SKILL.md must mention --real-issues in context of scenario-load delegation
+  local count
+  count=$(grep -c '\-\-real-issues' "$SKILL_FILE")
+  [ "$count" -ge 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: AskUserQuestion for ambiguous input
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md contains AskUserQuestion for mode selection" {
+  grep -q 'AskUserQuestion' "$SKILL_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: co-autopilot spawn path
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md Step 1 mentions co-autopilot spawn" {
+  grep -q 'co-autopilot' "$SKILL_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: local mode default behavior preserved
+# ---------------------------------------------------------------------------
+
+@test "co-self-improve: SKILL.md retains local mode reference" {
+  grep -qi 'local' "$SKILL_FILE"
+}


### PR DESCRIPTION
## 概要

`co-self-improve` SKILL.md の scenario-run モード Step 1 に `--real-issues` フラグルーティングを追加する。

## 変更内容

- **Step 1a**: フラグ解析テーブル追加（`--real-issues` / `--repo` / `--local`）
- **Step 1b**: real-issues / local モード別の init・scenario-load 委譲を明記
- **AskUserQuestion**: `--repo` 不足時および ambiguous 時のモード選択
- **session:spawn**: co-autopilot 起動経路を明文化
- DeltaSpec `issue-481`: proposal / design / specs / tasks / test-mapping 追加
- `co-self-improve-real-issues.bats`: 構造テスト追加

Closes #481