### PR TITLE
feat(hooks): PreToolUse コミットゲート実装 (#568)

### DIFF
--- a/.autopilot/issues/issue-568-context.md
+++ b/.autopilot/issues/issue-568-context.md
@@ -1,0 +1,23 @@
+# Workflow Context: Issue #568
+workflow: setup
+
+## completed_steps
+- init
+- worktree-create
+- board-status-update
+- crg-auto-build
+- arch-ref
+- change-propose
+- ac-extract
+
+## change_id
+issue-568
+
+## pr_number
+
+
+## test_results
+
+
+## review_findings
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -35,6 +35,18 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/pre-bash-commit-validate.sh",
+            "timeout": 5000
+          }
+        ]
+      }
     ]
   }
 }

--- a/deltaspec/changes/issue-568/.deltaspec.yaml
+++ b/deltaspec/changes/issue-568/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-13
+issue: 568
+name: issue-568
+status: pending

--- a/deltaspec/changes/issue-568/design.md
+++ b/deltaspec/changes/issue-568/design.md
@@ -1,0 +1,41 @@
+## Context
+
+TWiLL プロジェクトでは deps.yaml の型ルール整合性を `twl --validate` で検証するが、現状このコマンドはコミット前に自動実行されない。PreToolUse hook（`.claude/settings.json`）を使い `git commit` Bash ツール呼び出し時にスクリプトを介して `twl --validate` を実行する。
+
+settings.json の `hooks.PreToolUse[].hooks[].if` フィールドが Claude Code でサポートされているか未確認のため、スクリプト内で `$TOOL_INPUT_command` を参照する方式をフォールバック標準とする。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `git commit` 実行前に `twl --validate` を自動実行し、violations > 0 の場合に exit 2 でコミットをブロックする
+- `TWL_SKIP_COMMIT_GATE=1` 環境変数によるバイパスを提供する（Issue E 完了前の安全装置）
+- deps.yaml が存在しない場合（worktree 外など）は hook をスキップする
+- `git commit` 以外の Bash コマンドには影響しない
+
+**Non-Goals:**
+
+- deps.yaml の変更時の Pre/Post hook（Issue A, B）
+- 既知違反の解消（Issue E）
+- architecture ファイルのガード（Issue D）
+- 他プロジェクトへの適用
+
+## Decisions
+
+**スクリプト内 git commit 検出（`$TOOL_INPUT_command` フォールバック）**
+settings.json の `if` フィールドが PreToolUse でサポートされているか未確認のため、スクリプト先頭で `$TOOL_INPUT_command` を参照し `git commit` パターン以外は即 exit 0 する。`if` フィールドがサポートされている場合は settings 側にも追加して defense-in-depth を実現する。
+
+**hook CWD とスクリプト配置**
+hook の CWD はプロジェクトルート。`twl --validate` は `plugins/twl/` でのみ動作するため、スクリプト内で `cd plugins/twl` を実行。deps.yaml が見つからない場合は exit 0 でスキップ。
+
+**exit code 2 でブロック**
+Claude Code の PreToolUse hook は exit 2 をブロックシグナルとして扱う。exit 0 は通過。exit 1 はエラーとして扱われる可能性があるため、ブロック専用の exit 2 を使用する。
+
+**deps.yaml へのエントリ追加**
+`plugins/twl/deps.yaml` の `scripts` セクションに `hooks/pre-bash-commit-validate.sh` を追加し、loom CLI の管理下に置く。
+
+## Risks / Trade-offs
+
+- `twl --validate` の実行時間は ~0.4s。git commit 頻度が高い環境では微小な遅延が積み重なる可能性があるが、通常の開発では許容範囲
+- Issue E（既知 13 違反）解消前に hook が有効になると全コミットがブロックされるため、`TWL_SKIP_COMMIT_GATE=1` バイパスを必須とする
+- settings.json の `if` フィールドサポート状況が不明なため、スクリプト内フォールバックを標準実装とする（両方実装でリスク低減）

--- a/deltaspec/changes/issue-568/proposal.md
+++ b/deltaspec/changes/issue-568/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+deps.yaml の型ルール違反（can_spawn/spawnable_by/v3 schema）は `twl --validate` でしか検出できず、現状はコミット前に自動実行される仕組みがない。コミットを最終ゲートとして `--validate` を走らせることで、不整合な deps.yaml が main ブランチに入ることを防止する。
+
+## What Changes
+
+- `.claude/settings.json` に PreToolUse Bash hook を追加: `git commit` 実行前に `pre-bash-commit-validate.sh` を呼び出す
+- 新規スクリプト `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` を作成: `twl --validate` を実行し、違反ありなら exit 2 でコミットをブロック
+- `plugins/twl/deps.yaml` にスクリプトコンポーネントを追加
+- `$TOOL_INPUT_command` による `git commit` 検出フォールバック（settings.json の `if` フィールド非サポート対応）
+- `TWL_SKIP_COMMIT_GATE=1` 環境変数による無効化パス
+
+## Capabilities
+
+### New Capabilities
+
+- **PreToolUse commit gate**: `git commit` 実行時に `twl --validate` が自動実行され、型ルール違反がある場合はコミットがブロックされる
+- **スキップ機構**: `TWL_SKIP_COMMIT_GATE=1` 設定時はゲートをバイパス可能（Issue E 完了前の安全装置）
+
+### Modified Capabilities
+
+- **`.claude/settings.json`**: `hooks.PreToolUse` エントリが追加され、Bash tool 呼び出し時に commit validate hook が起動する
+
+## Impact
+
+- `.claude/settings.json` — `hooks` オブジェクトに `PreToolUse` キー追加
+- `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` — 新規スクリプト (~30 行)
+- `plugins/twl/deps.yaml` — `scripts` セクションにエントリ追加
+- `twl --validate` コマンド: 既存コマンド、~0.4s の実行時間

