### PR TITLE
fix(checkpoint): --autopilot-dir サポート追加 + read/write パス不整合修正

### DIFF
--- a/cli/twl/src/twl/autopilot/checkpoint.py
+++ b/cli/twl/src/twl/autopilot/checkpoint.py
@@ -3,9 +3,9 @@
 Replaces: checkpoint-write.sh, checkpoint-read.sh
 
 CLI usage:
-    python3 -m twl.autopilot.checkpoint write --step <step> --status <PASS|WARN|FAIL> [--findings <json>]
-    python3 -m twl.autopilot.checkpoint read  --step <step> --field <field>
-    python3 -m twl.autopilot.checkpoint read  --step <step> --critical-findings
+    python3 -m twl.autopilot.checkpoint write --step <step> --status <PASS|WARN|FAIL> [--findings <json>] [--autopilot-dir <dir>]
+    python3 -m twl.autopilot.checkpoint read  --step <step> --field <field> [--autopilot-dir <dir>]
+    python3 -m twl.autopilot.checkpoint read  --step <step> --critical-findings [--autopilot-dir <dir>]
 """
 
 from __future__ import annotations
@@ -166,14 +166,14 @@ class CheckpointManager:
 # ---------------------------------------------------------------------------
 
 def _parse_write_args(argv: list[str]) -> dict[str, Any]:
-    args: dict[str, Any] = {"step": None, "status": None, "findings": None}
+    args: dict[str, Any] = {"step": None, "status": None, "findings": None, "autopilot_dir": None}
     i = 0
     while i < len(argv):
         a = argv[i]
         if a in ("-h", "--help"):
             print(
                 "Usage: python3 -m twl.autopilot.checkpoint write "
-                "--step <step> --status <PASS|WARN|FAIL> [--findings <json_array>]"
+                "--step <step> --status <PASS|WARN|FAIL> [--findings <json_array>] [--autopilot-dir <dir>]"
             )
             sys.exit(0)
         elif a == "--step" and i + 1 < len(argv):
@@ -182,6 +182,8 @@ def _parse_write_args(argv: list[str]) -> dict[str, Any]:
             args["status"] = argv[i + 1]; i += 2
         elif a == "--findings" and i + 1 < len(argv):
             args["findings"] = argv[i + 1]; i += 2
+        elif a == "--autopilot-dir" and i + 1 < len(argv):
+            args["autopilot_dir"] = argv[i + 1]; i += 2
         else:
             print(f"ERROR: Unknown argument: {a}", file=sys.stderr)
             sys.exit(2)
@@ -195,14 +197,14 @@ def _parse_write_args(argv: list[str]) -> dict[str, Any]:
 
 
 def _parse_read_args(argv: list[str]) -> dict[str, Any]:
-    args: dict[str, Any] = {"step": None, "field": None, "critical_findings": False}
+    args: dict[str, Any] = {"step": None, "field": None, "critical_findings": False, "autopilot_dir": None}
     i = 0
     while i < len(argv):
         a = argv[i]
         if a in ("-h", "--help"):
             print(
                 "Usage: python3 -m twl.autopilot.checkpoint read "
-                "--step <step> (--field <field> | --critical-findings)"
+                "--step <step> (--field <field> | --critical-findings) [--autopilot-dir <dir>]"
             )
             sys.exit(0)
         elif a == "--step" and i + 1 < len(argv):
@@ -211,6 +213,8 @@ def _parse_read_args(argv: list[str]) -> dict[str, Any]:
             args["field"] = argv[i + 1]; i += 2
         elif a == "--critical-findings":
             args["critical_findings"] = True; i += 1
+        elif a == "--autopilot-dir" and i + 1 < len(argv):
+            args["autopilot_dir"] = argv[i + 1]; i += 2
         else:
             print(f"ERROR: Unknown argument: {a}", file=sys.stderr)
             sys.exit(2)
@@ -230,11 +234,12 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     subcmd, rest = args[0], args[1:]
-    mgr = CheckpointManager()
 
     try:
         if subcmd == "write":
             parsed = _parse_write_args(rest)
+            checkpoint_dir = Path(parsed["autopilot_dir"]) / "checkpoints" if parsed["autopilot_dir"] else None
+            mgr = CheckpointManager(checkpoint_dir=checkpoint_dir)
             findings: list[Any] | None = None
             if parsed["findings"] is not None:
                 findings = json.loads(parsed["findings"])
@@ -251,6 +256,8 @@ def main(argv: list[str] | None = None) -> int:
 
         elif subcmd == "read":
             parsed = _parse_read_args(rest)
+            checkpoint_dir = Path(parsed["autopilot_dir"]) / "checkpoints" if parsed["autopilot_dir"] else None
+            mgr = CheckpointManager(checkpoint_dir=checkpoint_dir)
             result = mgr.read(
                 step=parsed["step"],
                 field=parsed["field"],

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1096,18 +1096,18 @@ step_pr_comment_findings() {
     return 0
   fi
 
-  local autopilot_dir
-  autopilot_dir="$(resolve_autopilot_dir)"
-
   # checkpoint から findings 取得（merge-gate, ac-verify, phase-review を統合）
+  # 注: --autopilot-dir は使わず、checkpoint.py のデフォルト解決（git rev-parse）に任せる。
+  # merge-gate.md 等の write もデフォルト解決を使うため、同一 worktree 内で read/write が一致する。
+  # 各 Worker は独自の worktree を持つため並列安全。
   local mg_findings ac_findings pr_findings combined_findings
-  mg_findings=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step merge-gate --field findings 2>/dev/null || echo "[]")
-  ac_findings=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step ac-verify --field findings 2>/dev/null || echo "[]")
-  pr_findings=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step phase-review --field findings 2>/dev/null || echo "[]")
+  mg_findings=$(python3 -m twl.autopilot.checkpoint read --step merge-gate --field findings 2>/dev/null || echo "[]")
+  ac_findings=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --field findings 2>/dev/null || echo "[]")
+  pr_findings=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field findings 2>/dev/null || echo "[]")
   combined_findings=$(jq -s 'add // []' <(echo "$mg_findings") <(echo "$ac_findings") <(echo "$pr_findings") 2>/dev/null || echo "[]")
 
   local mg_status
-  mg_status=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step merge-gate --field status 2>/dev/null || echo "UNKNOWN")
+  mg_status=$(python3 -m twl.autopilot.checkpoint read --step merge-gate --field status 2>/dev/null || echo "UNKNOWN")
 
   # findings テーブル構築
   local findings_count
@@ -1187,14 +1187,12 @@ step_pr_comment_final() {
     return 0
   fi
 
-  local autopilot_dir
-  autopilot_dir="$(resolve_autopilot_dir)"
-
+  # checkpoint.py のデフォルト解決に任せる（write と同一 worktree 内で一致させる）
   local ac_status pr_test_status e2e_status mg_status
-  ac_status=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step ac-verify --field status 2>/dev/null || echo "N/A")
-  pr_test_status=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step pr-test --field status 2>/dev/null || echo "N/A")
-  e2e_status=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step e2e-screening --field status 2>/dev/null || echo "N/A")
-  mg_status=$(python3 -m twl.autopilot.checkpoint read --autopilot-dir "$autopilot_dir" --step merge-gate --field status 2>/dev/null || echo "N/A")
+  ac_status=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --field status 2>/dev/null || echo "N/A")
+  pr_test_status=$(python3 -m twl.autopilot.checkpoint read --step pr-test --field status 2>/dev/null || echo "N/A")
+  e2e_status=$(python3 -m twl.autopilot.checkpoint read --step e2e-screening --field status 2>/dev/null || echo "N/A")
+  mg_status=$(python3 -m twl.autopilot.checkpoint read --step merge-gate --field status 2>/dev/null || echo "N/A")
 
   local body="## Merge Gate Final"$'\n\n'
   body+="- ac-verify: ${ac_status}"$'\n'


### PR DESCRIPTION
## 概要

checkpoint.py が `--autopilot-dir` CLI パラメータを受け付けず、chain-runner.sh の `step_pr_comment_findings()` からの全 checkpoint read が exit 2 → `2>/dev/null` で握り潰し → `echo '[]'` フォールバック → 空 findings 投稿されていた問題を修正。

## 根本原因

1. **`checkpoint.py` が `--autopilot-dir` を認識しない**: 未知の引数として exit 2 で終了
2. **Write/Read パスの不整合**: merge-gate.md の write は `git rev-parse --show-toplevel`（worktree root）に書き込むが、`step_pr_comment_findings()` は `resolve_autopilot_dir()`（main worktree の `.autopilot/`）から読み取ろうとしていた

## 修正内容

| ファイル | 変更 |
|---|---|
| `cli/twl/src/twl/autopilot/checkpoint.py` | `--autopilot-dir` パラメータを read/write 両コマンドに追加 |
| `plugins/twl/scripts/chain-runner.sh` | `step_pr_comment_findings` / `step_pr_comment_final` から `--autopilot-dir` を除去し、checkpoint.py のデフォルト解決（`git rev-parse`）に統一 |

## 並列安全性

各 Worker は独自の worktree を持ち、checkpoint は worktree 内の `.autopilot/checkpoints/` に書き込まれるため、並列 Worker 間での上書きは発生しない。

Closes #640