### PR TITLE
fix(specialist): architecture-quality を SSOT に追加し phase-review/merge-gate に登録 (#558 フォローアップ)

### DIFF
--- a/plugins/twl/agents/worker-arch-doc-reviewer.md
+++ b/plugins/twl/agents/worker-arch-doc-reviewer.md
@@ -13,6 +13,7 @@ tools:
   - Glob
 skills:
   - ref-specialist-output-schema
+  - ref-specialist-few-shot
 ---
 
 # worker-arch-doc-reviewer: Architecture Docs 品質レビュー

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -1830,6 +1830,7 @@ commands:
       - specialist: worker-data-validator
       - specialist: worker-env-validator
       - specialist: worker-codex-reviewer
+      - specialist: worker-arch-doc-reviewer
       - specialist: worker-issue-pr-alignment
       - reference: ref-specialist-output-schema
       - reference: baseline-coding-style
@@ -1906,6 +1907,7 @@ commands:
       - specialist: worker-env-validator
       - specialist: worker-codex-reviewer
       - specialist: worker-architecture
+      - specialist: worker-arch-doc-reviewer
       - specialist: worker-issue-pr-alignment
       - reference: ref-specialist-output-schema
       - reference: ref-dci
@@ -2826,7 +2828,7 @@ agents:
     model: sonnet
     spawnable_by: [workflow, composite]
     can_spawn: []
-    skills: [ref-specialist-output-schema]
+    skills: [ref-specialist-output-schema, ref-specialist-few-shot]
     description: "architecture docs 変更自体の品質レビュー（ADR 論理性・glossary 一貫性・model 完全性）"
 
   worker-architecture:

--- a/plugins/twl/refs/ref-specialist-output-schema.md
+++ b/plugins/twl/refs/ref-specialist-output-schema.md
@@ -27,7 +27,7 @@
           "message": { "type": "string" },
           "category": {
             "type": "string",
-            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles", "ac-alignment", "ac-alignment-unknown", "architecture-drift", "chain-integrity-drift"]
+            "enum": ["vulnerability", "bug", "coding-convention", "structure", "principles", "ac-alignment", "ac-alignment-unknown", "architecture-drift", "chain-integrity-drift", "architecture-quality"]
           },
           "finding_target": { "type": "string", "enum": ["issue_description", "codebase_state"] }
         }
@@ -73,6 +73,7 @@ findings の severity から機械的に導出（AI 裁量禁止）:
 | `ac-alignment-unknown` | issue-pr-alignment（判断不能 AC、INFO のみ） |
 | `architecture-drift` | worker-architecture |
 | `chain-integrity-drift` | worker-workflow-integrity |
+| `architecture-quality` | worker-arch-doc-reviewer |
 
 **co-issue specialist 用**（merge-gate specialist は使用禁止）:
 


### PR DESCRIPTION
## 概要

PR #597（Issue #558）のマージ後に発見された SSOT 違反を修正する。

## 問題

1. `ref-specialist-output-schema.md` の category enum に `architecture-quality` が未登録
   - `worker-arch-doc-reviewer` は `"category": "architecture-quality"` を出力するが、SSOT に存在しない
2. `deps.yaml` の `phase-review` composite の `calls:` に `worker-arch-doc-reviewer` が未登録
3. `deps.yaml` の `merge-gate` composite の `calls:` に `worker-arch-doc-reviewer` が未登録
4. `deps.yaml` の `worker-arch-doc-reviewer` エントリの `skills` に `ref-specialist-few-shot` が未登録
5. `worker-arch-doc-reviewer.md` frontmatter の `skills` に `ref-specialist-few-shot` が未登録

## 変更内容

- `plugins/twl/refs/ref-specialist-output-schema.md`: category enum に `architecture-quality` を追加、category テーブルに `worker-arch-doc-reviewer` 行を追加
- `plugins/twl/deps.yaml`: `phase-review.calls` に `worker-arch-doc-reviewer` を追加
- `plugins/twl/deps.yaml`: `merge-gate.calls` に `worker-arch-doc-reviewer` を追加（`worker-architecture` の直後）
- `plugins/twl/deps.yaml`: `worker-arch-doc-reviewer.skills` に `ref-specialist-few-shot` を追加
- `plugins/twl/agents/worker-arch-doc-reviewer.md`: frontmatter `skills` に `ref-specialist-few-shot` を追加

Closes #600