--- a/deltaspec/changes/issue-568/specs/pre-bash-commit-validate/spec.md
+++ b/deltaspec/changes/issue-568/specs/pre-bash-commit-validate/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: PreToolUse commit validate hook
+`.claude/settings.json` の `hooks.PreToolUse` に Bash ツール向けのエントリを追加し、`git commit` 実行前に `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` が呼び出されなければならない（SHALL）。
+
+#### Scenario: git commit 時に validate hook が起動する
+- **WHEN** ユーザーが Claude Code から `git commit` を含む Bash コマンドを実行する
+- **THEN** `pre-bash-commit-validate.sh` が PreToolUse フェーズで自動実行される
+
+### Requirement: validate 失敗時のコミットブロック
+deps.yaml に型ルール違反がある状態で `git commit` を実行した場合、hook は exit 2 を返してコミットをブロックしなければならない（SHALL）。stderr に違反内容が表示されなければならない（SHALL）。
+
+#### Scenario: deps.yaml 型ルール違反ありの場合
+- **WHEN** `twl --validate` の実行結果で violations > 0 である
+- **THEN** スクリプトが exit 2 を返し、コミットがブロックされ、stderr に違反内容が出力される
+
+### Requirement: validate 通過時のコミット許可
+deps.yaml に型ルール違反がない状態では、hook は exit 0 を返してコミットを通過させなければならない（SHALL）。
+
+#### Scenario: deps.yaml に違反なしの場合
+- **WHEN** `twl --validate` の実行結果で violations == 0 である
+- **THEN** スクリプトが exit 0 を返し、コミットが通過する
+
+### Requirement: git commit 以外のコマンドはスキップ
+`git commit` を含まない Bash コマンドに対しては、hook は何もせず exit 0 を返さなければならない（SHALL）。
+
+#### Scenario: git status など git commit 以外の Bash コマンド
+- **WHEN** `$TOOL_INPUT_command` に `git commit` パターンが含まれない
+- **THEN** スクリプトが即 exit 0 を返し、何も実行しない
+
+### Requirement: deps.yaml 不在時のスキップ
+`plugins/twl/deps.yaml` が存在しないディレクトリ（worktree 外など）では、hook は exit 0 を返してスキップしなければならない（SHALL）。
+
+#### Scenario: deps.yaml が存在しない場合
+- **WHEN** スクリプトが `cd plugins/twl` した後に `deps.yaml` が見つからない
+- **THEN** スクリプトが exit 0 を返し、コミットをブロックしない
+
+### Requirement: TWL_SKIP_COMMIT_GATE によるバイパス
+`TWL_SKIP_COMMIT_GATE=1` 環境変数が設定されている場合、hook は `twl --validate` を実行せず exit 0 を返さなければならない（SHALL）。
+
+#### Scenario: TWL_SKIP_COMMIT_GATE=1 設定時
+- **WHEN** 環境変数 `TWL_SKIP_COMMIT_GATE` が `1` に設定された状態で `git commit` を実行する
+- **THEN** スクリプトが exit 0 を返し、コミットが通過する
+
+### Requirement: タイムアウト制限
+hook は `timeout: 5000`（5000ms）以内に完了しなければならない（SHALL）。
+
+#### Scenario: 通常の validate 実行時間
+- **WHEN** `twl --validate` が正常に実行される
+- **THEN** 5000ms 以内に完了し、timeout エラーが発生しない
+
+## ADDED Requirements
+
+### Requirement: deps.yaml スクリプトエントリ
+`plugins/twl/deps.yaml` の `scripts` セクションに `hooks/pre-bash-commit-validate.sh` のエントリが追加されなければならない（SHALL）。
+
+#### Scenario: deps.yaml へのスクリプト登録
+- **WHEN** `plugins/twl/deps.yaml` を参照する
+- **THEN** `scripts` セクションに `pre-bash-commit-validate` エントリが存在し、path と description が設定されている

--- a/deltaspec/changes/issue-568/tasks.md
+++ b/deltaspec/changes/issue-568/tasks.md
@@ -1,24 +1,24 @@
 ## 1. スクリプト実装
 
-- [ ] 1.1 `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` を新規作成
-- [ ] 1.2 スクリプトに `$TOOL_INPUT_command` による `git commit` 検出ロジックを実装
-- [ ] 1.3 `TWL_SKIP_COMMIT_GATE=1` バイパスロジックを実装
-- [ ] 1.4 `cd plugins/twl` 後に `deps.yaml` 存在チェックを実装
-- [ ] 1.5 `twl --validate` 実行と exit code 制御（violations > 0 → exit 2、0 → exit 0）を実装
+- [x] 1.1 `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` を新規作成
+- [x] 1.2 スクリプトに `$TOOL_INPUT_command` による `git commit` 検出ロジックを実装
+- [x] 1.3 `TWL_SKIP_COMMIT_GATE=1` バイパスロジックを実装
+- [x] 1.4 `cd plugins/twl` 後に `deps.yaml` 存在チェックを実装
+- [x] 1.5 `twl --validate` 実行と exit code 制御（violations > 0 → exit 2、0 → exit 0）を実装
 
 ## 2. settings.json 更新
 
-- [ ] 2.1 `.claude/settings.json` の `hooks` オブジェクトに `PreToolUse` キーを追加
-- [ ] 2.2 matcher: Bash、command: `bash plugins/twl/scripts/hooks/pre-bash-commit-validate.sh`、timeout: 5000 のエントリを設定
+- [x] 2.1 `.claude/settings.json` の `hooks` オブジェクトに `PreToolUse` キーを追加
+- [x] 2.2 matcher: Bash、command: `bash plugins/twl/scripts/hooks/pre-bash-commit-validate.sh`、timeout: 5000 のエントリを設定
 
 ## 3. deps.yaml 更新
 
-- [ ] 3.1 `plugins/twl/deps.yaml` の `scripts` セクションに `pre-bash-commit-validate` エントリを追加（path: `hooks/pre-bash-commit-validate.sh`、description 付き）
-- [ ] 3.2 `twl --check` で deps.yaml の整合性を確認
+- [x] 3.1 `plugins/twl/deps.yaml` の `scripts` セクションに `pre-bash-commit-validate` エントリを追加（path: `hooks/pre-bash-commit-validate.sh`、description 付き）
+- [x] 3.2 `twl --check` で deps.yaml の整合性を確認
 
 ## 4. 動作確認
 
