### PR TITLE
fix(worker-arch-doc-reviewer): refined_by/refined_at付与とプロンプト修正

### DIFF
--- a/plugins/twl/agents/worker-arch-doc-reviewer.md
+++ b/plugins/twl/agents/worker-arch-doc-reviewer.md
@@ -8,6 +8,7 @@ model: sonnet
 effort: medium
 maxTurns: 20
 tools:
+  - Bash
   - Read
   - Grep
   - Glob
@@ -19,6 +20,11 @@ skills:
 
 あなたは `architecture/` ディレクトリ配下のドキュメント変更自体の品質をレビューする specialist です。
 Task tool は使用禁止。全チェックを自身で実行してください。
+
+## 前提条件
+
+- git リポジトリで `origin/main` が fetch 済みであること（`git fetch origin` 実行済み）
+- `architecture/` ディレクトリを含むリポジトリで使用すること
 
 ## 入力
 

--- a/plugins/twl/agents/worker-arch-doc-reviewer.md
+++ b/plugins/twl/agents/worker-arch-doc-reviewer.md
@@ -122,7 +122,7 @@ ref-specialist-output-schema に従い JSON を出力すること。
       "file": "architecture/decisions/ADR-001.md",
       "line": 42,
       "message": "説明",
-      "category": "architecture-quality"
+      "category": "architecture-drift"
     }
   ]
 }

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2885,6 +2885,8 @@ agents:
 
   worker-arch-doc-reviewer:
     type: specialist
+    refined_by: "ref-prompt-guide@43b4e53e"
+    refined_at: "2026-04-13"
     path: agents/worker-arch-doc-reviewer.md
     model: sonnet
     spawnable_by: [workflow, composite]


### PR DESCRIPTION
fix(worker-arch-doc-reviewer): refined_by/refined_at付与とプロンプト修正

worker-prompt-reviewerによるレビューを実施しPASS取得後、
ref-prompt-guide@43b4e53eに基づいてdeps.yamlに refined_by/refined_at を付与。

プロンプト修正点:
- frontmatterのtoolsにBashを追加（git diffコマンド実行に必要）
- 前提条件セクションを追加（origin/mainのfetch状態を明記）

Closes #600

Co-Authored-By: Claude <noreply@anthropic.com>