### PR TITLE
docs(co-self-improve): bug 再現シナリオの実行手順を SKILL.md に追記

### DIFF
--- a/plugins/twl/refs/test-scenario-catalog.md
+++ b/plugins/twl/refs/test-scenario-catalog.md
@@ -329,6 +329,8 @@ regression-006:
 
 Wave 1-5 で発見された autopilot バグの再現シナリオ。`bug` level は特定の chain 遷移・stall パターンを検証し、`regression` level（並列実行 conflict 検証）と区別される。real-issues モードで各バグを再現確認できる。
 
+詳細な実行手順は `skills/co-self-improve/SKILL.md` の「Bug Reproduction Scenario の実行」を参照。
+
 ### bug-469-chain-stall: Worker 完了後の workflow-pr-verify 遷移停止
 
 ```yaml

--- a/plugins/twl/skills/co-self-improve/SKILL.md
+++ b/plugins/twl/skills/co-self-improve/SKILL.md
@@ -83,6 +83,25 @@ spawn 時プロンプトに情報が含まれない場合のみ AskUserQuestion 
    - spawn プロンプト: `/twl:co-autopilot`（test-target worktree で Issue を自律実行）
 6. spawn 後の window 名を取得し Step 2 へ
 
+### Bug Reproduction Scenario の実行
+
+bug level シナリオは既知の bug を意図的に再現するテストシナリオです。`--real-issues` モードと組み合わせて実行します:
+
+- `bug-469-chain-stall`: chain step 停滞の再現
+- `bug-470-state-path`: 状態パス異常の再現
+- `bug-471-refspec`: refspec 設定ミスの再現
+- `bug-472-monitor-stall`: monitor-channel 停滞の再現
+- `bug-combo-469-472`: 上記 bug の複合再現
+
+実行例:
+```
+/twl:co-self-improve scenario-run bug-469-chain-stall --real-issues --repo <owner>/<name>
+```
+
+注意:
+- bug level シナリオは `--real-issues` モード **必須**（local モードでは再現条件を満たさない）
+- 専用リポを事前に用意すること（test-project-init 参照）
+
 ## Step 2: scenario 実行中の observation loop 起動
 
 `Skill(twl:workflow-observe-loop)` を呼び出し、対象 window を引数で渡す。


### PR DESCRIPTION
docs(co-self-improve): bug 再現シナリオの実行手順を SKILL.md に追記

- SKILL.md に「Bug Reproduction Scenario の実行」サブセクションを追加
- bug-469/470/471/472/combo の 5 件のシナリオ概要と実行例を記載
- --real-issues モード必須・専用リポ事前準備の注記を追加
- test-scenario-catalog.md の bug level セクション冒頭に逆参照リンクを追加

Closes #519

Co-Authored-By: Claude <noreply@anthropic.com>