-- [ ] 4.1 deps.yaml に型ルール違反がある状態で `git commit` が exit 2 でブロックされることを確認
-- [ ] 4.2 deps.yaml に違反がない状態で `git commit` が通過することを確認
-- [ ] 4.3 `TWL_SKIP_COMMIT_GATE=1` 設定時にバイパスされることを確認
-- [ ] 4.4 `git status` などの `git commit` 以外のコマンドがスキップされることを確認
+- [x] 4.1 deps.yaml に型ルール違反がある状態で `git commit` が exit 2 でブロックされることを確認
+- [x] 4.2 deps.yaml に違反がない状態で `git commit` が通過することを確認
+- [x] 4.3 `TWL_SKIP_COMMIT_GATE=1` 設定時にバイパスされることを確認
+- [x] 4.4 `git status` などの `git commit` 以外のコマンドがスキップされることを確認

--- a/deltaspec/changes/issue-568/tasks.md
+++ b/deltaspec/changes/issue-568/tasks.md
@@ -1,0 +1,24 @@
+## 1. スクリプト実装
+
+- [ ] 1.1 `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` を新規作成
+- [ ] 1.2 スクリプトに `$TOOL_INPUT_command` による `git commit` 検出ロジックを実装
+- [ ] 1.3 `TWL_SKIP_COMMIT_GATE=1` バイパスロジックを実装
+- [ ] 1.4 `cd plugins/twl` 後に `deps.yaml` 存在チェックを実装
+- [ ] 1.5 `twl --validate` 実行と exit code 制御（violations > 0 → exit 2、0 → exit 0）を実装
+
+## 2. settings.json 更新
+
+- [ ] 2.1 `.claude/settings.json` の `hooks` オブジェクトに `PreToolUse` キーを追加
+- [ ] 2.2 matcher: Bash、command: `bash plugins/twl/scripts/hooks/pre-bash-commit-validate.sh`、timeout: 5000 のエントリを設定
+
+## 3. deps.yaml 更新
+
+- [ ] 3.1 `plugins/twl/deps.yaml` の `scripts` セクションに `pre-bash-commit-validate` エントリを追加（path: `hooks/pre-bash-commit-validate.sh`、description 付き）
+- [ ] 3.2 `twl --check` で deps.yaml の整合性を確認
+
+## 4. 動作確認
+
+- [ ] 4.1 deps.yaml に型ルール違反がある状態で `git commit` が exit 2 でブロックされることを確認
+- [ ] 4.2 deps.yaml に違反がない状態で `git commit` が通過することを確認
+- [ ] 4.3 `TWL_SKIP_COMMIT_GATE=1` 設定時にバイパスされることを確認
+- [ ] 4.4 `git status` などの `git commit` 以外のコマンドがスキップされることを確認

--- a/deltaspec/changes/issue-568/test-mapping.yaml
+++ b/deltaspec/changes/issue-568/test-mapping.yaml
@@ -1,0 +1,276 @@
+change_id: issue-568
+generated_at: "2026-04-13T00:00:00Z"
+test_framework: bats
+scenarios:
+  - id: "git-commit-hook-fires"
+    name: "git commit 時に validate hook が起動する"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 6
+    requirement: "PreToolUse commit validate hook"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git commit コマンドで twl --validate が呼び出される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "violations-gt-zero-exit-2"
+    name: "deps.yaml 型ルール違反ありの場合"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 13
+    requirement: "validate 失敗時のコミットブロック"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "violations > 0 のとき exit 2 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "violations-gt-zero-stderr"
+    name: "deps.yaml 型ルール違反ありの場合 — stderr 出力"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 13
+    requirement: "validate 失敗時のコミットブロック"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "violations > 0 のとき stderr に違反内容が出力される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "violations-exit-code-is-2-not-1"
+    name: "violations > 0 の場合、exit コードは必ず 2（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 13
+    requirement: "validate 失敗時のコミットブロック"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "violations > 0 のとき exit コードは 1 ではなく 2 である"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "violations-zero-exit-0"
+    name: "deps.yaml に違反なしの場合"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 21
+    requirement: "validate 通過時のコミット許可"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "violations == 0 のとき exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "violations-zero-stdout-empty"
+    name: "violations == 0 のとき stdout は空（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 21
+    requirement: "validate 通過時のコミット許可"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "violations == 0 のとき stdout は空（ノイズを出さない）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "non-git-commit-skip-git-status"
+    name: "git commit 以外のコマンドはスキップ — git status"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 27
+    requirement: "git commit 以外のコマンドはスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git status は git commit ではないので即 exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "non-git-commit-skip-git-push"
+    name: "git commit 以外のコマンドはスキップ — git push"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 27
+    requirement: "git commit 以外のコマンドはスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git push は git commit ではないので即 exit 0 を返す"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "non-git-commit-twl-not-called"
+    name: "git commit 以外では twl を呼ばない（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 27
+    requirement: "git commit 以外のコマンドはスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git commit 以外のコマンドでは twl を呼ばない（stdout/stderr 空）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "deps-yaml-not-found-skip"
+    name: "deps.yaml が存在しない場合"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 34
+    requirement: "deps.yaml 不在時のスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "deps.yaml が存在しない場合は exit 0 でスキップする"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "deps-yaml-not-found-twl-not-called"
+    name: "deps.yaml が存在しない場合は twl を呼ばない（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 34
+    requirement: "deps.yaml 不在時のスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "deps.yaml が存在しない場合は twl を呼ばない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "skip-gate-bypass-exit-0"
+    name: "TWL_SKIP_COMMIT_GATE=1 設定時"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 41
+    requirement: "TWL_SKIP_COMMIT_GATE によるバイパス"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "TWL_SKIP_COMMIT_GATE=1 のとき exit 0 でスキップする"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "skip-gate-bypass-twl-not-called"
+    name: "TWL_SKIP_COMMIT_GATE=1 のとき twl を呼ばない（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 41
+    requirement: "TWL_SKIP_COMMIT_GATE によるバイパス"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "TWL_SKIP_COMMIT_GATE=1 のとき twl を呼ばない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "skip-gate-zero-not-bypassed"
+    name: "TWL_SKIP_COMMIT_GATE=0 はバイパスしない（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 41
+    requirement: "TWL_SKIP_COMMIT_GATE によるバイパス"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "TWL_SKIP_COMMIT_GATE=0 のときはスキップしない（通常の validate を実行）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "timeout-within-5000ms"
+    name: "通常の validate 実行時間"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 48
+    requirement: "タイムアウト制限"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "validate 実行が 5000ms 以内に完了する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "deps-yaml-scripts-entry-exists"
+    name: "deps.yaml へのスクリプト登録"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 57
+    requirement: "deps.yaml スクリプトエントリ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "deps.yaml の scripts セクションに pre-bash-commit-validate エントリが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: "skipped until implementation is merged"
+
+  - id: "git-commit-options-hook-fires"
+    name: "git commit にオプションが付いた場合も hook が発火する（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 6
+    requirement: "PreToolUse commit validate hook"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git commit -m オプション付きでも hook が発火し twl を呼ぶ"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "git-commit-amend-hook-fires"
+    name: "git commit --amend でも hook が発火する（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 6
+    requirement: "PreToolUse commit validate hook"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git commit --amend でも hook が発火する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "tool-input-command-unset-noop"
+    name: "TOOL_INPUT_command 未設定は no-op（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 27
+    requirement: "git commit 以外のコマンドはスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "TOOL_INPUT_command 未設定の場合は exit 0 (no-op)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "twl-not-found-graceful-skip"
+    name: "twl コマンドが存在しない場合は graceful skip（edge case）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 34
+    requirement: "deps.yaml 不在時のスキップ"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "twl コマンドが存在しない場合は exit 0 でスキップする（グレースフル）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "twl-validate-flag-passed"
+    name: "twl --validate フラグ付きで呼ばれる（統合確認）"
+    spec_file: "specs/pre-bash-commit-validate/spec.md"
+    spec_line: 6
+    requirement: "PreToolUse commit validate hook"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats"
+    test_name: "git commit コマンドで twl --validate が --validate フラグ付きで呼び出される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2263,6 +2263,11 @@ scripts:
       - script: health-report
     description: "Worker 論理的異常検知（chain停止・エラー出力・input-waiting長時間）+ health-report 生成"
 
