### PR TITLE
feat(orchestrator): migrate CRG symlink to TWILL_REPO_ROOT env var

### DIFF
--- a/.dev-session/01.5-ac-checklist.md
+++ b/.dev-session/01.5-ac-checklist.md
@@ -1,6 +1,8 @@
-## 受け入れ基準（Issue #488）
+## 受け入れ基準（Issue #576）
 
-1. `plugins/twl/deps.yaml` の co-autopilot エントリ `spawnable_by` が `[user, su-observer]` になっている (L141 付近)
-2. `plugins/twl/skills/co-autopilot/SKILL.md` frontmatter の `spawnable_by` と deps.yaml の値が一致する
-3. `twl check` が PASS する
-4. `twl update-readme` 実行済み（必要な場合）
+1. `TWILL_REPO_ROOT` が `autopilot-orchestrator.sh` 内の worktree 作成処理冒頭で `effective_project_dir` から export される
+2. CRG symlink が `TWILL_REPO_ROOT` ベースで作成される
+3. main worktree に対して自己参照 symlink が作成されない（末尾スラッシュ strip 済みの文字列比較で判定）
+4. realpath ベースのガード（旧 line 324-329）が削除されている
+5. 既存の worktree 作成フローが正常動作する
+6. クロスリポ実行時（`ISSUE_REPO_PATH` 設定時）に `TWILL_REPO_ROOT` が twill モノリポルートを正しく指す

--- a/deltaspec/changes/issue-576/.deltaspec.yaml
+++ b/deltaspec/changes/issue-576/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-13
+issue: 576
+name: issue-576
+status: pending

--- a/deltaspec/changes/issue-576/design.md
+++ b/deltaspec/changes/issue-576/design.md
@@ -1,0 +1,64 @@
+## Context
+
+`autopilot-orchestrator.sh` は `launch_worker()` 関数内で CRG graph DB symlink を作成する（#532）。現行実装（line 324-329）は main worktree 自己参照を防ぐために `realpath` を使っているが、bare repo + worktree 構造では `realpath` の解決結果がアクセス経路（symlink 経由 / 直接）によって変わるため不安定。
+
+現行コード（line 324-329）:
+```bash
+local _crg_main="${effective_project_dir}/main/.code-review-graph"
+local _is_main=0
+[[ "$(realpath "$worktree_dir" 2>/dev/null)" == "$(realpath "${effective_project_dir}/main" 2>/dev/null)" ]] && _is_main=1
+[[ -d "$_crg_main" && "$_is_main" -eq 0 && ! -e "$worktree_dir/.code-review-graph" ]] && ln -sf "$_crg_main" "$worktree_dir/.code-review-graph"
+```
+
+`effective_project_dir` は line 274 で `PROJECT_DIR`（または `ISSUE_REPO_PATH`）から取得される。`TWILL_REPO_ROOT` は常に twill モノリポルート（`PROJECT_DIR`）を指し、`ISSUE_REPO_PATH` とは独立。
+
+## Goals / Non-Goals
+
+**Goals:**
+- `TWILL_REPO_ROOT` を `effective_project_dir`（= `PROJECT_DIR`）から export する
+- CRG symlink 参照先を `${TWILL_REPO_ROOT}/main/.code-review-graph` に変更
+- `_is_main` 判定を文字列比較（末尾スラッシュ strip）に変更
+- `realpath` ベースのガード（line 328）を削除
+
+**Non-Goals:**
+- `issue-lifecycle-orchestrator.sh` の CRG 対応
+- `cld-spawn` への `TWILL_REPO_ROOT` 伝搬
+- クロスリポジトリ時の CRG 参照先切り替え（`ISSUE_REPO_PATH` 設定時）
+
+## Decisions
+
+### D1: `TWILL_REPO_ROOT` の export タイミング
+
+`launch_worker()` の `effective_project_dir` 確定直後（line 274-276 の後、worktree 作成前）に export する。  
+**理由**: `effective_project_dir` が確定したタイミングが最も自然。後続の全処理で参照可能。
+
+```bash
+# line 276 の後に追加
+export TWILL_REPO_ROOT="${PROJECT_DIR}"
+```
+
+`ISSUE_REPO_PATH` が設定されている場合も `TWILL_REPO_ROOT` は twill モノリポルート固定（`PROJECT_DIR`）とする。CRG DB は常に twill モノリポの `main/.code-review-graph` を参照する。
+
+### D2: CRG symlink 参照先
+
+```bash
+local _crg_main="${TWILL_REPO_ROOT}/main/.code-review-graph"
+```
+
+`effective_project_dir` の代わりに `TWILL_REPO_ROOT` を使用。`ISSUE_REPO_PATH` 設定時も twill の CRG DB を参照する（クロスリポの CRG 対応は別 Issue）。
+
+### D3: `_is_main` 判定の簡素化
+
+```bash
+local _normalized_wt="${worktree_dir%/}"
+local _normalized_main="${TWILL_REPO_ROOT}/main"
+local _is_main=0
+[[ "$_normalized_wt" == "$_normalized_main" ]] && _is_main=1
+```
+
+`realpath` 呼び出しを廃止し、文字列比較に変更。末尾スラッシュを strip することで誤検知を防ぐ。
+
+## Risks / Trade-offs
+
+- **TWILL_REPO_ROOT 未設定環境**: `PROJECT_DIR` が空の場合は `TWILL_REPO_ROOT` も空になる。ただし `PROJECT_DIR` は orchestrator 起動時に必須チェックされているため、実質的なリスクは低い
+- **クロスリポ CRG**: `ISSUE_REPO_PATH` 設定時に当該リポの CRG DB を参照できないが、それは本 Issue スコープ外。将来的な拡張ポイントとして残す

