### PR TITLE
fix(session): detect_state() の for ループ変数 pattern に local 宣言を追加

### DIFF
--- a/plugins/session/scripts/session-state.sh
+++ b/plugins/session/scripts/session-state.sh
@@ -166,6 +166,7 @@ detect_state() {
     fi
 
     # error: エラーパターンが末尾に存在（プロンプトが不在の場合のみ）
+    local pattern
     for pattern in "${ERROR_PATTERNS[@]}"; do
         if echo "$last_lines" | grep -qF "$pattern"; then
             echo "error"


### PR DESCRIPTION
fix(session): detect_state() の for ループ変数 pattern に local 宣言を追加

ERROR_PATTERNS ループの `pattern` 変数がグローバルスコープに漏れる
問題を修正。`local pattern` を for ループ直前に追加。

Closes #524

Co-Authored-By: Claude <noreply@anthropic.com>