+  pre-bash-commit-validate:
+    type: script
+    path: scripts/hooks/pre-bash-commit-validate.sh
+    description: "PreToolUse hook: git commit 実行前に twl --validate を走らせ、型ルール違反がある場合は exit 2 でコミットをブロックする commit gate（TWL_SKIP_COMMIT_GATE=1 でバイパス可能）"
+
   pre-tool-use-worktree-boundary:
     type: script
     path: scripts/hooks/pre-tool-use-worktree-boundary.sh

--- a/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# PreToolUse hook: git commit 時に twl --validate を実行する commit gate
+#
+# Claude Code の PreToolUse フェーズで呼び出される。
+# Bash ツールの実行前に $TOOL_INPUT_command を確認し、
+# git commit を含む場合のみ twl --validate を実行する。
+#
+# 終了コード:
+#   0 — 通過（commit を許可）
+#   2 — ブロック（violations あり、commit を拒否）
+#
+# 環境変数:
+#   TOOL_INPUT_command     実行しようとしている Bash コマンド文字列（Claude Code が注入）
+#   TWL_SKIP_COMMIT_GATE   1 に設定するとゲートをバイパス（Issue E 完了前の安全装置）
+#   PLUGINS_TWL_DIR        テスト用オーバーライド（デフォルト: SCRIPT_DIR/../..）
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# PLUGINS_TWL_DIR: テスト用オーバーライドに対応。未設定時は scripts/hooks/ の 2 階層上
+PLUGINS_TWL_DIR="${PLUGINS_TWL_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+
+# --- Step 1: コマンド解決 ---
+# TOOL_INPUT_command 環境変数（Claude Code が PreToolUse で注入）を優先。
+# 未設定の場合は stdin から JSON を試みる（フォールバック）。
+CMD="${TOOL_INPUT_command:-}"
+if [[ -z "$CMD" ]]; then
+  # stdin から JSON payload を読み取り、tool_input.command を抽出
+  payload=""
+  if read -t 0 2>/dev/null || true; then
+    payload=$(cat 2>/dev/null || echo "")
+  fi
+  if [[ -n "$payload" ]] && echo "$payload" | jq empty 2>/dev/null; then
+    CMD=$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+  fi
+fi
+
+# コマンドが取得できなかった場合はスキップ（no-op）
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# --- Step 2: git commit 以外はスキップ ---
+case "$CMD" in
+  *"git commit"*) ;;
+  *) exit 0 ;;
+esac
+
+# --- Step 3: バイパスチェック ---
+if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]]; then
+  exit 0
+fi
+
+# --- Step 4: deps.yaml 存在チェック ---
+if [[ ! -f "${PLUGINS_TWL_DIR}/deps.yaml" ]]; then
+  # deps.yaml が見つからない（プロジェクトルート外など）→ スキップ
+  exit 0
+fi
+
+# --- Step 5: twl が存在するか確認 ---
+if ! command -v twl >/dev/null 2>&1; then
+  # twl コマンドが見つからない → スキップ（グレースフル）
+  exit 0
+fi
+
+# --- Step 6: twl --validate 実行 ---
+cd "$PLUGINS_TWL_DIR"
+if twl --validate 2>&1; then
+  exit 0
+else
+  exit 2
+fi

--- a/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
@@ -12,14 +12,21 @@
 # 環境変数:
 #   TOOL_INPUT_command     実行しようとしている Bash コマンド文字列（Claude Code が注入）
 #   TWL_SKIP_COMMIT_GATE   1 に設定するとゲートをバイパス（Issue E 完了前の安全装置）
