### PR TITLE
fix(deps): SU-6a su-observer.calls 補完 + su-compact 型ルール修正

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -323,6 +323,8 @@ skills:
       - reference: observation-pattern-catalog
       - reference: monitor-channel-catalog
       - atomic: su-compact  # SU-6b: context 逼迫時またはユーザー指示時にユーザーへ提案（SHOULD）
+      - atomic: wave-collect        # SU-6a: Wave 完了時の結果収集
+      - atomic: externalize-state   # SU-6a: Wave 完了時の外部化
     description: "メタ認知レイヤー: 全 controller の監視・介入。テストシナリオ実行は co-self-improve に委譲"
 
   workflow-setup:
@@ -1664,7 +1666,6 @@ commands:
     can_spawn: []
     calls:
       - reference: memory-mcp-config
-      - atomic: externalize-state
     description: "知識外部化 + compaction 制御（Long-term Memory 保存 → Working Memory 退避 → /compact）"
 
   # === externalize-state: 状態外部化 atomic コマンド (#367) ===


### PR DESCRIPTION
fix(deps): SU-6a su-observer.calls 補完 + su-compact 型ルール修正

- su-observer.calls に wave-collect と externalize-state を追加（違反1解消）
  Wave 完了フローで SKILL.md line 132-133 にて直接呼び出されていたが未宣言だった
- su-compact.calls から atomic: externalize-state を削除（違反2解消・案B採用）
  atomic が atomic を calls する型ルール違反。呼出経路を su-observer 直接に集約
- twl --validate: 型ルール違反 0 件確認済み

Closes #594