--- a/deltaspec/changes/issue-576/proposal.md
+++ b/deltaspec/changes/issue-576/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+bare repo + worktree 構造において、`autopilot-orchestrator.sh` の CRG symlink 作成ロジックが `realpath` ベースのガードに依存しているため、コンテキスト（symlink 経由 / 直接アクセス）によって `realpath` の結果が変わり main worktree への自己参照 symlink が発生しうる。`TWILL_REPO_ROOT` 環境変数方式に移行することで構造依存を排除し、確実な main worktree 判定を実現する。
+
+## What Changes
+
+- `plugins/twl/scripts/autopilot-orchestrator.sh` の `setup_worktree()`（または同等の worktree 作成処理）冒頭で `TWILL_REPO_ROOT` を `effective_project_dir` から export するロジックを追加
+- CRG symlink 作成ロジックを `TWILL_REPO_ROOT` ベースの参照（`${TWILL_REPO_ROOT}/main/.code-review-graph`）に変更
+- main worktree 判定（`_is_main`）を `${TWILL_REPO_ROOT}/main` との文字列比較に簡素化（末尾スラッシュ strip 済み）
+- 既存の `realpath` ベースのガード（旧 line 324-329）を削除
+
+## Capabilities
+
+### New Capabilities
+
+なし（既存動作の保証強化・脆弱性解消のみ）
+
+### Modified Capabilities
+
+- **CRG symlink 作成**: `realpath` ベースから `TWILL_REPO_ROOT` 環境変数ベースに変更。main worktree への自己参照 symlink が発生しなくなる
+- **`_is_main` 判定**: realpath 一致から文字列比較（末尾スラッシュ strip）に変更。マウントポイントやバインドマウントの影響を受けなくなる
+
+## Impact
+
+- **影響ファイル**: `plugins/twl/scripts/autopilot-orchestrator.sh`
+- **スコープ外**: `issue-lifecycle-orchestrator.sh`、`cld-spawn` env 伝搬、クロスリポジトリ時の `TWILL_REPO_ROOT` 設定（別 Issue で対応）
+- **クロスリポ**: `ISSUE_REPO_PATH` が設定された場合も `TWILL_REPO_ROOT` は常に twill モノリポルートを指す。独立性を維持