-#   PLUGINS_TWL_DIR        テスト用オーバーライド（デフォルト: SCRIPT_DIR/../..）
+#   PLUGINS_TWL_DIR        テスト専用オーバーライド（BATS_TEST_DIRNAME 設定時のみ有効）
 
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# PLUGINS_TWL_DIR: テスト用オーバーライドに対応。未設定時は scripts/hooks/ の 2 階層上
-PLUGINS_TWL_DIR="${PLUGINS_TWL_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+# PLUGINS_TWL_DIR: テスト環境（BATS_TEST_DIRNAME が設定されている場合）のみオーバーライドを許可。
+# 本番 hook 実行時は SCRIPT_DIR 起点の固定パスを使用し Path Traversal を防止する。
+if [[ -n "${BATS_TEST_DIRNAME:-}" && -n "${PLUGINS_TWL_DIR:-}" ]]; then
+  # bats テスト環境: PLUGINS_TWL_DIR オーバーライドを許可
+  PLUGINS_TWL_DIR="${PLUGINS_TWL_DIR}"
+else
+  # 本番環境: SCRIPT_DIR から固定パスで解決
+  PLUGINS_TWL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
 
 # --- Step 1: コマンド解決 ---
 # TOOL_INPUT_command 環境変数（Claude Code が PreToolUse で注入）を優先。
@@ -27,10 +34,7 @@ PLUGINS_TWL_DIR="${PLUGINS_TWL_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 CMD="${TOOL_INPUT_command:-}"
 if [[ -z "$CMD" ]]; then
   # stdin から JSON payload を読み取り、tool_input.command を抽出
-  payload=""
-  if read -t 0 2>/dev/null || true; then
-    payload=$(cat 2>/dev/null || echo "")
-  fi
+  payload="$(cat 2>/dev/null || echo "")"
   if [[ -n "$payload" ]] && echo "$payload" | jq empty 2>/dev/null; then
     CMD=$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
   fi
@@ -48,9 +52,10 @@ case "$CMD" in
 esac
 
 # --- Step 3: バイパスチェック ---
-# 環境変数（ホストプロセスから継承）またはコマンド文字列内の変数代入を確認
-# 例: `TWL_SKIP_COMMIT_GATE=1 git commit` のようにコマンド文字列内に記述された場合も対応
-if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]] || [[ "$CMD" == *"TWL_SKIP_COMMIT_GATE=1"* ]]; then
+# 環境変数 TWL_SKIP_COMMIT_GATE=1 のみでバイパス。
+# コマンド文字列内の文字列マッチは commit メッセージによる意図せぬバイパスを防ぐため行わない。
+if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]]; then
+  echo "[WARN] TWL_SKIP_COMMIT_GATE: commit gate bypassed" >&2
   exit 0
 fi
 
@@ -68,7 +73,7 @@ fi
 
 # --- Step 6: twl --validate 実行 ---
 cd "$PLUGINS_TWL_DIR"
-if twl --validate 2>&1; then
+if twl --validate; then
   exit 0
 else
   exit 2

--- a/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
@@ -21,8 +21,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # PLUGINS_TWL_DIR: テスト環境（BATS_TEST_DIRNAME が設定されている場合）のみオーバーライドを許可。
 # 本番 hook 実行時は SCRIPT_DIR 起点の固定パスを使用し Path Traversal を防止する。
 if [[ -n "${BATS_TEST_DIRNAME:-}" && -n "${PLUGINS_TWL_DIR:-}" ]]; then
-  # bats テスト環境: PLUGINS_TWL_DIR オーバーライドを許可
-  PLUGINS_TWL_DIR="${PLUGINS_TWL_DIR}"
+  # bats テスト環境: PLUGINS_TWL_DIR オーバーライドを許可（PLUGINS_TWL_DIR は既に設定済み）
+  :
 else
   # 本番環境: SCRIPT_DIR から固定パスで解決
   PLUGINS_TWL_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -34,7 +34,12 @@ fi
 CMD="${TOOL_INPUT_command:-}"
 if [[ -z "$CMD" ]]; then
   # stdin から JSON payload を読み取り、tool_input.command を抽出
-  payload="$(cat 2>/dev/null || echo "")"
+  # stdin が TTY（端末）の場合はスキップしてハングを防ぐ
+  if [ -t 0 ]; then
+    payload=""
+  else
+    payload="$(cat 2>/dev/null || echo "")"
+  fi
   if [[ -n "$payload" ]] && echo "$payload" | jq empty 2>/dev/null; then
     CMD=$(echo "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
   fi
@@ -52,9 +57,12 @@ case "$CMD" in
 esac
 
 # --- Step 3: バイパスチェック ---
-# 環境変数 TWL_SKIP_COMMIT_GATE=1 のみでバイパス。
-# コマンド文字列内の文字列マッチは commit メッセージによる意図せぬバイパスを防ぐため行わない。
-if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]]; then
+# 環境変数 TWL_SKIP_COMMIT_GATE=1 または
+# コマンド先頭の変数代入（^TWL_SKIP_COMMIT_GATE=1 <space>）でバイパス。
+# コマンド文字列の先頭チェックにより commit メッセージ内の文字列によるバイパスを防ぐ。
+# 例: `TWL_SKIP_COMMIT_GATE=1 git commit` → bypass OK
+# 例: `git commit -m 'TWL_SKIP_COMMIT_GATE=1 ...'` → bypass NG（先頭でないため）
+if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]] || [[ "$CMD" =~ ^TWL_SKIP_COMMIT_GATE=1[[:space:]] ]]; then
   echo "[WARN] TWL_SKIP_COMMIT_GATE: commit gate bypassed" >&2
   exit 0
 fi

--- a/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
@@ -48,7 +48,9 @@ case "$CMD" in
 esac
 
 # --- Step 3: バイパスチェック ---
-if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]]; then
+# 環境変数（ホストプロセスから継承）またはコマンド文字列内の変数代入を確認
+# 例: `TWL_SKIP_COMMIT_GATE=1 git commit` のようにコマンド文字列内に記述された場合も対応
+if [[ "${TWL_SKIP_COMMIT_GATE:-}" == "1" ]] || [[ "$CMD" == *"TWL_SKIP_COMMIT_GATE=1"* ]]; then
   exit 0
 fi
 

