### PR TITLE
fix(#541): orchestrator spawn を cld-spawn + inject-file パターンに移行

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2560,12 +2560,21 @@ scripts:
     path: scripts/spec-review-orchestrator.sh
     calls:
       - script: spec-review-session-init
-    description: "Bash ループで N Issue の spec-review を並列実行（tmux cld セッション spawn + ポーリング + 結果収集。MAX_PARALLEL 環境変数でバッチサイズ制御）"
+      - script: cld-spawn
+        plugin: session
+      - script: session-comm.sh
+        plugin: session
+    description: "Bash ループで N Issue の spec-review を並列実行（tmux cld セッション spawn + ポーリング + 結果収集。MAX_PARALLEL 環境変数でバッチサイズ制御。cld-spawn + inject-file パターンで spawn — #541）"
 
   issue-lifecycle-orchestrator:
     type: script
     path: scripts/issue-lifecycle-orchestrator.sh
-    description: "co-issue v2 Pilot が呼ぶバッチ orchestrator: N per-issue dir の workflow-issue-lifecycle を tmux cld で並列起動（spec-review-orchestrator.sh コードパターン流用。MAX_PARALLEL / flock / resume 対応。ADR-017 IM-7: N=1 初期化は各 Worker が個別に実施）"
+    calls:
+      - script: cld-spawn
+        plugin: session
+      - script: session-comm.sh
+        plugin: session
+    description: "co-issue v2 Pilot が呼ぶバッチ orchestrator: N per-issue dir の workflow-issue-lifecycle を tmux cld で並列起動（cld-spawn + inject-file パターンで spawn — #541。MAX_PARALLEL / flock / resume 対応。ADR-017 IM-7: N=1 初期化は各 Worker が個別に実施）"
 
   pre-tool-use-spec-review-gate:
     type: script

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -226,6 +226,7 @@ spawn_session() {
   # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
   "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
     rm -f "$prompt_file" 2>/dev/null || true
+    tmux kill-window -t "${window_name}" 2>/dev/null || true
     echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject-file 失敗" >&2
     return 1
   }

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -206,30 +206,31 @@ spawn_session() {
   prompt_file="$(mktemp /tmp/.coi-prompt-XXXXXX.txt)"
   printf '%s\n' "/twl:workflow-issue-lifecycle $(printf '%q' "$subdir")" > "$prompt_file"
 
-  # ラッパースクリプトを作成して tmux に渡す
-  local wrapper_file
-  wrapper_file="$(mktemp /tmp/.coi-wrapper-XXXXXX.sh)"
-  {
-    printf '#!/usr/bin/env bash\n'
-    printf 'set -euo pipefail\n'
-    printf "trap 'rm -f %q %q' EXIT\n" "$prompt_file" "$wrapper_file"
-    printf 'PROMPT_CONTENT="$(cat %q)"\n' "$prompt_file"
-    printf '%q "$PROMPT_CONTENT" > %q 2>&1\n' "$CLD_PATH" "${subdir}/OUT/cld-output.txt"
-  } > "$wrapper_file"
-  chmod +x "$wrapper_file"
+  local SESSION_SCRIPTS
+  SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
 
   echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
 
-  # flock 解放（tmux spawn 後）
+  # flock 解放（cld-spawn 前）
   exec {lockfd}>&-
 
-  tmux new-window -d -n "$window_name" "bash $(printf '%q' "$wrapper_file")" || {
-    rm -f "$prompt_file" "$wrapper_file" 2>/dev/null || true
-    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: tmux spawn 失敗" >&2
+  # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
+  "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: cld-spawn 失敗" >&2
     return 1
   }
 
   tmux set-option -t "$window_name" remain-on-exit on 2>/dev/null || true
+
+  # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
+  "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject-file 失敗" >&2
+    return 1
+  }
+
+  rm -f "$prompt_file" 2>/dev/null || true
 }
 
 # =============================================================================

