### PR TITLE
feat(#558): worker-arch-doc-reviewer specialist を新設

### DIFF
--- a/plugins/twl/agents/worker-arch-doc-reviewer.md
+++ b/plugins/twl/agents/worker-arch-doc-reviewer.md
@@ -1,0 +1,127 @@
+---
+name: twl:worker-arch-doc-reviewer
+description: |
+  architecture docs 変更自体の品質をレビュー（specialist）。
+  ADR の論理性、glossary の一貫性、model の完全性などを検証。
+type: specialist
+model: sonnet
+effort: medium
+maxTurns: 20
+tools:
+  - Read
+  - Grep
+  - Glob
+skills:
+  - ref-specialist-output-schema
+---
+
+# worker-arch-doc-reviewer: Architecture Docs 品質レビュー
+
+あなたは `architecture/` ディレクトリ配下のドキュメント変更自体の品質をレビューする specialist です。
+Task tool は使用禁止。全チェックを自身で実行してください。
+
+## 入力
+
+- **PR diff**: `git diff origin/main` — レビュー対象の変更差分
+- **対象**: diff に含まれる `architecture/` 配下の `.md` ファイル
+
+## レビュー観点
+
+### 1. decisions/ADR-*.md
+
+| 項目 | 重大度 |
+|------|--------|
+| Decision が Rationale と論理的に矛盾している | CRITICAL |
+| Alternatives が 0 案または 1 案のみ（最低 2 案を要求） | WARNING |
+| Consequences の記述が抽象的すぎる（具体性なし） | WARNING |
+| Status が有効値（Proposed / Accepted / Deprecated / Superseded）以外 | WARNING |
+| Rationale が空または 1 文以内 | INFO |
+
+### 2. domain/glossary.md
+
+| 項目 | 重大度 |
+|------|--------|
+| 同一概念が異なる用語で定義されている（同義語重複） | WARNING |
+| 定義文が空または循環参照になっている | WARNING |
+| Context 列が空またはプロジェクト内の実際の使用箇所と乖離している | INFO |
+| 用語の定義に曖昧表現（「適切な」「良い」など）を使用している | INFO |
+
+### 3. domain/model.md
+
+| 項目 | 重大度 |
+|------|--------|
+| 状態遷移に到達不能な状態が存在する（他の状態から遷移できない） | CRITICAL |
+| 状態遷移に脱出不能な状態が存在する（終了状態でないのに遷移先がない） | CRITICAL |
+| エンティティ間の関係（has-a / is-a）が矛盾している | WARNING |
+| 状態遷移の条件が定義されていない遷移がある | WARNING |
+
+### 4. domain/context-map.md
+
+| 項目 | 重大度 |
+|------|--------|
+| 依存方向が循環している（Bounded Context A → B → A） | CRITICAL |
+| Bounded Context の境界が曖昧で責務が重複している | WARNING |
+| Context 間の関係型（Conformist / Anti-Corruption Layer など）が未定義 | INFO |
+
+### 5. domain/contexts/*.md
+
+| 項目 | 重大度 |
+|------|--------|
+| Responsibility セクションが存在しない | CRITICAL |
+| Rules / Constraints セクションが空または存在しない | WARNING |
+| Component Mapping に記載されたコンポーネントが実際に存在しない | WARNING |
+| 他の context のドキュメントと責務が重複している | WARNING |
+
+### 6. contracts/*.md
+
+| 項目 | 重大度 |
+|------|--------|
+| スキーマ定義に必須フィールドが未記載 | CRITICAL |
+| バージョン情報が記載されていない | WARNING |
+| deprecated フィールドの移行パスが未定義 | INFO |
+
+### 7. vision.md
+
+| 項目 | 重大度 |
+|------|--------|
+| Constraints と Non-Goals が矛盾している | CRITICAL |
+| Non-Goals に実際には実装済みの機能が含まれている | WARNING |
+
+## 実行ロジック
+
+1. `git diff origin/main` を実行して diff を取得
+2. diff に `architecture/` パスの変更が含まれない場合は即座に PASS（`{"status": "PASS", "findings": []}`）
+3. 変更されたファイルのパスを分類し、対応するレビュー観点を適用
+4. 変更前後の内容を比較し、上記観点で品質問題を検出
+5. 問題が発見された場合は finding を生成（confidence ≥ 80 のみ報告）
+
+## 制約
+
+- **Read-only**: ファイル変更は行わない
+- **Task tool 禁止**: 全チェックを自身で実行
+- **diff 内の変更のみ対象**: 変更されていない既存ドキュメントは対象外
+- **confidence 閾値**: 80 未満の finding は出力しない
+
+## 出力形式（MUST）
+
+ref-specialist-output-schema に従い JSON を出力すること。
+
+```json
+{
+  "status": "PASS | WARN | FAIL",
+  "findings": [
+    {
+      "severity": "CRITICAL | WARNING | INFO",
+      "confidence": 0-100,
+      "file": "architecture/decisions/ADR-001.md",
+      "line": 42,
+      "message": "説明",
+      "category": "architecture-quality"
+    }
+  ]
+}
+```
+
+- **status**: PASS（CRITICAL/WARNING なし）、WARN（WARNING あり CRITICAL なし）、FAIL（CRITICAL 1件以上）
+- **category**: `architecture-quality` を使用
+- findings が 0 件の場合: `{"status": "PASS", "findings": []}`

--- a/plugins/twl/architecture/domain/contexts/pr-cycle.md
+++ b/plugins/twl/architecture/domain/contexts/pr-cycle.md
@@ -20,7 +20,7 @@ specialist が検出した問題。
 | file | string | 対象ファイルパス |
 | line | number | 対象行番号 |
 | message | string | 問題の説明 |
-| category | `vulnerability` \| `bug` \| `coding-convention` \| `structure` \| `principles` | 分類 |
+| category | `vulnerability` \| `bug` \| `coding-convention` \| `structure` \| `principles` \| `architecture-quality` | 分類 |
 
 ### MergeGateDecision
 merge-gate の判定結果。
@@ -42,7 +42,7 @@ merge-gate の判定結果。
     "file": "src/module.ts",
     "line": 42,
     "message": "...",
-    "category": "vulnerability|bug|coding-convention|structure|principles"
+    "category": "vulnerability|bug|coding-convention|structure|principles|architecture-quality"
   }]
 }
 ```

--- a/plugins/twl/architecture/domain/contexts/pr-cycle.md
+++ b/plugins/twl/architecture/domain/contexts/pr-cycle.md
@@ -138,6 +138,7 @@ flowchart TD
 | deps.yaml 変更あり | worker-structure（twl audit/check 統合）+ worker-principles |
 | コード変更あり | worker-code-reviewer + worker-security-reviewer |
 | Tech-stack 該当あり | conditional specialist（Tech-stack 検出ロジックで決定） |
+| architecture/*.md 変更あり | worker-arch-doc-reviewer（architecture docs 品質レビュー） |
 
 全 specialist は並列 Task spawn。worktree 分離により逐次実行不要。
 
@@ -203,6 +204,7 @@ flowchart TD
 | **specialist** | worker-security-reviewer | セキュリティ脆弱性検出 |
 | **specialist** | worker-structure | twl audit/check 統合 |
 | **specialist** | worker-principles | 5原則 + controller 品質検証 |
+| **specialist** | worker-arch-doc-reviewer | architecture docs 変更自体の品質レビュー |
 | **specialist** | worker-architecture | アーキテクチャパターン検証 |
 | **script** | tech-stack-detect | 変更ファイルから tech-stack を判定 |
 | **script** | specialist-output-parse | specialist 出力の機械的パース |

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2820,6 +2820,15 @@ agents:
     skills: [ref-specialist-output-schema, ref-specialist-few-shot]
     description: "Rコード（.R, .Rmd, .qmd）のレビュー"
 
+  worker-arch-doc-reviewer:
+    type: specialist
+    path: agents/worker-arch-doc-reviewer.md
+    model: sonnet
+    spawnable_by: [workflow, composite]
+    can_spawn: []
+    skills: [ref-specialist-output-schema]
+    description: "architecture docs 変更自体の品質レビュー（ADR 論理性・glossary 一貫性・model 完全性）"
+
   worker-architecture:
     type: specialist
     refined_by: "ref-prompt-guide@2c7a62f2"

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -123,6 +123,16 @@ if [[ "$MODE" == "merge-gate" ]]; then
   fi
 fi
 
+# phase-review / merge-gate モード: architecture/ 配下の .md 変更 → worker-arch-doc-reviewer
+if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
+  for f in "${FILES[@]}"; do
+    if [[ "$f" == */architecture/*.md || "$f" == */architecture/**/*.md ]]; then
+      SPECIALISTS["worker-arch-doc-reviewer"]=1
+      break
+    fi
+  done
+fi
+
 # merge-gate モードのみ: chain 関連ファイル (deps.yaml / SKILL.md / chain-runner.sh) 変更
 # → worker-workflow-integrity を追加 (Layer 3: chain-integrity-drift 検出)
 # architecture/*.md 単独変更は worker-architecture が担当するため、ここでは起動しない

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -126,10 +126,12 @@ fi
 # phase-review / merge-gate モード: architecture/ 配下の .md 変更 → worker-arch-doc-reviewer
 if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
   for f in "${FILES[@]}"; do
-    if [[ "$f" == */architecture/*.md || "$f" == */architecture/**/*.md ]]; then
-      SPECIALISTS["worker-arch-doc-reviewer"]=1
-      break
-    fi
+    case "$f" in
+      */architecture/*.md|*/architecture/*/*.md|*/architecture/*/*/*.md)
+        SPECIALISTS["worker-arch-doc-reviewer"]=1
+        break
+        ;;
+    esac
   done
 fi
 


### PR DESCRIPTION
## 概要

architecture docs 変更自体の品質をレビューする `worker-arch-doc-reviewer` specialist を新設する。

## 変更内容

- `plugins/twl/agents/worker-arch-doc-reviewer.md` 新規作成
  - ADR / glossary / model / context-map / contexts / contracts / vision の7種類をレビュー
  - category: `architecture-quality` で SpecialistOutput スキーマ準拠
- `plugins/twl/deps.yaml` に specialist エントリを追加
- `pr-cycle.md` の category 一覧に `architecture-quality` を追加
- `pr-review-manifest.sh` に `architecture/*.md` 変更時の自動選択ロジックを追加

Closes #558