--- a/deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+++ b/deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: TWILL_REPO_ROOT export
+
+`autopilot-orchestrator.sh` は `launch_worker()` 内の `effective_project_dir` 確定直後に `TWILL_REPO_ROOT` を `PROJECT_DIR` から export しなければならない（SHALL）。
+
+#### Scenario: worktree 作成時に TWILL_REPO_ROOT が設定される
+- **WHEN** `launch_worker()` が呼び出され、`effective_project_dir` が確定した後
+- **THEN** `TWILL_REPO_ROOT` 環境変数が `${PROJECT_DIR}` の値で export される
+
+#### Scenario: ISSUE_REPO_PATH 設定時も TWILL_REPO_ROOT は twill モノリポルートを指す
+- **WHEN** クロスリポジトリ実行で `ISSUE_REPO_PATH` が設定されている
+- **THEN** `TWILL_REPO_ROOT` は `PROJECT_DIR`（twill モノリポルート）を指し、`ISSUE_REPO_PATH` とは独立している
+
+## MODIFIED Requirements
+
+### Requirement: CRG symlink 参照先を TWILL_REPO_ROOT ベースに変更
+
+CRG symlink 作成ロジックは `TWILL_REPO_ROOT` 環境変数を使って参照先を決定しなければならない（MUST）。`effective_project_dir` を直接使ってはならない。
+
+#### Scenario: feature worktree への CRG symlink 作成
+- **WHEN** `worktree_dir` が main worktree でない feature worktree を指す
+- **THEN** `${TWILL_REPO_ROOT}/main/.code-review-graph` へのシンボリックリンクが `worktree_dir/.code-review-graph` に作成される
+
+#### Scenario: main worktree への自己参照 symlink を作成しない
+- **WHEN** `worktree_dir` が `${TWILL_REPO_ROOT}/main` と等しい（末尾スラッシュ strip 後の文字列比較）
+- **THEN** CRG symlink が作成されない（自己参照防止）
+
+### Requirement: _is_main 判定を文字列比較に変更
+
+main worktree 判定は `realpath` を使わず、`${TWILL_REPO_ROOT}/main` との文字列比較（末尾スラッシュ strip 済み）で行わなければならない（MUST）。
+
+#### Scenario: main worktree の正確な判定
+- **WHEN** `worktree_dir` が `/path/to/twill/main` または `/path/to/twill/main/` の形式
+- **THEN** `_is_main=1` と判定され、CRG symlink が作成されない
+
+#### Scenario: feature worktree は main と判定されない
+- **WHEN** `worktree_dir` が `/path/to/twill/worktrees/feat/xxx` の形式
+- **THEN** `_is_main=0` と判定され、CRG symlink 作成処理が続行される
+
+## REMOVED Requirements
+
+### Requirement: realpath ベースのガード削除
+
+旧来の `realpath` ベースの `_is_main` 判定コード（旧 line 328）を削除しなければならない（SHALL）。
+
+#### Scenario: realpath ガードが存在しない
+- **WHEN** `autopilot-orchestrator.sh` の CRG symlink 作成ブロックを確認する
+- **THEN** `realpath` を使った `_is_main` 判定が存在しない

--- a/deltaspec/changes/issue-576/tasks.md
+++ b/deltaspec/changes/issue-576/tasks.md
@@ -1,14 +1,14 @@
 ## 1. TWILL_REPO_ROOT export 追加
 
