### PR TITLE
fix(#571): workflow-issue-lifecycle に project-board-sync ステップを追加

### DIFF
--- a/plugins/twl/README.md
+++ b/plugins/twl/README.md
@@ -90,7 +90,7 @@ Autopilot で複数 Issue を一括実装:
 | twl:workflow-plugin-create | plugin-interview, plugin-research, plugin-design, plugin-generate |
 | twl:workflow-plugin-diagnose | plugin-migrate-analyze, plugin-diagnose, ◆plugin-phase-diagnose, plugin-fix, plugin-verify, ◆plugin-phase-verify |
 | twl:workflow-prompt-audit | prompt-audit-scan, ◆prompt-audit-review, prompt-audit-apply |
-| twl:workflow-issue-lifecycle | issue-structure, ◆issue-spec-review, issue-review-aggregate, issue-arch-drift, issue-create |
+| twl:workflow-issue-lifecycle | issue-structure, ◆issue-spec-review, issue-review-aggregate, issue-arch-drift, issue-create, project-board-sync |
 | post-fix-verify | ●worker-code-reviewer, ●worker-security-reviewer, ●worker-codex-reviewer |
 | all-pass-check | →twl:ref-dci |
 | issue-spec-review | ●issue-critic, ●issue-feasibility, ●worker-codex-reviewer |

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -560,6 +560,7 @@ skills:
       - atomic: issue-review-aggregate
       - atomic: issue-arch-drift
       - atomic: issue-create
+      - atomic: project-board-sync
       - script: spec-review-session-init
     description: "co-issue v2 Worker runtime: 1 issue の lifecycle 全体（structure → spec-review → aggregate → fix loop → arch-drift → create）を自律実行"
 
@@ -1149,7 +1150,7 @@ commands:
     refined_by: "ref-prompt-guide@2c7a62f2"
     refined_at: "2026-04-07"
     path: commands/project-board-sync.md
-    spawnable_by: [controller]
+    spawnable_by: [controller, workflow]
     can_spawn: []
     description: "Issue作成後に Project V2 へ自動追加+フィールドミラー"
 

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -562,7 +562,7 @@ skills:
       - atomic: issue-create
       - atomic: project-board-sync
       - script: spec-review-session-init
-    description: "co-issue v2 Worker runtime: 1 issue の lifecycle 全体（structure → spec-review → aggregate → fix loop → arch-drift → create）を自律実行"
+    description: "co-issue v2 Worker runtime: 1 issue の lifecycle 全体（structure → spec-review → aggregate → fix loop → arch-drift → create → project-board-sync）を自律実行"
 
 
 # リファレンス（B-6 で追加）

--- a/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
@@ -172,6 +172,13 @@ if round == policies.max_rounds and CRITICAL findings あり:
 - labels: policies.labels_hint
 - `--repo policies.target_repo`（null の場合は省略）
 
+### Step 6.5: project-board-sync
+
+Step 6 の `/twl:issue-create` 出力 URL（`https://github.com/<owner>/<repo>/issues/<N>` 形式）から issue_number を抽出し、`/twl:project-board-sync <issue_number>` を Skill tool で呼び出す。
+
+- issue_number: issue_url の末尾パスセグメント（`/issues/(\d+)` でマッチ）
+- 失敗時は `OUT/report.json` の `warnings_acknowledged` リストに warning エントリを追加（非ブロッキング）。STATE は変更しない
+
 ### Step 7: 完了
 
 ```bash


### PR DESCRIPTION
## 概要

workflow-issue-lifecycle の Step 6（issue-create）後に project-board-sync を呼び出すStep 6.5 を追加する。

## 変更内容

- `plugins/twl/skills/workflow-issue-lifecycle/SKILL.md`: Step 6.5 を追加（issue_url から issue_number 抽出 → `/twl:project-board-sync` 呼び出し。失敗時は warnings_acknowledged に追記して非ブロッキング）
- `plugins/twl/deps.yaml`: workflow-issue-lifecycle の calls に `project-board-sync` を追加
- `plugins/twl/deps.yaml`: project-board-sync の spawnable_by を `[controller, workflow]` に更新

## 関連

Closes #571