### PR TITLE
feat(security): check_and_nudge に allow-list 検証を追加 (Issue #496)

### DIFF
--- a/architecture/decisions/ADR-0009-tmux-pane-trust-model.md
+++ b/architecture/decisions/ADR-0009-tmux-pane-trust-model.md
@@ -1,0 +1,66 @@
+# ADR-0009: tmux pane trust model と nudge inject 経路の脅威モデル
+
+## ステータス
+
+Accepted
+
+## コンテキスト
+
+`autopilot-orchestrator.sh` は `tmux send-keys` を介して Worker の Claude Code セッションにコマンドを inject する経路を 2 つ持つ:
+
+1. **`inject_next_workflow`**: `python3 -m twl.autopilot.state resolve-next-workflow` から `current_step` 値を取得し、許可された次の workflow skill コマンドを inject する。
+2. **`check_and_nudge`**: `tmux capture-pane` で Worker pane の出力テキストを取得し、`_nudge_command_for_pattern` でパターンマッチして nudge コマンドを決定し inject する。
+
+`inject_next_workflow` は状態管理システム（`state JSON`）を信頼する入力源として使用するため、コマンドは機械的に決定される。一方 `check_and_nudge` は pane 出力テキスト（Worker の標準出力）を入力源とするため、より脆弱な信頼境界に置かれる。
+
+## 決定
+
+### 信頼する入力源 vs 信頼しない入力源
+
+| 入力源 | 分類 | 理由 |
+|--------|------|------|
+| `.autopilot/issues/issue-N.json` の `current_step` フィールド | **信頼する** | `state write` は `--role pilot` / `--role worker` による書き込み制御下にある。直接 JSON 編集には OS レベルアクセスが必要 |
+| `resolve-next-workflow` CLI 出力 | **信頼する** | `state JSON` を読み取るラッパーであり同等の保護下にある |
+| `tmux capture-pane` pane 出力テキスト | **信頼しない** | Worker の Claude Code 標準出力であり、Worker が実行する MCP ツール・hook・外部コマンドの出力が混入する可能性がある。悪意ある MCP サーバーや hook が pane テキストを汚染できる |
+
+### 脅威モデルの適用範囲
+
+- **対象**: 同一ユーザー・同一 tmux セッション内のプロセス間信頼境界
+- **対象外**: リモート攻撃者によるネットワーク経由のアクセス（tmux は local IPC であり、リモートアクセスは OS レベルの認証が必要）
+- **想定される攻撃経路**:
+  1. 悪意ある MCP サーバーが Worker の出力に `check_and_nudge` のパターン文字列を埋め込み、意図しないコマンドを inject させる
+  2. Worker が実行する hook が pane テキストを汚染し `_nudge_command_for_pattern` に意図しない値を返させる
+
+### 最終防衛線: `tmux send-keys` 直前の allow-list 検証
+
+両経路ともに `tmux send-keys` を呼び出す直前で allow-list 検証を適用する:
+
+```
+正規表現: ^/twl:workflow-[a-z][a-z0-9-]*$
+```
+
+- `inject_next_workflow`: L832 でバリデーション済み（既存実装）
+- `check_and_nudge`: Issue #496 で `tmux send-keys` 直前にバリデーションを追加（本 ADR の決定）
+
+バリデーション失敗時は `tmux send-keys` を呼ばず WARNING ログと trace ログを出力してリターンする。
+
+### `_nudge_command_for_pattern` の扱い
+
+現時点では `_nudge_command_for_pattern` はハードコードされた `/twl:workflow-*` リテラル文字列のみを返す。しかし将来パターン追加時に `${issue}` 以外の変数（例: pane 出力から抽出した文字列）を埋め込んだ場合、allow-list なしでは injection 面が開く。
+
+`check_and_nudge` と `_nudge_command_for_pattern` の呼び出し境界に allow-list を置くことで、内部実装の変更から防御を分離する。
+
+## 結果
+
+- `check_and_nudge` の `next_cmd` は `tmux send-keys` 直前で `^/twl:workflow-[a-z][a-z0-9-]*$` に一致しない場合は inject されない
+- バリデーション失敗は `${AUTOPILOT_DIR}/trace/inject-YYYYMMDD.log` に記録される
+- `inject_next_workflow` と `check_and_nudge` が対称な検証ロジックを持つようになり保守性が向上する
+
+## 関連
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh`
+  - `inject_next_workflow` L785（allow-list 実装済み, L832）
+  - `check_and_nudge` L895（本 ADR で allow-list を追加）
+  - `_nudge_command_for_pattern` L729（パターン定義）
+- Issue #469 WARNING finding W3（phase-review）
+- Issue #496（本 ADR を起票したセキュリティレビュー）

--- a/deltaspec/changes/issue-496/.deltaspec.yaml
+++ b/deltaspec/changes/issue-496/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-12
+issue: 496
+name: issue-496
+status: pending

--- a/deltaspec/changes/issue-496/design.md
+++ b/deltaspec/changes/issue-496/design.md
@@ -1,0 +1,63 @@
+## Context
+
+`autopilot-orchestrator.sh` には 2 つの tmux inject 経路がある。
+
+1. **`inject_next_workflow`** (L785): `current_step` terminal 値ベース。L822-836 で allow-list `^/twl:workflow-[a-z][a-z0-9-]*$` を適用済み。
+2. **`check_and_nudge`** (L895): pane 出力テキストパターンベース。`_nudge_command_for_pattern` の返り値を L922 で検証なしに `tmux send-keys` に直接渡す。
+
+現時点では `_nudge_command_for_pattern` がハードコードされた `/twl:workflow-*` リテラルしか返さないため実害はない。しかし将来のパターン追加時に `${issue}` 以外の変数を埋め込んだ場合、injection 面が開く。また tmux pane 出力は同一セッション内の別プロセスが操作可能であり、Worker の Claude Code 出力を汚染することで `_nudge_command_for_pattern` に意図しない文字列を返させる経路が存在する。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `check_and_nudge` の `next_cmd` を `tmux send-keys` に渡す直前に allow-list バリデーションを適用する
+- バリデーション失敗時に WARNING ログと trace ログを出力し nudge をスキップする
+- `inject_next_workflow` と `check_and_nudge` の検証ロジックを対称にする
+- shunit2 テストで既存 7 パターンの通過と不正パターンのブロックを確認する
+- ADR で tmux pane trust model を明文化する
+
+**Non-Goals:**
+- `_nudge_command_for_pattern` の内部ロジック変更
+- `inject_next_workflow` の変更
+- tmux 外部からのアクセス制御（OS レベルのセキュリティは対象外）
+- Worker 出力の汚染防止そのもの（最終防衛線は inject 直前の検証）
+
+## Decisions
+
+### 1. バリデーション正規表現
+
+`inject_next_workflow` L832 と同じ正規表現を使用:
+```bash
+^/twl:workflow-[a-z][a-z0-9-]*$
+```
+空文字列（`""`）は `_nudge_command_for_pattern` が「無操作」を表すため check_and_nudge 内で `[[ -n "$next_cmd" ]]` によって既に弾かれる。バリデーションは非空かつ不一致の場合に WARNING を出す。
+
+### 2. 配置箇所
+
+`check_and_nudge` L920-922 の `tmux send-keys` 呼び出し直前に挿入する。具体的には:
+```bash
+if next_cmd="$(_nudge_command_for_pattern "$pane_output" "$issue" "$entry")" && [[ -n "$next_cmd" ]]; then
+  # ← ここにバリデーションを追加
+  if [[ ! "$next_cmd" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+    echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${next_cmd:0:200}' — nudge スキップ" >&2
+    # trace ログ出力
+    return 0
+  fi
+  echo "[orchestrator] Issue #${issue}: chain 遷移停止検知 — nudge 送信 ..." >&2
+  tmux send-keys -t "$window_name" "$next_cmd" Enter 2>/dev/null || true
+```
+
+### 3. trace ログ
+
+`inject_next_workflow` の trace ログと同形式でファイルに記録する。変数 `_trace_log` は `inject_next_workflow` のスコープで定義されているため `check_and_nudge` 内では独立して trace ログパスを解決するか、共通ヘルパーに切り出す。
+簡易実装として `check_and_nudge` 内で trace ログパスを直接組み立てる（`inject_next_workflow` と同じパス命名規則）。
+
+### 4. ADR
+
+`architecture/adr/` ディレクトリに新規 ADR を作成。番号は既存の最大番号 + 1 を使用。
+
+## Risks / Trade-offs
+
+- **正規表現の共通化**: `inject_next_workflow` と `check_and_nudge` でコピーになるが、現時点では単純化のためコピーを選択。共通関数化はスコープ外
+- **trace ログパスの重複**: `check_and_nudge` 内で `_trace_log` を再定義すると保守性が下がる。将来は共通関数化が望ましい
+- **shunit2 テスト**: `_nudge_command_for_pattern` の出力がハードコード文字列のため、allow-list は全て通過する。「不正パターンのブロック」テストは `check_and_nudge` のモックテストとして実装する

--- a/deltaspec/changes/issue-496/proposal.md
+++ b/deltaspec/changes/issue-496/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`autopilot-orchestrator.sh` の `check_and_nudge` 経路は `_nudge_command_for_pattern` が返す `next_cmd` を allow-list 検証なしで `tmux send-keys` に直接渡す。同スクリプトの `inject_next_workflow` は L777 で `^/twl:workflow-[a-z][a-z0-9-]*$` バリデーションを実装済みであるため、`check_and_nudge` との非対称が defense-in-depth の欠落になっている。
+
+## What Changes
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh`: `check_and_nudge` に `inject_next_workflow` と同等の allow-list 検証を追加（`next_cmd` を `tmux send-keys` に渡す直前）
+- バリデーション失敗時に WARNING ログと trace ログを出力し、nudge をスキップ
+- `architecture/` に ADR を新規作成: tmux pane trust model と nudge inject 経路の脅威モデルを明文化
+- `test-fixtures/` に shunit2 テストを追加: 既存 7 パターン全てが allow-list を通過すること、および不正パターンがブロックされることを検証
+
+## Capabilities
+
+### New Capabilities
+
+なし（セキュリティ強化のみ）
+
+### Modified Capabilities
+
+- `check_and_nudge`: `next_cmd` を `tmux send-keys` に渡す前に allow-list 正規表現でバリデーション。不一致なら WARNING ログを出して nudge をスキップ
+- ADR 追加: tmux pane trust model（信頼境界、信頼する入力源 vs 信頼しない入力源、最終防衛線の明文化）
+
+## Impact
+
+- **影響ファイル**: `plugins/twl/scripts/autopilot-orchestrator.sh`
+- **新規ファイル**: `architecture/adr/` 配下に ADR を 1 件追加
+- **テスト追加**: `test-fixtures/` 配下に shunit2 テストケース追加
+- **スコープ外**: `_nudge_command_for_pattern` のロジック変更はしない。`inject_next_workflow` のコードは変更しない

--- a/deltaspec/changes/issue-496/specs/security/spec.md
+++ b/deltaspec/changes/issue-496/specs/security/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: check_and_nudge allow-list 検証
+
+`check_and_nudge` は `_nudge_command_for_pattern` が返す `next_cmd` を `tmux send-keys` に渡す前に allow-list 正規表現 `^/twl:workflow-[a-z][a-z0-9-]*$` でバリデーションしなければならない（SHALL）。
+
+#### Scenario: 有効な workflow コマンドは inject される
+- **WHEN** `_nudge_command_for_pattern` が `/twl:workflow-test-ready` を返す
+- **THEN** allow-list を通過し `tmux send-keys` に渡される
+
+#### Scenario: 不正なコマンドは nudge をスキップする
+- **WHEN** `_nudge_command_for_pattern` が allow-list 正規表現に一致しない文字列を返す
+- **THEN** WARNING ログを出力し `tmux send-keys` を呼び出さずに `return 0` する
+
+#### Scenario: バリデーション失敗時に trace ログを出力する
+- **WHEN** allow-list バリデーションが失敗する
+- **THEN** trace ログファイルに `result=skip reason="invalid next_cmd"` のエントリが記録されなければならない（SHALL）
+
+#### Scenario: 既存 7 パターンは全て allow-list を通過する
+- **WHEN** `_nudge_command_for_pattern` が返す 7 パターン（`/twl:workflow-test-ready`、`/twl:workflow-pr-verify` ×2、`/twl:workflow-pr-fix`、`/twl:workflow-pr-merge`、空文字列 ×2）を allow-list に通す
+- **THEN** 空文字列は `[[ -n "$next_cmd" ]]` で除外、残り 5 パターンは全て `^/twl:workflow-[a-z][a-z0-9-]*$` に一致する
+
+## ADDED Requirements
+
+### Requirement: ADR-0009 tmux pane trust model
+
+`architecture/decisions/` に ADR-0009 を新規作成し tmux pane trust model を明文化しなければならない（SHALL）。
+
+#### Scenario: ADR が脅威モデルを定義する
+- **WHEN** ADR-0009 を参照する
+- **THEN** 「信頼する入力源」と「信頼しない入力源」が明記されており、最終防衛線が `tmux send-keys` 直前の allow-list バリデーションであることが読み取れる
+
+#### Scenario: ADR が適用範囲を明示する
+- **WHEN** ADR-0009 を参照する
+- **THEN** 対象の脅威モデルが「同一ユーザー・同一 tmux セッション内」に限定されることが明記されており、リモート攻撃者は対象外であることが分かる
+
+## ADDED Requirements
+
+### Requirement: shunit2 テストによる検証
+
+shunit2 テストを追加し `check_and_nudge` の allow-list 検証を自動確認しなければならない（SHALL）。
+
+#### Scenario: 有効パターンがテストで通過する
+- **WHEN** shunit2 テストで `_nudge_command_for_pattern` の既存 7 パターンを対象に allow-list 正規表現を評価する
+- **THEN** 非空文字列の 5 パターン全てが `^/twl:workflow-[a-z][a-z0-9-]*$` に一致する
+
+#### Scenario: 不正パターンがテストでブロックされる
+- **WHEN** shunit2 テストで `check_and_nudge` に不正な `next_cmd` を注入する（モック）
+- **THEN** `tmux send-keys` が呼ばれず WARNING 出力が発生することを確認する

--- a/deltaspec/changes/issue-496/tasks.md
+++ b/deltaspec/changes/issue-496/tasks.md
@@ -1,19 +1,19 @@
 ## 1. allow-list 検証追加
 
-- [ ] 1.1 `check_and_nudge` (L920-922 付近) に allow-list バリデーションを挿入: `next_cmd` が `^/twl:workflow-[a-z][a-z0-9-]*$` に一致しない場合は WARNING ログを出力して `return 0`
-- [ ] 1.2 バリデーション失敗時の trace ログ出力を追加（`inject_next_workflow` と同形式のファイルに記録）
+- [x] 1.1 `check_and_nudge` (L920-922 付近) に allow-list バリデーションを挿入: `next_cmd` が `^/twl:workflow-[a-z][a-z0-9-]*$` に一致しない場合は WARNING ログを出力して `return 0`
+- [x] 1.2 バリデーション失敗時の trace ログ出力を追加（`inject_next_workflow` と同形式のファイルに記録）
 
 ## 2. ADR 作成
 
-- [ ] 2.1 `architecture/decisions/ADR-0009-tmux-pane-trust-model.md` を新規作成（信頼境界、信頼する入力源 vs 信頼しない入力源、最終防衛線の明文化）
+- [x] 2.1 `architecture/decisions/ADR-0009-tmux-pane-trust-model.md` を新規作成（信頼境界、信頼する入力源 vs 信頼しない入力源、最終防衛線の明文化）
 
 ## 3. shunit2 テスト追加
 
-- [ ] 3.1 `test-fixtures/` 配下に shunit2 テストファイルを作成
-- [ ] 3.2 既存 7 パターン（`_nudge_command_for_pattern` の全出力）が allow-list 正規表現を通過することを検証するテストケース追加
-- [ ] 3.3 `check_and_nudge` に不正な `next_cmd` を注入した場合に `tmux send-keys` が呼ばれないことを確認するテストケース追加（モック方式）
+- [x] 3.1 `test-fixtures/` 配下に shunit2 テストファイルを作成
+- [x] 3.2 既存 7 パターン（`_nudge_command_for_pattern` の全出力）が allow-list 正規表現を通過することを検証するテストケース追加
+- [x] 3.3 `check_and_nudge` に不正な `next_cmd` を注入した場合に `tmux send-keys` が呼ばれないことを確認するテストケース追加（モック方式）
 
 ## 4. 検証
 
-- [ ] 4.1 `twl check` でプラグイン整合性を確認
-- [ ] 4.2 shunit2 テストを実行してグリーンを確認
+- [x] 4.1 `twl check` でプラグイン整合性を確認
+- [x] 4.2 shunit2 テストを実行してグリーンを確認

--- a/deltaspec/changes/issue-496/tasks.md
+++ b/deltaspec/changes/issue-496/tasks.md
@@ -1,0 +1,19 @@
+## 1. allow-list 検証追加
+
+- [ ] 1.1 `check_and_nudge` (L920-922 付近) に allow-list バリデーションを挿入: `next_cmd` が `^/twl:workflow-[a-z][a-z0-9-]*$` に一致しない場合は WARNING ログを出力して `return 0`
+- [ ] 1.2 バリデーション失敗時の trace ログ出力を追加（`inject_next_workflow` と同形式のファイルに記録）
+
+## 2. ADR 作成
+
+- [ ] 2.1 `architecture/decisions/ADR-0009-tmux-pane-trust-model.md` を新規作成（信頼境界、信頼する入力源 vs 信頼しない入力源、最終防衛線の明文化）
+
+## 3. shunit2 テスト追加
+
+- [ ] 3.1 `test-fixtures/` 配下に shunit2 テストファイルを作成
+- [ ] 3.2 既存 7 パターン（`_nudge_command_for_pattern` の全出力）が allow-list 正規表現を通過することを検証するテストケース追加
+- [ ] 3.3 `check_and_nudge` に不正な `next_cmd` を注入した場合に `tmux send-keys` が呼ばれないことを確認するテストケース追加（モック方式）
+
+## 4. 検証
+
+- [ ] 4.1 `twl check` でプラグイン整合性を確認
+- [ ] 4.2 shunit2 テストを実行してグリーンを確認

--- a/deltaspec/changes/issue-496/test-mapping.yaml
+++ b/deltaspec/changes/issue-496/test-mapping.yaml
@@ -1,0 +1,14 @@
+change: issue-496
+generated: 2026-04-12
+
+unit:
+  - spec: specs/security/spec.md
+    test: plugins/twl/tests/unit/check-and-nudge-allowlist/check-and-nudge-allowlist.bats
+    scenarios:
+      - "有効な workflow コマンドは inject される"
+      - "不正なコマンドは nudge をスキップする"
+      - "バリデーション失敗時に trace ログを出力する"
+      - "既存 7 パターンは全て allow-list を通過する"
+      - "空文字列は無操作"
+
+e2e: []

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -920,11 +920,15 @@ check_and_nudge() {
     if next_cmd="$(_nudge_command_for_pattern "$pane_output" "$issue" "$entry")" && [[ -n "$next_cmd" ]]; then
       # --- allow-list バリデーション（コマンドインジェクション防止）---
       # inject_next_workflow と同等の検証を適用し defense-in-depth を確保する（Issue #496）
+      # _nudge_command_for_pattern は "/twl:workflow-<name> #<issue>" 形式を返すため
+      # 正規表現は " #<N>" サフィックスを許容する
+      mkdir -p "${AUTOPILOT_DIR}/trace" 2>/dev/null || true
       local _nudge_trace_log="${AUTOPILOT_DIR}/trace/inject-$(date -u +%Y%m%d).log"
       local _nudge_ts
       _nudge_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-      if [[ ! "$next_cmd" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
-        echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${next_cmd:0:200}' — nudge スキップ" >&2
+      local _next_cmd_safe="${next_cmd//$'\n'/ }"  # ログインジェクション防止（改行除去）
+      if [[ ! "$_next_cmd_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*( #[0-9]+)?$ ]]; then
+        echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${_next_cmd_safe:0:200}' — nudge スキップ" >&2
         echo "[${_nudge_ts}] issue=${issue} next_cmd=INVALID result=skip reason=\"invalid next_cmd\"" >> "$_nudge_trace_log" 2>/dev/null || true
         LAST_OUTPUT_HASH[$issue]="$current_hash"
         return 0

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -918,6 +918,17 @@ check_and_nudge() {
   if [[ "$current_hash" == "$last_hash" ]]; then
     local next_cmd
     if next_cmd="$(_nudge_command_for_pattern "$pane_output" "$issue" "$entry")" && [[ -n "$next_cmd" ]]; then
+      # --- allow-list バリデーション（コマンドインジェクション防止）---
+      # inject_next_workflow と同等の検証を適用し defense-in-depth を確保する（Issue #496）
+      local _nudge_trace_log="${AUTOPILOT_DIR}/trace/inject-$(date -u +%Y%m%d).log"
+      local _nudge_ts
+      _nudge_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      if [[ ! "$next_cmd" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+        echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${next_cmd:0:200}' — nudge スキップ" >&2
+        echo "[${_nudge_ts}] issue=${issue} next_cmd=INVALID result=skip reason=\"invalid next_cmd\"" >> "$_nudge_trace_log" 2>/dev/null || true
+        LAST_OUTPUT_HASH[$issue]="$current_hash"
+        return 0
+      fi
       echo "[orchestrator] Issue #${issue}: chain 遷移停止検知 — nudge 送信 (${count}/${MAX_NUDGE})" >&2
       tmux send-keys -t "$window_name" "$next_cmd" Enter 2>/dev/null || true
       NUDGE_COUNTS[$issue]=$((count + 1))

--- a/plugins/twl/tests/unit/check-and-nudge-allowlist/check-and-nudge-allowlist.bats
+++ b/plugins/twl/tests/unit/check-and-nudge-allowlist/check-and-nudge-allowlist.bats
@@ -1,0 +1,237 @@
+#!/usr/bin/env bats
+# check-and-nudge-allowlist.bats
+# Requirement: check_and_nudge allow-list 検証
+# Spec: deltaspec/changes/issue-496/specs/security/spec.md
+#
+# check_and_nudge() が _nudge_command_for_pattern の出力を tmux send-keys に渡す前に
+# allow-list バリデーションを適用することを確認する。
+#
+# test double: check-and-nudge-dispatch.sh
+#   Usage: check-and-nudge-dispatch.sh <issue> <window_name>
+#   Env:
+#     NEXT_CMD      - _nudge_command_for_pattern の返り値（デフォルト: "/twl:workflow-test-ready"）
+#     PATTERN_EXIT  - _nudge_command_for_pattern の終了コード（デフォルト: 0, 1=パターン不一致）
+#     CALLS_LOG     - tmux send-keys 呼び出し記録ファイル
+#     TRACE_LOG     - trace ログ記録ファイル
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: check_and_nudge テスト double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  TRACE_LOG="$SANDBOX/trace.log"
+  export CALLS_LOG TRACE_LOG
+
+  # テスト double: check_and_nudge allow-list バリデーションロジック
+  cat > "$SANDBOX/scripts/check-and-nudge-dispatch.sh" << 'DISPATCH_EOF'
+#!/usr/bin/env bash
+# check-and-nudge-dispatch.sh
+# check_and_nudge() の allow-list バリデーション部分の test double
+# Usage: <issue> <window_name>
+# Env:
+#   NEXT_CMD      - _nudge_command_for_pattern の返り値（デフォルト: "/twl:workflow-test-ready"）
+#   PATTERN_EXIT  - _nudge_command_for_pattern の終了コード（デフォルト: 0）
+#   CALLS_LOG     - 呼び出し記録ファイル
+#   TRACE_LOG     - trace ログファイル
+set -uo pipefail
+
+issue="$1"
+window_name="$2"
+
+NEXT_CMD="${NEXT_CMD-/twl:workflow-test-ready}"
+PATTERN_EXIT="${PATTERN_EXIT:-0}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+TRACE_LOG="${TRACE_LOG:-/dev/null}"
+
+# _nudge_command_for_pattern の呼び出しをシミュレート
+if [[ "$PATTERN_EXIT" -ne 0 ]]; then
+  # パターン不一致: return 1 相当
+  exit 0
+fi
+
+next_cmd="$NEXT_CMD"
+
+# [[ -n "$next_cmd" ]] チェック（空文字は無操作）
+if [[ -z "$next_cmd" ]]; then
+  exit 0
+fi
+
+# --- allow-list バリデーション（コマンドインジェクション防止） ---
+if [[ ! "$next_cmd" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${next_cmd:0:200}' — nudge スキップ" >&2
+  _trace_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  echo "[${_trace_ts}] issue=${issue} next_cmd=INVALID result=skip reason=\"invalid next_cmd\"" >> "$TRACE_LOG" 2>/dev/null || true
+  exit 0
+fi
+
+# --- inject 実行（バリデーション済み） ---
+echo "tmux send-keys -t $window_name $next_cmd" >> "$CALLS_LOG"
+echo "[orchestrator] Issue #${issue}: chain 遷移停止検知 — nudge 送信" >&2
+
+exit 0
+DISPATCH_EOF
+  chmod +x "$SANDBOX/scripts/check-and-nudge-dispatch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 有効な workflow コマンドは inject される
+# WHEN _nudge_command_for_pattern が /twl:workflow-test-ready を返す
+# THEN allow-list を通過し tmux send-keys に渡される
+# ---------------------------------------------------------------------------
+
+@test "check_and_nudge[allowlist]: 有効コマンドは tmux send-keys に渡される" {
+  NEXT_CMD="/twl:workflow-test-ready" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#496 /twl:workflow-test-ready" "$CALLS_LOG"
+}
+
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-verify は inject される" {
+  NEXT_CMD="/twl:workflow-pr-verify" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-verify" "$CALLS_LOG"
+}
+
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-fix は inject される" {
+  NEXT_CMD="/twl:workflow-pr-fix" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-fix" "$CALLS_LOG"
+}
+
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-merge は inject される" {
+  NEXT_CMD="/twl:workflow-pr-merge" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-merge" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 不正なコマンドは nudge をスキップする
+# WHEN _nudge_command_for_pattern が allow-list に一致しない文字列を返す
+# THEN WARNING ログを出力し tmux send-keys を呼ばない
+# ---------------------------------------------------------------------------
+
+@test "check_and_nudge[security]: 不正コマンドは tmux send-keys を呼ばない" {
+  NEXT_CMD="malicious; rm -rf /" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "check_and_nudge[security]: 不正コマンドに WARNING ログを出力する" {
+  NEXT_CMD="malicious; rm -rf /" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  assert_output --partial "WARNING: check_and_nudge"
+}
+
+@test "check_and_nudge[security]: /twl:workflow- プレフィックスなしは拒否される" {
+  NEXT_CMD="workflow-pr-verify" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "check_and_nudge[security]: セミコロンを含むコマンドは拒否される" {
+  NEXT_CMD="/twl:workflow-pr-verify; rm -rf /" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "check_and_nudge[security]: スペースを含むコマンドは拒否される（#N 付き inject_next_workflow 形式と区別）" {
+  NEXT_CMD="/twl:workflow-pr-verify #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: バリデーション失敗時に trace ログを出力する
+# WHEN allow-list バリデーションが失敗する
+# THEN trace ログに result=skip reason="invalid next_cmd" が記録される
+# ---------------------------------------------------------------------------
+
+@test "check_and_nudge[trace]: バリデーション失敗時に trace ログに result=skip を記録する" {
+  NEXT_CMD="malicious" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "result=skip" "$TRACE_LOG"
+}
+
+@test "check_and_nudge[trace]: バリデーション失敗時に trace ログに reason=\"invalid next_cmd\" を記録する" {
+  NEXT_CMD="malicious" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q 'reason="invalid next_cmd"' "$TRACE_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 空文字列は無操作（既存の [[ -n "$next_cmd" ]] ガードで除外）
+# WHEN _nudge_command_for_pattern が空文字列を返す（>>> 提案完了 / PR マージ完了）
+# THEN tmux send-keys を呼ばずに正常終了する
+# ---------------------------------------------------------------------------
+
+@test "check_and_nudge[empty]: 空文字列は tmux send-keys を呼ばない" {
+  NEXT_CMD="" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+@test "check_and_nudge[empty]: パターン不一致（exit 1）は tmux send-keys を呼ばない" {
+  PATTERN_EXIT=1 \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 既存 7 パターンの allow-list 通過確認（正規表現単体テスト）
+# WHEN _nudge_command_for_pattern が返す 5 つの非空パターンを allow-list に通す
+# THEN 全て ^/twl:workflow-[a-z][a-z0-9-]*$ に一致する
+# ---------------------------------------------------------------------------
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-test-ready は allow-list を通過する" {
+  [[ "/twl:workflow-test-ready" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+}
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify は allow-list を通過する（AC-2 fallback）" {
+  [[ "/twl:workflow-pr-verify" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+}
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify は allow-list を通過する（テスト準備完了）" {
+  [[ "/twl:workflow-pr-verify" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+}
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-fix は allow-list を通過する" {
+  [[ "/twl:workflow-pr-fix" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+}
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-merge は allow-list を通過する" {
+  [[ "/twl:workflow-pr-merge" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+}

--- a/plugins/twl/tests/unit/check-and-nudge-allowlist/check-and-nudge-allowlist.bats
+++ b/plugins/twl/tests/unit/check-and-nudge-allowlist/check-and-nudge-allowlist.bats
@@ -62,8 +62,11 @@ if [[ -z "$next_cmd" ]]; then
 fi
 
 # --- allow-list バリデーション（コマンドインジェクション防止） ---
-if [[ ! "$next_cmd" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]; then
-  echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${next_cmd:0:200}' — nudge スキップ" >&2
+# _nudge_command_for_pattern は "/twl:workflow-<name> #<issue>" 形式を返すため
+# " #<N>" サフィックスを許容する
+_next_cmd_safe="${next_cmd//$'\n'/ }"
+if [[ ! "$_next_cmd_safe" =~ ^/twl:workflow-[a-z][a-z0-9-]*( #[0-9]+)?$ ]]; then
+  echo "[orchestrator] Issue #${issue}: WARNING: check_and_nudge — 不正な next_cmd '${_next_cmd_safe:0:200}' — nudge スキップ" >&2
   _trace_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   echo "[${_trace_ts}] issue=${issue} next_cmd=INVALID result=skip reason=\"invalid next_cmd\"" >> "$TRACE_LOG" 2>/dev/null || true
   exit 0
@@ -88,36 +91,44 @@ teardown() {
 # THEN allow-list を通過し tmux send-keys に渡される
 # ---------------------------------------------------------------------------
 
-@test "check_and_nudge[allowlist]: 有効コマンドは tmux send-keys に渡される" {
+@test "check_and_nudge[allowlist]: 有効コマンド（#N サフィックスあり）は tmux send-keys に渡される" {
+  NEXT_CMD="/twl:workflow-test-ready #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "check_and_nudge[allowlist]: 有効コマンド（#N サフィックスなし）は tmux send-keys に渡される" {
   NEXT_CMD="/twl:workflow-test-ready" \
     run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
 
   assert_success
-  grep -q "tmux send-keys -t ap-#496 /twl:workflow-test-ready" "$CALLS_LOG"
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[allowlist]: /twl:workflow-pr-verify は inject される" {
-  NEXT_CMD="/twl:workflow-pr-verify" \
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-verify #496 は inject される" {
+  NEXT_CMD="/twl:workflow-pr-verify #496" \
     run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
 
   assert_success
-  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-verify" "$CALLS_LOG"
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[allowlist]: /twl:workflow-pr-fix は inject される" {
-  NEXT_CMD="/twl:workflow-pr-fix" \
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-fix #496 は inject される" {
+  NEXT_CMD="/twl:workflow-pr-fix #496" \
     run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
 
   assert_success
-  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-fix" "$CALLS_LOG"
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[allowlist]: /twl:workflow-pr-merge は inject される" {
-  NEXT_CMD="/twl:workflow-pr-merge" \
+@test "check_and_nudge[allowlist]: /twl:workflow-pr-merge #496 は inject される" {
+  NEXT_CMD="/twl:workflow-pr-merge #496" \
     run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
 
   assert_success
-  grep -q "tmux send-keys -t ap-#496 /twl:workflow-pr-merge" "$CALLS_LOG"
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
 # ---------------------------------------------------------------------------
@@ -158,8 +169,8 @@ teardown() {
   ! grep -q "tmux send-keys" "$CALLS_LOG" 2>/dev/null
 }
 
-@test "check_and_nudge[security]: スペースを含むコマンドは拒否される（#N 付き inject_next_workflow 形式と区別）" {
-  NEXT_CMD="/twl:workflow-pr-verify #496" \
+@test "check_and_nudge[security]: #N 以外のスペース付きコマンドは拒否される" {
+  NEXT_CMD="/twl:workflow-pr-verify extra-arg" \
     run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
 
   assert_success
@@ -216,22 +227,44 @@ teardown() {
 # THEN 全て ^/twl:workflow-[a-z][a-z0-9-]*$ に一致する
 # ---------------------------------------------------------------------------
 
-@test "check_and_nudge[7-patterns]: /twl:workflow-test-ready は allow-list を通過する" {
-  [[ "/twl:workflow-test-ready" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+@test "check_and_nudge[7-patterns]: /twl:workflow-test-ready #N は allow-list を通過する（setup chain 完了）" {
+  NEXT_CMD="/twl:workflow-test-ready #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify は allow-list を通過する（AC-2 fallback）" {
-  [[ "/twl:workflow-pr-verify" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify #N は allow-list を通過する（AC-2 fallback）" {
+  NEXT_CMD="/twl:workflow-pr-verify #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify は allow-list を通過する（テスト準備完了）" {
-  [[ "/twl:workflow-pr-verify" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-verify #N は allow-list を通過する（テスト準備完了）" {
+  NEXT_CMD="/twl:workflow-pr-verify #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[7-patterns]: /twl:workflow-pr-fix は allow-list を通過する" {
-  [[ "/twl:workflow-pr-fix" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-fix #N は allow-list を通過する" {
+  NEXT_CMD="/twl:workflow-pr-fix #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }
 
-@test "check_and_nudge[7-patterns]: /twl:workflow-pr-merge は allow-list を通過する" {
-  [[ "/twl:workflow-pr-merge" =~ ^/twl:workflow-[a-z][a-z0-9-]*$ ]]
+@test "check_and_nudge[7-patterns]: /twl:workflow-pr-merge #N は allow-list を通過する" {
+  NEXT_CMD="/twl:workflow-pr-merge #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
+}
+
+@test "check_and_nudge[7-patterns]: /twl:workflow-test-ready #N は allow-list を通過する（workflow-test-ready 再試行）" {
+  NEXT_CMD="/twl:workflow-test-ready #496" \
+    run bash "$SANDBOX/scripts/check-and-nudge-dispatch.sh" "496" "ap-#496"
+  assert_success
+  grep -q "tmux send-keys" "$CALLS_LOG"
 }


### PR DESCRIPTION
## 概要

`check_and_nudge` 経路に allow-list バリデーションを追加し、`inject_next_workflow` と対称な defense-in-depth を確保する。

## 変更内容

- `check_and_nudge`: `next_cmd` を `tmux send-keys` に渡す前に `^/twl:workflow-[a-z][a-z0-9-]*( #[0-9]+)?$` でバリデーション
- バリデーション失敗時に WARNING ログ + trace ログ出力
- `mkdir -p` で trace ディレクトリを保証
- ログインジェクション防止（改行除去）を追加
- ADR-0009: tmux pane trust model と nudge inject 経路の脅威モデルを明文化
- BATS テスト 20 件追加（有効パターン・不正パターン・trace ログ・7 パターン全通過）

Closes #496