-- [ ] 1.1 `autopilot-orchestrator.sh` の `launch_worker()` 内、`effective_project_dir` 確定直後（line 276 付近）に `export TWILL_REPO_ROOT="${PROJECT_DIR}"` を追加する
+- [x] 1.1 `autopilot-orchestrator.sh` の `launch_worker()` 内、`effective_project_dir` 確定直後（line 276 付近）に `export TWILL_REPO_ROOT="${PROJECT_DIR}"` を追加する
 
 ## 2. CRG symlink ロジック変更
 
-- [ ] 2.1 CRG symlink 参照先を `${TWILL_REPO_ROOT}/main/.code-review-graph` に変更する（`effective_project_dir` → `TWILL_REPO_ROOT`）
-- [ ] 2.2 `_is_main` 判定を文字列比較（末尾スラッシュ strip 付き）に変更する
-- [ ] 2.3 `realpath` ベースの `_is_main` 判定コード（旧 line 328）を削除する
+- [x] 2.1 CRG symlink 参照先を `${TWILL_REPO_ROOT}/main/.code-review-graph` に変更する（`effective_project_dir` → `TWILL_REPO_ROOT`）
+- [x] 2.2 `_is_main` 判定を文字列比較（末尾スラッシュ strip 付き）に変更する
+- [x] 2.3 `realpath` ベースの `_is_main` 判定コード（旧 line 328）を削除する
 
 ## 3. 動作確認
 
-- [ ] 3.1 feature worktree で CRG symlink が `${TWILL_REPO_ROOT}/main/.code-review-graph` を指すことを確認する
-- [ ] 3.2 main worktree に対して CRG symlink が作成されないことを確認する
+- [x] 3.1 feature worktree で CRG symlink が `${TWILL_REPO_ROOT}/main/.code-review-graph` を指すことを確認する
+- [x] 3.2 main worktree に対して CRG symlink が作成されないことを確認する

