### PR TITLE
feat(settings): architecture/domain/{model,context-map}.md に PreToolUse ガード追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'case \"${TOOL_INPUT_file_path:-}\" in *architecture/domain/model.md|*architecture/domain/context-map.md) echo \"architecture domain ファイルの変更は co-architect 経由で行ってください\" >&2; exit 2;; esac'",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
     "PreCompact": [
       {
         "matcher": "",


### PR DESCRIPTION
feat(settings): architecture/domain/{model,context-map}.md に PreToolUse ガード追加

Edit|Write hook で model.md と context-map.md への直接変更を exit 2 でブロックし、
co-architect 経由での変更を誘導するメッセージを表示する。

Closes #567

Co-Authored-By: Claude <noreply@anthropic.com>