### PR TITLE
feat(plugins/twl): deps.yaml PreToolUse YAML syntax guard を追加 (#565)

### DIFF
--- a/deltaspec/changes/issue-565/.deltaspec.yaml
+++ b/deltaspec/changes/issue-565/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-13
+issue: 565
+name: issue-565
+status: pending

--- a/deltaspec/changes/issue-565/design.md
+++ b/deltaspec/changes/issue-565/design.md
@@ -1,0 +1,32 @@
+## Context
+
+Claude Code v2.1.85+ の PreToolUse hook は、ツール実行前にシェルスクリプトを介して stdin JSON を受け取り、exit 2 でブロックできる。現在 deps.yaml の検証は PostToolUse のみで行われており、壊れた YAML が disk に書き込まれた後に `twl --check` がクラッシュする問題がある。`if` フィールドで対象ファイルを絞り込めるため、パフォーマンス影響を最小化できる。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Write(deps.yaml) および Edit(deps.yaml) 実行前に YAML syntax を検証し、不正な場合は exit 2 でブロックする
+- Edit の場合は `old_string`/`new_string` を使った simulated apply で検証する
+- 正常な YAML および deps.yaml 以外のファイルには影響を与えない
+- deps.yaml に新規スクリプトをコンポーネントとして登録する
+
+**Non-Goals:**
+- PostToolUse hook の修正
+- YAML の型ルールチェック（Post 層の責務）
+- git commit gate
+- `twl --validate` による意味的検証
+
+## Decisions
+
+**simulated apply の実装**: bash の `${current//"$old_str"/"$new_str"}` で文字列置換を行う。正規表現は使わないため glob 展開を防ぐために `set -f` を適用する。Edit ツール自体が unique マッチを前提としているため、複数マッチの問題は実用上発生しない。
+
+**YAML 検証コマンド**: `python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"` を使用。外部ライブラリへの依存なしに ~0.05s で実行可能。`python3` と `pyyaml` はプロジェクト環境で利用可能。
+
+**hook の `if` 条件**: `Edit(deps.yaml)|Write(deps.yaml)` で絞り込む。`if` が false のとき hook プロセスは spawn されないため、他のファイル編集にパフォーマンス影響なし。
+
+**timeout**: 3000ms。YAML parse は通常 50ms 以内であり、十分なマージン。
+
+## Risks / Trade-offs
+
+- `old_string` に bash 特殊文字が含まれる極端なケースでは simulated apply が不正確になる可能性があるが、`set -f` と引用符で実用上のリスクは低い
+- `python3` または `pyyaml` が存在しない環境では hook がエラーになる可能性があるが、プロジェクトの開発環境では必須依存として保証される

--- a/deltaspec/changes/issue-565/proposal.md
+++ b/deltaspec/changes/issue-565/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+deps.yaml の検証は PostToolUse（書き込み後）でのみ行われているため、壊れた YAML が一旦 disk に書き込まれると後続の `twl --check` 自体が YAML parse エラーでクラッシュし、有用なフィードバックを返せない。Write/Edit ツール実行前に YAML syntax を事前検証することで、この問題を根本的に防止する。
+
+## What Changes
+
+- 新規スクリプト `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh` を追加
+  - Write: `tool_input.content` から全文を取得し YAML parse
+  - Edit: `tool_input.old_string`/`new_string` で simulated apply を行い YAML parse
+  - YAML syntax エラー時 exit 2 + stderr にメッセージ出力
+- `plugins/twl/hooks/hooks.json` に PreToolUse エントリを追加（matcher: `Edit|Write`, if: `deps.yaml`）
+- `plugins/twl/deps.yaml` の scripts セクションに新規スクリプトのコンポーネントエントリを追加
+
+## Capabilities
+
+### New Capabilities
+
+- deps.yaml への Write/Edit が実行される前に YAML syntax を検証し、不正な YAML を disk に書き込む前にブロックできる
+- `python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"` による軽量（~0.05s）な YAML 検証
+
+### Modified Capabilities
+
+- `plugins/twl/hooks/hooks.json`: PreToolUse hook エントリが追加され、deps.yaml を対象とした Edit/Write の事前ガードが有効になる
+- `plugins/twl/deps.yaml`: 新規スクリプトが scripts セクションに登録される
+
+## Impact
+
+- 影響コード: `plugins/twl/hooks/hooks.json`, `plugins/twl/deps.yaml`, 新規ファイル `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh`
+- deps.yaml 以外のファイルへの Edit/Write には影響なし（`if` 条件で除外）
+- PostToolUse hook の動作には変更なし

--- a/deltaspec/changes/issue-565/specs/pre-tool-use-yaml-guard/spec.md
+++ b/deltaspec/changes/issue-565/specs/pre-tool-use-yaml-guard/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: PreToolUse YAML syntax guard スクリプト
+
+deps.yaml への Write/Edit ツール実行前に YAML syntax を検証するスクリプト `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh` が存在しなければならない（SHALL）。スクリプトは stdin から JSON を受け取り、YAML syntax エラー検出時は exit 2 で実行をブロックしなければならない（MUST）。
+
+#### Scenario: Write ツールで不正な YAML を送信した場合
+- **WHEN** `Write(deps.yaml)` で YAML parse エラーになるコンテンツが `tool_input.content` に含まれる
+- **THEN** exit 2 で終了し、stderr に YAML syntax エラーメッセージが表示される
+
+#### Scenario: Edit ツールで不正な YAML になる変更を送信した場合
+- **WHEN** `Edit(deps.yaml)` で `old_string`/`new_string` の simulated apply 後に YAML parse エラーになる
+- **THEN** exit 2 で終了し、stderr に YAML syntax エラーメッセージが表示される
+
+#### Scenario: 正常な YAML の Write を送信した場合
+- **WHEN** `Write(deps.yaml)` で有効な YAML コンテンツが送信される
+- **THEN** exit 0 で正常通過し、ツールの実行がブロックされない
+
+#### Scenario: 正常な YAML になる Edit を送信した場合
+- **WHEN** `Edit(deps.yaml)` の simulated apply 後も有効な YAML が維持される
+- **THEN** exit 0 で正常通過する
+
+### Requirement: hooks.json への PreToolUse エントリ追加
+
+`plugins/twl/hooks/hooks.json` に PreToolUse エントリを追加し、deps.yaml を対象とする Edit/Write のみに絞り込まなければならない（SHALL）。
+
+#### Scenario: deps.yaml 以外のファイルへの Edit/Write
+- **WHEN** deps.yaml 以外のファイルに対して Edit または Write ツールが実行される
+- **THEN** hook が発火しない（`if` 条件による除外）
+
+#### Scenario: PreToolUse hook のタイムアウト
+- **WHEN** hook スクリプトが実行される
+- **THEN** 3000ms 以内に完了する（SHALL）
+
+### Requirement: deps.yaml へのスクリプトコンポーネント登録
+
+`plugins/twl/deps.yaml` の scripts セクションに `pre-tool-use-deps-yaml-guard.sh` のコンポーネントエントリを追加しなければならない（SHALL）。
+
+#### Scenario: deps.yaml コンポーネント登録の整合性
+- **WHEN** `twl --check` を実行する
+- **THEN** 新規スクリプトが deps.yaml に登録されており、コンポーネント整合性チェックが通過する

--- a/deltaspec/changes/issue-565/tasks.md
+++ b/deltaspec/changes/issue-565/tasks.md
@@ -1,18 +1,18 @@
 ## 1. スクリプト作成
 
-- [ ] 1.1 `plugins/twl/scripts/hooks/` ディレクトリが存在することを確認（必要なら作成）
-- [ ] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh` を新規作成
+- [x] 1.1 `plugins/twl/scripts/hooks/` ディレクトリが存在することを確認（必要なら作成）
+- [x] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh` を新規作成
   - stdin JSON から `tool_name` を取得し Write/Edit を判定
   - Write: `tool_input.content` → YAML parse（`python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"`）
   - Edit: `old_string`/`new_string` で simulated apply（`set -f`、bash 文字列置換）→ YAML parse
   - YAML syntax エラー時: exit 2 + stderr にメッセージ出力
   - 正常時: exit 0
-- [ ] 1.3 スクリプトに実行権限を付与（`chmod +x`）
+- [x] 1.3 スクリプトに実行権限を付与（`chmod +x`）
 
 ## 2. hooks.json への PreToolUse エントリ追加
 
-- [ ] 2.1 `plugins/twl/hooks/hooks.json` を読み込み、現在の構造を確認
-- [ ] 2.2 PreToolUse セクションに以下のエントリを追加
+- [x] 2.1 `plugins/twl/hooks/hooks.json` を読み込み、現在の構造を確認
+- [x] 2.2 PreToolUse セクションに以下のエントリを追加
   ```json
   {
     "matcher": "Edit|Write",
@@ -29,10 +29,10 @@
 
 ## 3. deps.yaml へのコンポーネント登録
 
-- [ ] 3.1 `plugins/twl/deps.yaml` を読み込み、scripts セクションの構造を確認
-- [ ] 3.2 scripts セクションに `pre-tool-use-deps-yaml-guard.sh` のエントリを追加
+- [x] 3.1 `plugins/twl/deps.yaml` を読み込み、scripts セクションの構造を確認
+- [x] 3.2 scripts セクションに `pre-tool-use-deps-yaml-guard.sh` のエントリを追加
 
 ## 4. 動作検証
 
-- [ ] 4.1 `twl --check` を実行し deps.yaml の整合性を確認
-- [ ] 4.2 hook スクリプトのユニットテスト（不正 YAML での exit 2、正常 YAML での exit 0）
+- [x] 4.1 `twl --check` を実行し deps.yaml の整合性を確認
+- [x] 4.2 hook スクリプトのユニットテスト（不正 YAML での exit 2、正常 YAML での exit 0）

--- a/deltaspec/changes/issue-565/tasks.md
+++ b/deltaspec/changes/issue-565/tasks.md
@@ -1,0 +1,38 @@
+## 1. スクリプト作成
+
+- [ ] 1.1 `plugins/twl/scripts/hooks/` ディレクトリが存在することを確認（必要なら作成）
+- [ ] 1.2 `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh` を新規作成
+  - stdin JSON から `tool_name` を取得し Write/Edit を判定
+  - Write: `tool_input.content` → YAML parse（`python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"`）
+  - Edit: `old_string`/`new_string` で simulated apply（`set -f`、bash 文字列置換）→ YAML parse
+  - YAML syntax エラー時: exit 2 + stderr にメッセージ出力
+  - 正常時: exit 0
+- [ ] 1.3 スクリプトに実行権限を付与（`chmod +x`）
+
+## 2. hooks.json への PreToolUse エントリ追加
+
+- [ ] 2.1 `plugins/twl/hooks/hooks.json` を読み込み、現在の構造を確認
+- [ ] 2.2 PreToolUse セクションに以下のエントリを追加
+  ```json
+  {
+    "matcher": "Edit|Write",
+    "hooks": [
+      {
+        "type": "command",
+        "if": "Edit(deps.yaml)|Write(deps.yaml)",
+        "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool-use-deps-yaml-guard.sh",
+        "timeout": 3000
+      }
+    ]
+  }
+  ```
+
+## 3. deps.yaml へのコンポーネント登録
+
+- [ ] 3.1 `plugins/twl/deps.yaml` を読み込み、scripts セクションの構造を確認
+- [ ] 3.2 scripts セクションに `pre-tool-use-deps-yaml-guard.sh` のエントリを追加
+
+## 4. 動作検証
+
+- [ ] 4.1 `twl --check` を実行し deps.yaml の整合性を確認
+- [ ] 4.2 hook スクリプトのユニットテスト（不正 YAML での exit 2、正常 YAML での exit 0）

--- a/deltaspec/changes/issue-565/test-mapping.yaml
+++ b/deltaspec/changes/issue-565/test-mapping.yaml
@@ -1,0 +1,172 @@
+change_id: issue-565
+generated_at: "2026-04-13T00:00:00Z"
+test_framework: bats
+scenarios:
+  - id: "write-invalid-yaml-exit2"
+    name: "Write ツールで不正な YAML を送信した場合"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 7
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: 不正 YAML は exit 2 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "write-invalid-yaml-stderr"
+    name: "Write ツールで不正な YAML を送信した場合 (stderr 検証)"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 7
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: 不正 YAML は stderr にエラーメッセージを出力する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edit-invalid-yaml-exit2"
+    name: "Edit ツールで不正な YAML になる変更を送信した場合"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 12
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Edit: simulated apply 後に不正 YAML になる場合は exit 2 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edit-invalid-yaml-stderr"
+    name: "Edit ツールで不正な YAML になる変更を送信した場合 (stderr 検証)"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 12
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Edit: simulated apply 後の不正 YAML は stderr にエラーを出力する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "write-valid-yaml-exit0"
+    name: "正常な YAML の Write を送信した場合"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 16
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: 有効な YAML は exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edit-valid-yaml-exit0"
+    name: "正常な YAML になる Edit を送信した場合"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 19
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Edit: simulated apply 後も有効な YAML なら exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-invalid-json-noop"
+    name: "不正 JSON ペイロード -> no-op"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 5
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "不正 JSON ペイロードは no-op (exit 0)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-other-tool-noop"
+    name: "Write/Edit 以外の tool_name -> no-op"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 5
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "tool_name が Bash の場合は no-op (exit 0)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-empty-content-valid"
+    name: "content が空文字列 -> YAML として有効"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 7
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: content が空文字列は有効 YAML として通過する (exit 0)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-null-content-noop"
+    name: "content が null -> no-op フォールバック"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 7
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: content が null の場合は no-op (exit 0)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-old-string-not-found-exit2"
+    name: "Edit で old_string が file_content に存在しない -> exit 2"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 12
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Edit: old_string が file_content に見つからない場合は exit 2 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-tab-indent-invalid"
+    name: "タブ文字インデントによる不正 YAML -> exit 2"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 7
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: タブインデントを含む YAML は exit 2 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "edge-deeply-nested-valid"
+    name: "深くネストされた有効 YAML -> exit 0"
+    spec_file: "specs/pre-tool-use-yaml-guard/spec.md"
+    spec_line: 16
+    requirement: "PreToolUse YAML syntax guard スクリプト"
+    test_file: "plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats"
+    test_name: "Write: 深くネストされた有効 YAML は exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2273,6 +2273,11 @@ scripts:
     path: scripts/hooks/pre-tool-use-host-safety.sh
     description: "PreToolUse hook: Bash tool でホスト環境を破壊しうるコマンド（pip install, apt install, --break-system-packages）を deny（AUTOPILOT_DIR 設定時のみ）"
 
+  pre-tool-use-deps-yaml-guard:
+    type: script
+    path: scripts/hooks/pre-tool-use-deps-yaml-guard.sh
+    description: "PreToolUse hook: Write/Edit で deps.yaml を変更する前に YAML syntax を検証し、不正な YAML を disk に書き込む前に exit 2 でブロックする"
+
   tech-stack-detect:
     type: script
     path: scripts/tech-stack-detect.sh

--- a/plugins/twl/hooks/hooks.json
+++ b/plugins/twl/hooks/hooks.json
@@ -40,6 +40,17 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Edit(deps.yaml)|Write(deps.yaml)",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/hooks/pre-tool-use-deps-yaml-guard.sh",
+            "timeout": 3000
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# PreToolUse hook: deps.yaml YAML syntax guard
+#
+# Write/Edit ツールで deps.yaml を変更しようとする際、
+# 変更後の内容が有効な YAML かどうかを事前検証する。
+# 不正な YAML を disk に書き込む前に exit 2 でブロックする。
+#
+# Write: tool_input.content を直接 YAML parse
+# Edit:  tool_input.old_string / new_string で simulated apply 後に YAML parse
+#
+# 検証コマンド: python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"
+# (~0.05s で実行、pyyaml が開発環境で必須依存として保証される)
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || echo "")
+
+# JSON パース失敗時は no-op
+if ! echo "$payload" | jq empty 2>/dev/null; then
+  exit 0
+fi
+
+tool_name=$(echo "$payload" | jq -r '.tool_name // empty')
+case "$tool_name" in
+  Write|Edit) ;;
+  *) exit 0 ;;
+esac
+
+# ファイルパスを取得し、deps.yaml 対象かチェック
+file_path=$(echo "$payload" | jq -r '.tool_input.file_path // empty')
+if [[ -z "$file_path" ]]; then
+  exit 0
+fi
+
+# deps.yaml 以外は no-op（basename で末尾一致）
+if [[ "$(basename "$file_path")" != "deps.yaml" ]]; then
+  exit 0
+fi
+
+# --- YAML 検証関数 ---
+validate_yaml() {
+  local content="$1"
+  local err
+  err=$(echo "$content" | python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)" 2>&1)
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo "deps.yaml YAML syntax error: $err" >&2
+    return 1
+  fi
+  return 0
+}
+
+if [[ "$tool_name" == "Write" ]]; then
+  # content が null または存在しない場合は no-op
+  content=$(echo "$payload" | jq -r '.tool_input.content // empty')
+  if [[ -z "$content" ]]; then
+    exit 0
+  fi
+  validate_yaml "$content" || exit 2
+
+elif [[ "$tool_name" == "Edit" ]]; then
+  old_string=$(echo "$payload" | jq -r '.tool_input.old_string // empty')
+  new_string=$(echo "$payload" | jq -r '.tool_input.new_string // empty')
+
+  # old_string が空の場合は no-op（old_string 必須の Edit ツール仕様に従い）
+  if [[ -z "$old_string" ]]; then
+    exit 0
+  fi
+
+  # 対象ファイルが存在しない場合は no-op
+  if [[ ! -f "$file_path" ]]; then
+    exit 0
+  fi
+
+  current=$(cat "$file_path")
+
+  # old_string が存在しない場合（マッチしない）は no-op
+  # bash 文字列置換で simulated apply（set -f で glob 展開を防ぐ）
+  set -f
+  if [[ "$current" != *"$old_string"* ]]; then
+    set +f
+    exit 0
+  fi
+  applied="${current//"$old_string"/"$new_string"}"
+  set +f
+
+  validate_yaml "$applied" || exit 2
+fi
+
+exit 0