--- a/deltaspec/changes/issue-576/tasks.md
+++ b/deltaspec/changes/issue-576/tasks.md
@@ -1,0 +1,14 @@
+## 1. TWILL_REPO_ROOT export 追加
+
+- [ ] 1.1 `autopilot-orchestrator.sh` の `launch_worker()` 内、`effective_project_dir` 確定直後（line 276 付近）に `export TWILL_REPO_ROOT="${PROJECT_DIR}"` を追加する
+
+## 2. CRG symlink ロジック変更
+
+- [ ] 2.1 CRG symlink 参照先を `${TWILL_REPO_ROOT}/main/.code-review-graph` に変更する（`effective_project_dir` → `TWILL_REPO_ROOT`）
+- [ ] 2.2 `_is_main` 判定を文字列比較（末尾スラッシュ strip 付き）に変更する
+- [ ] 2.3 `realpath` ベースの `_is_main` 判定コード（旧 line 328）を削除する
+
+## 3. 動作確認
+
+- [ ] 3.1 feature worktree で CRG symlink が `${TWILL_REPO_ROOT}/main/.code-review-graph` を指すことを確認する
+- [ ] 3.2 main worktree に対して CRG symlink が作成されないことを確認する

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -324,9 +324,10 @@ launch_worker() {
 
   # CRG graph DB symlink（main の DB を参照、#532、#576）
   # main worktree 自身は除外（自己参照 symlink 防止、TWILL_REPO_ROOT 文字列比較）
-  local _crg_main="${TWILL_REPO_ROOT}/main/.code-review-graph"
+  # TWILL_REPO_ROOT は常に twill モノリポルート（PROJECT_DIR）を指す。ISSUE_REPO_PATH とは独立
+  local _crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
   local _normalized_wt="${worktree_dir%/}"
-  local _normalized_main="${TWILL_REPO_ROOT}/main"
+  local _normalized_main="${TWILL_REPO_ROOT%/}/main"
   local _is_main=0
   [[ "$_normalized_wt" == "$_normalized_main" ]] && _is_main=1
   [[ -d "$_crg_main" && "$_is_main" -eq 0 && ! -e "$worktree_dir/.code-review-graph" ]] && ln -sf "$_crg_main" "$worktree_dir/.code-review-graph"

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -275,6 +275,7 @@ launch_worker() {
   if [[ -n "$ISSUE_REPO_PATH" ]]; then
     effective_project_dir="$ISSUE_REPO_PATH"
   fi
+  export TWILL_REPO_ROOT="${PROJECT_DIR}"
 
   local worktree_dir=""
   # 既存 worktree の確認（冪等性: branch が state に記録済みの場合）
@@ -321,11 +322,13 @@ launch_worker() {
     echo "[orchestrator] Issue #${ISSUE}: worktree 作成完了: $worktree_dir" >&2
   fi
 
-  # CRG graph DB symlink（main の DB を参照、#532）
-  # main worktree 自身は除外（自己参照 symlink 防止）
-  local _crg_main="${effective_project_dir}/main/.code-review-graph"
+  # CRG graph DB symlink（main の DB を参照、#532、#576）
+  # main worktree 自身は除外（自己参照 symlink 防止、TWILL_REPO_ROOT 文字列比較）
+  local _crg_main="${TWILL_REPO_ROOT}/main/.code-review-graph"
+  local _normalized_wt="${worktree_dir%/}"
+  local _normalized_main="${TWILL_REPO_ROOT}/main"
   local _is_main=0
-  [[ "$(realpath "$worktree_dir" 2>/dev/null)" == "$(realpath "${effective_project_dir}/main" 2>/dev/null)" ]] && _is_main=1
+  [[ "$_normalized_wt" == "$_normalized_main" ]] && _is_main=1
   [[ -d "$_crg_main" && "$_is_main" -eq 0 && ! -e "$worktree_dir/.code-review-graph" ]] && ln -sf "$_crg_main" "$worktree_dir/.code-review-graph"
 
   local effective_model="${model_override:-${WORKER_MODEL:-sonnet}}"

--- a/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
+++ b/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
@@ -1,0 +1,325 @@
+#!/usr/bin/env bats
+# crg-symlink-reporoot.bats
+# Requirement: CRG symlink を TWILL_REPO_ROOT 環境変数方式に移行
+# Spec: deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# 検証する仕様:
+#   1. TWILL_REPO_ROOT が PROJECT_DIR から export される
+#   2. ISSUE_REPO_PATH 設定時も TWILL_REPO_ROOT は twill モノリポルートを指す
+#   3. CRG symlink が ${TWILL_REPO_ROOT}/main/.code-review-graph を参照する
+#   4. main worktree への自己参照 symlink が作成されない（文字列比較による判定）
+#   5. realpath ではなく文字列比較で _is_main を判定する
+#
+# test double: crg-symlink-dispatch.sh
+#   Env:
+#     PROJECT_DIR      - twill モノリポルート
+#     ISSUE_REPO_PATH  - クロスリポジトリ時のリポパス（省略可）
+#     WORKTREE_DIR     - 対象 worktree パス
+#     CALLS_LOG        - 呼び出し記録ファイル
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: テスト double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  export CALLS_LOG
+
+  # テスト用のフィクスチャディレクトリ構造
+  FAKE_REPO_ROOT="$SANDBOX/twill"
+  mkdir -p "$FAKE_REPO_ROOT/main/.code-review-graph"
+  mkdir -p "$FAKE_REPO_ROOT/worktrees/feat/576-test"
+  export FAKE_REPO_ROOT
+
+  # CRG symlink 作成ロジックの test double（新方式: TWILL_REPO_ROOT ベース）
+  cat > "$SANDBOX/scripts/crg-symlink-dispatch.sh" << 'DISPATCH_EOF'
+#!/usr/bin/env bash
+# crg-symlink-dispatch.sh
+# CRG symlink 作成ロジックの test double（issue-576 新方式）
+# Env:
+#   PROJECT_DIR      - twill モノリポルート
+#   ISSUE_REPO_PATH  - クロスリポジトリ時のリポパス（省略可）
+#   WORKTREE_DIR     - 対象 worktree パス
+#   CALLS_LOG        - 呼び出し記録ファイル
+set -uo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-}"
+ISSUE_REPO_PATH="${ISSUE_REPO_PATH:-}"
+WORKTREE_DIR="${WORKTREE_DIR:-}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+
+# --- TWILL_REPO_ROOT export（PROJECT_DIR から常に設定、ISSUE_REPO_PATH とは独立）---
+export TWILL_REPO_ROOT="${PROJECT_DIR}"
+echo "export TWILL_REPO_ROOT=${TWILL_REPO_ROOT}" >> "$CALLS_LOG"
+
+# --- _is_main 判定（文字列比較 + 末尾スラッシュ strip）---
+local_normalized_wt="${WORKTREE_DIR%/}"
+local_normalized_main="${TWILL_REPO_ROOT}/main"
+_is_main=0
+[[ "$local_normalized_wt" == "$local_normalized_main" ]] && _is_main=1
+echo "_is_main=${_is_main}" >> "$CALLS_LOG"
+
+# --- CRG symlink 作成（TWILL_REPO_ROOT ベース）---
+_crg_main="${TWILL_REPO_ROOT}/main/.code-review-graph"
+if [[ -d "$_crg_main" && "$_is_main" -eq 0 && ! -e "$WORKTREE_DIR/.code-review-graph" ]]; then
+  ln -sf "$_crg_main" "$WORKTREE_DIR/.code-review-graph"
+  echo "symlink_created=${WORKTREE_DIR}/.code-review-graph -> ${_crg_main}" >> "$CALLS_LOG"
+else
+  echo "symlink_skipped reason=_is_main=${_is_main}" >> "$CALLS_LOG"
+fi
+
+exit 0
+DISPATCH_EOF
+  chmod +x "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: TWILL_REPO_ROOT export
+# Spec: deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: worktree 作成時に TWILL_REPO_ROOT が設定される
+# WHEN launch_worker() が呼び出され、effective_project_dir が確定した後
+# THEN TWILL_REPO_ROOT 環境変数が ${PROJECT_DIR} の値で export される
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[export]: TWILL_REPO_ROOT が PROJECT_DIR で export される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "export TWILL_REPO_ROOT=${FAKE_REPO_ROOT}" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[export]: TWILL_REPO_ROOT が空でない" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  local val
+  val=$(grep "export TWILL_REPO_ROOT=" "$CALLS_LOG" | head -1 | sed 's/export TWILL_REPO_ROOT=//')
+  [[ -n "$val" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: ISSUE_REPO_PATH 設定時も TWILL_REPO_ROOT は twill モノリポルートを指す
+# WHEN クロスリポジトリ実行で ISSUE_REPO_PATH が設定されている
+# THEN TWILL_REPO_ROOT は PROJECT_DIR（twill モノリポルート）を指し、ISSUE_REPO_PATH とは独立している
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[cross-repo]: ISSUE_REPO_PATH 設定時も TWILL_REPO_ROOT は PROJECT_DIR を指す" {
+  OTHER_REPO="$SANDBOX/other-repo"
+  mkdir -p "$OTHER_REPO"
+
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  ISSUE_REPO_PATH="$OTHER_REPO" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "export TWILL_REPO_ROOT=${FAKE_REPO_ROOT}" "$CALLS_LOG"
+  # ISSUE_REPO_PATH の値（other-repo）は TWILL_REPO_ROOT に使われない
+  ! grep -q "export TWILL_REPO_ROOT=${OTHER_REPO}" "$CALLS_LOG"
+}
+
+# ===========================================================================
+# Requirement: CRG symlink 参照先を TWILL_REPO_ROOT ベースに変更
+# Spec: deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: feature worktree への CRG symlink 作成
+# WHEN worktree_dir が main worktree でない feature worktree を指す
+# THEN ${TWILL_REPO_ROOT}/main/.code-review-graph へのシンボリックリンクが作成される
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[symlink]: feature worktree に CRG symlink が作成される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  [[ -L "$FAKE_REPO_ROOT/worktrees/feat/576-test/.code-review-graph" ]]
+}
+
+@test "crg-reporoot[symlink]: CRG symlink が TWILL_REPO_ROOT/main/.code-review-graph を指す" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  local target
+  target=$(readlink "$FAKE_REPO_ROOT/worktrees/feat/576-test/.code-review-graph")
+  [[ "$target" == "${FAKE_REPO_ROOT}/main/.code-review-graph" ]]
+}
+
+@test "crg-reporoot[symlink]: calls.log に symlink_created が記録される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "symlink_created=" "$CALLS_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: main worktree への自己参照 symlink を作成しない
+# WHEN worktree_dir が ${TWILL_REPO_ROOT}/main と等しい（末尾スラッシュ strip 後の文字列比較）
+# THEN CRG symlink が作成されない（自己参照防止）
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[no-self-ref]: main worktree に CRG symlink が作成されない" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/main" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  [[ ! -e "$FAKE_REPO_ROOT/main/.code-review-graph" ]] || \
+    [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]  # 既存ディレクトリは symlink ではない
+}
+
+@test "crg-reporoot[no-self-ref]: main worktree で _is_main=1 と判定される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/main" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "_is_main=1" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[no-self-ref]: main worktree で symlink_skipped が記録される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/main" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "symlink_skipped" "$CALLS_LOG"
+}
+
+# ===========================================================================
+# Requirement: _is_main 判定を文字列比較に変更
+# Spec: deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: main worktree の正確な判定
+# WHEN worktree_dir が /path/to/twill/main または /path/to/twill/main/ の形式
+# THEN _is_main=1 と判定され、CRG symlink が作成されない
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[is-main]: 末尾スラッシュ付きの main パスも _is_main=1 と判定される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="${FAKE_REPO_ROOT}/main/" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "_is_main=1" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[is-main]: main パスで CRG symlink が作成されない" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="${FAKE_REPO_ROOT}/main" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  # main/.code-review-graph はディレクトリ（既存）であり symlink ではない
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: feature worktree は main と判定されない
+# WHEN worktree_dir が /path/to/twill/worktrees/feat/xxx の形式
+# THEN _is_main=0 と判定され、CRG symlink 作成処理が続行される
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[not-main]: feature worktree で _is_main=0 と判定される" {
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "_is_main=0" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[not-main]: 別ブランチ worktree でも _is_main=0 と判定される" {
+  mkdir -p "$FAKE_REPO_ROOT/worktrees/feat/other-branch"
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/other-branch" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "_is_main=0" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[not-main]: main-like 名のブランチ（例: main-backup）は main と判定されない" {
+  mkdir -p "$FAKE_REPO_ROOT/worktrees/main-backup"
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/main-backup" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  grep -q "_is_main=0" "$CALLS_LOG"
+}
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+# Edge case: .code-review-graph が既に存在する場合は symlink を作成しない（冪等性）
+@test "crg-reporoot[edge]: 既存 .code-review-graph がある場合 symlink を上書きしない" {
+  # 既存のファイルを作成
+  touch "$FAKE_REPO_ROOT/worktrees/feat/576-test/.code-review-graph"
+
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  # symlink が作られておらず元のファイルが残っている
+  [[ ! -L "$FAKE_REPO_ROOT/worktrees/feat/576-test/.code-review-graph" ]]
+}
+
+# Edge case: _crg_main（main/.code-review-graph）が存在しない場合は symlink を作成しない
+@test "crg-reporoot[edge]: CRG DB が存在しない場合 symlink を作成しない" {
+  # .code-review-graph ディレクトリを削除
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  PROJECT_DIR="$FAKE_REPO_ROOT" \
+  WORKTREE_DIR="$FAKE_REPO_ROOT/worktrees/feat/576-test" \
+    run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
+
+  assert_success
+  [[ ! -e "$FAKE_REPO_ROOT/worktrees/feat/576-test/.code-review-graph" ]]
+}
+
+# ===========================================================================
+# Requirement: realpath ベースのガード削除
+# Spec: deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: realpath ガードが存在しない
+# WHEN autopilot-orchestrator.sh の CRG symlink 作成ブロックを確認する
+# THEN realpath を使った _is_main 判定が存在しない
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[no-realpath]: autopilot-orchestrator.sh の CRG ブロックに realpath 判定が存在しない" {
+  local orchestrator="$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  [[ -f "$orchestrator" ]] || skip "autopilot-orchestrator.sh が REPO_ROOT/scripts に見つからない"
+
+  # CRG symlink セクションで realpath を使った _is_main 判定が存在しないことを確認
+  # grep で realpath && _is_main の組み合わせを検索（存在しないことを検証）
+  ! grep -A5 "_is_main=0" "$orchestrator" | grep -q "realpath"
+}

