### PR TITLE
test(co-self-improve): --real-issues E2E smoke テストを追加 (#517)

### DIFF
--- a/plugins/twl/tests/bats/e2e/co-self-improve-smoke.bats
+++ b/plugins/twl/tests/bats/e2e/co-self-improve-smoke.bats
@@ -188,6 +188,37 @@ teardown() {
   echo "$output" | jq -e '.recommended_labels | contains(["from-observation"])' > /dev/null
 }
 
+# Scenario: --real-issues --repo routes to test-project-init --mode real-issues --repo
+# WHEN test-project-init is called with --mode real-issues --repo owner/name
+# THEN command accepts the flags and output references the target repo (no actual GH API access)
+@test "co-self-improve smoke: --real-issues --repo で test-project-init 経由 scenario-load まで到達する" {
+  _require_cmd "test-project-init"
+  local init_cmd
+  init_cmd=$(_cmd_path "test-project-init")
+
+  # Stub gh to avoid actual GH API access
+  stub_command "gh" 'echo "mock gh: $*" >&2; exit 0'
+
+  # Invoke test-project-init in real-issues mode with dry-run to skip worktree creation
+  run bash "$init_cmd" --mode real-issues --repo "shuu5/twill-test" --dry-run
+  assert_success
+
+  # Output must reference the target repo, confirming --repo flag was parsed and delegated
+  echo "$output" | grep -q "shuu5/twill-test"
+}
+
+# Scenario: co-autopilot spawn targets worktrees/test-target
+# WHEN co-self-improve triggers co-autopilot spawn (Step 1b)
+# THEN SKILL.md spawn instruction specifies --cd worktrees/test-target
+@test "co-self-improve smoke: co-autopilot spawn 指示が正しい worktree を向く" {
+  _require_cmd "co-autopilot"
+
+  # Verify SKILL.md Step 1b spawn instruction targets the test-target worktree
+  local skill_file="$REPO_ROOT/skills/co-self-improve/SKILL.md"
+  [ -f "$skill_file" ]
+  grep -q 'worktrees/test-target' "$skill_file"
+}
+
 # Scenario: full chain - init → scenario-load → observe → detect → draft
 # WHEN the full co-self-improve pipeline is run end-to-end with stubs
 # THEN each step succeeds and the final draft has at least 1 detection


### PR DESCRIPTION
test(co-self-improve): --real-issues E2E smoke テストを追加 (#517)

co-self-improve-smoke.bats に 2 ケースを追加:
- --real-issues --repo フラグが test-project-init --mode real-issues --repo
  に委譲される経路の E2E 検証
- co-autopilot spawn 指示が worktrees/test-target を向くことの検証

両テストとも _require_cmd パターンで依存コマンド未実装時は skip し、
外部 GH API への実アクセスは stub_command で回避する。

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #517