### PR TITLE
docs(workflow-issue-refine): SKILL.md Step 3b に責務分離ノートを追記 (#465)

### DIFF
--- a/.autopilot/issues/issue-465-context.md
+++ b/.autopilot/issues/issue-465-context.md
@@ -1,0 +1,23 @@
+# Workflow Context: Issue #465
+workflow: setup
+
+## completed_steps
+- init
+- worktree-create
+- board-status-update
+- crg-auto-build
+- arch-ref
+- change-propose
+- ac-extract
+
+## change_id
+
+
+## pr_number
+
+
+## test_results
+
+
+## review_findings
+

--- a/cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py
+++ b/cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py
@@ -1,0 +1,269 @@
+"""Tests for Issue #465: workflow-issue-refine SKILL.md Step 3b 責務分離ノート.
+
+Spec: deltaspec/changes/issue-465/specs/skill-md-responsibility-note/spec.md
+
+Coverage:
+  Requirement: workflow-issue-refine SKILL.md Step 3b 責務分離ノート
+    - Scenario: 新規 reader が Step 3b を読む場合
+        WHEN 新規 reader（人間 or LLM）が workflow-issue-refine/SKILL.md Step 3b を読む
+        THEN 責務分離ノートにより「完了保証は hook により機械的に強制される」ことが理解できる
+
+    - Scenario: LLM が spec-review-session-init.sh 呼出を省略した場合
+        WHEN LLM が誤って spec-review-session-init.sh の呼出を省略し
+             Skill(issue-review-aggregate) を実行しようとする
+        THEN ノートの記述から「state ファイル不在時に hook が fallthrough する」ことが
+             読み取れ、省略のリスクを認識できる
+
+    - Scenario: 既存の Step 3b / 3c の動作
+        WHEN ノートを追記した後、workflow-issue-refine ワークフローが実行される
+        THEN Step 3b / 3c の動作ロジックは変更されず、既存の振る舞いが維持される（SHALL）
+
+Note: これはドキュメント専用変更（SKILL.md へのテキスト追記のみ）のテスト。
+コードロジックの変更がないため、テストはファイル内容の静的検証として実装する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SKILL_MD = _REPO_ROOT / "plugins" / "twl" / "skills" / "workflow-issue-refine" / "SKILL.md"
+_HOOK_SCRIPT = (
+    _REPO_ROOT
+    / "plugins"
+    / "twl"
+    / "scripts"
+    / "hooks"
+    / "pre-tool-use-spec-review-gate.sh"
+)
+
+
+def _read_skill_md() -> str:
+    return _SKILL_MD.read_text(encoding="utf-8")
+
+
+def _step_3b_section(content: str) -> str:
+    """Return the text from the Step 3b heading through Step 3c (exclusive)."""
+    lines = content.splitlines()
+    in_section = False
+    section_lines: list[str] = []
+    for line in lines:
+        if line.startswith("## Step 3b:"):
+            in_section = True
+        elif in_section and line.startswith("## "):
+            # Next top-level section terminates Step 3b
+            break
+        if in_section:
+            section_lines.append(line)
+    return "\n".join(section_lines)
+
+
+# ---------------------------------------------------------------------------
+# Requirement: workflow-issue-refine SKILL.md Step 3b 責務分離ノート
+# ---------------------------------------------------------------------------
+
+
+class TestStep3bResponsibilityNote:
+    """Requirement: workflow-issue-refine SKILL.md Step 3b 責務分離ノート"""
+
+    # ------------------------------------------------------------------
+    # Scenario: 新規 reader が Step 3b を読む場合
+    # WHEN: 新規 reader（人間 or LLM）が workflow-issue-refine/SKILL.md Step 3b を読む
+    # THEN: 責務分離ノートにより「完了保証は hook により機械的に強制される」ことが理解できる
+    # ------------------------------------------------------------------
+
+    def test_skill_md_exists(self) -> None:
+        """SKILL.md ファイルが存在すること（前提条件）。"""
+        assert _SKILL_MD.exists(), f"SKILL.md が見つかりません: {_SKILL_MD}"
+
+    def test_step_3b_section_exists(self) -> None:
+        """WHEN SKILL.md を読む THEN '## Step 3b:' セクションが存在する。"""
+        content = _read_skill_md()
+        assert "## Step 3b:" in content, (
+            "SKILL.md に '## Step 3b:' セクションが存在しない"
+        )
+
+    def test_step_3b_contains_hook_enforcement_statement(self) -> None:
+        """WHEN Step 3b を読む THEN hook による機械的強制に関する記述が存在する。
+
+        責務分離ノートには「完了保証は hook により機械的に強制される」という趣旨が
+        読み取れる記述が必要。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        # hook による強制・保証の記述が存在することを確認
+        hook_enforcement_keywords = ["hook", "強制", "保証", "deny", "gate"]
+        found = any(kw.lower() in step_3b.lower() for kw in hook_enforcement_keywords)
+        assert found, (
+            "Step 3b の責務分離ノートに hook による機械的強制の記述が見つからない。\n"
+            f"期待キーワード: {hook_enforcement_keywords}\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_contains_llm_guidance_and_hook_layer_distinction(self) -> None:
+        """WHEN Step 3b を読む THEN LLM ガイダンス層と hook 自動ゲート層の責務境界が説明されている。
+
+        Spec に「LLM ガイダンス層と hook 自動ゲート層の責務境界」の記載が求められる。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        # 両層の存在を示すキーワード
+        has_llm_layer = any(kw in step_3b for kw in ["LLM", "ガイダンス", "guidance"])
+        has_hook_layer = any(kw in step_3b for kw in ["hook", "Hook", "ゲート", "gate"])
+        assert has_llm_layer and has_hook_layer, (
+            "Step 3b は LLM ガイダンス層と hook 自動ゲート層の両方に言及する必要がある。\n"
+            f"LLM 層への言及: {has_llm_layer}, hook 層への言及: {has_hook_layer}\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_references_hook_script(self) -> None:
+        """WHEN Step 3b を読む THEN pre-tool-use-spec-review-gate.sh への参照が存在する。
+
+        Spec に「plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh への参照リンク」
+        が要求されている。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        assert "pre-tool-use-spec-review-gate" in step_3b, (
+            "Step 3b に 'pre-tool-use-spec-review-gate.sh' への参照リンクが存在しない。\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Scenario: LLM が spec-review-session-init.sh 呼出を省略した場合
+    # WHEN: LLM が誤って spec-review-session-init.sh の呼出を省略し
+    #       Skill(issue-review-aggregate) を実行しようとする
+    # THEN: ノートの記述から「state ファイル不在時に hook が fallthrough する」ことが
+    #       読み取れ、省略のリスクを認識できる
+    # ------------------------------------------------------------------
+
+    def test_step_3b_contains_session_init_script_reference(self) -> None:
+        """WHEN Step 3b を読む THEN spec-review-session-init.sh への言及が存在する。
+
+        省略リスクを認識させるためには、当該スクリプトの重要性が記述されている必要がある。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        assert "spec-review-session-init" in step_3b, (
+            "Step 3b に 'spec-review-session-init.sh' への言及が存在しない。\n"
+            "省略リスクを認識させるためにはスクリプト名の明示が必要。\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_contains_fallthrough_risk_description(self) -> None:
+        """WHEN Step 3b を読む THEN state ファイル不在時の fallthrough リスクが記述されている。
+
+        Spec に「state ファイル不在時に hook が fallthrough する」記述が要求されている。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        fallthrough_keywords = ["fallthrough", "fall through", "不在", "state ファイル", "state file"]
+        found = any(kw.lower() in step_3b.lower() for kw in fallthrough_keywords)
+        assert found, (
+            "Step 3b の責務分離ノートに state ファイル不在時の fallthrough リスク記述が見つからない。\n"
+            f"期待キーワード: {fallthrough_keywords}\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_contains_hook_deny_condition(self) -> None:
+        """WHEN Step 3b を読む THEN hook による deny 発動条件（completed < total）が記述されている。
+
+        Spec に「hook による deny 発動条件（completed < total）」の記述が要求されている。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        # "completed < total" または同等の記述
+        deny_condition_keywords = ["completed < total", "completed", "deny"]
+        found = any(kw in step_3b for kw in deny_condition_keywords)
+        assert found, (
+            "Step 3b の責務分離ノートに hook の deny 発動条件（completed < total）が見つからない。\n"
+            f"期待キーワード: {deny_condition_keywords}\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    # ------------------------------------------------------------------
+    # Scenario: 既存の Step 3b / 3c の動作
+    # WHEN: ノートを追記した後、workflow-issue-refine ワークフローが実行される
+    # THEN: Step 3b / 3c の動作ロジックは変更されず、既存の振る舞いが維持される（SHALL）
+    # ------------------------------------------------------------------
+
+    def test_step_3b_retains_issue_json_write_instruction(self) -> None:
+        """WHEN Step 3b を読む THEN Issue JSON 書き出し手順（MUST）が保持されている。
+
+        既存の Step 3b の核心動作：Issue JSON 書き出しが削除されていないことを確認。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        assert "Issue JSON" in step_3b or "issue-" in step_3b.lower(), (
+            "Step 3b から Issue JSON 書き出し手順が削除されている可能性がある。\n"
+            "ノート追記によって既存の動作指示が除去されてはならない。\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_retains_orchestrator_call_instruction(self) -> None:
+        """WHEN Step 3b を読む THEN オーケストレーター呼び出し手順（MUST）が保持されている。
+
+        既存の Step 3b の核心動作：spec-review-orchestrator.sh 呼び出しが削除されていないことを確認。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        assert "spec-review-orchestrator" in step_3b, (
+            "Step 3b から 'spec-review-orchestrator.sh' の呼び出し指示が削除されている。\n"
+            "ノート追記によって既存の動作指示が除去されてはならない。\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3b_retains_synchronization_barrier_instruction(self) -> None:
+        """WHEN Step 3b を読む THEN 同期バリア（MUST）の記述が保持されている。
+
+        既存の Step 3b の核心動作：同期バリア（Step 3c への進行禁止）が削除されていないことを確認。
+        """
+        content = _read_skill_md()
+        step_3b = _step_3b_section(content)
+
+        assert "同期バリア" in step_3b or "Step 3c" in step_3b, (
+            "Step 3b から同期バリアまたは Step 3c への進行条件の記述が削除されている。\n"
+            "ノート追記によって既存の動作指示が除去されてはならない。\n"
+            f"Step 3b の内容:\n{step_3b[:500]}"
+        )
+
+    def test_step_3c_section_exists_and_intact(self) -> None:
+        """WHEN SKILL.md を読む THEN Step 3c セクションが存在し、集約ロジックが保持されている。
+
+        ノート追記後も Step 3c（レビュー結果集約）の動作指示が維持されること。
+        """
+        content = _read_skill_md()
+        assert "## Step 3c:" in content, (
+            "SKILL.md から '## Step 3c:' セクションが削除されている。\n"
+            "ノート追記は Step 3c の動作を変更してはならない。"
+        )
+
+        # Step 3c 内のコアコンテンツを確認
+        assert "issue-review-aggregate" in content, (
+            "SKILL.md から 'issue-review-aggregate' への言及が削除されている。\n"
+            "Step 3c の動作ロジックが維持されている必要がある。"
+        )
+
+    def test_hook_script_file_exists(self) -> None:
+        """WHEN SKILL.md が参照する hook スクリプトへの参照を確認する THEN スクリプトが存在する。
+
+        責務分離ノートが参照する pre-tool-use-spec-review-gate.sh が
+        実際にリポジトリに存在することを確認（リンク切れ防止）。
+        """
+        assert _HOOK_SCRIPT.exists(), (
+            f"SKILL.md が参照する hook スクリプトが存在しない: {_HOOK_SCRIPT}\n"
+            "参照リンクは実在するファイルを指している必要がある。"
+        )

--- a/deltaspec/changes/issue-465/.deltaspec.yaml
+++ b/deltaspec/changes/issue-465/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 465
+name: issue-465
+status: pending

--- a/deltaspec/changes/issue-465/design.md
+++ b/deltaspec/changes/issue-465/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`workflow-issue-refine/SKILL.md` の Step 3b は spec-review セッションで N Issue × 3 specialist を spawn する手順を記述している。現行機構は LLM ガイダンス（SKILL.md）と hook 自動ゲート（`pre-tool-use-spec-review-gate.sh`）のハイブリッドだが、この責務分離が文書化されていない。
+
+現行スクリプト構成:
+- `spec-review-session-init.sh`: state ファイル（`/tmp/.spec-review-session-{hash}.json`）を初期化
+- `spec-review-manifest.sh`: 固定 3 specialist リストを出力
+- `pre-tool-use-spec-review-gate.sh`: `Skill(issue-review-aggregate)` 呼出前に `completed < total` なら PreToolUse hook で deny
+
+## Goals / Non-Goals
+
+**Goals:**
+- `workflow-issue-refine/SKILL.md` Step 3b 冒頭に責務分離ノートを追記
+- LLM ガイダンス層と hook 自動ゲート層の責務境界を明記
+- hook の deny 発動条件（`completed < total`）を明記
+- `spec-review-session-init.sh` の初期化必須性を明記
+
+**Non-Goals:**
+- Step 3b / 3c の動作ロジック変更
+- スクリプト・hook 自体の変更
+- `issue-spec-review.md` の state ファイル更新ロジック追加（別 Issue）
+
+## Decisions
+
+**変更箇所**: `plugins/twl/skills/workflow-issue-refine/SKILL.md` Step 3b 冒頭
+
+**ノート形式**: blockquote（`>`）を使用し、責務分離ノートとして視覚的に区別する
+
+**含める内容**:
+1. LLM ガイダンス層 vs hook 自動ゲート層の責務境界
+2. `spec-review-session-init.sh` の初期化が必須な理由（不在時の fallthrough）
+3. hook deny 発動条件（`completed < total`）
+4. `pre-tool-use-spec-review-gate.sh` への参照リンク
+
+## Risks / Trade-offs
+
+- **リスク**: なし（文書化のみで動作変更なし）
+- **トレードオフ**: ノート追加により Step 3b の記述が長くなるが、責務分離の明確化という価値がそれを上回る

--- a/deltaspec/changes/issue-465/proposal.md
+++ b/deltaspec/changes/issue-465/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`workflow-issue-refine/SKILL.md` Step 3b の記述が LLM ガイダンス層と hook 自動ゲート層の責務分離を文書化していないため、新規 reader が「完了保証は LLM の責務」と誤解するリスクがある。
+
+## What Changes
+
+- `plugins/twl/skills/workflow-issue-refine/SKILL.md` Step 3b 冒頭に「責務分離ノート」を追記
+
+## Capabilities
+
+### New Capabilities
+
+なし（文書化のみ）
+
+### Modified Capabilities
+
+- `workflow-issue-refine/SKILL.md` Step 3b に責務分離ノートを追加し、以下を明記:
+  - LLM ガイダンス層（spawn 手順・同期バリア）と hook 自動ゲート層（pre-tool-use-spec-review-gate.sh）の責務境界
+  - `spec-review-session-init.sh` の初期化が必須である理由
+  - hook による deny 発動条件（`completed < total`）
+  - `pre-tool-use-spec-review-gate.sh` への参照リンク
+
+## Impact
+
+- **影響ファイル**: `plugins/twl/skills/workflow-issue-refine/SKILL.md`
+- **動作変更なし**: 既存の Step 3b / 3c のロジックは変更しない
+- **依存なし**: スクリプト・hook の変更不要

--- a/deltaspec/changes/issue-465/specs/skill-md-responsibility-note/spec.md
+++ b/deltaspec/changes/issue-465/specs/skill-md-responsibility-note/spec.md
@@ -1,0 +1,24 @@
+## MODIFIED Requirements
+
+### Requirement: workflow-issue-refine SKILL.md Step 3b 責務分離ノート
+
+`workflow-issue-refine/SKILL.md` Step 3b 冒頭に、LLM ガイダンス層と hook 自動ゲート層の責務境界を説明する責務分離ノートを追記しなければならない（SHALL）。ノートには以下を含む:
+- LLM ガイダンス層（spawn 手順・同期バリア）と hook 自動ゲート層の責務境界
+- `spec-review-session-init.sh` の初期化が必須である理由（不在時の fallthrough）
+- hook による deny 発動条件（`completed < total`）
+- `plugins/twl/scripts/hooks/pre-tool-use-spec-review-gate.sh` への参照リンク
+
+#### Scenario: 新規 reader が Step 3b を読む場合
+
+- **WHEN** 新規 reader（人間 or LLM）が `workflow-issue-refine/SKILL.md` Step 3b を読む
+- **THEN** 責務分離ノートにより「完了保証は hook により機械的に強制される」ことが理解できる
+
+#### Scenario: LLM が spec-review-session-init.sh 呼出を省略した場合
+
+- **WHEN** LLM が誤って `spec-review-session-init.sh` の呼出を省略し `Skill(issue-review-aggregate)` を実行しようとする
+- **THEN** ノートの記述から「state ファイル不在時に hook が fallthrough する」ことが読み取れ、省略のリスクを認識できる
+
+#### Scenario: 既存の Step 3b / 3c の動作
+
+- **WHEN** ノートを追記した後、`workflow-issue-refine` ワークフローが実行される
+- **THEN** Step 3b / 3c の動作ロジックは変更されず、既存の振る舞いが維持される（SHALL）

--- a/deltaspec/changes/issue-465/tasks.md
+++ b/deltaspec/changes/issue-465/tasks.md
@@ -1,10 +1,10 @@
 ## 1. SKILL.md 責務分離ノート追記
 
-- [ ] 1.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` Step 3b を特定する
-- [ ] 1.2 Step 3b 冒頭に責務分離ノート（blockquote 形式）を追記する
-- [ ] 1.3 ノートに以下を含める: LLM ガイダンス層と hook 自動ゲート層の責務境界、`spec-review-session-init.sh` 初期化必須の理由、hook deny 発動条件（`completed < total`）、`pre-tool-use-spec-review-gate.sh` への参照リンク
+- [x] 1.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` Step 3b を特定する
+- [x] 1.2 Step 3b 冒頭に責務分離ノート（blockquote 形式）を追記する
+- [x] 1.3 ノートに以下を含める: LLM ガイダンス層と hook 自動ゲート層の責務境界、`spec-review-session-init.sh` 初期化必須の理由、hook deny 発動条件（`completed < total`）、`pre-tool-use-spec-review-gate.sh` への参照リンク
 
 ## 2. 動作確認
 
-- [ ] 2.1 既存の Step 3b / 3c の動作ロジックが変更されていないことを確認する
-- [ ] 2.2 追記内容が Issue #465 の AC を全て満たすことを確認する
+- [x] 2.1 既存の Step 3b / 3c の動作ロジックが変更されていないことを確認する
+- [x] 2.2 追記内容が Issue #465 の AC を全て満たすことを確認する

--- a/deltaspec/changes/issue-465/tasks.md
+++ b/deltaspec/changes/issue-465/tasks.md
@@ -1,0 +1,10 @@
+## 1. SKILL.md 責務分離ノート追記
+
+- [ ] 1.1 `plugins/twl/skills/workflow-issue-refine/SKILL.md` Step 3b を特定する
+- [ ] 1.2 Step 3b 冒頭に責務分離ノート（blockquote 形式）を追記する
+- [ ] 1.3 ノートに以下を含める: LLM ガイダンス層と hook 自動ゲート層の責務境界、`spec-review-session-init.sh` 初期化必須の理由、hook deny 発動条件（`completed < total`）、`pre-tool-use-spec-review-gate.sh` への参照リンク
+
+## 2. 動作確認
+
+- [ ] 2.1 既存の Step 3b / 3c の動作ロジックが変更されていないことを確認する
+- [ ] 2.2 追記内容が Issue #465 の AC を全て満たすことを確認する

--- a/deltaspec/changes/issue-465/test-mapping.yaml
+++ b/deltaspec/changes/issue-465/test-mapping.yaml
@@ -1,0 +1,120 @@
+change_id: issue-465
+generated_at: "2026-04-12T05:17:01Z"
+test_framework: pytest
+scenarios:
+  - id: "step-3b-reader-hook-enforcement"
+    name: "新規 reader が Step 3b を読む場合"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 11
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_contains_hook_enforcement_statement"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-reader-layer-distinction"
+    name: "新規 reader が Step 3b を読む場合（層分離の確認）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 11
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_contains_llm_guidance_and_hook_layer_distinction"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-reader-hook-script-reference"
+    name: "新規 reader が Step 3b を読む場合（hook スクリプト参照）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 11
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_references_hook_script"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-llm-omission-session-init-reference"
+    name: "LLM が spec-review-session-init.sh 呼出を省略した場合（スクリプト言及）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 16
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_contains_session_init_script_reference"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-llm-omission-fallthrough-risk"
+    name: "LLM が spec-review-session-init.sh 呼出を省略した場合（fallthrough リスク）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 16
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_contains_fallthrough_risk_description"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-llm-omission-deny-condition"
+    name: "LLM が spec-review-session-init.sh 呼出を省略した場合（deny 発動条件）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 16
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_contains_hook_deny_condition"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-existing-behavior-orchestrator"
+    name: "既存の Step 3b / 3c の動作（オーケストレーター呼び出し保持）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 21
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_retains_orchestrator_call_instruction"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3b-existing-behavior-sync-barrier"
+    name: "既存の Step 3b / 3c の動作（同期バリア保持）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 21
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3b_retains_synchronization_barrier_instruction"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "step-3c-section-intact"
+    name: "既存の Step 3b / 3c の動作（Step 3c セクション保持）"
+    spec_file: "specs/skill-md-responsibility-note/spec.md"
+    spec_line: 21
+    requirement: "workflow-issue-refine SKILL.md Step 3b 責務分離ノート"
+    test_file: "cli/twl/tests/scenarios/test_issue_465_skill_md_responsibility_note.py"
+    test_name: "TestStep3bResponsibilityNote::test_step_3c_section_exists_and_intact"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -40,7 +40,7 @@ co-issue Phase 3（Per-Issue 精緻化ループ）のロジックを担当する
 
 > **責務分離ノート**: 本 Step の spawn 手順・同期バリアは LLM ガイダンスだが、
 > `Skill(issue-review-aggregate)` 呼出前の完了保証は
-> [`pre-tool-use-spec-review-gate.sh`](../../../scripts/hooks/pre-tool-use-spec-review-gate.sh)
+> [`pre-tool-use-spec-review-gate.sh`](../../scripts/hooks/pre-tool-use-spec-review-gate.sh)
 > により機械的に強制される。state ファイル（`/tmp/.spec-review-session-{hash}.json`）
 > は `spec-review-session-init.sh` で初期化されており、`completed < total` の状態で
 > aggregate 呼出が発生すると hook が deny する。

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -38,6 +38,16 @@ co-issue Phase 3（Per-Issue 精緻化ループ）のロジックを担当する
 
 ## Step 3b: specialist レビュー（外部オーケストレーター経由）
 
+> **責務分離ノート**: 本 Step の spawn 手順・同期バリアは LLM ガイダンスだが、
+> `Skill(issue-review-aggregate)` 呼出前の完了保証は
+> [`pre-tool-use-spec-review-gate.sh`](../../../scripts/hooks/pre-tool-use-spec-review-gate.sh)
+> により機械的に強制される。state ファイル（`/tmp/.spec-review-session-{hash}.json`）
+> は `spec-review-session-init.sh` で初期化されており、`completed < total` の状態で
+> aggregate 呼出が発生すると hook が deny する。
+> つまり Step 3b を LLM が誤って省略しても、Step 3c が hook でブロックされる。
+> `spec-review-session-init.sh` の呼出が行われない場合は state ファイルが不在となり、
+> hook が fallthrough して完了保証が効かなくなるため、初期化は必須である。
+
 **Issue JSON 書き出し（MUST -- 最初に実行）**: 各 Issue データを一時ディレクトリに書き出す:
 
 ```bash


### PR DESCRIPTION
## 変更内容
- workflow-issue-refine SKILL.md Step 3b に責務分離ノートを追記
- Issue #465 の AC に対応

Closes #465