### PR TITLE
refactor(change-propose): Step 0 の冗長な echo 補完処理を削除 #448

### DIFF
--- a/cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py
+++ b/cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py
@@ -258,67 +258,48 @@ class TestDeltaspecYamlNoDuplicates:
     # THEN: .deltaspec.yaml に name:, status:, issue: が各 1 回のみ存在する
     # ------------------------------------------------------------------
 
-    def test_name_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
-        """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に name: が 1 回のみ存在する。"""
+    @pytest.fixture()
+    def yaml_content_448(self, tmp_path: Path, monkeypatch) -> str:
+        """issue-448 で twl spec new を実行し .deltaspec.yaml の内容を返す共通フィクスチャ。"""
         monkeypatch.chdir(make_project(tmp_path))
         rc = cmd_new("issue-448")
         assert rc == 0
-
         yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
         assert yaml_path.exists(), ".deltaspec.yaml が作成されていません"
-        content = yaml_path.read_text(encoding="utf-8")
+        return yaml_path.read_text(encoding="utf-8")
 
-        name_lines = [line for line in content.splitlines() if line.startswith("name:")]
+    def test_name_field_appears_exactly_once(self, yaml_content_448: str) -> None:
+        """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に name: が 1 回のみ存在する。"""
+        name_lines = [line for line in yaml_content_448.splitlines() if line.startswith("name:")]
         assert len(name_lines) == 1, (
             f"name: フィールドが {len(name_lines)} 回存在します（期待: 1 回）\n"
-            f"内容:\n{content}"
+            f"内容:\n{yaml_content_448}"
         )
 