--- a/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
@@ -6,7 +6,9 @@
 # 不正な YAML を disk に書き込む前に exit 2 でブロックする。
 #
 # Write: tool_input.content を直接 YAML parse
-# Edit:  tool_input.old_string / new_string で simulated apply 後に YAML parse
+# Edit:  tool_input.file_content（ペイロード内の現在内容）を優先して取得し、
+#        なければ file_path のディスク内容にフォールバック。
+#        old_string/new_string で simulated apply 後に YAML parse。
 #
 # 検証コマンド: python3 -c "import sys,yaml; yaml.safe_load(sys.stdin)"
 # (~0.05s で実行、pyyaml が開発環境で必須依存として保証される)
@@ -67,22 +69,23 @@ elif [[ "$tool_name" == "Edit" ]]; then
     exit 0
   fi
 
-  # 対象ファイルが存在しない場合は no-op
-  if [[ ! -f "$file_path" ]]; then
-    exit 0
+  # ペイロード内の file_content を優先して取得（テスト・互換性対応）
+  # なければ file_path のディスク内容にフォールバック
+  current=$(echo "$payload" | jq -r '.tool_input.file_content // empty')
+  if [[ -z "$current" ]]; then
+    if [[ ! -f "$file_path" ]]; then
+      exit 0
+    fi
+    current=$(cat "$file_path")
   fi
 
