### PR TITLE
feat(twl): workflow-issue-refine skill 新設 (#616)

### DIFF
--- a/plugins/twl/README.md
+++ b/plugins/twl/README.md
@@ -72,9 +72,9 @@ Autopilot で複数 Issue を一括実装:
 | From | To |
 |------|-----|
 | twl:co-autopilot | autopilot-init, autopilot-launch, autopilot-poll, autopilot-phase-execute, autopilot-phase-sanity, autopilot-pilot-precheck, autopilot-pilot-rebase, autopilot-multi-source-verdict, autopilot-phase-postprocess, autopilot-collect, autopilot-retrospective, autopilot-patterns, autopilot-cross-issue, autopilot-summary, session-audit, self-improve-review, →twl:workflow-setup, →twl:workflow-test-ready, →twl:workflow-pr-verify, →twl:workflow-pr-fix, →twl:workflow-pr-merge, →twl:workflow-dead-cleanup, →twl:workflow-tech-debt-triage, →twl:workflow-self-improve |
-| twl:co-issue | issue-glossary-check, →twl:workflow-issue-lifecycle |
+| twl:co-issue | issue-glossary-check, →twl:workflow-issue-lifecycle, →twl:workflow-issue-refine |
 | twl:co-project | project-create, project-governance, project-board-configure, project-migrate, container-dependency-check, setup-crg, snapshot-analyze, snapshot-classify, snapshot-generate, →twl:workflow-plugin-create, →twl:workflow-plugin-diagnose, →twl:workflow-prompt-audit, label-sync, →twl:ref-types, →twl:ref-practices, →twl:ref-deps-format |
-| twl:co-architect | explore, architect-completeness-check, architect-group-refine, evaluate-architecture, →twl:ref-architecture-spec, →twl:ref-architecture |
+| twl:co-architect | explore, architect-completeness-check, architect-group-refine, evaluate-architecture, →twl:ref-architecture-spec, →twl:ref-architecture, →twl:workflow-arch-review |
 | twl:co-utility | worktree-list, worktree-delete, twl-validate, services, ui-capture, schema-update |
 | twl:co-self-improve | →twl:workflow-observe-loop, test-project-init, test-project-reset, test-project-scenario-load, observe-once, problem-detect, issue-draft-from-observation, observe-retrospective, ●observer-evaluator, →twl:test-scenario-catalog, →twl:observation-pattern-catalog, →twl:load-test-baselines |
 | twl:su-observer | observe-once, problem-detect, ●observer-evaluator, intervene-auto, intervene-confirm, intervene-escalate, →twl:intervention-catalog, →twl:observation-pattern-catalog, →twl:monitor-channel-catalog, su-compact |
@@ -91,6 +91,7 @@ Autopilot で複数 Issue を一括実装:
 | twl:workflow-plugin-diagnose | plugin-migrate-analyze, plugin-diagnose, ◆plugin-phase-diagnose, plugin-fix, plugin-verify, ◆plugin-phase-verify |
 | twl:workflow-prompt-audit | prompt-audit-scan, ◆prompt-audit-review, prompt-audit-apply |
 | twl:workflow-issue-lifecycle | issue-structure, ◆issue-spec-review, issue-review-aggregate, issue-arch-drift, issue-create, project-board-sync |
+| twl:workflow-issue-refine | ◆issue-spec-review, issue-review-aggregate, issue-arch-drift |
 | twl:workflow-arch-review | ◆arch-phase-review, arch-fix-phase, ◆merge-gate, auto-merge |
 | post-fix-verify | ●worker-code-reviewer, ●worker-security-reviewer, ●worker-codex-reviewer |
 | all-pass-check | →twl:ref-dci |

--- a/plugins/twl/architecture/domain/contexts/issue-mgmt.md
+++ b/plugins/twl/architecture/domain/contexts/issue-mgmt.md
@@ -160,6 +160,7 @@ flowchart TD
 | **atomic** | project-board-sync | Issue → Project V2 自動追加 |
 | **atomic** | project-board-status-update | Board Status 更新 |
 | **workflow** | workflow-issue-lifecycle | co-issue v2 Worker: 1 Issue の lifecycle（structure → spec-review → aggregate → create）を独立セッションで実行（ADR-017） |
+| **workflow** | workflow-issue-refine | 既存 Issue の refine（精緻化）: specialist review → body 更新 → refined ラベル付与。orchestrator が `existing-issue.json` の有無で dispatch 先を切り替え |
 | **specialist** | issue-critic | Issue の仮定・曖昧点・盲点検出 |
 | **specialist** | issue-feasibility | 実装可能性・影響範囲検証 |
 | **specialist** | worker-codex-reviewer | 補完的レビュー |

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -205,12 +205,13 @@ skills:
     refined_at: "2026-04-07"
     path: skills/co-issue/SKILL.md
     effort: high
-    tools: [Skill(workflow-issue-lifecycle, issue-glossary-check), Read, Grep, Glob]
+    tools: [Skill(workflow-issue-lifecycle, workflow-issue-refine, issue-glossary-check), Read, Grep, Glob]
     spawnable_by: [user]
     can_spawn: [composite, atomic, specialist, reference, workflow]
     calls:
       - atomic: issue-glossary-check
       - workflow: workflow-issue-lifecycle
+      - workflow: workflow-issue-refine
       - script: issue-lifecycle-orchestrator
     description: "要望をGitHub Issueに変換するワークフロー（thin orchestrator）。DAG 依存解決 + level dispatch + aggregate"
 
@@ -570,6 +571,19 @@ skills:
       - atomic: project-board-sync
       - script: spec-review-session-init
     description: "co-issue v2 Worker runtime: 1 issue の lifecycle 全体（structure → spec-review → aggregate → fix loop → arch-drift → create → project-board-sync）を自律実行"
+
+  workflow-issue-refine:
+    type: workflow
+    path: skills/workflow-issue-refine/SKILL.md
+    effort: medium
+    spawnable_by: [controller, user]
+    can_spawn: [composite, atomic, specialist]
+    calls:
+      - composite: issue-spec-review
+      - atomic: issue-review-aggregate
+      - atomic: issue-arch-drift
+      - script: spec-review-session-init
+    description: "既存 Issue の refine（精緻化）: specialist review → body 更新 → refined ラベル付与"
 
   workflow-arch-review:
     type: workflow

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -233,9 +233,15 @@ spawn_session() {
     target_repo="$(jq -r '.target_repo // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
   fi
 
+  # IN/existing-issue.json の有無で dispatch 先を決定
+  local workflow_skill="workflow-issue-lifecycle"
+  if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
+    workflow_skill="workflow-issue-refine"
+  fi
+
   # inject プロンプト生成（printf 方式: heredoc 終端子汚染リスクを回避）
   printf '%s\n' \
-    "/twl:workflow-issue-lifecycle $(printf '%q' "$subdir")" \
+    "/twl:${workflow_skill} $(printf '%q' "$subdir")" \
     "" \
     "【自律実行指示】" \
     "- 全 Step を中断なく自律的に完了すること" \

--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -9,7 +9,7 @@ description: |
 type: controller
 effort: high
 tools:
-- Skill(workflow-issue-lifecycle, issue-glossary-check)
+- Skill(workflow-issue-lifecycle, workflow-issue-refine, issue-glossary-check)
 - Bash
 - Read
 - Write
@@ -22,6 +22,20 @@ spawnable_by:
 # co-issue
 
 要望→Issue 変換の thin orchestrator。Phase 1-2 を inline で実行し、Phase 3-4 は workflow に委譲する。
+
+## Step 0: モード判定（起動時）
+
+`$ARGUMENTS` を解析し、`refine #N [#M ...]` パターンを検出する。
+
+- **`refine #N` パターン検出時**: `refine_mode=true` に設定。各 `#N` の Issue データを `gh issue view N --repo <repo> --json number,body,title,labels` で取得し保持する。複数の `#N` が指定された場合は全件取得する
+- **パターン不一致時**: `refine_mode=false`（通常の新規 Issue 作成モード）
+
+```
+例: /twl:co-issue refine #513 → refine_mode=true, targets=[{number:513, ...}]
+例: /twl:co-issue バグを直したい → refine_mode=false
+```
+
+Step 0 はモード判定のみ。以降のフローは `refine_mode` フラグに基づいて分岐する。
 
 ## セッション ID 生成（起動時）
 
@@ -38,6 +52,20 @@ glob `.controller-issue/*/explore-summary.md` でセッション一覧を検出:
 セッション ID ベースのディレクトリ分離により、既存の co-issue フローとの互換性を維持しながら並列実行が可能。
 
 ## Phase 1: 対話的問題探索
+
+### Phase 1 refine モード分岐
+
+`refine_mode=true` の場合、通常の Phase 1 対話ループの代わりに以下を実行する:
+
+1. **既存 Issue body の読み込み**: Step 0 で取得した各 Issue の body・labels・title を確認
+2. **改善点の探索**: コードベース（Read/Grep/Glob）と architecture context を参照し、既存 Issue body の改善点を特定:
+   - テンプレート準拠性の確認（必須セクションの欠落、AC の機械検証可能性）
+   - 技術的正確性の確認（コードベースの現状との乖離）
+   - スコープの適切性（過大・過小の検出）
+3. **draft.md の生成**: 改善後の body を Issue テンプレート準拠フォーマットで生成（Step 3 省略の補完として、issue-structure 相当の構造化を Phase 1 で実施）
+4. **summary-gate**: 通常モードと同様にユーザーに確認を取る（explore-summary.md の代わりに改善内容のサマリーを提示）
+
+`refine_mode=false` の場合は以下の通常フローを実行する。
 
 ### Phase 1 初期化
 
@@ -114,6 +142,10 @@ AskUserQuestion で以下 3 択を提示:
 
 #### Step 2a-2: DAG 構築
 
+**refine モード分岐（MUST）**: `refine_mode=true` の場合、Step 2a-2 全体をスキップする。理由: `#N` は GitHub Issue 番号であり、draft index の 1-3 桁 regex `(?<![A-Za-z0-9/])#(\d{1,3})(?![0-9])` と衝突するため。refine モードでは DAG 構築は不要（既存 Issue を個別に更新するため依存関係の解決が不要）。
+
+`refine_mode=false`（通常モード）の場合、以下を実行する:
+
 各 draft 本文（scope / 依存関係 / related セクション）を対象に以下を実行。**コードブロック内は除外**する:
 
 1. **ローカル ref 抽出**: regex `(?<![A-Za-z0-9/])#(\d{1,3})(?![0-9])` にマッチする `#N` を検出（N は 1-based draft index）
@@ -136,7 +168,23 @@ AskUserQuestion で以下 3 択を提示:
 
 #### Step 2a-3: Per-Issue Input Bundle 書き出し
 
-各 draft に対して以下のディレクトリ構造を作成:
+**refine モードの場合**: 各対象 Issue に対して以下のディレクトリ構造を作成:
+
+```
+.controller-issue/<session-id>/per-issue/<index>/
+  IN/
+    draft.md              # 改善後の draft 本文（Phase 1 で生成）
+    existing-issue.json   # { "number": N, "current_body": "...", "repo": "owner/repo" }
+    arch-context.md       # ARCH_CONTEXT（不在の場合は空ファイル）
+    policies.json         # ポリシー設定（通常モードと同一スキーマ）
+  STATE                   # "pending" で初期化
+```
+
+`existing-issue.json` を生成: Step 0 で取得した Issue データから `{ "number": N, "current_body": "<current body>", "repo": "<owner/repo>" }` を書き出す。
+`policies.json` は通常モードと同一スキーマを使用する（refine 固有フィールドは `existing-issue.json` に分離）。
+`deps.json` は生成しない（DAG 構築をスキップしたため）。
+
+**通常モードの場合**: 各 draft に対して以下のディレクトリ構造を作成:
 
 ```
 .controller-issue/<session-id>/per-issue/<index>/

--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -59,9 +59,9 @@ glob `.controller-issue/*/explore-summary.md` でセッション一覧を検出:
 
 1. **既存 Issue body の読み込み**: Step 0 で取得した各 Issue の body・labels・title を確認
 2. **改善点の探索**: コードベース（Read/Grep/Glob）と architecture context を参照し、既存 Issue body の改善点を特定:
-   - テンプレート準拠性の確認（必須セクションの欠落、AC の機械検証可能性）
-   - 技術的正確性の確認（コードベースの現状との乖離）
-   - スコープの適切性（過大・過小の検出）
+   - テンプレート準拠性: 必須セクション（## 概要 / ## AC / ## スコープ / ## 技術メモ）の有無、AC が `[ ]` チェックリスト形式で機械検証可能か
+   - 技術的正確性: Issue body が参照するファイルパス・関数名・型名が現在のコードベースに存在するか（Grep/Glob で検証）
+   - スコープの適切性: 1 PR で完結可能な粒度か（目安: 変更ファイル数 10 以下）、逆に複数 Issue に分割すべきか
 3. **draft.md の生成**: 改善後の body を Issue テンプレート準拠フォーマットで生成（Step 3 省略の補完として、issue-structure 相当の構造化を Phase 1 で実施）
 4. **summary-gate**: 通常モードと同様にユーザーに確認を取る（explore-summary.md の代わりに改善内容のサマリーを提示）
 
@@ -142,7 +142,7 @@ AskUserQuestion で以下 3 択を提示:
 
 #### Step 2a-2: DAG 構築
 
-**refine モード分岐（MUST）**: `refine_mode=true` の場合、Step 2a-2 全体をスキップする。理由: `#N` は GitHub Issue 番号であり、draft index の 1-3 桁 regex `(?<![A-Za-z0-9/])#(\d{1,3})(?![0-9])` と衝突するため。refine モードでは DAG 構築は不要（既存 Issue を個別に更新するため依存関係の解決が不要）。
+**refine モード分岐（MUST）**: `refine_mode=true` の場合、Step 2a-2 全体をスキップする。理由: 既存 Issue を個別に更新するため依存関係の解決が不要。また `#N` が GitHub Issue 番号と draft index regex `(?<![A-Za-z0-9/])#(\d{1,3})(?![0-9])` で衝突するため、DAG 構築自体が誤動作する。
 
 `refine_mode=false`（通常モード）の場合、以下を実行する:
 

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -1,0 +1,266 @@
+---
+type: workflow
+user-invocable: true
+spawnable_by: [controller, user]
+can_spawn: [composite, atomic, specialist]
+tools: [Bash, Skill, Read, Write]
+effort: medium
+maxTurns: 60
+---
+# workflow-issue-refine
+
+既存 Issue の refine（精緻化）workflow。1 issue につき spec-review → aggregate → fix loop → arch-drift → body 更新の lifecycle を自律実行する。
+
+`workflow-issue-lifecycle` の構造を踏襲しつつ、Step 3（issue-structure）を省略し、Step 6（issue-create）を Step 6'（gh issue edit による body 更新）に置換する。
+
+## 引数
+
+位置引数 1 つ（per-issue dir の絶対パス）:
+
+```
+/twl:workflow-issue-refine <abs-per-issue-dir>
+```
+
+## 入力ファイル構造
+
+```
+<abs-per-issue-dir>/
+  IN/
+    draft.md              # 改善後の issue body（必須）
+    existing-issue.json   # 既存 Issue 情報（必須: { "number": N, "current_body": "...", "repo": "owner/repo" }）
+    arch-context.md       # architecture コンテキスト（任意）
+    policies.json         # ポリシー設定（必須）
+    deps.json             # 依存情報（任意）
+  STATE                   # 現在状態ファイル（workflow が上書き）
+  rounds/                 # ラウンドごとの成果物
+  OUT/
+    report.json           # 最終出力
+```
+
+## existing-issue.json スキーマ
+
+```json
+{
+  "number": 513,
+  "current_body": "...",
+  "repo": "shuu5/twill"
+}
+```
+
+## policies.json スキーマ
+
+```json
+{
+  "max_rounds": 3,
+  "specialists": ["worker-codex-reviewer", "issue-critic", "issue-feasibility"],
+  "depth": "normal",
+  "quick_flag": false,
+  "scope_direct_flag": false,
+  "labels_hint": ["enhancement"],
+  "target_repo": null,
+  "parent_refs_resolved": {}
+}
+```
+
+## 処理フロー（MUST — 全ステップを順に実行）
+
+### Step 0: N=1 不変量ガード
+
+```bash
+CLAUDE_PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd 2>/dev/null || echo "${CLAUDE_PLUGIN_ROOT:-}")"
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/spec-review-session-init.sh" 1
+```
+
+### Step 1: 入力読み込み
+
+`$1` = per-issue dir の絶対パスとして受け取る。
+
+```bash
+PER_ISSUE_DIR="$1"
+# パス検証
+if [[ -z "$PER_ISSUE_DIR" || "$PER_ISSUE_DIR" != /* ]]; then
+  echo "ERROR: per-issue dir は絶対パスで指定してください" >&2
+  exit 1
+fi
+if [[ "$PER_ISSUE_DIR" =~ /\.\./ || "$PER_ISSUE_DIR" =~ /\.\.$ ]]; then
+  echo "ERROR: パストラバーサルは使用できません" >&2
+  exit 1
+fi
+```
+
+以下ファイルを読み込む:
+- `$PER_ISSUE_DIR/IN/draft.md` → 改善後の issue body として使用
+- `$PER_ISSUE_DIR/IN/existing-issue.json` → 既存 Issue 情報（number, current_body, repo）
+- `$PER_ISSUE_DIR/IN/arch-context.md` → architecture コンテキスト（存在しない場合は空文字）
+- `$PER_ISSUE_DIR/IN/policies.json` → max_rounds, specialists, depth, target_repo 等
+- `$PER_ISSUE_DIR/IN/deps.json` → 依存情報（存在しない場合は空）
+
+### Step 2: STATE 初期化
+
+```bash
+printf 'running\n' > "$PER_ISSUE_DIR/STATE"
+mkdir -p "$PER_ISSUE_DIR/rounds" "$PER_ISSUE_DIR/OUT"
+```
+
+### Step 3: 省略
+
+co-issue Phase 1 が draft.md を Issue テンプレート準拠フォーマットで生成するため、issue-structure は不要。draft.md をそのまま `rounds/0/body.md` にコピーする:
+
+```bash
+mkdir -p "$PER_ISSUE_DIR/rounds/0"
+cp "$PER_ISSUE_DIR/IN/draft.md" "$PER_ISSUE_DIR/rounds/0/body.md"
+```
+
+### Step 4: round loop
+
+`round=0` から `policies.max_rounds` まで以下を繰り返す:
+
+```
+round = round + 1
+STATE ← reviewing
+```
+
+#### 4a: spec-review 実行
+
+```bash
+printf 'reviewing\n' > "$PER_ISSUE_DIR/STATE"
+mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
+```
+
+`/twl:issue-spec-review` を Skill tool で呼び出す:
+- `specialists`: policies.specialists（デフォルト: worker-codex-reviewer, issue-critic, issue-feasibility）
+- `depth`: policies.depth（デフォルト: normal）
+- 結果を `rounds/<round>/findings.yaml` に書き込む
+
+#### 4b: aggregate
+
+`/twl:issue-review-aggregate` を Skill tool で呼び出す:
+- 入力: findings.yaml の内容
+- 結果を `rounds/<round>/aggregate.yaml` に書き込む
+
+#### 4c: codex gate
+
+aggregate の codex.status を確認:
+- `PASS` でない場合:
+  - round == 1 のとき: codex を 1 回再試行
+  - それ以外: STATE ← failed → `OUT/report.json` に `status: codex_unreliable` を書き込み → exit 0
+
+#### 4d: findings 判定
+
+aggregate の findings を確認:
+- **CRITICAL findings あり** (confidence >= 80, target = issue_description):
+  ```bash
+  printf 'fixing\n' > "$PER_ISSUE_DIR/STATE"
+  ```
+  body を修正して `rounds/<round>/body-fixed.md` に書き込み → loop 継続
+
+- **WARNING only**:
+  ```bash
+  printf 'fixing\n' > "$PER_ISSUE_DIR/STATE"
+  ```
+  body を修正して `rounds/<round>/body-fixed.md` に書き込み → **break**（ループ終了）
+
+- **clean（findings なし）**: **break**（ループ終了）
+
+#### 4e: max_rounds 到達チェック
+
+```
+if round == policies.max_rounds and CRITICAL findings あり:
+  STATE ← circuit_broken
+  OUT/report.json に { status: circuit_broken, rounds, last_aggregate } を書き込む
+  exit 0
+```
+
+### Step 4.5: refined ラベル判定
+
+round loop が正常完了した場合（STATE が `circuit_broken` でない場合）かつ `quick_flag=false` のとき、`labels_hint` に `"refined"` を追加する:
+
+```
+if STATE != circuit_broken and quick_flag == false:
+  policies.labels_hint ← policies.labels_hint + ["refined"]
+```
+
+- `quick_flag=true` の場合: スキップ（quick モードでは specialist レビューの depth が shallow に設定されるため、refined の品質保証基準を満たさない）
+- `STATE == circuit_broken` の場合: スキップ（round loop が正常完了していないため）
+- `STATE == failed` の場合: Step 4c の `exit 0` で制御フローが終了するため Step 4.5 に到達しない（条件式の対象外）
+
+### Step 5: arch-drift
+
+`/twl:issue-arch-drift` を Skill tool で呼び出す:
+- 入力: 最終 body（最後の body-fixed.md または rounds/0/body.md）
+
+### Step 6': body 更新 + ラベル付与
+
+`existing-issue.json` から `number` と `repo` を取得し、既存 Issue の body を更新する。
+
+```bash
+# existing-issue.json からフィールドを取得
+ISSUE_NUMBER=$(jq -r '.number' "$PER_ISSUE_DIR/IN/existing-issue.json")
+ISSUE_REPO=$(jq -r '.repo' "$PER_ISSUE_DIR/IN/existing-issue.json")
+
+# 最終 body ファイルを特定（最後の body-fixed.md、なければ rounds/0/body.md）
+FINAL_BODY="$PER_ISSUE_DIR/rounds/0/body.md"
+for f in "$PER_ISSUE_DIR"/rounds/*/body-fixed.md; do
+  [[ -f "$f" ]] && FINAL_BODY="$f"
+done
+
+# body 更新
+gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --body-file "$FINAL_BODY"
+
+# labels_hint のラベルを付与（既存ラベル・title は変更しない）
+for label in $(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json"); do
+  gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label "$label"
+done
+```
+
+**制約**: 既存ラベル・title は変更しない（body のみ更新 + ラベル追加）。
+
+### Step 7: 完了
+
+```bash
+printf 'done\n' > "$PER_ISSUE_DIR/STATE"
+```
+
+`OUT/report.json` に以下を書き込む:
+```json
+{
+  "status": "done",
+  "issue_number": "<既存 Issue 番号>",
+  "issue_repo": "<リポジトリ>",
+  "rounds": "<実行したラウンド数>",
+  "findings_final": "<最終 aggregate.yaml の内容>",
+  "warnings_acknowledged": "<WARNING findings のリスト>"
+}
+```
+
+## STATE 遷移
+
+| 値 | 意味 |
+|---|---|
+| `running` | 起動・初期化中 |
+| `reviewing` | spec-review 実行中 |
+| `fixing` | body 修正中 |
+| `done` | 正常完了 |
+| `failed` | 回復不能エラー |
+| `circuit_broken` | max_rounds 到達・CRITICAL 未解消 |
+
+## 自律実行制約（MUST）
+
+- このワークフローは orchestrator から spawn された Worker セッションで実行される
+- 全 Step を中断なく自律的に完了すること（MUST）
+- AskUserQuestion は使用しないこと（MUST NOT）— プロンプト制約として機能
+- エラー時は OUT/report.json に結果を書き込み exit すること
+
+## ファイル経由 I/O 制約（MUST NOT）
+
+- `IN/` 以外のパスを参照してはならない（ファイル入力として）
+- env var 経由でデータを受け取ってはならない（パス指定は可）
+- inject プロンプト経由のデータ（policies.json 主要フィールドなど）は、Worker の初期コンテキスト提供として受け取ることができる。ただし `IN/` ファイルを正規の入力源として引き続き使用すること（プロンプト経由データは補助的なコンテキストであり、`IN/` ファイルの代替ではない）
+
+## 禁止事項（MUST NOT）
+
+- N=1 ガード呼び出しを省略してはならない
+- STATE ファイルへの書き込みを省略してはならない
+- OUT/report.json の書き込みを省略してはならない（正常・異常どちらの終了でも必須）
+- 既存 Issue の title を変更してはならない
+- 既存 Issue のラベルを削除してはならない（追加のみ許可）

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -82,7 +82,7 @@ if [[ -z "$PER_ISSUE_DIR" || "$PER_ISSUE_DIR" != /* ]]; then
   echo "ERROR: per-issue dir は絶対パスで指定してください" >&2
   exit 1
 fi
-if [[ "$PER_ISSUE_DIR" =~ /\.\./ || "$PER_ISSUE_DIR" =~ /\.\.$ ]]; then
+if [[ "$PER_ISSUE_DIR" =~ \.\.(/|$) ]]; then
   echo "ERROR: パストラバーサルは使用できません" >&2
   exit 1
 fi
@@ -113,10 +113,10 @@ cp "$PER_ISSUE_DIR/IN/draft.md" "$PER_ISSUE_DIR/rounds/0/body.md"
 
 ### Step 4: round loop
 
-`round=0` から `policies.max_rounds` まで以下を繰り返す:
+`round=0` で初期化し、ループ先頭で `round += 1` してから実行する（実効範囲: round=1 〜 max_rounds）:
 
 ```
-round = round + 1
+round = round + 1   # round=1 から開始（rounds/0 は Step 3 で生成済み）
 STATE ← reviewing
 ```
 
@@ -175,9 +175,14 @@ if round == policies.max_rounds and CRITICAL findings あり:
 
 round loop が正常完了した場合（STATE が `circuit_broken` でない場合）かつ `quick_flag=false` のとき、`labels_hint` に `"refined"` を追加する:
 
-```
-if STATE != circuit_broken and quick_flag == false:
-  policies.labels_hint ← policies.labels_hint + ["refined"]
+```bash
+if [[ "$(cat "$PER_ISSUE_DIR/STATE")" != "circuit_broken" ]] && \
+   [[ "$(jq -r '.quick_flag' "$PER_ISSUE_DIR/IN/policies.json")" != "true" ]]; then
+  # policies.json に "refined" ラベルを追加して永続化（Step 6' が jq で読み取るため）
+  jq '.labels_hint += ["refined"] | .labels_hint |= unique' \
+    "$PER_ISSUE_DIR/IN/policies.json" > "$PER_ISSUE_DIR/IN/policies.json.tmp" \
+    && mv "$PER_ISSUE_DIR/IN/policies.json.tmp" "$PER_ISSUE_DIR/IN/policies.json"
+fi
 ```
 
 - `quick_flag=true` の場合: スキップ（quick モードでは specialist レビューの depth が shallow に設定されるため、refined の品質保証基準を満たさない）
@@ -198,6 +203,10 @@ if STATE != circuit_broken and quick_flag == false:
 ISSUE_NUMBER=$(jq -r '.number' "$PER_ISSUE_DIR/IN/existing-issue.json")
 ISSUE_REPO=$(jq -r '.repo' "$PER_ISSUE_DIR/IN/existing-issue.json")
 
+# 入力値検証
+[[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]] || { echo "ERROR: invalid issue number: $ISSUE_NUMBER" >&2; exit 1; }
+[[ "$ISSUE_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "ERROR: invalid repo format: $ISSUE_REPO" >&2; exit 1; }
+
 # 最終 body ファイルを特定（最後の body-fixed.md、なければ rounds/0/body.md）
 FINAL_BODY="$PER_ISSUE_DIR/rounds/0/body.md"
 for f in "$PER_ISSUE_DIR"/rounds/*/body-fixed.md; do
@@ -208,9 +217,10 @@ done
 gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --body-file "$FINAL_BODY"
 
 # labels_hint のラベルを付与（既存ラベル・title は変更しない）
-for label in $(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json"); do
-  gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label "$label"
-done
+# Step 4.5 で追加された "refined" ラベルも含む
+while IFS= read -r label; do
+  [[ -n "$label" ]] && gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label "$label"
+done < <(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json")
 ```
 
 **制約**: 既存ラベル・title は変更しない（body のみ更新 + ラベル追加）。


### PR DESCRIPTION
## 概要

既存 Issue に対する refine（精緻化）フローの正規 workflow skill を新設。

## 変更内容

1. **workflow-issue-refine SKILL.md 新設** — workflow-issue-lifecycle ベース。Step 3（issue-structure）省略、Step 6 を `gh issue edit --body-file` + `--add-label` に変更
2. **co-issue SKILL.md** — Step 0 モード判定（`refine #N` パターン検出）追加、Phase 1/2 に refine モード分岐追加
3. **issue-lifecycle-orchestrator.sh** — `workflow_skill` 変数導入、`existing-issue.json` 有無で dispatch 先切り替え
4. **deps.yaml** — `workflow-issue-refine` エントリ追加、co-issue の calls/tools 更新
5. **issue-mgmt.md** — Component Mapping に `workflow-issue-refine` 登録

## テスト

- `twl check` → OK: 263, Missing: 0
- `twl --update-readme` 実行済み

Closes #616