--- a/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
@@ -267,12 +267,8 @@ _run_hook_payload() {
 #      path と description が設定されている
 # ---------------------------------------------------------------------------
 @test "deps.yaml の scripts セクションに pre-bash-commit-validate エントリが存在する" {
-  local deps_yaml="$REPO_ROOT/../deps.yaml"
-  # Resolve actual deps.yaml from REPO_ROOT (plugins/twl/)
-  if [[ ! -f "$deps_yaml" ]]; then
-    deps_yaml="$REPO_ROOT/deps.yaml"
-  fi
-  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+  local deps_yaml="$REPO_ROOT/deps.yaml"
+  [[ -f "$deps_yaml" ]] || { echo "deps.yaml not found at $deps_yaml" >&2; return 1; }
   grep -q "pre-bash-commit-validate" "$deps_yaml" || {
     echo "pre-bash-commit-validate not found in deps.yaml" >&2
     return 1
@@ -280,11 +276,21 @@ _run_hook_payload() {
 }
 
 @test "deps.yaml の pre-bash-commit-validate エントリに path が設定されている" {
-  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+  local deps_yaml="$REPO_ROOT/deps.yaml"
+  [[ -f "$deps_yaml" ]] || { echo "deps.yaml not found at $deps_yaml" >&2; return 1; }
+  grep -A5 "pre-bash-commit-validate:" "$deps_yaml" | grep -q "path:" || {
+    echo "path field not found in pre-bash-commit-validate entry" >&2
+    return 1
+  }
 }
 
 @test "deps.yaml の pre-bash-commit-validate エントリに description が設定されている" {
-  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+  local deps_yaml="$REPO_ROOT/deps.yaml"
+  [[ -f "$deps_yaml" ]] || { echo "deps.yaml not found at $deps_yaml" >&2; return 1; }
+  grep -A5 "pre-bash-commit-validate:" "$deps_yaml" | grep -q "description:" || {
+    echo "description field not found in pre-bash-commit-validate entry" >&2
+    return 1
+  }
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
@@ -1,0 +1,331 @@
+#!/usr/bin/env bats
+# pre-bash-commit-validate.bats
+#
+# Tests for plugins/twl/scripts/hooks/pre-bash-commit-validate.sh
+#
+# Spec: deltaspec/changes/issue-568/specs/pre-bash-commit-validate/spec.md
+#
+# Scenarios:
+#   1. git commit 時に validate hook が起動する
+#      WHEN ユーザーが Claude Code から `git commit` を含む Bash コマンドを実行する
+#      THEN pre-bash-commit-validate.sh が PreToolUse フェーズで自動実行される
+#
+#   2. deps.yaml 型ルール違反ありの場合
+#      WHEN `twl --validate` の実行結果で violations > 0 である
+#      THEN スクリプトが exit 2 を返し、コミットがブロックされ、stderr に違反内容が出力される
+#
+#   3. deps.yaml に違反なしの場合
+#      WHEN `twl --validate` の実行結果で violations == 0 である
+#      THEN スクリプトが exit 0 を返し、コミットが通過する
+#
+#   4. git status など git commit 以外の Bash コマンド
+#      WHEN $TOOL_INPUT_command に `git commit` パターンが含まれない
+#      THEN スクリプトが即 exit 0 を返し、何も実行しない
+#
+#   5. deps.yaml が存在しない場合
+#      WHEN スクリプトが `cd plugins/twl` した後に `deps.yaml` が見つからない
+#      THEN スクリプトが exit 0 を返し、コミットをブロックしない
+#
+#   6. TWL_SKIP_COMMIT_GATE=1 設定時
+#      WHEN 環境変数 TWL_SKIP_COMMIT_GATE が `1` に設定された状態で `git commit` を実行する
+#      THEN スクリプトが exit 0 を返し、コミットが通過する
+#
+#   7. 通常の validate 実行時間
+#      WHEN `twl --validate` が正常に実行される
+#      THEN 5000ms 以内に完了し、timeout エラーが発生しない
+#
+#   8. deps.yaml へのスクリプト登録
+#      WHEN `plugins/twl/deps.yaml` を参照する
+#      THEN `scripts` セクションに `pre-bash-commit-validate` エントリが存在し、path と description が設定されている
+#
+# Edge cases:
+#   9. git commit -m "message" など git commit にオプションが付いた場合も hook が発火する
+#  10. TOOL_INPUT_command 未設定（環境変数なし）→ exit 0 (no-op)
+#  11. 不正 JSON 入力 → exit 0 (no-op)
+#  12. twl コマンドが存在しない場合 → exit 0 (skip gracefully)
+#  13. violations == 0 でも stdout は空（ノイズを出さない）
+#  14. violations > 0 の場合、exit コードは必ず 2（1 でなく 2）
+
+load '../helpers/common'
+
+HOOK_SRC=""
+
+setup() {
+  common_setup
+
+  HOOK_SRC="$(cd "$REPO_ROOT" && pwd)/scripts/hooks/pre-bash-commit-validate.sh"
+
+  # Setup a fake plugins/twl directory structure inside sandbox
+  mkdir -p "$SANDBOX/plugins/twl"
+
+  # Default: deps.yaml exists (most tests assume it)
+  touch "$SANDBOX/plugins/twl/deps.yaml"
+
+  # Default: TOOL_INPUT_command is unset; individual tests set it as needed
+  unset TOOL_INPUT_command
+  unset TWL_SKIP_COMMIT_GATE
+}
+
+teardown() {
+  common_teardown
+}
+
+# Helper: invoke hook with TOOL_INPUT_command set
+_run_hook() {
+  local cmd="${1:-}"
+  TOOL_INPUT_command="$cmd" \
+  PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" \
+    bash "$HOOK_SRC"
+}
+
+# Helper: invoke hook passing a JSON payload on stdin (Claude Code PreToolUse format)
+_run_hook_payload() {
+  local payload="$1"
+  shift
+  PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" \
+    bash "$HOOK_SRC" <<< "$payload"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 2: violations > 0 → exit 2, stderr に違反内容
+# WHEN twl --validate の実行結果で violations > 0
+# THEN exit 2、コミットがブロックされ stderr に違反内容が出力される
+# ---------------------------------------------------------------------------
+@test "violations > 0 のとき exit 2 を返す" {
+  stub_command "twl" 'echo "violation: type mismatch on deps.yaml:10" >&2; exit 2'
+  run _run_hook "git commit -m 'wip'"
+  [ "$status" -eq 2 ]
+}
+
+@test "violations > 0 のとき stderr に違反内容が出力される" {
+  stub_command "twl" 'echo "violation: type mismatch on deps.yaml:10" >&2; exit 2'
+  run _run_hook "git commit -m 'wip'"
+  [ "$status" -eq 2 ]
+  # bats captures stderr in $output when run captures it; verify violation message present
+  [[ "$output" == *"violation"* ]] || [[ "$stderr" == *"violation"* ]]
+}
+
+@test "violations > 0 のとき exit コードは 1 ではなく 2 である" {
+  stub_command "twl" 'exit 2'
+  run _run_hook "git commit -m 'test'"
+  [ "$status" -ne 1 ]
+  [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: violations == 0 → exit 0
+# WHEN twl --validate の実行結果で violations == 0
+# THEN exit 0、コミットが通過する
+# ---------------------------------------------------------------------------
+@test "violations == 0 のとき exit 0 を返す" {
+  stub_command "twl" 'exit 0'
+  run _run_hook "git commit -m 'clean'"
+  [ "$status" -eq 0 ]
+}
+
+@test "violations == 0 のとき stdout は空（ノイズを出さない）" {
+  stub_command "twl" 'exit 0'
+  run _run_hook "git commit -m 'clean'"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 4: git commit 以外のコマンド → exit 0、何も実行しない
+# WHEN $TOOL_INPUT_command に git commit パターンが含まれない
+# THEN 即 exit 0、twl を呼ばない
+# ---------------------------------------------------------------------------
+@test "git status は git commit ではないので即 exit 0 を返す" {
+  stub_command "twl" 'exit 99'  # Should never be called
+  run _run_hook "git status"
+  [ "$status" -eq 0 ]
+}
+
+@test "git push は git commit ではないので即 exit 0 を返す" {
+  stub_command "twl" 'exit 99'
+  run _run_hook "git push origin main"
+  [ "$status" -eq 0 ]
+}
+
+@test "ls -la は git commit ではないので即 exit 0 を返す" {
+  stub_command "twl" 'exit 99'
+  run _run_hook "ls -la"
+  [ "$status" -eq 0 ]
+}
+
+@test "git commit 以外のコマンドでは twl を呼ばない（stdout/stderr 空）" {
+  stub_command "twl" 'echo "twl_was_called" >&2; exit 0'
+  run _run_hook "git diff --stat"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"twl_was_called"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 9: git commit にオプションが付いた場合も hook が発火する
+# ---------------------------------------------------------------------------
+@test "git commit -m オプション付きでも hook が発火し twl を呼ぶ" {
+  stub_command "twl" 'exit 0'
+  run _run_hook "git commit -m 'feat: add feature'"
+  [ "$status" -eq 0 ]
+}
+
+@test "git commit --amend でも hook が発火する" {
+  stub_command "twl" 'exit 0'
+  run _run_hook "git commit --amend --no-edit"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 5: deps.yaml が存在しない場合 → exit 0 (skip)
+# WHEN スクリプトが plugins/twl に cd した後に deps.yaml が見つからない
+# THEN exit 0、コミットをブロックしない
+# ---------------------------------------------------------------------------
+@test "deps.yaml が存在しない場合は exit 0 でスキップする" {
+  rm -f "$SANDBOX/plugins/twl/deps.yaml"
+  stub_command "twl" 'exit 99'  # Should never be called
+  run _run_hook "git commit -m 'wip'"
+  [ "$status" -eq 0 ]
+}
+
+@test "deps.yaml が存在しない場合は twl を呼ばない" {
+  rm -f "$SANDBOX/plugins/twl/deps.yaml"
+  stub_command "twl" 'echo "twl_was_called" >&2; exit 0'
+  run _run_hook "git commit -m 'wip'"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"twl_was_called"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 6: TWL_SKIP_COMMIT_GATE=1 → exit 0 (bypass)
+# WHEN 環境変数 TWL_SKIP_COMMIT_GATE が 1 に設定されている
+# THEN exit 0、twl を呼ばない
+# ---------------------------------------------------------------------------
+@test "TWL_SKIP_COMMIT_GATE=1 のとき exit 0 でスキップする" {
+  stub_command "twl" 'exit 99'
+  TWL_SKIP_COMMIT_GATE=1 run _run_hook "git commit -m 'bypass'"
+  [ "$status" -eq 0 ]
+}
+
+@test "TWL_SKIP_COMMIT_GATE=1 のとき twl を呼ばない" {
+  stub_command "twl" 'echo "twl_was_called" >&2; exit 0'
+  TWL_SKIP_COMMIT_GATE=1 run _run_hook "git commit -m 'bypass'"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"twl_was_called"* ]]
+}
+
+@test "TWL_SKIP_COMMIT_GATE=0 のときはスキップしない（通常の validate を実行）" {
+  stub_command "twl" 'exit 0'
+  TWL_SKIP_COMMIT_GATE=0 run _run_hook "git commit -m 'normal'"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 7: タイムアウト制限 — 5000ms 以内に完了
+# WHEN twl --validate が正常に実行される
+# THEN 5000ms 以内に完了する
+# ---------------------------------------------------------------------------
+@test "validate 実行が 5000ms 以内に完了する" {
+  stub_command "twl" 'exit 0'
+  local start_ms
+  local end_ms
+  start_ms=$(date +%s%3N)
+  run _run_hook "git commit -m 'timing'"
+  end_ms=$(date +%s%3N)
+  local elapsed=$(( end_ms - start_ms ))
+  [ "$status" -eq 0 ]
+  [ "$elapsed" -lt 5000 ] || {
+    echo "Elapsed ${elapsed}ms exceeds 5000ms timeout" >&2
+    return 1
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 10: TOOL_INPUT_command 未設定 → exit 0 (no-op)
+# ---------------------------------------------------------------------------
+@test "TOOL_INPUT_command 未設定の場合は exit 0 (no-op)" {
+  stub_command "twl" 'exit 99'
+  unset TOOL_INPUT_command
+  PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" run bash "$HOOK_SRC"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Edge case 12: twl コマンドが存在しない場合 → exit 0 (graceful skip)
+# ---------------------------------------------------------------------------
+@test "twl コマンドが存在しない場合は exit 0 でスキップする（グレースフル）" {
+  # Do NOT stub twl; it should not exist in the minimal stub PATH
+  # Remove any stub that might exist
+  rm -f "$STUB_BIN/twl"
+  run _run_hook "git commit -m 'no-twl'"
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 8: deps.yaml へのスクリプト登録
+# WHEN plugins/twl/deps.yaml を参照する
+# THEN scripts セクションに pre-bash-commit-validate エントリが存在し、
+#      path と description が設定されている
+# ---------------------------------------------------------------------------
+@test "deps.yaml の scripts セクションに pre-bash-commit-validate エントリが存在する" {
+  local deps_yaml="$REPO_ROOT/../deps.yaml"
+  # Resolve actual deps.yaml from REPO_ROOT (plugins/twl/)
+  if [[ ! -f "$deps_yaml" ]]; then
+    deps_yaml="$REPO_ROOT/deps.yaml"
+  fi
+  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+  grep -q "pre-bash-commit-validate" "$deps_yaml" || {
+    echo "pre-bash-commit-validate not found in deps.yaml" >&2
+    return 1
+  }
+}
+
+@test "deps.yaml の pre-bash-commit-validate エントリに path が設定されている" {
+  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+}
+
+@test "deps.yaml の pre-bash-commit-validate エントリに description が設定されている" {
+  skip "deps.yaml の実エントリ確認は実装後に有効化 (issue-568)"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 1: git commit 時に validate hook が起動する（統合確認）
+# WHEN ユーザーが git commit を含む Bash コマンドを実行する
+# THEN pre-bash-commit-validate.sh が PreToolUse フェーズで自動実行され
+#      twl --validate が呼ばれる
+# ---------------------------------------------------------------------------
+@test "git commit コマンドで twl --validate が呼び出される" {
+  local twl_called_flag="$SANDBOX/twl_called"
+  cat > "$STUB_BIN/twl" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *"--validate"* ]]; then
+  touch "${TWL_CALLED_FLAG}"
+fi
+exit 0
+STUB
+  chmod +x "$STUB_BIN/twl"
+  TWL_CALLED_FLAG="$twl_called_flag" \
+  PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" \
+  TOOL_INPUT_command="git commit -m 'hook test'" \
+    bash "$HOOK_SRC"
+  [ -f "$twl_called_flag" ] || {
+    echo "twl --validate was not called" >&2
+    return 1
+  }
+}
+
+@test "git commit コマンドで twl --validate が --validate フラグ付きで呼び出される" {
+  local args_file="$SANDBOX/twl_args"
+  cat > "$STUB_BIN/twl" <<STUB
+#!/usr/bin/env bash
+echo "\$*" > "$args_file"
+exit 0
+STUB
+  chmod +x "$STUB_BIN/twl"
+  run _run_hook "git commit -m 'check args'"
+  [ "$status" -eq 0 ]
+  [ -f "$args_file" ] || { echo "twl was not called" >&2; return 1; }
+  grep -q "\-\-validate" "$args_file" || {
+    echo "twl was called without --validate: $(cat "$args_file")" >&2
+    return 1
+  }
+}

--- a/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats
@@ -71,10 +71,12 @@ teardown() {
 }
 
 # Helper: invoke hook with TOOL_INPUT_command set
+# BATS_TEST_DIRNAME を明示的に渡して PLUGINS_TWL_DIR サンドボックスオーバーライドを有効化する
 _run_hook() {
   local cmd="${1:-}"
   TOOL_INPUT_command="$cmd" \
   PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" \
+  BATS_TEST_DIRNAME="${BATS_TEST_DIRNAME}" \
     bash "$HOOK_SRC"
 }
 
@@ -83,6 +85,7 @@ _run_hook_payload() {
   local payload="$1"
   shift
   PLUGINS_TWL_DIR="$SANDBOX/plugins/twl" \
+  BATS_TEST_DIRNAME="${BATS_TEST_DIRNAME}" \
     bash "$HOOK_SRC" <<< "$payload"
 }
 
@@ -253,10 +256,16 @@ _run_hook_payload() {
 # Edge case 12: twl コマンドが存在しない場合 → exit 0 (graceful skip)
 # ---------------------------------------------------------------------------
 @test "twl コマンドが存在しない場合は exit 0 でスキップする（グレースフル）" {
-  # Do NOT stub twl; it should not exist in the minimal stub PATH
-  # Remove any stub that might exist
+  # Do NOT stub twl; remove any stub and shadow real twl with a "not found" stub
   rm -f "$STUB_BIN/twl"
-  run _run_hook "git commit -m 'no-twl'"
+  # PATH に存在しない dummy ディレクトリを先頭に追加して twl を隠す
+  # twl が $STUB_BIN にも dummy_no_twl_bin にも存在しないことで command -v twl が失敗する
+  local dummy_bin="$SANDBOX/dummy_no_twl_bin"
+  mkdir -p "$dummy_bin"
+  # 元の PATH から ~/.local/bin を除外して twl が見つからない環境を作る
+  local filtered_path
+  filtered_path=$(echo "$PATH" | tr ':' '\n' | grep -v 'local/bin' | tr '\n' ':' | sed 's/:$//')
+  PATH="$STUB_BIN:$filtered_path" run _run_hook "git commit -m 'no-twl'"
   [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
## 概要

PreToolUse フックを追加し、コミット実行前に `twl --validate` を実行する commit gate を実装する。

deps.yaml に型ルール違反がある場合は exit 2 でコミットをブロックし、TWL_SKIP_COMMIT_GATE=1 でバイパス可能。

## 変更点

- `plugins/twl/scripts/hooks/pre-bash-commit-validate.sh` — PreToolUse hook スクリプト
- `.claude/settings.json` — PreToolUse フックエントリ追加
- `plugins/twl/deps.yaml` — pre-bash-commit-validate エントリ追加
- `plugins/twl/tests/bats/scripts/pre-bash-commit-validate.bats` — bats テスト 24 件
- `deltaspec/changes/issue-568/` — DeltaSpec

## セキュリティ修正

- PLUGINS_TWL_DIR: BATS_TEST_DIRNAME 環境でのみオーバーライドを許可（Path Traversal 防止）
- TWL_SKIP_COMMIT_GATE bypass: コマンド先頭 prefix regex のみ有効（Broken Access Control 修正）
- stdin: TTY ハング防止（TTY チェック追加）
- twl --validate: stderr を stdout に混入させない（2>&1 削除）

Closes #568
