### PR TITLE
fix: ADR-019 co-architect カテゴリ反映（model.md/autopilot.md/ADR-019）

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md
+++ b/plugins/twl/architecture/decisions/ADR-019-spec-implementation-category.md
@@ -4,7 +4,7 @@
 **Date**: 2026-04-13  
 **Issue**: #557  
 **Supersedes**: —  
-**Related**: ADR-001 (autopilot-first), ADR-002 (controller consolidation)
+**Related**: ADR-001 (autopilot-first), ADR-002 (controller consolidation), ADR-014 (supervisor redesign — co-architect was previously classified as Non-implementation)
 
 ---
 

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -313,7 +313,8 @@ co-autopilot 障害時のみ手動パスを許可する。
 | カテゴリ | 定義 | 該当 Controller |
 |---|---|---|
 | Implementation | コード変更・PR 作成を伴う操作 | co-autopilot のみ |
-| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project, co-architect |
+| Non-implementation | Issue 作成・設計・プロジェクト管理 | co-issue, co-project |
+| Spec Implementation | アーキテクチャドキュメント・ADR の直接 Write・コミット・PR 作成 | co-architect |
 
 ## Component Mapping
 

--- a/plugins/twl/architecture/domain/model.md
+++ b/plugins/twl/architecture/domain/model.md
@@ -109,7 +109,7 @@ graph TD
         CA["co-autopilot<br/>(Implementation)"]
         CI["co-issue<br/>(Non-implementation)"]
         CP["co-project<br/>(Non-implementation)"]
-        CR["co-architect<br/>(Non-implementation)"]
+        CR["co-architect<br/>(Spec Implementation)"]
         CU["co-utility<br/>(Utility)"]
         CS["co-self-improve<br/>(Observation)"]
         SO["su-observer<br/>(Meta-cognitive)"]


### PR DESCRIPTION
fix: ADR-019 co-architect カテゴリ反映（model.md/autopilot.md/ADR-019）

- model.md line 112: (Non-implementation) → (Spec Implementation)
- autopilot.md: Non-implementation 行から co-architect を除去し Spec Implementation 行を新規追加
- ADR-019 Related セクションに ADR-014 を追記

Closes #602