-  current=$(cat "$file_path")
-
-  # old_string が存在しない場合（マッチしない）は no-op
-  # bash 文字列置換で simulated apply（set -f で glob 展開を防ぐ）
-  set -f
+  # old_string が存在しない場合は exit 2（apply 失敗 = YAML 未検証 = ブロック）
   if [[ "$current" != *"$old_string"* ]]; then
-    set +f
-    exit 0
+    echo "deps.yaml YAML guard: old_string not found in current content — ブロック" >&2
+    exit 2
   fi
+
   applied="${current//"$old_string"/"$new_string"}"
-  set +f
 
   validate_yaml "$applied" || exit 2
 fi

--- a/plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats
+++ b/plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats
@@ -1,0 +1,360 @@
+#!/usr/bin/env bats
+# pre-tool-use-deps-yaml-guard.bats
+#
+# Tests for plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
+#
+# Spec: deltaspec/changes/issue-565/specs/pre-tool-use-yaml-guard/spec.md
+#   Requirement: PreToolUse YAML syntax guard スクリプト
+#
+# The hook receives stdin JSON with tool_name (Write or Edit) and tool_input.
+# - Write: validates tool_input.content as YAML
+# - Edit:  simulates old_string/new_string apply on tool_input.file_content,
+#          then validates the result as YAML
+# - Invalid YAML -> exit 2 + stderr message
+# - Valid YAML   -> exit 0
+#
+# Coverage: --type=unit --coverage=edge-cases
+#
+# Scenarios:
+#   1. Write で不正 YAML -> exit 2 + stderr にエラーメッセージ
+#   2. Edit で simulated apply 後に不正 YAML -> exit 2 + stderr にエラーメッセージ
+#   3. Write で有効 YAML -> exit 0
+#   4. Edit で simulated apply 後も有効 YAML -> exit 0
+#   5. 不正 JSON ペイロード -> no-op (exit 0)
+#   6. tool_name が Write/Edit 以外 -> no-op (exit 0)
+#   7. content が空文字列 -> YAML として有効 (exit 0)
+#   8. YAML 構文エラーメッセージが stderr に出力される (exit 2 時)
+#   9. Write で content が null/未設定 -> no-op (exit 0, フォールバック)
+#  10. Edit で old_string が file_content 内に存在しない -> exit 2 (apply 失敗)
+#  11. Edit で new_string 適用後に YAML コロン欠落エラー -> exit 2
+#  12. 深くネストされた有効 YAML (Write) -> exit 0
+#  13. タブ文字を含む不正 YAML (Write) -> exit 2
+
+load '../helpers/common'
+
+HOOK_SRC=""
+
+setup() {
+  common_setup
+
+  HOOK_SRC="$(cd "$REPO_ROOT" && pwd)/scripts/hooks/pre-tool-use-deps-yaml-guard.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# Helper: invoke hook with given JSON payload via stdin
+_run_hook() {
+  local payload="$1"
+  printf '%s' "$payload" | bash "$HOOK_SRC"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: Write ツールで不正な YAML を送信した場合
+# WHEN Write(deps.yaml) で YAML parse エラーになるコンテンツが tool_input.content に含まれる
+# THEN exit 2 で終了し、stderr に YAML syntax エラーメッセージが表示される
+# ---------------------------------------------------------------------------
+
+@test "Write: 不正 YAML は exit 2 を返す" {
+  local invalid_yaml='key: value
+  bad_indent:
+- not: valid
+    extra: colon: here'
+  local payload
+  payload=$(jq -nc --arg content "$invalid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}
+
+@test "Write: 不正 YAML は stderr にエラーメッセージを出力する" {
+  local invalid_yaml=': bad yaml {unclosed bracket'
+  local payload stderr_file
+  payload=$(jq -nc --arg content "$invalid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  stderr_file=$(mktemp)
+  printf '%s' "$payload" | bash "$HOOK_SRC" 2>"$stderr_file"
+  local exit_code=$?
+  local stderr_output
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  [ "$exit_code" -eq 2 ]
+  [[ -n "$stderr_output" ]]
+}
+
+@test "Write: コロン重複による不正 YAML は exit 2 を返す" {
+  # key: value: extra はパーサ依存だが mapping ではない形式でエラーになるケース
+  local invalid_yaml='key: [unclosed list
+another: key'
+  local payload
+  payload=$(jq -nc --arg content "$invalid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: Edit ツールで不正な YAML になる変更を送信した場合
+# WHEN Edit(deps.yaml) で old_string/new_string の simulated apply 後に YAML parse エラーになる
+# THEN exit 2 で終了し、stderr に YAML syntax エラーメッセージが表示される
+# ---------------------------------------------------------------------------
+
+@test "Edit: simulated apply 後に不正 YAML になる場合は exit 2 を返す" {
+  # 元のファイルは有効 YAML だが, new_string 適用後は不正になる
+  local original_content='plugins:
+  name: my-plugin
+  version: "1.0"'
+  local old_string='  version: "1.0"'
+  local new_string='  version: [broken'
+  local payload
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "$old_string" \
+    --arg ns "$new_string" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}
+
+@test "Edit: simulated apply 後の不正 YAML は stderr にエラーを出力する" {
+  local original_content='key: value'
+  local old_string='key: value'
+  local new_string='key: {broken'
+  local payload stderr_file
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "$old_string" \
+    --arg ns "$new_string" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  stderr_file=$(mktemp)
+  printf '%s' "$payload" | bash "$HOOK_SRC" 2>"$stderr_file"
+  local exit_code=$?
+  local stderr_output
+  stderr_output=$(cat "$stderr_file")
+  rm -f "$stderr_file"
+  [ "$exit_code" -eq 2 ]
+  [[ -n "$stderr_output" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: 正常な YAML の Write を送信した場合
+# WHEN Write(deps.yaml) で有効な YAML コンテンツが送信される
+# THEN exit 0 で正常通過し、ツールの実行がブロックされない
+# ---------------------------------------------------------------------------
+
+@test "Write: 有効な YAML は exit 0 を返す" {
+  local valid_yaml='name: my-plugin
+version: "1.0"
+dependencies:
+  - dep-a
+  - dep-b'
+  local payload
+  payload=$(jq -nc --arg content "$valid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "Write: 有効 YAML 通過時は stdout が空である" {
+  local valid_yaml='key: value'
+  local payload
+  payload=$(jq -nc --arg content "$valid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "Write: マルチドキュメント YAML は exit 0 を返す" {
+  local valid_yaml='---
+key: value
+---
+another: doc'
+  local payload
+  payload=$(jq -nc --arg content "$valid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: 正常な YAML になる Edit を送信した場合
+# WHEN Edit(deps.yaml) の simulated apply 後も有効な YAML が維持される
+# THEN exit 0 で正常通過する
+# ---------------------------------------------------------------------------
+
+@test "Edit: simulated apply 後も有効な YAML なら exit 0 を返す" {
+  local original_content='name: my-plugin
+version: "1.0"'
+  local old_string='version: "1.0"'
+  local new_string='version: "2.0"'
+  local payload
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "$old_string" \
+    --arg ns "$new_string" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "Edit: simulated apply 後の有効 YAML は stdout を出力しない" {
+  local original_content='key: old_value'
+  local old_string='key: old_value'
+  local new_string='key: new_value'
+  local payload
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "$old_string" \
+    --arg ns "$new_string" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 5: 不正 JSON ペイロード -> no-op (exit 0)
+# ---------------------------------------------------------------------------
+
+@test "不正 JSON ペイロードは no-op (exit 0)" {
+  run bash -c "printf 'not-valid-json{' | bash '$HOOK_SRC'"
+  [ "$status" -eq 0 ]
+}
+
+@test "空ペイロードは no-op (exit 0)" {
+  run bash -c "printf '' | bash '$HOOK_SRC'"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 6: tool_name が Write/Edit 以外 -> no-op (exit 0)
+# ---------------------------------------------------------------------------
+
+@test "tool_name が Bash の場合は no-op (exit 0)" {
+  local payload
+  payload=$(jq -nc '{tool_name:"Bash", tool_input:{command:"echo hello"}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "tool_name が Read の場合は no-op (exit 0)" {
+  local payload
+  payload=$(jq -nc '{tool_name:"Read", tool_input:{file_path:"deps.yaml"}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 7: content が空文字列 -> YAML として有効 (exit 0)
+# ---------------------------------------------------------------------------
+
+@test "Write: content が空文字列は有効 YAML として通過する (exit 0)" {
+  local payload
+  payload=$(jq -nc --arg content "" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 9: Write で content が null/未設定 -> no-op (exit 0, フォールバック)
+# ---------------------------------------------------------------------------
+
+@test "Write: content が null の場合は no-op (exit 0)" {
+  local payload
+  payload=$(jq -nc \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:null}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "Write: tool_input に content フィールドなし -> no-op (exit 0)" {
+  local payload
+  payload=$(jq -nc \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml"}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 10: Edit で old_string が file_content 内に存在しない -> exit 2
+# (simulated apply 失敗 = YAML 未検証 = ブロック)
+# ---------------------------------------------------------------------------
+
+@test "Edit: old_string が file_content に見つからない場合は exit 2 を返す" {
+  local original_content='key: value'
+  local payload
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "nonexistent_string" \
+    --arg ns "replacement" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 11: Edit で new_string 適用後に YAML コロン欠落エラー -> exit 2
+# ---------------------------------------------------------------------------
+
+@test "Edit: new_string 適用後にインデント崩れで不正 YAML になる場合 exit 2" {
+  local original_content='plugins:
+  name: valid-plugin
+  version: "1.0"'
+  local old_string='  name: valid-plugin'
+  # インデントなしで配置するとブロックマッピングの構文エラーになる
+  local new_string='name: [broken indent'
+  local payload
+  payload=$(jq -nc \
+    --arg fc "$original_content" \
+    --arg os "$old_string" \
+    --arg ns "$new_string" \
+    '{tool_name:"Edit", tool_input:{file_path:"deps.yaml", file_content:$fc, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 12: 深くネストされた有効 YAML (Write) -> exit 0
+# ---------------------------------------------------------------------------
+
+@test "Write: 深くネストされた有効 YAML は exit 0 を返す" {
+  local valid_yaml='level1:
+  level2:
+    level3:
+      level4:
+        key: deep_value
+        list:
+          - item1
+          - item2
+        nested_map:
+          a: 1
+          b: 2'
+  local payload
+  payload=$(jq -nc --arg content "$valid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 13: タブ文字を含む不正 YAML (Write) -> exit 2
+# YAML 仕様ではインデントにタブ文字は使用不可
+# ---------------------------------------------------------------------------
+
+@test "Write: タブインデントを含む YAML は exit 2 を返す" {
+  # タブ文字によるインデントは YAML 仕様違反
+  local invalid_yaml
+  # printf で実際のタブ文字を埋め込む
+  invalid_yaml="key: value
+$(printf '\t')bad_tab_indent: here"
+  local payload
+  payload=$(jq -nc --arg content "$invalid_yaml" \
+    '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## 概要

deps.yaml の編集時に壊れた YAML が disk に書き込まれることを防ぐ PreToolUse hook を追加する。

## 変更内容

- `plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh`: 新規作成
  - Write: `tool_input.content` を YAML parse
  - Edit: `tool_input.file_content`（優先）/ disk フォールバックで simulated apply → YAML parse
  - YAML syntax エラー時 exit 2 + stderr にメッセージ
- `plugins/twl/hooks/hooks.json`: PreToolUse エントリを追加（`if: Edit(deps.yaml)|Write(deps.yaml)`、timeout 3000ms）
- `plugins/twl/deps.yaml`: `pre-tool-use-deps-yaml-guard` スクリプトを登録
- `plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats`: 21テスト（bats）
- `deltaspec/changes/issue-565/`: DeltaSpec artifacts（proposal, design, specs, tasks, test-mapping）

## AC 確認

- [x] Write(deps.yaml) で壊れた YAML → exit 2 + stderr エラーメッセージ
- [x] Edit(deps.yaml) で壊れた YAML → exit 2
- [x] 正常な YAML の Write/Edit → exit 0
- [x] deps.yaml 以外 → hook 発火しない（`if` 条件で除外）
- [x] timeout 3000ms 以内に完了

Closes #565