### PR TITLE
refactor(twl): spawn_sessionを3つのヘルパー関数に分割 (#583)

### DIFF
--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -183,6 +183,83 @@ window_name_for_subdir() {
 }
 
 # =============================================================================
+# セッション spawn ヘルパー
+# =============================================================================
+
+# subdir の IN/policies.json から主要フィールドを抽出する
+# 引数: subdir ref_max_rounds ref_specialists ref_depth ref_quick_flag ref_target_repo
+# ref_* は nameref で書き込む変数名
+_extract_policies_fields() {
+  local subdir="$1"
+  local -n _pf_max_rounds="$2"
+  local -n _pf_specialists="$3"
+  local -n _pf_depth="$4"
+  local -n _pf_quick_flag="$5"
+  local -n _pf_target_repo="$6"
+  _pf_max_rounds="" ; _pf_specialists="" ; _pf_depth="" ; _pf_quick_flag="" ; _pf_target_repo=""
+  if [[ -f "${subdir}/IN/policies.json" ]] && command -v jq >/dev/null 2>&1; then
+    _pf_max_rounds="$(jq -r '.max_rounds // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
+    _pf_specialists="$(jq -r '(.specialists // []) | join(",")' "${subdir}/IN/policies.json" 2>/dev/null || true)"
+    _pf_depth="$(jq -r '.depth // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
+    _pf_quick_flag="$(jq -r '.quick_flag // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
+    _pf_target_repo="$(jq -r '.target_repo // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
+  fi
+}
+
+# プロンプトテンポラリファイルを生成して ref_prompt_file に書き込む
+# 引数: subdir max_rounds specialists depth quick_flag target_repo ref_prompt_file
+_build_worker_prompt() {
+  local subdir="$1" max_rounds="$2" specialists="$3" depth="$4" quick_flag="$5" target_repo="$6"
+  local -n _bwp_prompt_file="$7"
+  local workflow_skill="workflow-issue-lifecycle"
+  if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
+    workflow_skill="workflow-issue-refine"
+  fi
+  _bwp_prompt_file="$(mktemp /tmp/.coi-prompt-XXXXXX.txt)"
+  # inject プロンプト生成（printf 方式: heredoc 終端子汚染リスクを回避）
+  printf '%s\n' \
+    "/twl:${workflow_skill} $(printf '%q' "$subdir")" \
+    "" \
+    "【自律実行指示】" \
+    "- 全 Step を中断なく自律的に完了すること" \
+    "- 途中で AskUserQuestion を使用しないこと" \
+    "- エラー発生時は OUT/report.json に status: failed を書き込んで exit すること" \
+    "- policies.json の設定に従い specialist review を実行すること" \
+    "" \
+    "【policies.json 主要フィールド】" \
+    "- max_rounds: ${max_rounds}" \
+    "- specialists: ${specialists}" \
+    "- depth: ${depth}" \
+    "- quick_flag: ${quick_flag}" \
+    "- target_repo: ${target_repo}" \
+    > "$_bwp_prompt_file"
+}
+
+# cld-spawn でウィンドウを起動し inject-file でプロンプトを送達する
+# 引数: subdir window_name prompt_file
+_spawn_tmux_window_with_prompt() {
+  local subdir="$1" window_name="$2" prompt_file="$3"
+  local SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
+  echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
+  # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
+  # env-file は CLD_ENV_FILE 環境変数のフォールバックに委譲（cld-spawn が自動検出）
+  "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" --model "${WORKER_MODEL}" || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: cld-spawn 失敗" >&2
+    return 1
+  }
+  tmux set-option -t "$window_name" remain-on-exit on 2>/dev/null || true
+  # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
+  "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
+    rm -f "$prompt_file" 2>/dev/null || true
+    tmux kill-window -t "${window_name}" 2>/dev/null || true
+    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject-file 失敗" >&2
+    return 1
+  }
+  rm -f "$prompt_file" 2>/dev/null || true
+}
+
+# =============================================================================
 # セッション spawn
 # =============================================================================
 
