### PR TITLE
[Feature] ADR-019: co-architect を Spec Implementation controller に再分類 (#557)

### DIFF
--- a/deltaspec/changes/issue-557/.deltaspec.yaml
+++ b/deltaspec/changes/issue-557/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-13
+issue: 557
+name: issue-557
+status: pending

--- a/deltaspec/changes/issue-557/.deltaspec.yaml
+++ b/deltaspec/changes/issue-557/.deltaspec.yaml
@@ -2,4 +2,4 @@ schema: spec-driven
 created: 2026-04-13
 issue: 557
 name: issue-557
-status: pending
+status: done

--- a/deltaspec/changes/issue-557/design.md
+++ b/deltaspec/changes/issue-557/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`co-architect` は `vision.md` で "Non-implementation" カテゴリに属するが、`architecture/` ディレクトリへの直接 Write とコミットを行うため、「コード変更・PR 作成を伴わない」という Non-implementation の定義と矛盾している。
+この矛盾を ADR-019 として記録し、新カテゴリ「Spec Implementation」を公式化することで、vision.md と実態を整合させる。
+変更スコープは docs-only（ADR + vision.md + glossary.md）であり、実装ロジック（SKILL.md, deps.yaml）は変更しない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- ADR-019 (`plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md`) を作成し、Context/Decision/Consequences/Alternatives を記録する
+- `vision.md` の「Controller 操作カテゴリ」テーブルに「Spec Implementation」行を追加し、co-architect を Non-implementation から移動する
+- `vision.md` の「Non-implementation controller は co-autopilot を spawn しない」説明文を更新する
+- `glossary.md` の MUST 用語テーブルに「Spec Implementation」を追加する
+
+**Non-Goals:**
+
+- co-architect の SKILL.md を変更する（#4 で対応）
+- deps.yaml の controller カテゴリを変更する（#4, #5 で対応）
+- vision.md 以外の architecture spec ファイルを変更する（Constraints/Non-Goals セクションは触れない）
+
+## Decisions
+
+### D-1: ADR フォーマット準拠
+
+既存 ADR（ADR-018 等）のフォーマットに倣い、`# ADR-019: <title>`・**Status**・**Date**・**Issue**・**Supersedes**・**Related** ヘッダーを使用する。
+Status は `Accepted`、Date は `2026-04-13`、Issue は `#557`。
+
+### D-2: vision.md のテーブル更新（方法 A — 行追加）
+
+"Implementation" と "Non-implementation" の間に "Spec Implementation" 行を挿入する。
+Non-implementation の「該当 Controller」から `co-architect` を削除する。
+
+変更後テーブル:
+
+| カテゴリ | 定義 | 該当 Controller |
+|---|---|---|
+| Implementation | コード変更・PR 作成を伴う操作 | co-autopilot のみ |
+| Spec Implementation | Architecture spec 変更・PR 作成 | co-architect |
+| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project |
+| Utility | スタンドアロンユーティリティ操作 | co-utility |
+| Observation | ライブセッション観察・問題検出・Issue 起票 | co-self-improve |
+| Supervisor | controller の動作を監視・介入するメタレイヤー | su-observer |
+
+テーブル直下の説明文: 「Non-implementation controller は co-autopilot を spawn しない。」→「Non-implementation controller と Spec Implementation controller は co-autopilot を spawn しない。」に更新。
+「co-architect が「設計 + 実装」を要求された場合〜」の文は vision.md に残す。
+
+### D-3: glossary.md MUST 用語追加
+
+MUST 用語テーブルの末尾に追加:
+
+| Spec Implementation | Architecture spec の変更・PR 作成を担う controller カテゴリ。co-architect のみ該当。Implementation（コード変更）とは区別される（ADR-019） | 全体 |
+
+### D-4: Alternatives は ADR-019 に記録
+
+Issue body で言及された 2 つの Alternatives（「既存 Implementation に統合」「ADR 例外として対応」）を ADR-019 の Alternatives セクションに記録する。
+
+## Risks / Trade-offs
+
+- vision.md の Constraints セクション（「Controller は6つ」）と CLAUDE.md の記述は今回変更しない。これらは controller の本数を示しており、カテゴリ変更と直交する
+- glossary.md の照合ポリシーは完全一致のみのため「Spec Implementation」を正式名称として登録することで、co-issue Step 1.5 での用語照合が機能するようになる

--- a/deltaspec/changes/issue-557/proposal.md
+++ b/deltaspec/changes/issue-557/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`co-architect` は `vision.md` で「Non-implementation controller」に分類されているが、実際には `architecture/` にファイルを直接 Write し main worktree にコミットしている。この分類と実態の矛盾を ADR-019 として記録し、新カテゴリ「Spec Implementation」を導入することで整合性を回復する。
+
+## What Changes
+
+- `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md`（新規）を作成し、Decision と Consequences を記録する
+- `plugins/twl/architecture/vision.md` の controller カテゴリテーブルに「Spec Implementation」行を追加する（Non-implementation から co-architect を移動）
+- `plugins/twl/architecture/domain/glossary.md` の MUST 用語リストに「Spec Implementation」を追加する
+
+## Capabilities
+
+### New Capabilities
+
+- ADR-019 による「Spec Implementation」カテゴリの公式定義（Architecture spec 変更・PR 作成を担う controller カテゴリ）
+
+### Modified Capabilities
+
+- `vision.md` controller カテゴリテーブルが 5 行 → 6 行に拡大（co-architect が Non-implementation から Spec Implementation に再分類）
+- `glossary.md` MUST 用語に「Spec Implementation」が追加される
+
+## Impact
+
+- `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md`（新規）
+- `plugins/twl/architecture/vision.md`（カテゴリテーブル更新）
+- `plugins/twl/architecture/domain/glossary.md`（用語追加）
+- SKILL.md・deps.yaml への変更なし（#4, #5 で対応）

--- a/deltaspec/changes/issue-557/specs/adr-019-spec-implementation-category/spec.md
+++ b/deltaspec/changes/issue-557/specs/adr-019-spec-implementation-category/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: ADR-019 ファイルの作成
+
+ADR-019 は `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md` に作成されなければならない（SHALL）。
+ADR は **Status**: Accepted、**Date**: 2026-04-13、**Issue**: #557 のヘッダーを持ち、Context/Decision/Consequences/Alternatives の各セクションを含まなければならない（SHALL）。
+
+#### Scenario: ADR-019 ファイルが正しい場所に作成される
+- **WHEN** issue-557 の実装タスクが完了した後
+- **THEN** `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md` が存在し、`Status: Accepted` と `Issue: #557` を含む
+
+#### Scenario: Alternatives セクションが記録される
+- **WHEN** ADR-019 を参照したとき
+- **THEN** 「既存 Implementation に統合」と「ADR 例外として対応」の 2 つの代替案がそれぞれ選択しなかった理由とともに記載されている
+
+## MODIFIED Requirements
+
+### Requirement: vision.md controller カテゴリテーブルの更新
+
+`plugins/twl/architecture/vision.md` の「Controller 操作カテゴリ」テーブルは「Spec Implementation」行を含まなければならない（SHALL）。
+`co-architect` は Non-implementation から Spec Implementation カテゴリに移動されなければならない（MUST）。
+Non-implementation の「該当 Controller」列は `co-issue, co-project` のみを含まなければならない（SHALL）。
+
+#### Scenario: Spec Implementation 行が追加される
+- **WHEN** 更新後の vision.md を参照したとき
+- **THEN** カテゴリテーブルに `Spec Implementation | Architecture spec 変更・PR 作成 | co-architect` の行が存在する
+
+#### Scenario: Non-implementation から co-architect が除外される
+- **WHEN** 更新後の vision.md を参照したとき
+- **THEN** Non-implementation の「該当 Controller」列には `co-architect` が含まれず `co-issue, co-project` のみである
+
+#### Scenario: 説明文が更新される
+- **WHEN** 更新後の vision.md の Spec Implementation 行直下を参照したとき
+- **THEN** 「Non-implementation controller と Spec Implementation controller は co-autopilot を spawn しない。」の文が存在する
+
+### Requirement: glossary.md MUST 用語への追加
+
+`plugins/twl/architecture/domain/glossary.md` の MUST 用語テーブルに「Spec Implementation」エントリが追加されなければならない（SHALL）。
+エントリは用語・定義・Context 列を持ち、定義には ADR-019 への参照を含まなければならない（MUST）。
+
+#### Scenario: Spec Implementation 用語が MUST テーブルに存在する
+- **WHEN** 更新後の glossary.md を参照したとき
+- **THEN** MUST 用語テーブルに「Spec Implementation」の行が存在し、定義には「ADR-019」への参照が含まれる
+
+#### Scenario: 用語照合で検出可能になる
+- **WHEN** co-issue Step 1.5 が Issue body の「Spec Implementation」という用語を照合したとき
+- **THEN** glossary.md の完全一致で「Spec Implementation」が定義済み用語として検出される

--- a/deltaspec/changes/issue-557/tasks.md
+++ b/deltaspec/changes/issue-557/tasks.md
@@ -1,0 +1,18 @@
+## 1. ADR-019 作成
+
+- [x] 1.1 `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md` を新規作成する（Status: Accepted, Date: 2026-04-13, Issue: #557）
+- [x] 1.2 Context セクションを記述する（co-architect の Non-implementation 分類との矛盾）
+- [x] 1.3 Decision セクションを記述する（Spec Implementation カテゴリの導入）
+- [x] 1.4 Consequences セクションを記述する（vision.md テーブルの変更、glossary.md 用語追加）
+- [x] 1.5 Alternatives セクションを記述する（「既存 Implementation に統合」「ADR 例外として対応」を選択しなかった理由付きで記録）
+
+## 2. vision.md 更新
+
+- [x] 2.1 `plugins/twl/architecture/vision.md` を読み込み、「Controller 操作カテゴリ」テーブルを確認する
+- [x] 2.2 テーブルに「Spec Implementation | Architecture spec 変更・PR 作成 | co-architect」行を追加する（Implementation と Non-implementation の間）
+- [x] 2.3 Non-implementation 行の「該当 Controller」から `co-architect` を除去し `co-issue, co-project` のみにする
+- [x] 2.4 テーブル直下の説明文を「Non-implementation controller と Spec Implementation controller は co-autopilot を spawn しない。」に更新する
+
+## 3. glossary.md 更新
+
+- [x] 3.1 `plugins/twl/architecture/domain/glossary.md` の MUST 用語テーブルに「Spec Implementation」エントリを追加する（定義に ADR-019 参照を含む）

--- a/plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md
+++ b/plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md
@@ -1,0 +1,70 @@
+# ADR-019: co-architect を Spec Implementation controller に再分類
+
+**Status**: Accepted  
+**Date**: 2026-04-13  
+**Issue**: #557  
+**Supersedes**: —  
+**Related**: ADR-001 (autopilot-first), ADR-002 (controller consolidation)
+
+---
+
+## Context
+
+`co-architect` は `vision.md` の「Controller 操作カテゴリ」テーブルで "Non-implementation" に分類されていた。Non-implementation の定義は「Issue 作成・設計・プロジェクト管理（コード変更・PR 作成を伴わない）」である。
+
+しかし `co-architect` の実際の動作は以下を含む:
+
+- `architecture/` ディレクトリへのファイル直接 Write（`vision.md`, `context-map.md`, `glossary.md`, ADR ファイル等）
+- main worktree へのコミット
+- （#5 対応後）PR 作成フロー
+
+これは「コード変更・PR 作成を伴わない」という Non-implementation の定義と明確に矛盾する。また #5（co-architect branch/PR 化）で PR 作成フローを追加すると、Non-implementation 定義との乖離がさらに拡大する。
+
+## Decision
+
+**新カテゴリ「Spec Implementation」を導入し、co-architect をこのカテゴリに再分類する。**
+
+Spec Implementation の定義: **Architecture spec（`architecture/` 配下のドキュメント）の変更・PR 作成を担う controller カテゴリ。**
+
+- `vision.md` の Controller 操作カテゴリテーブルに「Spec Implementation」行を追加する
+- `co-architect` を Non-implementation から Spec Implementation に移動する
+- `glossary.md` の MUST 用語に「Spec Implementation」を登録する
+
+## Consequences
+
+### vision.md 変更
+
+Controller 操作カテゴリテーブルが 5行 → 6行に拡大する:
+
+| カテゴリ | 定義 | 該当 Controller |
+|---|---|---|
+| Implementation | コード変更・PR 作成を伴う操作 | co-autopilot のみ |
+| **Spec Implementation** | **Architecture spec 変更・PR 作成** | **co-architect** |
+| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project |
+| Utility | スタンドアロンユーティリティ操作 | co-utility |
+| Observation | ライブセッション観察・問題検出・Issue 起票 | co-self-improve |
+| Supervisor | controller の動作を監視・介入するメタレイヤー | su-observer |
+
+テーブル直下の説明文を更新:「Non-implementation controller と Spec Implementation controller は co-autopilot を spawn しない。」
+
+### glossary.md 変更
+
+MUST 用語テーブルに「Spec Implementation」を追加する（ADR-019 参照付き）。
+
+### SKILL.md・deps.yaml への影響
+
+本 ADR は分類の記録のみ。co-architect の SKILL.md 変更は #4 で、deps.yaml の変更は #4・#5 で対応する。
+
+## Alternatives
+
+### Alternative A: 既存「Implementation」カテゴリに統合
+
+co-architect を co-autopilot と同じ Implementation カテゴリに統合する案。
+
+**採用しなかった理由**: Implementation は「コード変更・PR 作成を伴う操作」であり co-autopilot のみが担う設計（ADR-001）。co-architect を統合すると co-autopilot の責務が膨らみ過ぎ、「単一の実装 controller」という原則（ADR-002）が崩れる。また co-architect が扱う対象は Architecture spec ドキュメントであり、アプリケーションコードとは性質が異なる。
+
+### Alternative B: ADR 例外として対応（分類変更せず記録のみ）
+
+カテゴリテーブルは変更せず、co-architect が Non-implementation の例外である旨を注記で記録する案。
+
+**採用しなかった理由**: 例外扱いは co-issue Step 1.5 の glossary 照合や他の LLM コンポーネントが「Non-implementation = PR 作成しない」と誤解するリスクを残す。明示的なカテゴリ定義によってドキュメントと実態を一致させることが ADR の本来の目的であり、注記による回避は技術的負債を増やす。

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -22,6 +22,7 @@
 | ECC | 外部知識ソース（doobidoo memory）。自己改善の教師データとして活用 | Self-Improve |
 | Emergency Bypass | co-autopilot 障害時のみ許可される手動実装パス。retrospective 記録義務あり | Autopilot |
 | Architecture Spec | 設計意図の前方参照。co-issue/co-architect が DCI で参照する living document | 全体 |
+| Spec Implementation | Architecture spec（`architecture/` 配下のドキュメント）の変更・PR 作成を担う controller カテゴリ。co-architect のみ該当。Implementation（コード変更）とは区別される（ADR-019） | 全体 |
 | DCI | Dynamic Context Injection。実行時にファイルを Read してコンテキストに注入するパターン | 全体 |
 | CRG | Code Review Graph。MCP 経由でコード依存関係を可視化・分析するツール | TWiLL Integration |
 | Supervisor | プロジェクト常駐のメタ認知レイヤー。全 controller を監視・調整・知識外部化する上位層（ADR-014） | Supervision |

--- a/plugins/twl/architecture/vision.md
+++ b/plugins/twl/architecture/vision.md
@@ -19,12 +19,13 @@ chain-driven + autopilot-first アーキテクチャに基づく Claude Code 開
 | カテゴリ | 定義 | 該当 Controller |
 |----------|------|-----------------|
 | Implementation | コード変更・PR 作成を伴う操作 | co-autopilot のみ |
-| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project, co-architect |
+| Spec Implementation | Architecture spec 変更・PR 作成 | co-architect |
+| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project |
 | Utility | スタンドアロンユーティリティ操作 | co-utility |
 | Observation | ライブセッション観察・問題検出・Issue 起票 | co-self-improve |
 | Supervisor | controller の動作を監視・介入するメタレイヤー | su-observer |
 
-Non-implementation controller は co-autopilot を spawn しない。
+Non-implementation controller と Spec Implementation controller は co-autopilot を spawn しない。
 co-architect が「設計 + 実装」を要求された場合: 設計完了 → Issue 起票（co-issue 経由）→ co-autopilot で実装。
 
 ### 機械 / LLM の境界


### PR DESCRIPTION
## 概要

ADR-019 を作成し、co-architect を新カテゴリ「Spec Implementation」に再分類する。

## 変更内容

- `plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md` 新規作成
- `plugins/twl/architecture/vision.md` Controller カテゴリテーブル更新（Spec Implementation 行追加）
- `plugins/twl/architecture/domain/glossary.md` MUST 用語に Spec Implementation 追加
- `deltaspec/changes/issue-557/` DeltaSpec artifacts 追加

Closes #557