-    def test_status_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+    def test_status_field_appears_exactly_once(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に status: が 1 回のみ存在する。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-
-        status_lines = [line for line in content.splitlines() if line.startswith("status:")]
+        status_lines = [line for line in yaml_content_448.splitlines() if line.startswith("status:")]
         assert len(status_lines) == 1, (
             f"status: フィールドが {len(status_lines)} 回存在します（期待: 1 回）\n"
-            f"内容:\n{content}"
+            f"内容:\n{yaml_content_448}"
         )
 
-    def test_issue_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+    def test_issue_field_appears_exactly_once(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に issue: が 1 回のみ存在する。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-
-        issue_lines = [line for line in content.splitlines() if line.startswith("issue:")]
+        issue_lines = [line for line in yaml_content_448.splitlines() if line.startswith("issue:")]
         assert len(issue_lines) == 1, (
             f"issue: フィールドが {len(issue_lines)} 回存在します（期待: 1 回）\n"
-            f"内容:\n{content}"
+            f"内容:\n{yaml_content_448}"
         )
 
-    def test_all_three_fields_appear_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+    def test_all_three_fields_appear_exactly_once(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN name:, status:, issue: が各 1 回のみ存在する。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-        lines = content.splitlines()
-
+        lines = yaml_content_448.splitlines()
         for field in ("name:", "status:", "issue:"):
-            field_lines = [l for l in lines if l.startswith(field)]
+            field_lines = [line for line in lines if line.startswith(field)]
             assert len(field_lines) == 1, (
                 f"'{field}' フィールドが {len(field_lines)} 回存在します（期待: 1 回）\n"
-                f"内容:\n{content}"
+                f"内容:\n{yaml_content_448}"
             )
 
     def test_no_duplicates_after_spec_new_issue_1(self, tmp_path: Path, monkeypatch) -> None:
@@ -332,7 +313,7 @@ class TestDeltaspecYamlNoDuplicates:
         lines = content.splitlines()
 
         for field in ("name:", "status:", "issue:"):
-            count = sum(1 for l in lines if l.startswith(field))
+            count = sum(1 for line in lines if line.startswith(field))
             assert count == 1, (
                 f"'issue-1' の .deltaspec.yaml: '{field}' が {count} 回 (期待: 1 回)\n"
                 f"内容:\n{content}"
@@ -351,44 +332,26 @@ class TestDeltaspecYamlNoDuplicates:
         lines = content.splitlines()
 
         for field in ("name:", "status:", "issue:"):
-            count = sum(1 for l in lines if l.startswith(field))
+            count = sum(1 for line in lines if line.startswith(field))
             assert count == 1, (
                 f"'issue-9999' の .deltaspec.yaml: '{field}' が {count} 回 (期待: 1 回)\n"
                 f"内容:\n{content}"
             )
 
-    def test_name_value_matches_change_id(self, tmp_path: Path, monkeypatch) -> None:
+    def test_name_value_matches_change_id(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN name: の値が 'issue-448' である。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-        assert "name: issue-448" in content, (
-            f"name: フィールドの値が 'issue-448' ではありません\n内容:\n{content}"
+        assert "name: issue-448" in yaml_content_448, (
+            f"name: フィールドの値が 'issue-448' ではありません\n内容:\n{yaml_content_448}"
         )
 
-    def test_status_value_is_pending(self, tmp_path: Path, monkeypatch) -> None:
+    def test_status_value_is_pending(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN status: の値が 'pending' である。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-        assert "status: pending" in content, (
-            f"status: フィールドの値が 'pending' ではありません\n内容:\n{content}"
+        assert "status: pending" in yaml_content_448, (
+            f"status: フィールドの値が 'pending' ではありません\n内容:\n{yaml_content_448}"
         )
 
-    def test_issue_number_extracted_correctly(self, tmp_path: Path, monkeypatch) -> None:
+    def test_issue_number_extracted_correctly(self, yaml_content_448: str) -> None:
         """WHEN twl spec new 'issue-448' THEN issue: の値が 448 である。"""
-        monkeypatch.chdir(make_project(tmp_path))
-        rc = cmd_new("issue-448")
-        assert rc == 0
-
-        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
-        content = yaml_path.read_text(encoding="utf-8")
-        assert "issue: 448" in content, (
-            f"issue: フィールドの値が 448 ではありません\n内容:\n{content}"
+        assert "issue: 448" in yaml_content_448, (
+            f"issue: フィールドの値が 448 ではありません\n内容:\n{yaml_content_448}"
         )

--- a/cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py
+++ b/cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py
@@ -1,0 +1,394 @@
+"""Tests for Issue #448: change-propose.md Step 0 auto_init echo 補完削除.
+
+Spec: deltaspec/changes/issue-448/specs/remove-echo-redundancy/spec.md
+
+Coverage:
+
+  Requirement: Step 0 auto_init フローの echo 補完削除
+    - Scenario: twl spec new 呼出後に echo 補完が存在しない
+        WHEN: change-propose.md の Step 0 auto_init フローを参照する
+        THEN: `echo "name: ..." >> .deltaspec.yaml` および
+              `echo "status: ..." >> .deltaspec.yaml` の行が存在しない
+
+    - Scenario: twl spec new の自動補完を説明するコメントが存在する
+        WHEN: change-propose.md の Step 0 内の `twl spec new "issue-<N>"` 呼出直後を参照する
+        THEN: `twl spec new` が issue 番号・name・status を自動補完することを説明する
+              コメントが存在する
+
+  Requirement: .deltaspec.yaml への重複エントリ防止
+    - Scenario: issue-N 形式の change 作成後に .deltaspec.yaml が重複なし (integration)
+        WHEN: twl spec new "issue-<N>" を実行する
+        THEN: .deltaspec.yaml に name:, status:, issue: が各 1 回のみ存在する
+
+  Edge cases (--coverage=edge-cases):
+    - echo 行が部分一致（コメントなど）しても誤検知しないこと
+    - 空の .deltaspec.yaml に対して cmd_new が正常に動作すること
+    - issue-0 のような境界値 issue 番号でも重複なし
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "src"))
+
+from twl.spec.new import cmd_new
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# change-propose.md へのパス（リポジトリルート相対）
+# conftest.py が sys.path を調整しているが、ファイルパスはこのテストファイルから算出する
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+_CHANGE_PROPOSE_MD = _REPO_ROOT / "plugins" / "twl" / "commands" / "change-propose.md"
+
+# Step 0 auto_init セクション（### Step 0 から 次の ### Step まで）を抽出する正規表現
+_STEP0_RE = re.compile(
+    r"### Step 0:.*?(?=### Step [^0]|\Z)",
+    re.DOTALL,
+)
+
+# echo 補完行のパターン: `echo "name: ...`  or  `echo "status: ...` が .deltaspec.yaml へ append
+_ECHO_NAME_RE = re.compile(r'echo\s+"name:\s*[^"]*"\s*>>\s*\S*\.deltaspec\.yaml')
+_ECHO_STATUS_RE = re.compile(r'echo\s+"status:\s*[^"]*"\s*>>\s*\S*\.deltaspec\.yaml')
+
+# twl spec new 呼出行のパターン
+_SPEC_NEW_RE = re.compile(r'twl\s+spec\s+new\s+"issue-')
+
+
+def _load_step0_content() -> str:
+    """change-propose.md から Step 0 セクションのテキストを抽出して返す。"""
+    assert _CHANGE_PROPOSE_MD.exists(), (
+        f"change-propose.md が見つかりません: {_CHANGE_PROPOSE_MD}\n"
+        "テスト対象ファイルが存在することを確認してください。"
+    )
+    content = _CHANGE_PROPOSE_MD.read_text(encoding="utf-8")
+    m = _STEP0_RE.search(content)
+    assert m is not None, "change-propose.md に '### Step 0:' セクションが見つかりません"
+    return m.group(0)
+
+
+def make_project(tmp_path: Path) -> Path:
+    """最小限の deltaspec プロジェクト構造を作成する。"""
+    (tmp_path / "deltaspec" / "changes").mkdir(parents=True)
+    (tmp_path / "deltaspec" / "config.yaml").write_text(
+        "schema: spec-driven\ncontext: {}\n", encoding="utf-8"
+    )
+    return tmp_path
+
+
+# ===========================================================================
+# Requirement: Step 0 auto_init フローの echo 補完削除
+# ===========================================================================
+
+
+class TestEchoCompletionRemoved:
+    """Requirement: Step 0 auto_init フローの echo 補完削除
+
+    change-propose.md の Step 0 auto_init フローに echo による手動補完行が
+    存在しないことを確認する（Markdown コンテンツ検証）。
+    """
+
+    # ------------------------------------------------------------------
+    # Scenario: twl spec new 呼出後に echo 補完が存在しない
+    # WHEN: change-propose.md の Step 0 auto_init フローを参照する
+    # THEN: `echo "name: ..." >> .deltaspec.yaml` および
+    #       `echo "status: ..." >> .deltaspec.yaml` の行が存在しない
+    # ------------------------------------------------------------------
+
+    def test_echo_name_line_absent_in_step0(self) -> None:
+        """WHEN Step 0 を参照 THEN `echo "name: ..." >> .deltaspec.yaml` が存在しない。"""
+        step0 = _load_step0_content()
+        matches = _ECHO_NAME_RE.findall(step0)
+        assert matches == [], (
+            "Step 0 に `echo \"name: ...\" >> .deltaspec.yaml` 行が残っています。\n"
+            f"削除が必要な行: {matches}"
+        )
+
+    def test_echo_status_line_absent_in_step0(self) -> None:
+        """WHEN Step 0 を参照 THEN `echo "status: ..." >> .deltaspec.yaml` が存在しない。"""
+        step0 = _load_step0_content()
+        matches = _ECHO_STATUS_RE.findall(step0)
+        assert matches == [], (
+            "Step 0 に `echo \"status: ...\" >> .deltaspec.yaml` 行が残っています。\n"
+            f"削除が必要な行: {matches}"
+        )
+
+    def test_neither_echo_name_nor_echo_status_present(self) -> None:
+        """WHEN Step 0 を参照 THEN echo による name/status 補完行がどちらも存在しない。"""
+        step0 = _load_step0_content()
+        name_matches = _ECHO_NAME_RE.findall(step0)
+        status_matches = _ECHO_STATUS_RE.findall(step0)
+        assert name_matches == [] and status_matches == [], (
+            f"name echo 行: {name_matches}, status echo 行: {status_matches}"
+        )
+
+    def test_echo_append_pattern_not_present_for_deltaspec_yaml(self) -> None:
+        """Edge case: `.deltaspec.yaml` への echo append がコード例として残っていないこと。
+
+        コメント内の記述例も含め、echo >> .deltaspec.yaml 形式の行が Step 0 にないことを確認。
+        """
+        step0 = _load_step0_content()
+        # より広いパターン: echo ... >> ... .deltaspec.yaml
+        broad_echo_re = re.compile(r'echo\s+["\']?(name|status):', re.IGNORECASE)
+        matches = [line for line in step0.splitlines() if broad_echo_re.search(line)]
+        assert matches == [], (
+            "Step 0 に echo name:/status: パターンの行が残存しています:\n"
+            + "\n".join(f"  {line}" for line in matches)
+        )
+
+
+# ===========================================================================
+# Requirement: Step 0 auto_init フローの echo 補完削除
+# （コメント追加確認）
+# ===========================================================================
+
+
+class TestAutoCompletionCommentPresent:
+    """Requirement: twl spec new 自動補完コメントの存在確認
+
+    twl spec new 呼出後に、name/status/issue の自動補完を説明するコメントが
+    存在することを確認する（Markdown コンテンツ検証）。
+    """
+
+    # ------------------------------------------------------------------
+    # Scenario: twl spec new の自動補完を説明するコメントが存在する
+    # WHEN: change-propose.md の Step 0 内の `twl spec new "issue-<N>"` 呼出直後を参照する
+    # THEN: twl spec new が issue 番号・name・status を自動補完することを説明する
+    #       コメントが存在する
+    # ------------------------------------------------------------------
+
+    def test_auto_completion_comment_exists_after_spec_new(self) -> None:
+        """WHEN Step 0 の `twl spec new` 呼出直後を参照 THEN 自動補完コメントが存在する。"""
+        step0 = _load_step0_content()
+
+        # twl spec new 呼出行を探し、その後に自動補完に言及するテキストがあるか確認
+        spec_new_pos = step0.find("twl spec new")
+        assert spec_new_pos != -1, "Step 0 に `twl spec new` 呼出が見つかりません"
+
+        # twl spec new 呼出より後の内容を検索対象とする
+        after_spec_new = step0[spec_new_pos:]
+
+        # 自動補完に言及するキーワードを確認（日本語・英語どちらでも可）
+        auto_complete_keywords = [
+            "自動補完",
+            "auto",
+            "automatically",
+            "automatically fills",
+            "fills in",
+        ]
+        has_comment = any(kw in after_spec_new for kw in auto_complete_keywords)
+        assert has_comment, (
+            "`twl spec new` 呼出後に自動補完を説明するコメントが見つかりません。\n"
+            "キーワード候補: " + ", ".join(repr(k) for k in auto_complete_keywords) + "\n"
+            "Step 0 の該当箇所:\n" + after_spec_new[:500]
+        )
+
+    def test_auto_completion_comment_mentions_name_or_status(self) -> None:
+        """WHEN 自動補完コメントを参照 THEN name または status フィールドに言及している。"""
+        step0 = _load_step0_content()
+        spec_new_pos = step0.find("twl spec new")
+        assert spec_new_pos != -1, "Step 0 に `twl spec new` 呼出が見つかりません"
+        after_spec_new = step0[spec_new_pos:]
+
+        # name か status のどちらかに言及していること
+        mentions_field = "name" in after_spec_new or "status" in after_spec_new
+        assert mentions_field, (
+            "自動補完コメントに `name` または `status` フィールドへの言及がありません。\n"
+            "Step 0 (twl spec new 以降):\n" + after_spec_new[:500]
+        )
+
+    def test_step0_retains_spec_new_call(self) -> None:
+        """WHEN Step 0 を参照 THEN `twl spec new "issue-<N>"` 呼出が存在する。
+
+        リファクタリング後も twl spec new 自体は削除されていないことを確認。
+        """
+        step0 = _load_step0_content()
+        assert _SPEC_NEW_RE.search(step0) is not None, (
+            "Step 0 に `twl spec new \"issue-<N>\"` 呼出が見つかりません。"
+        )
+
+    def test_no_manual_echo_replaced_by_comment_not_new_code(self) -> None:
+        """Edge case: echo 削除後に別の手動補完コードが追加されていないこと。
+
+        echo を別のファイル書き込みコード（python/awk など）に置き換えていないことを確認。
+        """
+        step0 = _load_step0_content()
+        # 許容しない代替パターン: name: や status: を .deltaspec.yaml に書き込む命令
+        # bash の printf/tee 経由での書き込みも禁止
+        forbidden_patterns = [
+            re.compile(r'printf\s+["\']name:'),
+            re.compile(r'printf\s+["\']status:'),
+            re.compile(r'tee\s+-a\s+\S*\.deltaspec\.yaml'),
+            re.compile(r'python.*name.*\.deltaspec\.yaml'),
+        ]
+        violations: list[str] = []
+        for line in step0.splitlines():
+            for pat in forbidden_patterns:
+                if pat.search(line):
+                    violations.append(line.strip())
+
+        assert violations == [], (
+            "Step 0 に echo 以外の手動フィールド書き込みが検出されました:\n"
+            + "\n".join(f"  {v}" for v in violations)
+        )
+
+
+# ===========================================================================
+# Requirement: .deltaspec.yaml への重複エントリ防止 (integration)
+# ===========================================================================
+
+
+class TestDeltaspecYamlNoDuplicates:
+    """Requirement: .deltaspec.yaml への重複エントリ防止
+
+    `twl spec new "issue-<N>"` 実行後に .deltaspec.yaml に name:, status:, issue: が
+    各 1 回のみ存在することを統合テストで確認する。
+    """
+
+    # ------------------------------------------------------------------
+    # Scenario: issue-N 形式の change 作成後に .deltaspec.yaml が重複なし
+    # WHEN: change-propose.md の Step 0 フローに従い `twl spec new "issue-<N>"` を実行する
+    # THEN: .deltaspec.yaml に name:, status:, issue: が各 1 回のみ存在する
+    # ------------------------------------------------------------------
+
+    def test_name_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に name: が 1 回のみ存在する。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        assert yaml_path.exists(), ".deltaspec.yaml が作成されていません"
+        content = yaml_path.read_text(encoding="utf-8")
+
+        name_lines = [line for line in content.splitlines() if line.startswith("name:")]
+        assert len(name_lines) == 1, (
+            f"name: フィールドが {len(name_lines)} 回存在します（期待: 1 回）\n"
+            f"内容:\n{content}"
+        )
+
+    def test_status_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に status: が 1 回のみ存在する。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+
+        status_lines = [line for line in content.splitlines() if line.startswith("status:")]
+        assert len(status_lines) == 1, (
+            f"status: フィールドが {len(status_lines)} 回存在します（期待: 1 回）\n"
+            f"内容:\n{content}"
+        )
+
+    def test_issue_field_appears_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN .deltaspec.yaml に issue: が 1 回のみ存在する。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+
+        issue_lines = [line for line in content.splitlines() if line.startswith("issue:")]
+        assert len(issue_lines) == 1, (
+            f"issue: フィールドが {len(issue_lines)} 回存在します（期待: 1 回）\n"
+            f"内容:\n{content}"
+        )
+
+    def test_all_three_fields_appear_exactly_once(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN name:, status:, issue: が各 1 回のみ存在する。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+
+        for field in ("name:", "status:", "issue:"):
+            field_lines = [l for l in lines if l.startswith(field)]
+            assert len(field_lines) == 1, (
+                f"'{field}' フィールドが {len(field_lines)} 回存在します（期待: 1 回）\n"
+                f"内容:\n{content}"
+            )
+
+    def test_no_duplicates_after_spec_new_issue_1(self, tmp_path: Path, monkeypatch) -> None:
+        """Edge case: WHEN twl spec new 'issue-1' THEN 最小 issue 番号でも重複なし。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-1")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-1" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+
+        for field in ("name:", "status:", "issue:"):
+            count = sum(1 for l in lines if l.startswith(field))
+            assert count == 1, (
+                f"'issue-1' の .deltaspec.yaml: '{field}' が {count} 回 (期待: 1 回)\n"
+                f"内容:\n{content}"
+            )
+
+    def test_no_duplicates_after_spec_new_large_issue_number(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Edge case: WHEN twl spec new 'issue-9999' THEN 大きな issue 番号でも重複なし。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-9999")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-9999" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        lines = content.splitlines()
+
+        for field in ("name:", "status:", "issue:"):
+            count = sum(1 for l in lines if l.startswith(field))
+            assert count == 1, (
+                f"'issue-9999' の .deltaspec.yaml: '{field}' が {count} 回 (期待: 1 回)\n"
+                f"内容:\n{content}"
+            )
+
+    def test_name_value_matches_change_id(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN name: の値が 'issue-448' である。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        assert "name: issue-448" in content, (
+            f"name: フィールドの値が 'issue-448' ではありません\n内容:\n{content}"
+        )
+
+    def test_status_value_is_pending(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN status: の値が 'pending' である。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        assert "status: pending" in content, (
+            f"status: フィールドの値が 'pending' ではありません\n内容:\n{content}"
+        )
+
+    def test_issue_number_extracted_correctly(self, tmp_path: Path, monkeypatch) -> None:
+        """WHEN twl spec new 'issue-448' THEN issue: の値が 448 である。"""
+        monkeypatch.chdir(make_project(tmp_path))
+        rc = cmd_new("issue-448")
+        assert rc == 0
+
+        yaml_path = tmp_path / "deltaspec" / "changes" / "issue-448" / ".deltaspec.yaml"
+        content = yaml_path.read_text(encoding="utf-8")
+        assert "issue: 448" in content, (
+            f"issue: フィールドの値が 448 ではありません\n内容:\n{content}"
+        )

--- a/deltaspec/changes/issue-448/.deltaspec.yaml
+++ b/deltaspec/changes/issue-448/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 448
+name: issue-448
+status: pending

--- a/deltaspec/changes/issue-448/design.md
+++ b/deltaspec/changes/issue-448/design.md
@@ -1,0 +1,37 @@
+## Context
+
+`plugins/twl/commands/change-propose.md` の Step 0 auto_init フローでは、`twl spec new "issue-<N>"` の呼出後に echo 2 行で `.deltaspec.yaml` を手動補完している。しかし `twl spec new` 自体が `name:`, `status:`, `issue:` を自動書き込みするため、この補完は二重書き込みとなる。
+
+Issue #448 のスコープは `change-propose.md` の該当 echo 行の削除とコメント追加のみ。CLI 側（`cli/twl/src/twl/spec/new.py`）は変更しない。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `change-propose.md` Step 0 の echo 2 行（name/status 補完）を削除する
+- `twl spec new` 呼出箇所に自動補完の説明コメントを追加する
+- `.deltaspec.yaml` への重複エントリを防止する
+
+**Non-Goals:**
+- `cli/twl/` のコードを変更しない
+- `twl spec new` の動作を変更しない
+- 他のステップ（Step 1〜6）を変更しない
+
+## Decisions
+
+**削除対象（change-propose.md:40-46 付近）:**
+```bash
+5. .deltaspec.yaml に必須フィールドを補完:
+   echo "name: issue-<N>" >> deltaspec/changes/issue-<N>/.deltaspec.yaml
+   echo "status: pending" >> deltaspec/changes/issue-<N>/.deltaspec.yaml
+```
+→ この箇条書き項目 5（echo 2 行）を完全に削除する。
+
+**追加コメント（`twl spec new` 呼出直後）:**
+```bash
+# twl spec new が自動補完する（issue 番号・name・status）
+```
+
+## Risks / Trade-offs
+
+- リスクなし（機能的変更なし）
+- ドキュメントの削除は後方互換性に影響しない

--- a/deltaspec/changes/issue-448/proposal.md
+++ b/deltaspec/changes/issue-448/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+`twl spec new` コマンドは `issue:`, `name:`, `status:` フィールドを `.deltaspec.yaml` に自動書き込みするが、`change-propose.md` の Step 0 auto_init フローにはこれと重複する `echo` 補完処理が残存しており、ファイルへの重複エントリ書き込みを引き起こす。
+
+## What Changes
+
+- `plugins/twl/commands/change-propose.md` Step 0 の `.deltaspec.yaml` 補完用 echo 2 行（`name:` と `status:`）を削除する
+- `twl spec new` 呼出直後に「`twl spec new` が自動補完する（issue 番号・name・status）」のコメントを追加する
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- `change-propose.md` Step 0 auto_init フロー: `twl spec new` に補完を一任し、echo による手動補完を廃止する
+
+## Impact
+
+- `plugins/twl/commands/change-propose.md`（Step 0、40-46 行付近）
+- 機能的影響なし（冗長処理の除去のみ）
+- 依存コンポーネントへの破壊的変更なし

--- a/deltaspec/changes/issue-448/specs/remove-echo-redundancy/spec.md
+++ b/deltaspec/changes/issue-448/specs/remove-echo-redundancy/spec.md
@@ -1,0 +1,21 @@
+## MODIFIED Requirements
+
+### Requirement: Step 0 auto_init フローの echo 補完削除
+
+`change-propose.md` の Step 0 auto_init フローにおいて、`twl spec new` が自動補完するフィールド（`name:`, `status:`, `issue:`）を手動で echo 書き込みする処理を削除しなければならない（SHALL）。
+
+#### Scenario: twl spec new 呼出後に echo 補完が存在しない
+- **WHEN** `change-propose.md` の Step 0 auto_init フローを参照する
+- **THEN** `echo "name: ..." >> .deltaspec.yaml` および `echo "status: ..." >> .deltaspec.yaml` の行が存在しない
+
+#### Scenario: twl spec new の自動補完を説明するコメントが存在する
+- **WHEN** `change-propose.md` の Step 0 内の `twl spec new "issue-<N>"` 呼出直後を参照する
+- **THEN** `twl spec new` が `issue 番号・name・status` を自動補完することを説明するコメントが存在する
+
+### Requirement: .deltaspec.yaml への重複エントリ防止
+
+`twl spec new "issue-<N>"` 実行後に `.deltaspec.yaml` に重複フィールドが生成されてはならない（MUST NOT）。
+
+#### Scenario: issue-N 形式の change 作成後に .deltaspec.yaml が重複なし
+- **WHEN** `change-propose.md` の Step 0 フローに従い `twl spec new "issue-<N>"` を実行する
+- **THEN** `.deltaspec.yaml` に `name:`, `status:`, `issue:` が各 1 回のみ存在する

--- a/deltaspec/changes/issue-448/tasks.md
+++ b/deltaspec/changes/issue-448/tasks.md
@@ -1,0 +1,9 @@
+## 1. change-propose.md 修正
+
+- [ ] 1.1 `plugins/twl/commands/change-propose.md` の Step 0 auto_init フローにある echo 2 行（`name:` / `status:` 補完）を削除する
+- [ ] 1.2 `twl spec new "issue-<N>"` 呼出直後に「`twl spec new` が自動補完する（issue 番号・name・status）」のコメントを追加する
+
+## 2. 検証
+
+- [ ] 2.1 `deltaspec/changes/issue-448/.deltaspec.yaml` に重複エントリがないことを確認する
+- [ ] 2.2 `twl spec status "issue-448"` が正常に返ることを確認する

--- a/deltaspec/changes/issue-448/tasks.md
+++ b/deltaspec/changes/issue-448/tasks.md
@@ -1,9 +1,9 @@
 ## 1. change-propose.md 修正
 
-- [ ] 1.1 `plugins/twl/commands/change-propose.md` の Step 0 auto_init フローにある echo 2 行（`name:` / `status:` 補完）を削除する
-- [ ] 1.2 `twl spec new "issue-<N>"` 呼出直後に「`twl spec new` が自動補完する（issue 番号・name・status）」のコメントを追加する
+- [x] 1.1 `plugins/twl/commands/change-propose.md` の Step 0 auto_init フローにある echo 2 行（`name:` / `status:` 補完）を削除する
+- [x] 1.2 `twl spec new "issue-<N>"` 呼出直後に「`twl spec new` が自動補完する（issue 番号・name・status）」のコメントを追加する
 
 ## 2. 検証
 
-- [ ] 2.1 `deltaspec/changes/issue-448/.deltaspec.yaml` に重複エントリがないことを確認する
-- [ ] 2.2 `twl spec status "issue-448"` が正常に返ることを確認する
+- [x] 2.1 `deltaspec/changes/issue-448/.deltaspec.yaml` に重複エントリがないことを確認する
+- [x] 2.2 `twl spec status "issue-448"` が正常に返ることを確認する

--- a/deltaspec/changes/issue-448/test-mapping.yaml
+++ b/deltaspec/changes/issue-448/test-mapping.yaml
@@ -1,0 +1,224 @@
+change_id: issue-448
+generated_at: "2026-04-12T00:00:00Z"
+test_framework: pytest
+scenarios:
+  - id: "echo-name-line-absent-in-step0"
+    name: "twl spec new 呼出後に echo 補完が存在しない (name)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 7
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestEchoCompletionRemoved::test_echo_name_line_absent_in_step0"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "echo-status-line-absent-in-step0"
+    name: "twl spec new 呼出後に echo 補完が存在しない (status)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 7
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestEchoCompletionRemoved::test_echo_status_line_absent_in_step0"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "neither-echo-name-nor-echo-status-present"
+    name: "twl spec new 呼出後に echo 補完が存在しない (name/status 両方)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 7
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestEchoCompletionRemoved::test_neither_echo_name_nor_echo_status_present"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "echo-append-pattern-not-present"
+    name: "echo >> .deltaspec.yaml パターンが Step 0 に存在しない (edge case)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 7
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestEchoCompletionRemoved::test_echo_append_pattern_not_present_for_deltaspec_yaml"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "auto-completion-comment-exists-after-spec-new"
+    name: "twl spec new の自動補完を説明するコメントが存在する"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 11
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestAutoCompletionCommentPresent::test_auto_completion_comment_exists_after_spec_new"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "auto-completion-comment-mentions-name-or-status"
+    name: "自動補完コメントが name または status フィールドに言及する"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 11
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestAutoCompletionCommentPresent::test_auto_completion_comment_mentions_name_or_status"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step0-retains-spec-new-call"
+    name: "Step 0 に twl spec new 呼出が存在する (回帰)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 11
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestAutoCompletionCommentPresent::test_step0_retains_spec_new_call"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "no-manual-echo-replaced-by-new-code"
+    name: "echo 削除後に別の手動補完コードが追加されていない (edge case)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 11
+    requirement: "Step 0 auto_init フローの echo 補完削除"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestAutoCompletionCommentPresent::test_no_manual_echo_replaced_by_comment_not_new_code"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "name-field-appears-exactly-once"
+    name: "issue-N 形式の change 作成後に .deltaspec.yaml の name: が重複なし"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_name_field_appears_exactly_once"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "status-field-appears-exactly-once"
+    name: "issue-N 形式の change 作成後に .deltaspec.yaml の status: が重複なし"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_status_field_appears_exactly_once"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "issue-field-appears-exactly-once"
+    name: "issue-N 形式の change 作成後に .deltaspec.yaml の issue: が重複なし"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_issue_field_appears_exactly_once"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "all-three-fields-appear-exactly-once"
+    name: "issue-N 形式の change 作成後に name:, status:, issue: が各 1 回のみ存在する"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_all_three_fields_appear_exactly_once"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "no-duplicates-after-spec-new-issue-1"
+    name: "最小 issue 番号 (issue-1) でも .deltaspec.yaml に重複なし (edge case)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_no_duplicates_after_spec_new_issue_1"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "no-duplicates-after-spec-new-large-issue-number"
+    name: "大きな issue 番号 (issue-9999) でも .deltaspec.yaml に重複なし (edge case)"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_no_duplicates_after_spec_new_large_issue_number"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "name-value-matches-change-id"
+    name: "twl spec new 後の name: 値が change-id と一致する"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_name_value_matches_change_id"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "status-value-is-pending"
+    name: "twl spec new 後の status: 値が pending である"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_status_value_is_pending"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "issue-number-extracted-correctly"
+    name: "twl spec new 後の issue: 値が正確な番号である"
+    spec_file: "specs/remove-echo-redundancy/spec.md"
+    spec_line: 19
+    requirement: ".deltaspec.yaml への重複エントリ防止"
+    test_file: "cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py"
+    test_name: "TestDeltaspecYamlNoDuplicates::test_issue_number_extracted_correctly"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/commands/change-propose.md
+++ b/plugins/twl/commands/change-propose.md
@@ -37,13 +37,9 @@ DELTASPEC_EXISTS=$(test -f deltaspec/config.yaml && echo "true" || echo "false")
 4. change ディレクトリを作成:
    ```bash
    twl spec new "issue-<N>"
+   # twl spec new が自動補完する（issue 番号・name・status）
    ```
-5. `.deltaspec.yaml` に必須フィールドを補完:
-   ```bash
-   echo "name: issue-<N>" >> deltaspec/changes/issue-<N>/.deltaspec.yaml
-   echo "status: pending" >> deltaspec/changes/issue-<N>/.deltaspec.yaml
-   ```
-6. **Step 1 をスキップして Step 3 へ進む**
+5. **Step 1 をスキップして Step 3 へ進む**
 
 **それ以外の場合**: Step 1 へ進む。
 


### PR DESCRIPTION
## 概要

`twl spec new` が `name/status/issue` フィールドを自動補完するため、`change-propose.md` Step 0 の手動 echo 補完 2 行を削除。

## 変更内容

- `plugins/twl/commands/change-propose.md`: echo 2 行削除 + 自動補完コメント追加
- `cli/twl/tests/scenarios/test_issue_448_remove_echo_redundancy.py`: 回帰テスト追加（17テスト）
- `deltaspec/changes/issue-448/`: DeltaSpec artifacts

Closes #448