### PR TITLE
feat(#483): Wave 1-5 バグ再現 E2E シナリオ + catalog 追加 (#442/#443 補完)

### DIFF
--- a/deltaspec/changes/issue-483/.deltaspec.yaml
+++ b/deltaspec/changes/issue-483/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 483
+name: issue-483
+status: pending

--- a/deltaspec/changes/issue-483/design.md
+++ b/deltaspec/changes/issue-483/design.md
@@ -1,0 +1,37 @@
+## Context
+
+Wave 1-5 で発見された 4 つの autopilot バグ（#469/#470/#471/#472）は個別に修正されたが、それぞれの再現シナリオが test-scenario-catalog に存在しない。また observation-pattern-catalog の `bug-*` セクションには Wave 1-3 由来の 3 パターンのみで、Wave 4-5 由来のパターンが欠落している。
+
+現在 `test-scenario-catalog.md` のシナリオ YAML スキーマには `bug_target` フィールドが定義されておらず、`level` enum も `smoke | regression | load` の 3 値しかない。`observation.md` の `LoadScenario` エンティティが `bug_target` を参照しているにも関わらず catalog 側に定義がないため不整合がある。
+
+## Goals / Non-Goals
+
+**Goals:**
+- test-scenario-catalog のスキーマに `bug_target` フィールドと `bug` level を追加
+- 5 シナリオ（bug-469/470/471/472/combo）を catalog に追加
+- 対応する `bug-*` パターン 5 件を observation-pattern-catalog に追加（`related_issue` 紐付き）
+- `observation-references.bats` に検証ケースを追加
+- #442/#443 に補完コメントを追記
+
+**Non-Goals:**
+- 各バグ（#469-#472）自体の修正
+- su-observer 介入ロジックの改修（#475）
+- real-issues モードでの実際の再現確認（CI は catalog 構造の静的検証のみ）
+
+## Decisions
+
+**bug level の追加**: `smoke | regression | load | bug` の 4 値に拡張する。`regression` は並列実行の conflict 検証、`bug` は特定の chain 遷移・stall パターン検証、と明確に責務を分ける。
+
+**bug_target フィールド**: null 許容（汎用シナリオは null）。bug 再現シナリオは対象 Bug Issue 番号（整数または null）を格納する。
+
+**combo シナリオの定義**: `bug-combo-469-472` は `issues_count: 3, expected_conflicts: 0, expected_duration_max: 60` で定義し、#469 と #472 の複合 stall パターンを再現する。`bug_target: null` で description に両 Issue を参照。
+
+**bats テスト戦略**: 既存の `observation-references.bats` に新規テストケースを追加する（Case 5: bug-4xx パターン検証）。パターン数要件も `bug_count >= 3` を `bug_count >= 7` に引き上げる。
+
+**パターン命名**: `bug-469-*`, `bug-470-*`, `bug-471-*`, `bug-472-*` の形式。既存の `bug-chain-stall` (#438) と区別するため Issue 番号を埋め込む。
+
+## Risks / Trade-offs
+
+- bats のテスト数を増やすことで CI 実行時間が増加するが、ref catalog の静的検証なので影響は軽微
+- `level: bug` を追加した場合、既存の `level: load` テスト（`load_definitions -eq 0` 前提）との兼ね合いを確認する必要があるが、`bug` level は別カウントなので影響なし
+- 既存 bats で `bug_count -ge 3` の閾値テストがあるため、新規追加後に閾値を引き上げる必要がある

--- a/deltaspec/changes/issue-483/proposal.md
+++ b/deltaspec/changes/issue-483/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Wave 1-5 で発見された autopilot バグ（#469/#470/#471/#472）の再現 E2E シナリオが test-scenario-catalog に存在せず、#442/#443 がクローズ済みでも catalog の bug 再現シナリオと observation-pattern-catalog の `bug-*` パターンが未追加のままである。real-issues モードで各バグを再現・検証できる状態を確立し、regression 防止基盤を整備する。
+
+## What Changes
+
+- `plugins/twl/refs/test-scenario-catalog.md`: スキーマに `bug_target` フィールドを追加、level enum に `bug` を追加、5 シナリオ（bug-469/470/471/472/combo）を追加
+- `plugins/twl/refs/observation-pattern-catalog.md`: `bug-*` プレフィックスで各バグに対応する検出パターンを追加（`related_issue` 紐付き）
+- `tests/bats/refs/observation-references.bats`: bug-* パターンの検証ケースを追加
+- #442/#443 の GitHub Issue に「本 Issue で未達 AC を補完」の comment を追記
+
+## Capabilities
+
+### New Capabilities
+
+- **bug 再現シナリオ**: `bug-469-chain-stall`、`bug-470-state-path`、`bug-471-refspec`、`bug-472-monitor-stall`、`bug-combo-469-472` の 5 シナリオが real-issues モードで実行可能になる
+- **bug-* 検出パターン**: 各バグの chain 遷移・stall パターンを observation-pattern-catalog で検出できる
+- **bats 検証**: observation-references.bats が bug-* パターンの存在を自動検証する
+
+### Modified Capabilities
+
+- **test-scenario-catalog スキーマ**: `bug_target` フィールドと `bug` level が追加され、より豊富なシナリオ分類が可能になる
+- **observation-pattern-catalog**: `bug-*` プレフィックスパターンが `hist-*` と並列して管理される
+
+## Impact
+
+- `plugins/twl/refs/test-scenario-catalog.md`（スキーマ拡張 + 5 シナリオ追加）
+- `plugins/twl/refs/observation-pattern-catalog.md`（bug-* パターン追加）
+- `tests/bats/refs/observation-references.bats`（検証ケース追加）
+- #442/#443 Issues（コメント追記）

--- a/deltaspec/changes/issue-483/specs/catalog-schema-extension/spec.md
+++ b/deltaspec/changes/issue-483/specs/catalog-schema-extension/spec.md
@@ -1,0 +1,87 @@
+## ADDED Requirements
+
+### Requirement: test-scenario-catalog bug_target フィールド追加
+
+test-scenario-catalog.md のシナリオ YAML スキーマに `bug_target` フィールドを追加しなければならない（SHALL）。`bug_target` は整数または null 許容で、bug 再現シナリオはバグ Issue 番号を、汎用シナリオは null を指定する。
+
+#### Scenario: bug_target フィールドがスキーマに定義される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** scenario YAML フォーマットセクションに `bug_target:` フィールドが定義されている
+
+#### Scenario: bug 再現シナリオが bug_target を持つ
+- **WHEN** bug-469-chain-stall シナリオを読み込む
+- **THEN** `bug_target: 469` が設定されている
+
+#### Scenario: combo シナリオが bug_target null を持つ
+- **WHEN** bug-combo-469-472 シナリオを読み込む
+- **THEN** `bug_target: null` が設定され description に #469 と #472 の両方が参照されている
+
+### Requirement: test-scenario-catalog bug level 追加
+
+test-scenario-catalog.md の level enum に `bug` 値を追加しなければならない（SHALL）。`bug` level は特定の chain 遷移・stall パターンの再現検証に特化し、`regression` level（並列実行 conflict 検証）と明確に区別される。
+
+#### Scenario: level enum に bug が追加される
+- **WHEN** test-scenario-catalog.md のスキーマ定義を読み込む
+- **THEN** `level: smoke | regression | load | bug` として 4 値が定義されている
+
+### Requirement: 5 バグ再現シナリオの追加
+
+test-scenario-catalog.md に Wave 1-5 由来の 5 シナリオを追加しなければならない（SHALL）。各シナリオは必須フィールド（level/description/issues_count/expected_duration_max/expected_conflicts/bug_target）を全て含む。
+
+#### Scenario: bug-469-chain-stall シナリオが追加される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** `bug-469-chain-stall:` エントリが存在し `level: bug, bug_target: 469` を持つ
+
+#### Scenario: bug-470-state-path シナリオが追加される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** `bug-470-state-path:` エントリが存在し `level: bug, bug_target: 470` を持つ
+
+#### Scenario: bug-471-refspec シナリオが追加される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** `bug-471-refspec:` エントリが存在し `level: bug, bug_target: 471` を持つ
+
+#### Scenario: bug-472-monitor-stall シナリオが追加される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** `bug-472-monitor-stall:` エントリが存在し `level: bug, bug_target: 472` を持つ
+
+#### Scenario: bug-combo-469-472 シナリオが追加される
+- **WHEN** test-scenario-catalog.md を読み込む
+- **THEN** `bug-combo-469-472:` エントリが存在し `issues_count: 3, expected_conflicts: 0, expected_duration_max: 60, bug_target: null` を持つ
+
+## MODIFIED Requirements
+
+### Requirement: observation-pattern-catalog bug-* パターン追加
+
+observation-pattern-catalog.md の bug-reproduction patterns セクションに Wave 4-5 由来の bug-* パターンを追加しなければならない（SHALL）。各パターンは `regex`/`severity`/`category`/`description`/`related_issue` フィールドを全て含む。
+
+#### Scenario: bug-469 パターンが追加される
+- **WHEN** observation-pattern-catalog.md を読み込む
+- **THEN** `bug-469-` プレフィックスを持つパターンが存在し `related_issue: "469"` を持つ
+
+#### Scenario: bug-470 パターンが追加される
+- **WHEN** observation-pattern-catalog.md を読み込む
+- **THEN** `bug-470-` プレフィックスを持つパターンが存在し `related_issue: "470"` を持つ
+
+#### Scenario: bug-471 パターンが追加される
+- **WHEN** observation-pattern-catalog.md を読み込む
+- **THEN** `bug-471-` プレフィックスを持つパターンが存在し `related_issue: "471"` を持つ
+
+#### Scenario: bug-472 パターンが追加される
+- **WHEN** observation-pattern-catalog.md を読み込む
+- **THEN** `bug-472-` プレフィックスを持つパターンが存在し `related_issue: "472"` を持つ
+
+#### Scenario: bug パターン合計数が 7 以上になる
+- **WHEN** observation-pattern-catalog.md を読み込む
+- **THEN** `^bug-` にマッチするエントリが 7 件以上存在する（既存 3 件 + 新規 4 件）
+
+### Requirement: observation-references.bats 検証ケース追加
+
+`plugins/twl/tests/bats/refs/observation-references.bats` に bug-4xx パターンの検証ケースを追加しなければならない（SHALL）。既存の `bug_count -ge 3` 閾値を `bug_count -ge 7` に引き上げる。
+
+#### Scenario: bats に bug-469 検証ケースが追加される
+- **WHEN** observation-references.bats を実行する
+- **THEN** `bug-469-` パターンの存在と `related_issue: "469"` を検証するテストがパスする
+
+#### Scenario: bats の bug_count 閾値が 7 に更新される
+- **WHEN** observation-references.bats を読み込む
+- **THEN** `bug_count -ge 7` 条件が記載されている

--- a/deltaspec/changes/issue-483/tasks.md
+++ b/deltaspec/changes/issue-483/tasks.md
@@ -1,0 +1,32 @@
+## 1. test-scenario-catalog スキーマ拡張
+
+- [x] 1.1 `plugins/twl/refs/test-scenario-catalog.md` の scenario YAML フォーマットに `bug_target:` フィールドを追加
+- [x] 1.2 level enum を `smoke | regression | load | bug` に更新
+- [x] 1.3 `## bug level シナリオ` セクションを新規追加
+
+## 2. bug 再現シナリオ追加（test-scenario-catalog）
+
+- [x] 2.1 `bug-469-chain-stall` シナリオを追加（level: bug, bug_target: 469）
+- [x] 2.2 `bug-470-state-path` シナリオを追加（level: bug, bug_target: 470）
+- [x] 2.3 `bug-471-refspec` シナリオを追加（level: bug, bug_target: 471）
+- [x] 2.4 `bug-472-monitor-stall` シナリオを追加（level: bug, bug_target: 472）
+- [x] 2.5 `bug-combo-469-472` シナリオを追加（level: bug, bug_target: null, issues_count: 3, expected_conflicts: 0, expected_duration_max: 60）
+
+## 3. observation-pattern-catalog bug-* パターン追加
+
+- [x] 3.1 `bug-469-chain-end` パターンを追加（related_issue: "469"）
+- [x] 3.2 `bug-470-state-path` パターンを追加（related_issue: "470"）
+- [x] 3.3 `bug-471-refspec` パターンを追加（related_issue: "471"）
+- [x] 3.4 `bug-472-monitor-stall` パターンを追加（related_issue: "472"）
+
+## 4. bats 検証ケース追加
+
+- [x] 4.1 `plugins/twl/tests/bats/refs/observation-references.bats` に bug-469/470/471/472 パターンの検証ケースを追加
+- [x] 4.2 既存 `bug_count -ge 3` 閾値を `bug_count -ge 7` に引き上げ
+- [x] 4.3 `test-scenario-catalog: bug-469-chain-stall defined` テストケースを追加
+- [x] 4.4 bats テストを実行して全ケースがパスすること確認
+
+## 5. GitHub Issue コメント追記
+
+- [x] 5.1 Issue #442 に「本 Issue (#483) で未達 AC を補完した」コメントを追記
+- [x] 5.2 Issue #443 に「本 Issue (#483) で未達 AC を補完した」コメントを追記

--- a/deltaspec/changes/issue-483/test-mapping.yaml
+++ b/deltaspec/changes/issue-483/test-mapping.yaml
@@ -1,0 +1,211 @@
+change_id: issue-483
+generated_at: "2026-04-12T00:00:00Z"
+test_framework: bats
+scenarios:
+  - id: "bug-target-field-defined"
+    name: "bug_target フィールドがスキーマに定義される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 7
+    requirement: "test-scenario-catalog bug_target フィールド追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: schema defines bug_target field"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-469-chain-stall-has-bug-target"
+    name: "bug 再現シナリオが bug_target を持つ"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 11
+    requirement: "test-scenario-catalog bug_target フィールド追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-469-chain-stall scenario defined with level bug and bug_target 469"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-combo-has-bug-target-null"
+    name: "combo シナリオが bug_target null を持つ"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 15
+    requirement: "test-scenario-catalog bug_target フィールド追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-combo-469-472 scenario has bug_target null and issues_count 3"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "level-enum-includes-bug"
+    name: "level enum に bug が追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 23
+    requirement: "test-scenario-catalog bug level 追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: level enum includes bug value"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-469-chain-stall-scenario-added"
+    name: "bug-469-chain-stall シナリオが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 31
+    requirement: "5 バグ再現シナリオの追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-469-chain-stall scenario defined with level bug and bug_target 469"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-470-state-path-scenario-added"
+    name: "bug-470-state-path シナリオが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 35
+    requirement: "5 バグ再現シナリオの追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-470-state-path scenario defined with bug_target 470"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-471-refspec-scenario-added"
+    name: "bug-471-refspec シナリオが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 39
+    requirement: "5 バグ再現シナリオの追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-471-refspec scenario defined with bug_target 471"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-472-monitor-stall-scenario-added"
+    name: "bug-472-monitor-stall シナリオが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 43
+    requirement: "5 バグ再現シナリオの追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-472-monitor-stall scenario defined with bug_target 472"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bug-combo-469-472-scenario-added"
+    name: "bug-combo-469-472 シナリオが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 47
+    requirement: "5 バグ再現シナリオの追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "test-scenario-catalog: bug-combo-469-472 scenario has bug_target null and issues_count 3"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "obs-bug-469-pattern-added"
+    name: "bug-469 パターンが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 57
+    requirement: "observation-pattern-catalog bug-* パターン追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug-469 pattern exists with related_issue 469"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "obs-bug-470-pattern-added"
+    name: "bug-470 パターンが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 62
+    requirement: "observation-pattern-catalog bug-* パターン追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug-470 pattern exists with related_issue 470"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "obs-bug-471-pattern-added"
+    name: "bug-471 パターンが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 67
+    requirement: "observation-pattern-catalog bug-* パターン追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug-471 pattern exists with related_issue 471"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "obs-bug-472-pattern-added"
+    name: "bug-472 パターンが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 72
+    requirement: "observation-pattern-catalog bug-* パターン追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug-472 pattern exists with related_issue 472"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "obs-bug-count-ge-7"
+    name: "bug パターン合計数が 7 以上になる"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 73
+    requirement: "observation-pattern-catalog bug-* パターン追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug_count is at least 7 after issue-483 additions"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-bug-469-verification-added"
+    name: "bats に bug-469 検証ケースが追加される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 81
+    requirement: "observation-references.bats 検証ケース追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: bug-469 pattern exists with related_issue 469"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-bug-count-threshold-7"
+    name: "bats の bug_count 閾値が 7 に更新される"
+    spec_file: "specs/catalog-schema-extension/spec.md"
+    spec_line: 85
+    requirement: "observation-references.bats 検証ケース追加"
+    test_file: "plugins/twl/tests/bats/refs/observation-references.bats"
+    test_name: "observation-pattern-catalog: has at least 9 patterns across all categories"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/refs/observation-pattern-catalog.md
+++ b/plugins/twl/refs/observation-pattern-catalog.md
@@ -119,7 +119,7 @@ bug-phase-review-skip:
 bug-469-chain-end:
   regex: 'non_terminal_chain_end|chain.*end.*non.terminal|WorkflowTransitionError'
   severity: error
-  category: chain-transition-stall
+  category: non-terminal-chain-end
   description: "Worker 完了後の non_terminal_chain_end による workflow-pr-verify 遷移停止検出 (#469 関連)"
   related_issue: "469"
 

--- a/plugins/twl/refs/observation-pattern-catalog.md
+++ b/plugins/twl/refs/observation-pattern-catalog.md
@@ -115,6 +115,34 @@ bug-phase-review-skip:
   category: phase-review-skip
   description: "phase-review スキップ / phase-review.json 不在検出 (#439 関連)"
   related_issue: "439"
+
+bug-469-chain-end:
+  regex: 'non_terminal_chain_end|chain.*end.*non.terminal|WorkflowTransitionError'
+  severity: error
+  category: chain-transition-stall
+  description: "Worker 完了後の non_terminal_chain_end による workflow-pr-verify 遷移停止検出 (#469 関連)"
+  related_issue: "469"
+
+bug-470-state-path:
+  regex: 'state.*path.*not found|state file.*missing|autopilot.*state.*resolve.*fail'
+  severity: error
+  category: state-path-resolution
+  description: "Pilot state file パス誤認による state 参照失敗検出 (#470 関連)"
+  related_issue: "470"
+
+bug-471-refspec:
+  regex: 'refspec.*missing|remote\.origin\.fetch.*not set|fetch.*origin.*main.*fail'
+  severity: error
+  category: refspec-missing
+  description: "remote.origin.fetch refspec 欠落による git fetch 失敗検出 (#471 関連)"
+  related_issue: "471"
+
+bug-472-monitor-stall:
+  regex: 'PHASE_COMPLETE.*wait.*timeout|Monitor.*stall|Monitor.*hang|phase.*complete.*never'
+  severity: error
+  category: monitor-stall
+  description: "Pilot Monitor の PHASE_COMPLETE wait 無限 stall 検出 (#472 関連)"
+  related_issue: "472"
 ```
 
 ## 拡張ガイド

--- a/plugins/twl/refs/test-scenario-catalog.md
+++ b/plugins/twl/refs/test-scenario-catalog.md
@@ -22,7 +22,7 @@ co-self-improve framework のテストプロジェクト (test-target/main workt
   expected_conflicts: <件数>
   expected_pr_count: <件数>
   observer_polling_interval: <秒>
-  bug_target: <Bug Issue 番号 | null>  # bug level 専用。汎用シナリオは null、bug 再現シナリオは対象 Bug Issue 番号
+  bug_target: <Bug Issue 番号 | null>  # bug level 専用（optional）。smoke/regression/load シナリオでは省略可。bug 再現シナリオは対象 Bug Issue 番号、複合シナリオは null
   issue_templates:
     - title: <タイトル>
       body: <body, multi-line>

--- a/plugins/twl/refs/test-scenario-catalog.md
+++ b/plugins/twl/refs/test-scenario-catalog.md
@@ -14,7 +14,7 @@ co-self-improve framework のテストプロジェクト (test-target/main workt
 
 ```yaml
 <scenario-id>:
-  level: smoke | regression | load
+  level: smoke | regression | load | bug
   description: <一行説明>
   issues_count: <数>
   expected_duration_min: <最小分>
@@ -22,6 +22,7 @@ co-self-improve framework のテストプロジェクト (test-target/main workt
   expected_conflicts: <件数>
   expected_pr_count: <件数>
   observer_polling_interval: <秒>
+  bug_target: <Bug Issue 番号 | null>  # bug level 専用。汎用シナリオは null、bug 再現シナリオは対象 Bug Issue 番号
   issue_templates:
     - title: <タイトル>
       body: <body, multi-line>
@@ -322,4 +323,155 @@ regression-006:
 ```yaml
 # load-001: TBD (将来 Issue で実装)
 # load-002: TBD (将来 Issue で実装)
+```
+
+## bug level シナリオ (Wave 1-5 バグ再現, #483 追加)
+
+Wave 1-5 で発見された autopilot バグの再現シナリオ。`bug` level は特定の chain 遷移・stall パターンを検証し、`regression` level（並列実行 conflict 検証）と区別される。real-issues モードで各バグを再現確認できる。
+
+### bug-469-chain-stall: Worker 完了後の workflow-pr-verify 遷移停止
+
+```yaml
+bug-469-chain-stall:
+  level: bug
+  description: "Worker 実装完了後の non_terminal_chain_end による workflow-pr-verify 遷移停止再現 (#469)"
+  issues_count: 1
+  expected_duration_min: 3
+  expected_duration_max: 15
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 30
+  bug_target: 469
+  issue_templates:
+    - title: "[Test] bug-469: add simple function to test non_terminal_chain_end"
+      body: |
+        ## Goal
+        test-target plugin に `simple_func()` 関数を追加する。
+
+        ## AC
+        - [ ] `scripts/simple_func.sh` が新規作成される
+        - [ ] workflow-pr-verify に正常遷移する
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+```
+
+### bug-470-state-path: Pilot state file パス誤認再現
+
+```yaml
+bug-470-state-path:
+  level: bug
+  description: "Pilot が Worker state file を誤ったパスで参照するバグ再現 (#470)"
+  issues_count: 1
+  expected_duration_min: 3
+  expected_duration_max: 15
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 30
+  bug_target: 470
+  issue_templates:
+    - title: "[Test] bug-470: trivial change to verify state file path resolution"
+      body: |
+        ## Goal
+        test-target plugin に README 更新を行い、Pilot が state を正しく追跡できるか検証する。
+
+        ## AC
+        - [ ] README.md に 1 行追加される
+        - [ ] Pilot の state file が正しいパスを参照する
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+```
+
+### bug-471-refspec: remote.origin.fetch refspec 欠落再現
+
+```yaml
+bug-471-refspec:
+  level: bug
+  description: "bare repo worktree 作成時の remote.origin.fetch refspec 欠落による fetch 失敗再現 (#471)"
+  issues_count: 1
+  expected_duration_min: 3
+  expected_duration_max: 15
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 30
+  bug_target: 471
+  issue_templates:
+    - title: "[Test] bug-471: trivial change to verify refspec is set after worktree create"
+      body: |
+        ## Goal
+        worktree 作成後に remote.origin.fetch refspec が正しく設定されているか検証する。
+
+        ## AC
+        - [ ] `.bare/config` に `+refs/heads/*:refs/remotes/origin/*` が含まれる
+        - [ ] `git fetch origin` が origin/main を正しく更新する
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+```
+
+### bug-472-monitor-stall: Pilot Monitor PHASE_COMPLETE wait 無限 stall 再現
+
+```yaml
+bug-472-monitor-stall:
+  level: bug
+  description: "Pilot Monitor が PHASE_COMPLETE を待機し続ける無限 stall 再現 (#472)"
+  issues_count: 1
+  expected_duration_min: 3
+  expected_duration_max: 20
+  expected_conflicts: 0
+  expected_pr_count: 1
+  observer_polling_interval: 30
+  bug_target: 472
+  issue_templates:
+    - title: "[Test] bug-472: trivial change to verify Monitor does not stall on PHASE_COMPLETE"
+      body: |
+        ## Goal
+        trivial な変更を通じて Pilot Monitor が PHASE_COMPLETE を受信後に正常終了することを検証する。
+
+        ## AC
+        - [ ] Monitor が PHASE_COMPLETE を受信後に停止する
+        - [ ] Pilot が次のフェーズに正常遷移する
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+```
+
+### bug-combo-469-472: #469 + #472 複合 stall 再現
+
+```yaml
+bug-combo-469-472:
+  level: bug
+  description: "non_terminal_chain_end (#469) と Monitor stall (#472) の複合停止パターン再現 (#469/#472 参照)"
+  issues_count: 3
+  expected_duration_min: 5
+  expected_duration_max: 60
+  expected_conflicts: 0
+  expected_pr_count: 3
+  observer_polling_interval: 30
+  bug_target: null
+  issue_templates:
+    - title: "[Test] bug-combo-1: add function A"
+      body: |
+        ## Goal
+        test-target に function A を追加する。
+
+        ## AC
+        - [ ] `scripts/func_a.sh` が新規作成される
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+    - title: "[Test] bug-combo-2: add function B"
+      body: |
+        ## Goal
+        test-target に function B を追加する。
+
+        ## AC
+        - [ ] `scripts/func_b.sh` が新規作成される
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
+    - title: "[Test] bug-combo-3: add function C"
+      body: |
+        ## Goal
+        test-target に function C を追加する。
+
+        ## AC
+        - [ ] `scripts/func_c.sh` が新規作成される
+      labels: [test, scope/test-target, complexity-trivial]
+      complexity: trivial
 ```

--- a/plugins/twl/tests/bats/refs/observation-references.bats
+++ b/plugins/twl/tests/bats/refs/observation-references.bats
@@ -105,14 +105,14 @@ setup() {
   hist_count=$(grep -c '^hist-' "$file" || true)
   [ "$hist_count" -ge 2 ]
 
-  # Count bug patterns (3+) added in issue-443
+  # Count bug patterns (7+) added in issue-443 + issue-483
   local bug_count
   bug_count=$(grep -c '^bug-' "$file" || true)
-  [ "$bug_count" -ge 3 ]
+  [ "$bug_count" -ge 7 ]
 
-  # Total 12+ (error 3 + warn 2 + info 2 + hist 2 + bug 3)
+  # Total 16+ (error 3 + warn 2 + info 2 + hist 2 + bug 7)
   local total=$((error_count + warn_count + info_count + hist_count + bug_count))
-  [ "$total" -ge 12 ]
+  [ "$total" -ge 16 ]
 }
 
 @test "observation-pattern-catalog: all regex patterns are valid for grep -E" {
@@ -200,4 +200,98 @@ setup() {
   local file="$REPO_ROOT/refs/load-test-baselines.md"
 
   grep -q '30 分以内' "$file"
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: issue-483 bug-4xx パターン追加検証
+# ---------------------------------------------------------------------------
+
+@test "observation-pattern-catalog: bug-469 pattern exists with related_issue 469" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'bug-469-' "$file"
+  grep -q 'related_issue: "469"' "$file"
+}
+
+@test "observation-pattern-catalog: bug-470 pattern exists with related_issue 470" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'bug-470-' "$file"
+  grep -q 'related_issue: "470"' "$file"
+}
+
+@test "observation-pattern-catalog: bug-471 pattern exists with related_issue 471" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'bug-471-' "$file"
+  grep -q 'related_issue: "471"' "$file"
+}
+
+@test "observation-pattern-catalog: bug-472 pattern exists with related_issue 472" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'bug-472-' "$file"
+  grep -q 'related_issue: "472"' "$file"
+}
+
+@test "observation-pattern-catalog: bug_count is at least 7 after issue-483 additions" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  local bug_count
+  bug_count=$(grep -c '^bug-' "$file" || true)
+  [ "$bug_count" -ge 7 ]
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: issue-483 test-scenario-catalog bug level + bug_target 検証
+# ---------------------------------------------------------------------------
+
+@test "test-scenario-catalog: schema defines bug_target field" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug_target:' "$file"
+}
+
+@test "test-scenario-catalog: level enum includes bug value" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -qE 'level: smoke \| regression \| load \| bug' "$file"
+}
+
+@test "test-scenario-catalog: bug-469-chain-stall scenario defined with level bug and bug_target 469" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug-469-chain-stall:' "$file"
+  grep -q 'level: bug' "$file"
+  grep -q 'bug_target: 469' "$file"
+}
+
+@test "test-scenario-catalog: bug-470-state-path scenario defined with bug_target 470" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug-470-state-path:' "$file"
+  grep -q 'bug_target: 470' "$file"
+}
+
+@test "test-scenario-catalog: bug-471-refspec scenario defined with bug_target 471" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug-471-refspec:' "$file"
+  grep -q 'bug_target: 471' "$file"
+}
+
+@test "test-scenario-catalog: bug-472-monitor-stall scenario defined with bug_target 472" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug-472-monitor-stall:' "$file"
+  grep -q 'bug_target: 472' "$file"
+}
+
+@test "test-scenario-catalog: bug-combo-469-472 scenario has bug_target null and issues_count 3" {
+  local file="$REPO_ROOT/refs/test-scenario-catalog.md"
+
+  grep -q 'bug-combo-469-472:' "$file"
+  grep -q 'bug_target: null' "$file"
+  grep -q 'issues_count: 3' "$file"
+  grep -q 'expected_conflicts: 0' "$file"
 }

--- a/plugins/twl/tests/bats/refs/observation-references.bats
+++ b/plugins/twl/tests/bats/refs/observation-references.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 # observation-references.bats - structural validation of co-self-improve data catalog references
 #
-# 9 test cases for #179 reference catalogs
+# 27 test cases for #179 reference catalogs (Case 5+6 added in #483)
 
 setup() {
   # Resolve REPO_ROOT to plugins/twl/
@@ -294,4 +294,5 @@ setup() {
   grep -q 'bug_target: null' "$file"
   grep -q 'issues_count: 3' "$file"
   grep -q 'expected_conflicts: 0' "$file"
+  grep -q 'expected_duration_max: 60' "$file"
 }


### PR DESCRIPTION
## 概要

Wave 1-5 で発見された autopilot バグ（#469/#470/#471/#472）を再現する E2E シナリオを test-scenario-catalog に追加し、対応する検出パターンを observation-pattern-catalog に追加する。#442/#443 の未達 AC を補完する。

## 変更内容

- `plugins/twl/refs/test-scenario-catalog.md`: bug_target フィールド + bug level 追加、5 シナリオ（bug-469/470/471/472/combo）追加
- `plugins/twl/refs/observation-pattern-catalog.md`: bug-469/470/471/472 の bug-* パターン 4 件追加
- `plugins/twl/tests/bats/refs/observation-references.bats`: Case 5/6 追加（12 ケース）、bug_count 閾値 3→7 更新
- `deltaspec/changes/issue-483/`: DeltaSpec artifacts 追加

## 関連 Issue

Closes #483
refs: #442 #443 #469 #470 #471 #472

## Deferred

- #519: bug 再現シナリオ使い方ドキュメント追記
- #520: observation-pattern-catalog severity enum スキーマ整合