--- a/plugins/twl/scripts/spec-review-orchestrator.sh
+++ b/plugins/twl/scripts/spec-review-orchestrator.sh
@@ -176,31 +176,28 @@ print(str(d.get('is_quick_candidate', False)).lower())
   printf '\n' >> "$prompt_file"
   printf '%s\n' "書き出す内容: specialist_results の全文（JSON または Markdown 形式）" >> "$prompt_file"
 
-  # ラッパースクリプトを作成して tmux に渡す
-  # - printf '%q' によるエスケープをファイルへの書き出しに使用（tmux 引数には使用しない）
-  # - tmux には "bash /path/to/wrapper.sh" のみ渡す（POSIX sh 非互換回避、CRITICAL #3 対応）
-  local wrapper_file
-  wrapper_file="$(mktemp /tmp/.spec-review-wrapper-XXXXXX.sh)"
-  {
-    printf '#!/usr/bin/env bash\n'
-    printf 'set -euo pipefail\n'
-    # EXIT trap: cld 失敗時も含め確実にテンポラリファイルを削除（WARNING #1 対応）
-    printf "trap 'rm -f %q %q' EXIT\n" "$prompt_file" "$wrapper_file"
-    printf 'PROMPT_CONTENT="$(cat %q)"\n' "$prompt_file"
-    printf '%q --model sonnet "$PROMPT_CONTENT" > %q 2>&1\n' "$CLD_PATH" "$result_file"
-  } > "$wrapper_file"
-  chmod +x "$wrapper_file"
+  local SESSION_SCRIPTS
+  SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
 
   echo "[spec-review-orchestrator] Issue #${issue_num}: spawn (window=${window_name})" >&2
-  # tmux 起動失敗時はテンポラリファイルをクリーンアップ（WARNING #2 対応）
-  tmux new-window -d -n "$window_name" "bash $(printf '%q' "$wrapper_file")" || {
-    rm -f "$prompt_file" "$wrapper_file" 2>/dev/null || true
-    echo "[spec-review-orchestrator] Issue #${issue_num}: tmux spawn 失敗" >&2
+  # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
+  "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    echo "[spec-review-orchestrator] Issue #${issue_num}: cld-spawn 失敗" >&2
     return 1
   }
 
   # remain-on-exit: ポーリング後の確認に使用
   tmux set-option -t "$window_name" remain-on-exit on 2>/dev/null || true
+
+  # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
+  "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    echo "[spec-review-orchestrator] Issue #${issue_num}: inject-file 失敗" >&2
+    return 1
+  }
+
+  rm -f "$prompt_file" 2>/dev/null || true
 }
 
 # =============================================================================

--- a/plugins/twl/scripts/spec-review-orchestrator.sh
+++ b/plugins/twl/scripts/spec-review-orchestrator.sh
@@ -193,6 +193,7 @@ print(str(d.get('is_quick_candidate', False)).lower())
   # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
   "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
     rm -f "$prompt_file" 2>/dev/null || true
+    tmux kill-window -t "${window_name}" 2>/dev/null || true
     echo "[spec-review-orchestrator] Issue #${issue_num}: inject-file 失敗" >&2
     return 1
   }


### PR DESCRIPTION
## 概要

Issue #541 で報告された orchestrator の cld セッション spawn バグを修正。

## 変更内容

### spec-review-orchestrator.sh / issue-lifecycle-orchestrator.sh
-  関数の `cld one-shot モード`（`cld "$PROMPT" > result.txt`）を廃止
- `cld-spawn`（対話モード）+ `session-comm.sh inject-file` パターンに置換
- inject-file 失敗時の `tmux kill-window` でウィンドウ孤立を防止（ポーリングの1時間ハング問題を解消）

### deps.yaml
- 両 orchestrator に `cld-spawn` / `session-comm.sh` 依存を追加

## Root Cause

`cld "$PROMPT_CONTENT" > result.txt 2>&1` は cld が systemd-run 経由で Claude を起動するため、claude の one-shot モード出力が result.txt に届かない。autopilot Worker と同じ cld-spawn + inject-file パターンに統一することで解消。

Closes #541