@@ -214,76 +291,19 @@ spawn_session() {
     return 0
   fi
 
-  # 既存ウィンドウがあれば kill
   tmux kill-window -t "$window_name" 2>/dev/null || true
-
   mkdir -p "${subdir}/OUT"
 
-  # プロンプトをテンポラリファイルに書き出す（自律実行指示 + policies.json 主要フィールドを注入）
-  local prompt_file
-  prompt_file="$(mktemp /tmp/.coi-prompt-XXXXXX.txt)"
-
-  # policies.json 主要フィールドを抽出（jq がなければ空文字。全変数を空文字で初期化し set -u エラーを回避）
   local max_rounds="" specialists="" depth="" quick_flag="" target_repo=""
-  if [[ -f "${subdir}/IN/policies.json" ]] && command -v jq >/dev/null 2>&1; then
-    max_rounds="$(jq -r '.max_rounds // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
-    specialists="$(jq -r '(.specialists // []) | join(",")' "${subdir}/IN/policies.json" 2>/dev/null || true)"
-    depth="$(jq -r '.depth // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
-    quick_flag="$(jq -r '.quick_flag // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
-    target_repo="$(jq -r '.target_repo // empty' "${subdir}/IN/policies.json" 2>/dev/null || true)"
-  fi
+  _extract_policies_fields "$subdir" max_rounds specialists depth quick_flag target_repo
 
-  # IN/existing-issue.json の有無で dispatch 先を決定
-  local workflow_skill="workflow-issue-lifecycle"
-  if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
-    workflow_skill="workflow-issue-refine"
-  fi
-
-  # inject プロンプト生成（printf 方式: heredoc 終端子汚染リスクを回避）
-  printf '%s\n' \
-    "/twl:${workflow_skill} $(printf '%q' "$subdir")" \
-    "" \
-    "【自律実行指示】" \
-    "- 全 Step を中断なく自律的に完了すること" \
-    "- 途中で AskUserQuestion を使用しないこと" \
-    "- エラー発生時は OUT/report.json に status: failed を書き込んで exit すること" \
-    "- policies.json の設定に従い specialist review を実行すること" \
-    "" \
-    "【policies.json 主要フィールド】" \
-    "- max_rounds: ${max_rounds}" \
-    "- specialists: ${specialists}" \
-    "- depth: ${depth}" \
-    "- quick_flag: ${quick_flag}" \
-    "- target_repo: ${target_repo}" \
-    > "$prompt_file"
-
-  local SESSION_SCRIPTS
-  SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
-
-  echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
+  local prompt_file=""
+  _build_worker_prompt "$subdir" "$max_rounds" "$specialists" "$depth" "$quick_flag" "$target_repo" prompt_file
 
   # flock 解放（cld-spawn 前）
   exec {lockfd}>&-
 
-  # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
-  # env-file は CLD_ENV_FILE 環境変数のフォールバックに委譲（cld-spawn が自動検出）
-  "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" --model "${WORKER_MODEL}" || {
-    rm -f "$prompt_file" 2>/dev/null || true
-    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: cld-spawn 失敗" >&2
-    return 1
-  }
-
-  tmux set-option -t "$window_name" remain-on-exit on 2>/dev/null || true
-
-  # inject-file: プロンプトをセッションに安全に送達（wait-ready 後）
-  "${SESSION_SCRIPTS}/session-comm.sh" inject-file "${window_name}" "${prompt_file}" --wait 60 || {
-    rm -f "$prompt_file" 2>/dev/null || true
-    tmux kill-window -t "${window_name}" 2>/dev/null || true
-    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject-file 失敗" >&2
-    return 1
-  }
-
-  rm -f "$prompt_file" 2>/dev/null || true
+  _spawn_tmux_window_with_prompt "$subdir" "$window_name" "$prompt_file"
 }
 
 # =============================================================================


### PR DESCRIPTION
refactor(twl): spawn_sessionを3つのヘルパー関数に分割 (#583)

- _extract_policies_fields: policies.jsonフィールド抽出（15行）
- _build_worker_prompt: プロンプトファイル生成（25行）
- _spawn_tmux_window_with_prompt: cld-spawn + inject-file実行（20行）
- spawn_session: 薄いオーケストレーション層に縮小（41行）

全関数が50行以下となり、baseline-coding-style.md の閾値を満たす。

Closes #583