--- a/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
+++ b/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
@@ -46,7 +46,7 @@ setup() {
 #   ISSUE_REPO_PATH  - クロスリポジトリ時のリポパス（省略可）
 #   WORKTREE_DIR     - 対象 worktree パス
 #   CALLS_LOG        - 呼び出し記録ファイル
-set -uo pipefail
+set -euo pipefail
 
 PROJECT_DIR="${PROJECT_DIR:-}"
 ISSUE_REPO_PATH="${ISSUE_REPO_PATH:-}"
@@ -186,8 +186,8 @@ teardown() {
     run bash "$SANDBOX/scripts/crg-symlink-dispatch.sh"
 
   assert_success
-  [[ ! -e "$FAKE_REPO_ROOT/main/.code-review-graph" ]] || \
-    [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]  # 既存ディレクトリは symlink ではない
+  # symlink が作成されていないことを厳密に検証（-L は symlink のみ真、-d は symlink 先まで辿る）
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
 }
 
 @test "crg-reporoot[no-self-ref]: main worktree で _is_main=1 と判定される" {

--- a/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
+++ b/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
@@ -59,7 +59,7 @@ echo "export TWILL_REPO_ROOT=${TWILL_REPO_ROOT}" >> "$CALLS_LOG"
 
 # --- _is_main 判定（文字列比較 + 末尾スラッシュ strip）---
 local_normalized_wt="${WORKTREE_DIR%/}"
-local_normalized_main="${TWILL_REPO_ROOT}/main"
+local_normalized_main="${TWILL_REPO_ROOT%/}/main"
 _is_main=0
 [[ "$local_normalized_wt" == "$local_normalized_main" ]] && _is_main=1
 echo "_is_main=${_is_main}" >> "$CALLS_LOG"


### PR DESCRIPTION
## 概要

autopilot-orchestrator.sh の CRG graph DB symlink ロジックを `realpath` ベースから `TWILL_REPO_ROOT` 環境変数方式に移行。bare repo + worktree 構造での `realpath` 不安定性を解消する。

## 変更内容

- `launch_worker()` 内で `export TWILL_REPO_ROOT="${PROJECT_DIR}"` を追加（`effective_project_dir` 確定直後）
- CRG symlink 参照先を `${TWILL_REPO_ROOT%/}/main/.code-review-graph` に変更
- `_is_main` 判定を `realpath` → 文字列比較（末尾スラッシュ strip 済み）に変更
- 旧 `realpath` ガードを削除
- Unit test 追加: 17 シナリオ (TWILL_REPO_ROOT export、symlink 作成、自己参照防止、エッジケース)

## DeltaSpec

- Change: `issue-576`
- Spec: `deltaspec/changes/issue-576/specs/crg-symlink-reporoot/spec.md`

Closes #576