### PR TITLE
fix(hooks): pre-tool-use-deps-yaml-guard の deps.yaml パスを動的解決に変更 (#587)

### DIFF
--- a/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
+++ b/plugins/twl/scripts/hooks/pre-tool-use-deps-yaml-guard.sh
@@ -73,10 +73,28 @@ elif [[ "$tool_name" == "Edit" ]]; then
   # なければ file_path のディスク内容にフォールバック
   current=$(echo "$payload" | jq -r '.tool_input.file_content // empty')
   if [[ -z "$current" ]]; then
-    if [[ ! -f "$file_path" ]]; then
+    # path traversal 防御: realpath 正規化 + リポジトリルート配下確認
+    # python3 を使用して realpath 不在環境（macOS BSD 等）にも対応
+    canonical_path=$(python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))" "$file_path" 2>/dev/null) || {
+      echo "ERROR: file_path を解決できません: $file_path" >&2
+      exit 1
+    }
+    repo_root=$(git -C "$(dirname "$canonical_path")" rev-parse --show-toplevel 2>/dev/null) || {
+      echo "ERROR: git リポジトリが見つかりません: $canonical_path" >&2
+      exit 1
+    }
+    case "$canonical_path" in
+      "$repo_root"/*)
+        ;;
+      *)
+        echo "ERROR: リポジトリ外のパスは guard 対象外: $canonical_path (root: $repo_root)" >&2
+        exit 1
+        ;;
+    esac
+    if [[ ! -f "$canonical_path" ]]; then
       exit 0
     fi
-    current=$(cat "$file_path")
+    current=$(cat "$canonical_path")
   fi
 
   # old_string が存在しない場合は exit 2（apply 失敗 = YAML 未検証 = ブロック）

--- a/plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats
+++ b/plugins/twl/tests/bats/scripts/pre-tool-use-deps-yaml-guard.bats
@@ -31,6 +31,7 @@
 #  13. タブ文字を含む不正 YAML (Write) -> exit 2
 
 load '../helpers/common'
+load '../helpers/git-fixture'
 
 HOOK_SRC=""
 
@@ -357,4 +358,83 @@ $(printf '\t')bad_tab_indent: here"
     '{tool_name:"Write", tool_input:{file_path:"deps.yaml", content:$content}}')
   run _run_hook "$payload"
   [ "$status" -eq 2 ]
+}
+
+# ---------------------------------------------------------------------------
+# Path traversal guard: Edit ブランチのディスク読み込み時パス検証
+# file_content を省略することで disk fallback パスを使用
+# ---------------------------------------------------------------------------
+
+@test "Edit: リポ内の正常パス（deps.yaml）はディスク読み込み時に通過する" {
+  # 一時 git リポジトリを作成し、deps.yaml を配置
+  local tmp_repo
+  tmp_repo=$(init_temp_repo)
+  local valid_yaml='name: test-plugin
+version: "1.0"'
+  echo "$valid_yaml" > "$tmp_repo/deps.yaml"
+  (cd "$tmp_repo" && git add deps.yaml && git commit -m "add deps.yaml" -q)
+
+  # file_content を省略してディスク読み込みパスを使用
+  local payload
+  payload=$(jq -nc \
+    --arg fp "$tmp_repo/deps.yaml" \
+    --arg os 'version: "1.0"' \
+    --arg ns 'version: "2.0"' \
+    '{tool_name:"Edit", tool_input:{file_path:$fp, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  cleanup_temp_repo "$tmp_repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "Edit: トラバーサルパス（../../deps.yaml）はディスク読み込み時に exit 1 で拒否" {
+  # 一時 git リポジトリを作成（リポ外への相対トラバーサルを検証）
+  local tmp_repo
+  tmp_repo=$(init_temp_repo)
+
+  # tmp_repo の 2 階層上 (例: /tmp) は git リポジトリではないため拒否される
+  local traversal_path="$tmp_repo/../../deps.yaml"
+
+  local payload
+  payload=$(jq -nc \
+    --arg fp "$traversal_path" \
+    --arg os "old" \
+    --arg ns "new" \
+    '{tool_name:"Edit", tool_input:{file_path:$fp, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  cleanup_temp_repo "$tmp_repo"
+  [ "$status" -eq 1 ]
+}
+
+@test "Edit: リポ外パス（/tmp/deps.yaml）はディスク読み込み時に exit 1 で拒否" {
+  local tmp_file
+  tmp_file=$(mktemp --suffix=deps.yaml --tmpdir)
+  # basename が deps.yaml になるようにリネームして作成
+  local tmp_dir
+  tmp_dir=$(dirname "$tmp_file")
+  local target_file="$tmp_dir/deps.yaml"
+  echo "key: value" > "$target_file"
+
+  local payload
+  payload=$(jq -nc \
+    --arg fp "$target_file" \
+    --arg os "key: value" \
+    --arg ns "key: new_value" \
+    '{tool_name:"Edit", tool_input:{file_path:$fp, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  rm -f "$tmp_file" "$target_file"
+  [ "$status" -eq 1 ]
+}
+
+@test "Edit: 存在しないリポ外パスはディスク読み込み時に exit 1 で拒否" {
+  # git リポジトリが存在しないパスを指定
+  local nonexistent_path="/tmp/no_git_repo_dir_$$_$(date +%s)/deps.yaml"
+
+  local payload
+  payload=$(jq -nc \
+    --arg fp "$nonexistent_path" \
+    --arg os "old" \
+    --arg ns "new" \
+    '{tool_name:"Edit", tool_input:{file_path:$fp, old_string:$os, new_string:$ns}}')
+  run _run_hook "$payload"
+  [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
fix(hooks): pre-tool-use-deps-yaml-guard の deps.yaml パスを動的解決に変更 (#587)

- Edit ブランチのディスク読み込み時に realpath + git リポルート確認を追加
- python3 os.path.realpath でシンボリックリンク・相対パスを正規化
- git -C dirname でリポジトリルートを取得し配下であることを検証
- リポ外パス・トラバーサルパスを exit 1 で拒否
- bats テスト 4 ケース追加（正常/トラバーサル/リポ外/存在しない）

Closes #587