### PR TITLE
feat(#561): co-architect に branch/PR + workflow-arch-review フローを追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -250,7 +250,7 @@ skills:
     effort: high
     tools: [Agent(worker-architecture, worker-structure)]
     spawnable_by: [user]
-    can_spawn: [atomic, reference]
+    can_spawn: [atomic, reference, workflow]
     calls:
       - atomic: explore
       - atomic: architect-completeness-check
@@ -258,7 +258,8 @@ skills:
       - atomic: evaluate-architecture
       - reference: ref-architecture-spec
       - reference: ref-architecture
-    description: "対話的アーキテクチャ構築ワークフロー"
+      - workflow: workflow-arch-review
+    description: "対話的アーキテクチャ構築ワークフロー（branch/PR + review フロー付き）"
 
   co-utility:
     type: controller

--- a/plugins/twl/skills/co-architect/SKILL.md
+++ b/plugins/twl/skills/co-architect/SKILL.md
@@ -3,6 +3,7 @@ name: twl:co-architect
 description: |
   対話的アーキテクチャ構築ワークフロー。
   explore を活用し architecture/ に設計意図を段階的にキャプチャ。
+  branch 上で作業し PR 経由でレビュー・マージするフローを含む。
   完全性チェックまで実行し、Issue 化は co-issue に委譲。
 
   Use when user: says アーキテクチャ設計/architecture/全体設計,
@@ -10,7 +11,7 @@ description: |
   says --group/グループ深堀り/スケルトン精緻化.
 type: controller
 effort: high
-tools: [Agent(worker-architecture, worker-structure), AskUserQuestion, Read, Skill, Write]
+tools: [Agent(worker-architecture, worker-structure), AskUserQuestion, Bash, Read, Skill, Write]
 - Agent(worker-architecture, worker-structure)
 spawnable_by:
 - user
@@ -19,12 +20,12 @@ maxTurns: 60
 
 # co-architect
 
-対話的アーキテクチャ構築 → 完全性チェック。Issue 化は co-issue に委譲。Non-implementation controller（chain-driven 不要）。
+対話的アーキテクチャ構築 → branch/PR + workflow-arch-review 経由マージ。Issue 化は co-issue に委譲。Non-implementation controller（chain-driven 不要）。
 
 ## Step 0: --group 分岐
 
 `--group <context-name>` が含まれる場合:
-→ `/twl:architect-group-refine <context-name>` を実行して終了（Step 1〜8 スキップ）。
+→ `/twl:architect-group-refine <context-name>` を実行して終了（Step 1〜7 スキップ）。
 
 `--group` なし → Step 1 へ。
 
@@ -39,9 +40,20 @@ TaskCreate 「Architecture: コンテキスト収集」(status: in_progress)
 
 TaskUpdate → completed
 
-## Step 2: 対話的アーキテクチャ探索
+## Step 2: Worktree 作成 + 対話的アーキテクチャ探索
 
-TaskCreate 「Architecture: 対話的探索」(status: in_progress)
+TaskCreate 「Architecture: Worktree 作成 + 対話的探索」(status: in_progress)
+
+**Worktree 作成:**
+
+```bash
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+bash plugins/twl/scripts/worktree-create.sh "arch/${TIMESTAMP}"
+```
+
+作成した worktree ディレクトリに移動し、以下の探索を実施する。
+
+**対話的探索（worktree 上）:**
 
 `/twl:explore` を Skill tool で呼び出す。以下をコンテキストとして注入:
 
@@ -63,12 +75,76 @@ TaskCreate 「Architecture: 完全性チェック」(status: in_progress)
 `/twl:architect-completeness-check` を実行。
 
 WARNING がある場合 → ユーザーに不足箇所を提示し補完するか確認。
-補完する場合 → Step 2 に戻り explore を再開。
+補完する場合 → Step 2 の探索ループに戻る。
 
 TaskUpdate → completed
 
+## Step 4: ユーザー確認
+
+**AskUserQuestion tool** で以下を提示:
+
+> Architecture spec の探索が完了しました。次のアクションを選択してください:
+> [A] PR を作成してレビューを開始する
+> [B] 追加探索を続ける
+> [C] 変更を破棄して終了する
+
+- [A] → Step 5 へ
+- [B] → Step 2 に戻り explore を再開
+- [C] → worktree を削除して終了:
+  ```bash
+  bash plugins/twl/scripts/worktree-delete.sh "arch/${TIMESTAMP}"
+  ```
+
+## Step 5: PR 作成
+
+TaskCreate 「Architecture: PR 作成」(status: in_progress)
+
+worktree 上で commit + PR を作成する:
+
+```bash
+# worktree 内で実行
+git add -A
+git commit -m "docs(architecture): <変更内容の簡潔な説明>"
+git push origin "arch/${TIMESTAMP}"
+PR_NUMBER=$(gh pr create --base main --title "Architecture: <変更内容>" \
+  --body "Architecture docs の更新。co-architect による自動作成。" \
+  --json number -q '.number')
+echo "PR #${PR_NUMBER} を作成しました"
 ```
->>> Architecture spec 作成完了
+
+TaskUpdate → completed
+
+## Step 6: workflow-arch-review 呼び出し
+
+TaskCreate 「Architecture: レビュー実行」(status: in_progress)
+
+`/twl:workflow-arch-review` を Skill tool で実行する。
+PR 番号を引数として渡す: `Skill("twl:workflow-arch-review", args="#${PR_NUMBER}")`
+
+workflow-arch-review は以下を実行する:
+- arch-phase-review（worker-arch-doc-reviewer + worker-architecture による並列レビュー）
+- arch-fix-phase（CRITICAL/WARNING 修正）
+- merge-gate（マージ判定）
+- auto-merge（squash merge → cleanup）
+
+TaskUpdate → completed
+
+## Step 7: クリーンアップ
+
+merge-gate が PASS してマージ完了した場合:
+
+```bash
+# worktree 削除 + remote branch 削除
+bash plugins/twl/scripts/worktree-delete.sh "arch/${TIMESTAMP}"
+git push origin --delete "arch/${TIMESTAMP}" 2>/dev/null || true
+```
+
+merge-gate が REJECT した場合:
+- ユーザーに報告し、worktree を保持する
+- 手動で修正後に `/twl:workflow-arch-review` を再実行するよう案内する
+
+```
+>>> Architecture spec 作成・マージ完了
 
 次のステップ:
   - Issue 化: /twl:co-issue で architecture spec ベースに Issue 群を作成
@@ -79,5 +155,6 @@ TaskUpdate → completed
 
 - ユーザーの設計判断を代替してはならない（UX ルール。提案は可、決定はユーザー）
 - controller 内に実質処理を記述してはならない（設計ルール。atomic に委譲）
+- main worktree に直接 Write してはならない（branch/PR 経由を必須とする）
 
 Issue Management 制約の正典は `plugins/twl/architecture/domain/contexts/issue-mgmt.md`

--- a/plugins/twl/skills/co-architect/SKILL.md
+++ b/plugins/twl/skills/co-architect/SKILL.md
@@ -48,7 +48,8 @@ TaskCreate 「Architecture: Worktree 作成 + 対話的探索」(status: in_prog
 
 ```bash
 TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-bash plugins/twl/scripts/worktree-create.sh "arch/${TIMESTAMP}"
+BRANCH="docs/arch-${TIMESTAMP}"
+python3 -m twl.autopilot.worktree create "${BRANCH}"
 ```
 
 作成した worktree ディレクトリに移動し、以下の探索を実施する。
@@ -92,7 +93,8 @@ TaskUpdate → completed
 - [B] → Step 2 に戻り explore を再開
 - [C] → worktree を削除して終了:
   ```bash
-  bash plugins/twl/scripts/worktree-delete.sh "arch/${TIMESTAMP}"
+  bash plugins/twl/scripts/worktree-delete.sh "${BRANCH}"
+  git push origin --delete "${BRANCH}" 2>/dev/null || true
   ```
 
 ## Step 5: PR 作成
@@ -102,13 +104,16 @@ TaskCreate 「Architecture: PR 作成」(status: in_progress)
 worktree 上で commit + PR を作成する:
 
 ```bash
-# worktree 内で実行
+# worktree 内で実行（BRANCH 変数は Step 2 で設定済み）
 git add -A
-git commit -m "docs(architecture): <変更内容の簡潔な説明>"
-git push origin "arch/${TIMESTAMP}"
-PR_NUMBER=$(gh pr create --base main --title "Architecture: <変更内容>" \
+# コミットメッセージ: architecture/ 変更ファイルを確認して具体的な内容を記述
+git commit -m "docs(architecture): <変更した context/decision/model 名を記述>"
+git push origin "${BRANCH}"
+PR_NUMBER=$(gh pr create --base main --head "${BRANCH}" \
+  --title "docs(architecture): <変更内容の概要>" \
   --body "Architecture docs の更新。co-architect による自動作成。" \
   --json number -q '.number')
+echo "${PR_NUMBER}" > /tmp/co-architect-pr-number.txt
 echo "PR #${PR_NUMBER} を作成しました"
 ```
 
@@ -119,7 +124,13 @@ TaskUpdate → completed
 TaskCreate 「Architecture: レビュー実行」(status: in_progress)
 
 `/twl:workflow-arch-review` を Skill tool で実行する。
-PR 番号を引数として渡す: `Skill("twl:workflow-arch-review", args="#${PR_NUMBER}")`
+PR 番号を取得してから引数として渡す:
+
+```bash
+PR_NUMBER=$(cat /tmp/co-architect-pr-number.txt 2>/dev/null || echo "")
+```
+
+`Skill("twl:workflow-arch-review", args="#${PR_NUMBER}")`
 
 workflow-arch-review は以下を実行する:
 - arch-phase-review（worker-arch-doc-reviewer + worker-architecture による並列レビュー）
@@ -134,9 +145,10 @@ TaskUpdate → completed
 merge-gate が PASS してマージ完了した場合:
 
 ```bash
-# worktree 削除 + remote branch 削除
-bash plugins/twl/scripts/worktree-delete.sh "arch/${TIMESTAMP}"
-git push origin --delete "arch/${TIMESTAMP}" 2>/dev/null || true
+# worktree 削除 + remote branch 削除（BRANCH は Step 2 で設定）
+bash plugins/twl/scripts/worktree-delete.sh "${BRANCH}"
+git push origin --delete "${BRANCH}" 2>/dev/null || true
+rm -f /tmp/co-architect-pr-number.txt
 ```
 
 merge-gate が REJECT した場合:


### PR DESCRIPTION
feat(#561): co-architect に branch/PR + workflow-arch-review フローを追加

- SKILL.md: Step 2 を Worktree 作成 + 探索に変更、Step 4〜7 追加
  (ユーザー確認 / PR 作成 / workflow-arch-review 呼び出し / クリーンアップ)
- deps.yaml: co-architect.can_spawn に workflow 追加
- deps.yaml: co-architect.calls に workflow-arch-review 追加

Closes #561