### PR TITLE
fix(642): simplify OR-condition in audit dir resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # code-review-graph local cache
 .code-review-graph/
+
+# autopilot audit session data
+.audit/

--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -119,7 +119,7 @@ def audit_on(run_id: str | None = None, project_root: Path | None = None) -> dic
     active_data = {
         "run_id": run_id,
         "started_at": started_at,
-        "audit_dir": f".audit/{run_id}",
+        "audit_dir": str(audit_dir),
     }
     active_file = root / ".audit" / ".active"
     active_file.write_text(json.dumps(active_data, ensure_ascii=False) + "\n", encoding="utf-8")

--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -15,11 +15,15 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import random
 import string
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+
+# run_id は英数字・ハイフン・アンダースコアのみ許可（path traversal 防止）
+_VALID_RUN_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 # ---------------------------------------------------------------------------
@@ -38,8 +42,13 @@ def _project_root() -> Path:
     return Path(result.stdout.strip())
 
 
-def _active_file() -> Path:
-    return _project_root() / ".audit" / ".active"
+def _resolve_root(project_root: Path | None) -> Path:
+    """Return project_root if provided, otherwise resolve via git."""
+    return project_root if project_root is not None else _project_root()
+
+
+def _active_file(project_root: Path | None = None) -> Path:
+    return _resolve_root(project_root) / ".audit" / ".active"
 
 
 def _now_utc() -> str:
@@ -52,43 +61,57 @@ def _gen_run_id() -> str:
     return f"{ts}_{suffix}"
 
 
+def _validate_run_id(run_id: str) -> None:
+    """Raise ValueError if run_id contains path-traversal characters."""
+    if not _VALID_RUN_ID_RE.match(run_id):
+        raise ValueError(
+            f"Invalid run_id {run_id!r}: only alphanumeric characters, hyphens, and underscores are allowed"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
-def is_audit_active() -> bool:
+def is_audit_active(project_root: Path | None = None) -> bool:
     """Return True if audit is active (TWL_AUDIT=1 env OR .audit/.active exists)."""
     if os.environ.get("TWL_AUDIT") == "1":
         return True
     try:
-        return _active_file().is_file()
+        return _active_file(project_root).is_file()
     except Exception:
         return False
 
 
-def resolve_audit_dir() -> Path | None:
+def resolve_audit_dir(project_root: Path | None = None) -> Path | None:
     """Resolve audit directory: TWL_AUDIT_DIR env → .audit/.active → None."""
     env = os.environ.get("TWL_AUDIT_DIR")
     if env:
         return Path(env)
     try:
-        active = _active_file()
+        active = _active_file(project_root)
         if active.is_file():
             data = json.loads(active.read_text(encoding="utf-8"))
             audit_dir = data.get("audit_dir")
             if audit_dir:
-                return _project_root() / audit_dir
+                root = _resolve_root(project_root)
+                resolved = root / audit_dir
+                # Ensure resolved path stays within project root
+                resolved = resolved.resolve()
+                return resolved
     except Exception:
         pass
     return None
 
 
-def audit_on(run_id: str | None = None) -> dict:
+def audit_on(run_id: str | None = None, project_root: Path | None = None) -> dict:
     """Start an audit session. Create .audit/<run-id>/ and .audit/.active."""
     if run_id is None:
         run_id = _gen_run_id()
 
-    root = _project_root()
+    _validate_run_id(run_id)
+
+    root = _resolve_root(project_root)
     audit_dir = root / ".audit" / run_id
     audit_dir.mkdir(parents=True, exist_ok=True)
 
@@ -104,34 +127,32 @@ def audit_on(run_id: str | None = None) -> dict:
     return active_data
 
 
-def audit_off() -> dict:
+def audit_off(project_root: Path | None = None) -> dict:
     """Stop an audit session. Remove .audit/.active and write index.json."""
-    active = _active_file()
+    active = _active_file(project_root)
     if not active.is_file():
         raise RuntimeError("audit is not active")
 
     data = json.loads(active.read_text(encoding="utf-8"))
     run_id = data["run_id"]
-    root = _project_root()
+    root = _resolve_root(project_root)
     audit_dir = root / ".audit" / run_id
 
     ended_at = _now_utc()
 
-    # Collect files
-    files: dict = {}
+    # Collect files as a flat list of relative paths
+    files: list[str] = []
     specialists_dir = audit_dir / "specialists"
     if specialists_dir.is_dir():
-        files["specialists"] = [
-            str(p.relative_to(audit_dir)) for p in sorted(specialists_dir.iterdir())
-        ]
+        for p in sorted(specialists_dir.iterdir()):
+            files.append(str(p.relative_to(audit_dir)))
     checkpoints_dir = audit_dir / "checkpoints"
     if checkpoints_dir.is_dir():
-        files["checkpoints"] = [
-            str(p.relative_to(audit_dir)) for p in sorted(checkpoints_dir.iterdir())
-        ]
+        for p in sorted(checkpoints_dir.iterdir()):
+            files.append(str(p.relative_to(audit_dir)))
     state_log = audit_dir / "state-log.jsonl"
     if state_log.is_file():
-        files["state_log"] = "state-log.jsonl"
+        files.append("state-log.jsonl")
 
     index = {
         "run_id": run_id,
@@ -146,9 +167,9 @@ def audit_off() -> dict:
     return index
 
 
-def audit_status() -> dict:
+def audit_status(project_root: Path | None = None) -> dict:
     """Return current audit status as dict."""
-    active = _active_file()
+    active = _active_file(project_root)
     if not active.is_file() and os.environ.get("TWL_AUDIT") != "1":
         return {"active": False}
 
@@ -165,7 +186,7 @@ def audit_status() -> dict:
             pass
 
     # TWL_AUDIT=1 but no .active file
-    audit_dir = resolve_audit_dir()
+    audit_dir = resolve_audit_dir(project_root)
     return {
         "active": True,
         "run_id": None,
@@ -192,7 +213,11 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
     if args.cmd == "on":
-        result = audit_on(args.run_id)
+        try:
+            result = audit_on(args.run_id)
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
         print(f"audit started: run_id={result['run_id']}, dir={result['audit_dir']}")
         return 0
 

--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -1,0 +1,225 @@
+"""Audit session management for autopilot execution history persistence.
+
+CLI usage:
+    python3 -m twl.autopilot.audit on [--run-id ID]
+    python3 -m twl.autopilot.audit off
+    python3 -m twl.autopilot.audit status
+
+Files:
+    .audit/.active        — active session marker (JSON)
+    .audit/<run-id>/      — session directory
+    .audit/<run-id>/index.json — session summary (written on off)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import string
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _project_root() -> Path:
+    """Resolve project root via git rev-parse --show-toplevel."""
+    import subprocess
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _active_file() -> Path:
+    return _project_root() / ".audit" / ".active"
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _gen_run_id() -> str:
+    ts = int(datetime.now(timezone.utc).timestamp())
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+    return f"{ts}_{suffix}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def is_audit_active() -> bool:
+    """Return True if audit is active (TWL_AUDIT=1 env OR .audit/.active exists)."""
+    if os.environ.get("TWL_AUDIT") == "1":
+        return True
+    try:
+        return _active_file().is_file()
+    except Exception:
+        return False
+
+
+def resolve_audit_dir() -> Path | None:
+    """Resolve audit directory: TWL_AUDIT_DIR env → .audit/.active → None."""
+    env = os.environ.get("TWL_AUDIT_DIR")
+    if env:
+        return Path(env)
+    try:
+        active = _active_file()
+        if active.is_file():
+            data = json.loads(active.read_text(encoding="utf-8"))
+            audit_dir = data.get("audit_dir")
+            if audit_dir:
+                return _project_root() / audit_dir
+    except Exception:
+        pass
+    return None
+
+
+def audit_on(run_id: str | None = None) -> dict:
+    """Start an audit session. Create .audit/<run-id>/ and .audit/.active."""
+    if run_id is None:
+        run_id = _gen_run_id()
+
+    root = _project_root()
+    audit_dir = root / ".audit" / run_id
+    audit_dir.mkdir(parents=True, exist_ok=True)
+
+    started_at = _now_utc()
+    active_data = {
+        "run_id": run_id,
+        "started_at": started_at,
+        "audit_dir": f".audit/{run_id}",
+    }
+    active_file = root / ".audit" / ".active"
+    active_file.write_text(json.dumps(active_data, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    return active_data
+
+
+def audit_off() -> dict:
+    """Stop an audit session. Remove .audit/.active and write index.json."""
+    active = _active_file()
+    if not active.is_file():
+        raise RuntimeError("audit is not active")
+
+    data = json.loads(active.read_text(encoding="utf-8"))
+    run_id = data["run_id"]
+    root = _project_root()
+    audit_dir = root / ".audit" / run_id
+
+    ended_at = _now_utc()
+
+    # Collect files
+    files: dict = {}
+    specialists_dir = audit_dir / "specialists"
+    if specialists_dir.is_dir():
+        files["specialists"] = [
+            str(p.relative_to(audit_dir)) for p in sorted(specialists_dir.iterdir())
+        ]
+    checkpoints_dir = audit_dir / "checkpoints"
+    if checkpoints_dir.is_dir():
+        files["checkpoints"] = [
+            str(p.relative_to(audit_dir)) for p in sorted(checkpoints_dir.iterdir())
+        ]
+    state_log = audit_dir / "state-log.jsonl"
+    if state_log.is_file():
+        files["state_log"] = "state-log.jsonl"
+
+    index = {
+        "run_id": run_id,
+        "started_at": data.get("started_at", ""),
+        "ended_at": ended_at,
+        "files": files,
+    }
+    index_file = audit_dir / "index.json"
+    index_file.write_text(json.dumps(index, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    active.unlink()
+    return index
+
+
+def audit_status() -> dict:
+    """Return current audit status as dict."""
+    active = _active_file()
+    if not active.is_file() and os.environ.get("TWL_AUDIT") != "1":
+        return {"active": False}
+
+    if active.is_file():
+        try:
+            data = json.loads(active.read_text(encoding="utf-8"))
+            return {
+                "active": True,
+                "run_id": data.get("run_id", ""),
+                "started_at": data.get("started_at", ""),
+                "audit_dir": data.get("audit_dir", ""),
+            }
+        except Exception:
+            pass
+
+    # TWL_AUDIT=1 but no .active file
+    audit_dir = resolve_audit_dir()
+    return {
+        "active": True,
+        "run_id": None,
+        "audit_dir": str(audit_dir) if audit_dir else None,
+        "source": "TWL_AUDIT env",
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+    parser = argparse.ArgumentParser(description="twl audit — autopilot execution history")
+    sub = parser.add_subparsers(dest="cmd", metavar="<command>")
+
+    on_p = sub.add_parser("on", help="Start audit session")
+    on_p.add_argument("--run-id", dest="run_id", default=None, help="Custom run ID")
+
+    sub.add_parser("off", help="Stop audit session and write index.json")
+    sub.add_parser("status", help="Show current audit status")
+
+    args = parser.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.cmd == "on":
+        result = audit_on(args.run_id)
+        print(f"audit started: run_id={result['run_id']}, dir={result['audit_dir']}")
+        return 0
+
+    if args.cmd == "off":
+        try:
+            result = audit_off()
+            print(f"audit stopped: run_id={result['run_id']}, ended_at={result['ended_at']}")
+            return 0
+        except RuntimeError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
+
+    if args.cmd == "status":
+        result = audit_status()
+        if result["active"]:
+            print(f"active: true")
+            if result.get("run_id"):
+                print(f"run_id: {result['run_id']}")
+            if result.get("audit_dir"):
+                print(f"audit_dir: {result['audit_dir']}")
+        else:
+            print("active: false")
+        return 0
+
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -96,8 +96,11 @@ def resolve_audit_dir(project_root: Path | None = None) -> Path | None:
             if audit_dir:
                 root = _resolve_root(project_root)
                 resolved = root / audit_dir
-                # Ensure resolved path stays within project root
                 resolved = resolved.resolve()
+                # Enforce path containment: audit_dir must stay within project root
+                root_resolved = root.resolve()
+                if not resolved.is_relative_to(root_resolved):
+                    raise ValueError(f"audit_dir is outside project root: {resolved}")
                 return resolved
     except Exception:
         pass
@@ -135,6 +138,7 @@ def audit_off(project_root: Path | None = None) -> dict:
 
     data = json.loads(active.read_text(encoding="utf-8"))
     run_id = data["run_id"]
+    _validate_run_id(run_id)
     root = _resolve_root(project_root)
     audit_dir = root / ".audit" / run_id
 

--- a/cli/twl/src/twl/autopilot/checkpoint.py
+++ b/cli/twl/src/twl/autopilot/checkpoint.py
@@ -103,6 +103,21 @@ class CheckpointManager:
             "timestamp": _now_utc(),
         }
         file = self.checkpoint_dir / f"{step}.json"
+
+        # audit 保全: 上書き前に既存ファイルをタイムスタンプ付きでコピー
+        try:
+            from twl.autopilot.audit import is_audit_active, resolve_audit_dir
+            if is_audit_active() and file.is_file():
+                audit_dir = resolve_audit_dir()
+                if audit_dir is not None:
+                    import shutil
+                    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+                    checkpoints_audit = audit_dir / "checkpoints"
+                    checkpoints_audit.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(file, checkpoints_audit / f"{step}-{ts}.json")
+        except Exception:
+            pass
+
         _atomic_write(file, data)
         return f"checkpoint written: {file} ({status}, {findings_summary})"
 

--- a/cli/twl/src/twl/autopilot/checkpoint.py
+++ b/cli/twl/src/twl/autopilot/checkpoint.py
@@ -114,7 +114,13 @@ class CheckpointManager:
                     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
                     checkpoints_audit = audit_dir / "checkpoints"
                     checkpoints_audit.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(file, checkpoints_audit / f"{step}-{ts}.json")
+                    dest = checkpoints_audit / f"{step}-{ts}.json"
+                    if dest.exists():
+                        counter = 2
+                        while (checkpoints_audit / f"{step}-{ts}-{counter}.json").exists():
+                            counter += 1
+                        dest = checkpoints_audit / f"{step}-{ts}-{counter}.json"
+                    shutil.copy2(file, dest)
         except Exception:
             pass
 

--- a/cli/twl/src/twl/autopilot/launcher.py
+++ b/cli/twl/src/twl/autopilot/launcher.py
@@ -182,15 +182,15 @@ class WorkerLauncher:
         if repo_owner and repo_name:
             env_flags += ["-e", f"REPO_OWNER={repo_owner}", "-e", f"REPO_NAME={repo_name}"]
 
-        # audit 環境変数の伝搬（resolve_audit_dir で絶対パスを解決して渡す）
-        if os.environ.get("TWL_AUDIT") == "1":
-            try:
-                from twl.autopilot.audit import resolve_audit_dir
+        # audit 環境変数の伝搬（is_audit_active で OR 条件判定、resolve_audit_dir で絶対パス解決）
+        try:
+            from twl.autopilot.audit import is_audit_active, resolve_audit_dir
+            if is_audit_active():
                 audit_dir_path = resolve_audit_dir()
                 if audit_dir_path is not None:
                     env_flags += ["-e", "TWL_AUDIT=1", "-e", f"TWL_AUDIT_DIR={audit_dir_path}"]
-            except Exception:
-                pass
+        except Exception:
+            pass
 
         cld_args = [cld_path, "--model", model]
         if context:

--- a/cli/twl/src/twl/autopilot/launcher.py
+++ b/cli/twl/src/twl/autopilot/launcher.py
@@ -182,6 +182,16 @@ class WorkerLauncher:
         if repo_owner and repo_name:
             env_flags += ["-e", f"REPO_OWNER={repo_owner}", "-e", f"REPO_NAME={repo_name}"]
 
+        # audit 環境変数の伝搬（resolve_audit_dir で絶対パスを解決して渡す）
+        if os.environ.get("TWL_AUDIT") == "1":
+            try:
+                from twl.autopilot.audit import resolve_audit_dir
+                audit_dir_path = resolve_audit_dir()
+                if audit_dir_path is not None:
+                    env_flags += ["-e", "TWL_AUDIT=1", "-e", f"TWL_AUDIT_DIR={audit_dir_path}"]
+            except Exception:
+                pass
+
         cld_args = [cld_path, "--model", model]
         if context:
             cld_args += ["--append-system-prompt", context]

--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -220,6 +220,7 @@ class StateManager:
             raise StateArgError("--set が指定されていません")
 
         data = json.loads(file.read_text(encoding="utf-8"))
+        old_data = dict(data)
 
         for kv in sets:
             key, _, raw_value = kv.partition("=")
@@ -232,6 +233,34 @@ class StateManager:
 
         if type_ == "issue":
             data["updated_at"] = _now_utc()
+
+        # audit state-log 追記
+        try:
+            from twl.autopilot.audit import is_audit_active, resolve_audit_dir
+            if is_audit_active():
+                audit_dir = resolve_audit_dir()
+                if audit_dir is not None:
+                    import datetime as _dt
+                    ts = _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                    state_log = audit_dir / "state-log.jsonl"
+                    state_log.parent.mkdir(parents=True, exist_ok=True)
+                    for kv in (sets or []):
+                        key, _, raw_value = kv.partition("=")
+                        old_val = str(old_data.get(key, ""))
+                        new_val = str(data.get(key, raw_value))
+                        if old_val != new_val:
+                            record = json.dumps({
+                                "ts": ts,
+                                "issue": int(issue) if issue and str(issue).isdigit() else issue,
+                                "field": key,
+                                "old": old_val,
+                                "new": new_val,
+                                "role": role,
+                            }, ensure_ascii=False)
+                            with open(state_log, "a", encoding="utf-8") as f:
+                                f.write(record + "\n")
+        except Exception:
+            pass
 
         self._atomic_write(file, data)
         return f"OK: {file} を更新しました"

--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -32,6 +32,11 @@ def _load_plugin_context():
 
 
 def main():
+    # audit サブコマンド（autopilot 実行履歴の永続化）
+    if len(sys.argv) >= 2 and sys.argv[1] == 'audit':
+        from twl.autopilot.audit import main as audit_main
+        sys.exit(audit_main(sys.argv[2:]))
+
     # audit-history サブコマンドの前処理（Phase 3 / Layer 1 経験的監査）
     if len(sys.argv) >= 2 and sys.argv[1] == 'audit-history':
         from twl.autopilot.audit_history import main as audit_history_main

--- a/cli/twl/tests/test_audit_checkpoint_integration.py
+++ b/cli/twl/tests/test_audit_checkpoint_integration.py
@@ -1,0 +1,257 @@
+"""Tests for audit integration in checkpoint.write() (issue-642).
+
+Covers:
+- checkpoint 保全コピー: audit 有効時に既存ファイルをタイムスタンプ付きでコピーしてから上書き
+- checkpoint 初回 write は保全不要: 既存ファイルなしのケースはコピーなし
+- audit 無効時の動作不変: コピーなしで通常の書き込みのみ
+
+Scenarios from: spec.md Requirement: checkpoint 自動保全
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+
+import pytest
+
+from twl.autopilot.checkpoint import CheckpointManager
+
+
+def _write_active(project_dir: Path, run_id: str = "cp-test-run") -> Path:
+    """Write .audit/.active and return the audit run directory."""
+    audit_dir = project_dir / ".audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = audit_dir / run_id
+    run_dir.mkdir(exist_ok=True)
+    (run_dir / "checkpoints").mkdir(exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "started_at": "2024-01-01T00:00:00Z",
+        "audit_dir": str(run_dir),
+    }
+    (audit_dir / ".active").write_text(json.dumps(payload), encoding="utf-8")
+    return run_dir
+
+
+# ===========================================================================
+# Requirement: checkpoint 自動保全
+# ===========================================================================
+
+
+class TestCheckpointAuditPreservation:
+    """Scenario: checkpoint 保全コピー"""
+
+    def test_existing_checkpoint_copied_before_overwrite(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN audit が有効で既存 phase-review.json がある状態で checkpoint.write() を実行する
+        THEN 既存ファイルが .audit/<run-id>/checkpoints/phase-review-<ISO8601>.json にコピーされ
+             新データで上書きされる"""
+        # Setup: create checkpoint dir + existing checkpoint
+        ckpt_dir = tmp_path / ".autopilot" / "checkpoints"
+        ckpt_dir.mkdir(parents=True)
+        original_data = {
+            "step": "phase-review", "status": "PASS",
+            "findings": [], "critical_count": 0,
+            "findings_summary": "0 CRITICAL, 0 WARNING",
+            "timestamp": "2024-01-01T00:00:00Z",
+        }
+        (ckpt_dir / "phase-review.json").write_text(
+            json.dumps(original_data), encoding="utf-8"
+        )
+
+        # Setup: audit active
+        run_dir = _write_active(tmp_path, run_id="cp-audit-run")
+
+        # Patch is_audit_active and resolve_audit_dir if audit module exists
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        mgr = CheckpointManager(checkpoint_dir=ckpt_dir)
+        mgr.write(step="phase-review", status="FAIL", findings=[
+            {"severity": "CRITICAL", "message": "new finding"}
+        ])
+
+        # New checkpoint written
+        new_data = json.loads((ckpt_dir / "phase-review.json").read_text())
+        assert new_data["status"] == "FAIL"
+
+        # Archived copy exists in audit dir
+        archive_dir = run_dir / "checkpoints"
+        archived = list(archive_dir.glob("phase-review-*.json"))
+        assert len(archived) == 1, \
+            f"Expected exactly 1 archived checkpoint, got: {list(archive_dir.iterdir())}"
+
+        # Archive filename has ISO8601 timestamp pattern
+        archived_name = archived[0].name
+        assert re.search(r"phase-review-\d{8}T\d{6}Z\.json", archived_name), \
+            f"Archive filename does not match expected pattern: {archived_name}"
+
+        # Archived content is the original data
+        archived_data = json.loads(archived[0].read_text())
+        assert archived_data["status"] == "PASS"
+
+    def test_first_write_no_archive_created(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN audit が有効な状態で既存ファイルなしに checkpoint.write() を実行する
+        THEN コピーなしで通常通り新規書き込みされる"""
+        ckpt_dir = tmp_path / ".autopilot" / "checkpoints"
+        ckpt_dir.mkdir(parents=True)
+
+        run_dir = _write_active(tmp_path, run_id="first-write-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        # No existing checkpoint
+        assert not (ckpt_dir / "phase-review.json").exists()
+
+        mgr = CheckpointManager(checkpoint_dir=ckpt_dir)
+        mgr.write(step="phase-review", status="PASS")
+
+        # Checkpoint created normally
+        assert (ckpt_dir / "phase-review.json").is_file()
+
+        # No archive (no previous file to copy)
+        archive_dir = run_dir / "checkpoints"
+        archived = list(archive_dir.glob("phase-review-*.json")) if archive_dir.exists() else []
+        assert len(archived) == 0, \
+            f"Expected no archived copies for first write, got: {archived}"
+
+    def test_audit_inactive_no_archive(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN audit が無効な状態で checkpoint.write() を実行する
+        THEN コピーなしで通常の書き込みのみ（既存動作不変）"""
+        ckpt_dir = tmp_path / ".autopilot" / "checkpoints"
+        ckpt_dir.mkdir(parents=True)
+        (ckpt_dir / "phase-review.json").write_text(
+            json.dumps({"step": "phase-review", "status": "PASS", "findings": []}),
+            encoding="utf-8"
+        )
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: False
+            )
+        except ImportError:
+            # audit not implemented — assume checkpoint behaves normally
+            pass
+
+        mgr = CheckpointManager(checkpoint_dir=ckpt_dir)
+        mgr.write(step="phase-review", status="FAIL")
+
+        # New data written
+        data = json.loads((ckpt_dir / "phase-review.json").read_text())
+        assert data["status"] == "FAIL"
+
+        # No audit directory created
+        audit_dir = tmp_path / ".audit"
+        if audit_dir.exists():
+            for run_dir in audit_dir.iterdir():
+                cp_dir = run_dir / "checkpoints"
+                if cp_dir.exists():
+                    assert list(cp_dir.glob("phase-review-*.json")) == [], \
+                        "Audit archive should not be created when audit is inactive"
+
+    def test_multiple_writes_create_multiple_archives(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: 複数回 write すると複数のアーカイブが作成される"""
+        ckpt_dir = tmp_path / ".autopilot" / "checkpoints"
+        ckpt_dir.mkdir(parents=True)
+        run_dir = _write_active(tmp_path, run_id="multi-write-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        mgr = CheckpointManager(checkpoint_dir=ckpt_dir)
+        mgr.write(step="phase-review", status="PASS")  # first: no archive
+        time.sleep(0.01)  # ensure different timestamps
+        mgr.write(step="phase-review", status="WARN")  # second: archives first
+        time.sleep(0.01)
+        mgr.write(step="phase-review", status="FAIL")  # third: archives second
+
+        archive_dir = run_dir / "checkpoints"
+        archived = list(archive_dir.glob("phase-review-*.json")) if archive_dir.exists() else []
+        assert len(archived) >= 2, \
+            f"Expected at least 2 archives after 3 writes, got {len(archived)}: {archived}"
+
+
+# ===========================================================================
+# Edge cases: archive timestamp format
+# ===========================================================================
+
+
+class TestCheckpointArchiveTimestamp:
+    def test_archive_filename_timestamp_format(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: アーカイブファイル名のタイムスタンプが YYYYMMDDTHHMMSSz 形式"""
+        ckpt_dir = tmp_path / ".autopilot" / "checkpoints"
+        ckpt_dir.mkdir(parents=True)
+        (ckpt_dir / "e2e-screening.json").write_text(
+            json.dumps({"step": "e2e-screening", "status": "PASS", "findings": []}),
+            encoding="utf-8"
+        )
+        run_dir = _write_active(tmp_path, run_id="ts-format-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        mgr = CheckpointManager(checkpoint_dir=ckpt_dir)
+        mgr.write(step="e2e-screening", status="FAIL")
+
+        archive_dir = run_dir / "checkpoints"
+        archived = list(archive_dir.glob("e2e-screening-*.json")) if archive_dir.exists() else []
+        assert archived, "Expected at least one archived file"
+        # Check: YYYYMMDDTHHMMSSz pattern
+        pattern = re.compile(r"e2e-screening-\d{8}T\d{6}Z\.json")
+        assert pattern.match(archived[0].name), \
+            f"Archive filename format mismatch: {archived[0].name}"

--- a/cli/twl/tests/test_audit_gitignore.py
+++ b/cli/twl/tests/test_audit_gitignore.py
@@ -1,0 +1,139 @@
+"""Tests for .gitignore and deps.yaml requirements (issue-642).
+
+Covers:
+- .gitignore への .audit/ 追加: .audit/ が gitignore で除外されているか
+- deps.yaml への audit.py エントリ追加: loom --check が通るか
+
+Scenarios from: spec.md Requirement: .gitignore への .audit/ 追加 / deps.yaml への audit.py エントリ追加
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Project root detection
+# ---------------------------------------------------------------------------
+
+def _find_repo_root() -> Path:
+    """Find the git repo root from the test file's location."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent),
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip())
+    except Exception:
+        pass
+    return Path(__file__).parent.parent.parent.parent.parent
+
+
+# ===========================================================================
+# Requirement: .gitignore への .audit/ 追加
+# ===========================================================================
+
+
+class TestGitignoreAuditDir:
+    """Scenario: .audit/ の gitignore 確認"""
+
+    def test_audit_dir_in_gitignore(self) -> None:
+        """WHEN .audit/ ディレクトリが作成される
+        THEN git status に untracked として表示されない（gitignore によって除外される）"""
+        repo_root = _find_repo_root()
+        gitignore_candidates = [
+            repo_root / ".gitignore",
+            Path(__file__).parent.parent.parent.parent.parent / ".gitignore",
+        ]
+
+        gitignore_content = ""
+        for candidate in gitignore_candidates:
+            if candidate.is_file():
+                gitignore_content = candidate.read_text(encoding="utf-8")
+                break
+
+        if not gitignore_content:
+            pytest.skip("No .gitignore found — cannot verify .audit/ exclusion")
+
+        # .audit/ must appear in .gitignore
+        lines = gitignore_content.splitlines()
+        matching_lines = [
+            line.strip() for line in lines
+            if line.strip() in (".audit/", ".audit", "/.audit/", "/.audit")
+        ]
+        assert matching_lines, \
+            f".audit/ not found in .gitignore. Current entries: {lines[:20]}"
+
+    def test_audit_dir_not_tracked_by_git(self, tmp_path: Path) -> None:
+        """Edge case: git check-ignore で .audit/ が除外されることを確認"""
+        repo_root = _find_repo_root()
+        audit_candidate = repo_root / ".audit"
+
+        result = subprocess.run(
+            ["git", "check-ignore", "-q", ".audit/"],
+            capture_output=True,
+            text=True,
+            cwd=str(repo_root),
+        )
+        # Exit code 0 means the path IS ignored (matched by .gitignore)
+        # Exit code 1 means NOT ignored
+        assert result.returncode == 0, \
+            f".audit/ is NOT excluded by .gitignore (git check-ignore returned {result.returncode}). " \
+            f"Add '.audit/' to .gitignore in the repo root."
+
+
+# ===========================================================================
+# Requirement: deps.yaml への audit.py エントリ追加
+# ===========================================================================
+
+
+class TestDepsYamlAuditEntry:
+    """Scenario: deps.yaml の audit.py エントリ"""
+
+    def _find_deps_yaml(self) -> Path | None:
+        """Find the main twl plugin deps.yaml (not test-fixture)."""
+        # Primary: plugins/twl/deps.yaml relative to repo root
+        repo_root = _find_repo_root()
+        primary = repo_root / "plugins" / "twl" / "deps.yaml"
+        if primary.is_file():
+            return primary
+
+        # Fallback: test file parent traversal
+        candidate = Path(__file__).parent.parent.parent.parent.parent / "plugins" / "twl" / "deps.yaml"
+        if candidate.is_file():
+            return candidate
+
+        return None
+
+    def test_audit_py_entry_in_deps_yaml(self) -> None:
+        """WHEN loom --check が実行される
+        THEN audit.py が deps.yaml に登録されておりチェックが通る"""
+        deps_yaml = self._find_deps_yaml()
+        if deps_yaml is None:
+            pytest.skip("deps.yaml not found")
+
+        content = deps_yaml.read_text(encoding="utf-8")
+        assert "audit" in content, \
+            f"'audit' not found in {deps_yaml}. " \
+            f"The audit.py module must be registered in deps.yaml."
+
+    def test_audit_py_path_in_deps_yaml(self) -> None:
+        """Edge case: deps.yaml に audit.py のパスエントリが存在する"""
+        deps_yaml = self._find_deps_yaml()
+        if deps_yaml is None:
+            pytest.skip("deps.yaml not found")
+
+        content = deps_yaml.read_text(encoding="utf-8")
+        # Check for audit.py reference (either as path or as module name)
+        has_audit_py = "audit.py" in content or (
+            "audit" in content and "autopilot" in content
+        )
+        assert has_audit_py, \
+            f"audit.py module not found in deps.yaml. " \
+            f"Expected an entry referencing 'audit.py' in the autopilot section."

--- a/cli/twl/tests/test_audit_launcher_integration.py
+++ b/cli/twl/tests/test_audit_launcher_integration.py
@@ -1,0 +1,238 @@
+"""Tests for audit integration in launcher.py (issue-642).
+
+Covers:
+- Worker への audit 環境変数伝搬: TWL_AUDIT=1 時に TWL_AUDIT=1 と TWL_AUDIT_DIR=<絶対パス> が env_flags に設定される
+- TWL_AUDIT 未設定時は env_flags に audit 関連フラグが追加されない
+- launcher が resolve_audit_dir() を呼び出して絶対パスを設定する責任を持つ
+
+Scenarios from: spec.md Requirement: launcher による TWL_AUDIT_DIR 伝搬
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from twl.autopilot.launcher import WorkerLauncher
+
+
+def _write_active(project_dir: Path, run_id: str = "launcher-run") -> Path:
+    """Write .audit/.active and return the audit run directory."""
+    audit_dir = project_dir / ".audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = audit_dir / run_id
+    run_dir.mkdir(exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "started_at": "2024-01-01T00:00:00Z",
+        "audit_dir": str(run_dir),
+    }
+    (audit_dir / ".active").write_text(json.dumps(payload), encoding="utf-8")
+    return run_dir
+
+
+def _collect_env_flags(env_flags: list[str]) -> dict[str, str]:
+    """Parse ['-e', 'K=V', '-e', 'K2=V2'] into {'K': 'V', 'K2': 'V2'}."""
+    result = {}
+    i = 0
+    while i < len(env_flags):
+        if env_flags[i] == "-e" and i + 1 < len(env_flags):
+            kv = env_flags[i + 1]
+            k, _, v = kv.partition("=")
+            result[k] = v
+            i += 2
+        else:
+            i += 1
+    return result
+
+
+# ===========================================================================
+# Requirement: launcher による TWL_AUDIT_DIR 伝搬
+# ===========================================================================
+
+
+class TestLauncherAuditEnvPropagation:
+    """Scenario: Worker への audit 環境変数伝搬"""
+
+    def test_audit_env_flags_set_when_twl_audit_is_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN TWL_AUDIT=1 が設定された状態で launcher が Worker を起動する
+        THEN env_flags に TWL_AUDIT=1 と TWL_AUDIT_DIR=<絶対パス> が設定される"""
+        monkeypatch.setenv("TWL_AUDIT", "1")
+        run_dir = _write_active(tmp_path, run_id="env-prop-run")
+        monkeypatch.setenv("TWL_AUDIT_DIR", str(run_dir))
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        captured_tmux_argv: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            captured_tmux_argv.append(argv)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = ""
+            return mock
+
+        ap_dir = tmp_path / ".autopilot"
+        ap_dir.mkdir()
+        (ap_dir / "issues").mkdir()
+
+        launcher = WorkerLauncher(scripts_root=tmp_path / "scripts")
+
+        with patch("twl.autopilot.launcher.subprocess.run", side_effect=fake_run), \
+             patch("twl.autopilot.launcher.shutil.which", return_value="/usr/bin/cld"), \
+             patch("twl.autopilot.launcher.WorkerLauncher._detect_quick_label", return_value=False):
+            try:
+                launcher.launch(
+                    issue="1",
+                    project_dir=str(tmp_path),
+                    autopilot_dir=str(ap_dir),
+                    model="sonnet",
+                )
+            except Exception:
+                pass  # State init may fail in isolation — we care about tmux argv
+
+        # Find the tmux new-window call
+        tmux_calls = [a for a in captured_tmux_argv if a and a[0] == "tmux" and "new-window" in a]
+        if not tmux_calls:
+            pytest.skip("No tmux call captured — launcher integration not yet modified for audit")
+
+        tmux_argv = tmux_calls[0]
+        env_flags = _collect_env_flags(tmux_argv)
+
+        assert "TWL_AUDIT" in env_flags, \
+            f"TWL_AUDIT not in env_flags: {env_flags}"
+        assert env_flags["TWL_AUDIT"] == "1"
+        assert "TWL_AUDIT_DIR" in env_flags, \
+            f"TWL_AUDIT_DIR not in env_flags: {env_flags}"
+        assert Path(env_flags["TWL_AUDIT_DIR"]).is_absolute(), \
+            f"TWL_AUDIT_DIR is not absolute: {env_flags['TWL_AUDIT_DIR']}"
+        assert env_flags["TWL_AUDIT_DIR"] == str(run_dir)
+
+    def test_no_audit_env_when_twl_audit_not_set(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN TWL_AUDIT が未設定の状態で launcher が Worker を起動する
+        THEN env_flags に TWL_AUDIT_DIR が追加されない"""
+        monkeypatch.delenv("TWL_AUDIT", raising=False)
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: False
+            )
+        except ImportError:
+            pass  # OK — we verify env_flags don't contain TWL_AUDIT_DIR
+
+        captured_tmux_argv: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            captured_tmux_argv.append(argv)
+            mock = MagicMock()
+            mock.returncode = 0
+            mock.stdout = ""
+            return mock
+
+        ap_dir = tmp_path / ".autopilot"
+        ap_dir.mkdir()
+        (ap_dir / "issues").mkdir()
+
+        launcher = WorkerLauncher(scripts_root=tmp_path / "scripts")
+
+        with patch("twl.autopilot.launcher.subprocess.run", side_effect=fake_run), \
+             patch("twl.autopilot.launcher.shutil.which", return_value="/usr/bin/cld"), \
+             patch("twl.autopilot.launcher.WorkerLauncher._detect_quick_label", return_value=False):
+            try:
+                launcher.launch(
+                    issue="1",
+                    project_dir=str(tmp_path),
+                    autopilot_dir=str(ap_dir),
+                    model="sonnet",
+                )
+            except Exception:
+                pass
+
+        tmux_calls = [a for a in captured_tmux_argv if a and a[0] == "tmux" and "new-window" in a]
+        if not tmux_calls:
+            return  # No tmux call — acceptable if audit not integrated
+
+        tmux_argv = tmux_calls[0]
+        env_flags = _collect_env_flags(tmux_argv)
+
+        assert "TWL_AUDIT_DIR" not in env_flags, \
+            f"TWL_AUDIT_DIR should NOT be in env_flags when audit is inactive: {env_flags}"
+
+    def test_audit_dir_is_absolute_path_in_env_flags(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: TWL_AUDIT_DIR に設定されるパスは絶対パス（resolve_audit_dir() の結果）"""
+        monkeypatch.setenv("TWL_AUDIT", "1")
+        run_dir = tmp_path / ".audit" / "abs-test"
+        run_dir.mkdir(parents=True)
+        monkeypatch.setenv("TWL_AUDIT_DIR", str(run_dir))
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        captured: list[list[str]] = []
+
+        def fake_run(argv, **kwargs):
+            captured.append(argv)
+            m = MagicMock()
+            m.returncode = 0
+            m.stdout = ""
+            return m
+
+        ap_dir = tmp_path / ".autopilot"
+        ap_dir.mkdir(exist_ok=True)
+        (ap_dir / "issues").mkdir(exist_ok=True)
+        launcher = WorkerLauncher(scripts_root=tmp_path / "scripts")
+
+        with patch("twl.autopilot.launcher.subprocess.run", side_effect=fake_run), \
+             patch("twl.autopilot.launcher.shutil.which", return_value="/usr/bin/cld"), \
+             patch("twl.autopilot.launcher.WorkerLauncher._detect_quick_label", return_value=False):
+            try:
+                launcher.launch(
+                    issue="2",
+                    project_dir=str(tmp_path),
+                    autopilot_dir=str(ap_dir),
+                    model="sonnet",
+                )
+            except Exception:
+                pass
+
+        tmux_calls = [a for a in captured if a and a[0] == "tmux" and "new-window" in a]
+        if not tmux_calls:
+            pytest.skip("No tmux call captured")
+
+        env_flags = _collect_env_flags(tmux_calls[0])
+        if "TWL_AUDIT_DIR" in env_flags:
+            assert Path(env_flags["TWL_AUDIT_DIR"]).is_absolute(), \
+                f"TWL_AUDIT_DIR must be absolute: {env_flags['TWL_AUDIT_DIR']}"

--- a/cli/twl/tests/test_audit_module.py
+++ b/cli/twl/tests/test_audit_module.py
@@ -1,0 +1,480 @@
+"""Tests for twl.autopilot.audit (issue-642: twl audit subcommand).
+
+Covers:
+- is_audit_active(): env var, .active file, neither
+- resolve_audit_dir(): TWL_AUDIT_DIR env, .active file, neither
+- audit_on(): auto-generate run-id, explicit run-id, creates dir + .active
+- audit_off(): removes .active, writes index.json, error if not active
+- audit_status(): active state output, inactive state output
+
+All scenarios from deltaspec/changes/issue-642/specs/audit-subcommand/spec.md.
+Edge cases: concurrent .active writes, malformed .active JSON, path edge cases.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Lazy import helpers — audit.py does not exist yet, tests guard with skip
+# ---------------------------------------------------------------------------
+
+def _import_audit():
+    """Import audit module, skip test if not yet implemented."""
+    try:
+        import twl.autopilot.audit as audit  # type: ignore[import]
+        return audit
+    except ImportError:
+        pytest.skip("twl.autopilot.audit not yet implemented")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """Isolated project directory with .audit/ ready."""
+    audit_dir = tmp_path / ".audit"
+    audit_dir.mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def active_file(project_dir: Path) -> Path:
+    """Return the path to .audit/.active within project_dir."""
+    return project_dir / ".audit" / ".active"
+
+
+def _write_active(project_dir: Path, run_id: str = "test-run-001") -> dict:
+    """Helper: write a valid .audit/.active file."""
+    audit_dir = project_dir / ".audit"
+    audit_dir.mkdir(exist_ok=True)
+    run_dir = audit_dir / run_id
+    run_dir.mkdir(exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "started_at": "2024-01-01T00:00:00Z",
+        "audit_dir": str(run_dir),
+    }
+    (audit_dir / ".active").write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+# ===========================================================================
+# Requirement: is_audit_active()
+# ===========================================================================
+
+
+class TestIsAuditActive:
+    """Scenarios: 環境変数での有効化 / ファイルでの有効化 / 無効状態"""
+
+    def test_env_var_twl_audit_1_returns_true(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT=1 が設定されている THEN is_audit_active() が True を返す"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT", "1")
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        assert audit.is_audit_active(project_root=project_dir) is True
+
+    def test_active_file_returns_true_without_env(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN .audit/.active が存在する THEN is_audit_active() が True を返す（環境変数なしでも）"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT", raising=False)
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        _write_active(project_dir)
+        assert audit.is_audit_active(project_root=project_dir) is True
+
+    def test_neither_env_nor_file_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT 未設定かつ .audit/.active が存在しない THEN False を返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT", raising=False)
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        # Ensure .active does not exist
+        active = project_dir / ".audit" / ".active"
+        active.unlink(missing_ok=True)
+        assert audit.is_audit_active(project_root=project_dir) is False
+
+    def test_env_var_zero_does_not_activate(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: TWL_AUDIT=0 は有効化しない"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT", "0")
+        active = project_dir / ".audit" / ".active"
+        active.unlink(missing_ok=True)
+        assert audit.is_audit_active(project_root=project_dir) is False
+
+    def test_env_var_empty_string_does_not_activate(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: TWL_AUDIT='' は有効化しない"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT", "")
+        active = project_dir / ".audit" / ".active"
+        active.unlink(missing_ok=True)
+        assert audit.is_audit_active(project_root=project_dir) is False
+
+    def test_both_env_and_file_returns_true(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: 両方存在しても True"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT", "1")
+        _write_active(project_dir)
+        assert audit.is_audit_active(project_root=project_dir) is True
+
+
+# ===========================================================================
+# Requirement: resolve_audit_dir()
+# ===========================================================================
+
+
+class TestResolveAuditDir:
+    """Scenarios: 環境変数からの解決 / .active ファイルからの解決"""
+
+    def test_env_var_twl_audit_dir_returned(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT_DIR=/abs/path THEN resolve_audit_dir() が Path を返す"""
+        audit = _import_audit()
+        expected = "/abs/path/to/audit"
+        monkeypatch.setenv("TWL_AUDIT_DIR", expected)
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result == Path(expected)
+
+    def test_active_file_audit_dir_returned(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT_DIR 未設定で .audit/.active が存在する THEN audit_dir フィールドを返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        payload = _write_active(project_dir, run_id="run-20240101")
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result is not None
+        assert result == Path(payload["audit_dir"])
+        assert result.is_absolute()
+
+    def test_neither_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT_DIR 未設定かつ .active なし THEN None を返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        (project_dir / ".audit" / ".active").unlink(missing_ok=True)
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result is None
+
+    def test_env_var_takes_priority_over_active_file(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: TWL_AUDIT_DIR が .active より優先される"""
+        audit = _import_audit()
+        env_path = "/env/path/audit"
+        monkeypatch.setenv("TWL_AUDIT_DIR", env_path)
+        _write_active(project_dir, run_id="other-run")
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result == Path(env_path)
+
+    def test_active_file_relative_audit_dir_resolved_to_absolute(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: .active の audit_dir が相対パスでも絶対パスで返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        audit_dir = project_dir / ".audit"
+        run_dir = audit_dir / "rel-run"
+        run_dir.mkdir(exist_ok=True)
+        # Write .active with relative path
+        payload = {
+            "run_id": "rel-run",
+            "started_at": "2024-01-01T00:00:00Z",
+            "audit_dir": ".audit/rel-run",  # relative
+        }
+        (audit_dir / ".active").write_text(json.dumps(payload), encoding="utf-8")
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result is not None
+        assert result.is_absolute()
+
+    def test_malformed_active_file_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: .active が不正 JSON でも例外にならず None を返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        (project_dir / ".audit" / ".active").write_text("NOT_JSON", encoding="utf-8")
+        result = audit.resolve_audit_dir(project_root=project_dir)
+        assert result is None
+
+
+# ===========================================================================
+# Requirement: twl audit on サブコマンド
+# ===========================================================================
+
+
+class TestAuditOn:
+    """Scenarios: run-id 自動生成で audit on / 指定 run-id で audit on"""
+
+    def test_auto_generated_run_id_creates_dir_and_active(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN audit_on() を run_id なしで呼び出す
+        THEN .audit/<timestamp>_<random>/ ディレクトリと .active が作成される"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT_DIR", raising=False)
+        result = audit.audit_on(project_root=project_dir)
+
+        run_id = result["run_id"]
+        # Format: <unix_timestamp>_<4char>
+        assert re.match(r"^\d+_[a-zA-Z0-9]{4}$", run_id), \
+            f"Expected <timestamp>_<4char> format, got: {run_id}"
+
+        # Directory created
+        run_dir = project_dir / ".audit" / run_id
+        assert run_dir.is_dir(), f"run dir not created: {run_dir}"
+
+        # .active file created
+        active = project_dir / ".audit" / ".active"
+        assert active.is_file()
+
+        # .active content
+        data = json.loads(active.read_text())
+        assert data["run_id"] == run_id
+        assert "started_at" in data
+        assert "audit_dir" in data
+
+    def test_explicit_run_id_creates_named_dir(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN audit_on(run_id='my-run-001') THEN .audit/my-run-001/ が作成され .active の run_id が 'my-run-001'"""
+        audit = _import_audit()
+        result = audit.audit_on(run_id="my-run-001", project_root=project_dir)
+
+        assert result["run_id"] == "my-run-001"
+
+        run_dir = project_dir / ".audit" / "my-run-001"
+        assert run_dir.is_dir()
+
+        active = project_dir / ".audit" / ".active"
+        data = json.loads(active.read_text())
+        assert data["run_id"] == "my-run-001"
+
+    def test_active_json_has_required_fields(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: .active の JSON に必須フィールドが全て含まれる"""
+        audit = _import_audit()
+        audit.audit_on(run_id="field-check", project_root=project_dir)
+        data = json.loads((project_dir / ".audit" / ".active").read_text())
+        assert "run_id" in data
+        assert "started_at" in data
+        assert "audit_dir" in data
+
+    def test_audit_dir_field_is_absolute_path(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: .active の audit_dir は絶対パス"""
+        audit = _import_audit()
+        audit.audit_on(run_id="abs-path-check", project_root=project_dir)
+        data = json.loads((project_dir / ".audit" / ".active").read_text())
+        assert Path(data["audit_dir"]).is_absolute()
+
+    def test_run_id_auto_unique_on_rapid_calls(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: 連続呼び出しで run-id が衝突しない"""
+        audit = _import_audit()
+        r1 = audit.audit_on(project_root=project_dir)
+        # Remove .active to simulate second call
+        (project_dir / ".audit" / ".active").unlink(missing_ok=True)
+        r2 = audit.audit_on(project_root=project_dir)
+        assert r1["run_id"] != r2["run_id"], "run-ids must be unique"
+
+    def test_special_chars_in_run_id_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: run-id にパストラバーサル文字が含まれる場合は拒否する"""
+        audit = _import_audit()
+        with pytest.raises((ValueError, OSError, Exception)):
+            audit.audit_on(run_id="../evil", project_root=project_dir)
+
+
+# ===========================================================================
+# Requirement: twl audit off サブコマンド
+# ===========================================================================
+
+
+class TestAuditOff:
+    """Scenarios: 正常な audit off / audit 未開始での off"""
+
+    def test_normal_off_removes_active_and_creates_index(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN .active が存在する状態で audit_off() を呼び出す
+        THEN .active が削除され、.audit/<run-id>/index.json が作成される"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="off-test-001")
+
+        audit.audit_off(project_root=project_dir)
+
+        # .active removed
+        active = project_dir / ".audit" / ".active"
+        assert not active.exists(), ".active should be removed after audit off"
+
+        # index.json created
+        index_path = project_dir / ".audit" / "off-test-001" / "index.json"
+        assert index_path.is_file(), f"index.json not created: {index_path}"
+
+        data = json.loads(index_path.read_text())
+        assert data["run_id"] == "off-test-001"
+        assert "started_at" in data
+        assert "ended_at" in data
+        assert "files" in data
+
+    def test_index_json_schema(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: index.json が {run_id, started_at, ended_at, files} を持つ"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="schema-check")
+        audit.audit_off(project_root=project_dir)
+
+        index_path = project_dir / ".audit" / "schema-check" / "index.json"
+        data = json.loads(index_path.read_text())
+        for field in ("run_id", "started_at", "ended_at", "files"):
+            assert field in data, f"Missing field: {field}"
+        assert isinstance(data["files"], list)
+
+    def test_off_without_active_raises_error(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN .active が存在しない状態で audit_off() を呼び出す
+        THEN 'audit is not active' を示すエラーが発生する"""
+        audit = _import_audit()
+        (project_dir / ".audit" / ".active").unlink(missing_ok=True)
+
+        with pytest.raises(Exception, match="not active|not_active|audit.*inactive"):
+            audit.audit_off(project_root=project_dir)
+
+    def test_off_cleans_up_active_atomically(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: off 後に .active が残存しないことを確認"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="atomic-off")
+        audit.audit_off(project_root=project_dir)
+        assert not (project_dir / ".audit" / ".active").exists()
+
+    def test_ended_at_is_iso8601(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: index.json の ended_at が ISO8601 形式"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="ts-check")
+        audit.audit_off(project_root=project_dir)
+        index_path = project_dir / ".audit" / "ts-check" / "index.json"
+        data = json.loads(index_path.read_text())
+        ended_at = data["ended_at"]
+        # Should be parseable ISO8601
+        assert "T" in ended_at and "Z" in ended_at, \
+            f"ended_at is not ISO8601: {ended_at}"
+
+
+# ===========================================================================
+# Requirement: twl audit status サブコマンド
+# ===========================================================================
+
+
+class TestAuditStatus:
+    """Scenarios: audit active 時の status / audit inactive 時の status"""
+
+    def test_status_active_returns_true_with_run_id(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN .active が存在する状態で audit_status() を呼び出す
+        THEN active: True, run_id, audit_dir を含む情報を返す"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="status-active-001")
+        result = audit.audit_status(project_root=project_dir)
+
+        assert result["active"] is True
+        assert result["run_id"] == "status-active-001"
+        assert "audit_dir" in result
+
+    def test_status_inactive_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN .active が存在しない状態で audit_status() を呼び出す
+        THEN active: False を返す"""
+        audit = _import_audit()
+        monkeypatch.delenv("TWL_AUDIT", raising=False)
+        (project_dir / ".audit" / ".active").unlink(missing_ok=True)
+        result = audit.audit_status(project_root=project_dir)
+
+        assert result["active"] is False
+
+    def test_status_active_audit_dir_is_absolute(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: status の audit_dir は絶対パス"""
+        audit = _import_audit()
+        _write_active(project_dir, run_id="abs-status")
+        result = audit.audit_status(project_root=project_dir)
+        assert Path(result["audit_dir"]).is_absolute()
+
+    def test_status_via_env_var_active(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path, tmp_path: Path
+    ) -> None:
+        """Edge case: .active なしでも TWL_AUDIT=1 なら is_audit_active=True"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT", "1")
+        (project_dir / ".audit" / ".active").unlink(missing_ok=True)
+        # audit_status may return active=True when env var is set
+        result = audit.audit_status(project_root=project_dir)
+        assert result["active"] is True
+
+
+# ===========================================================================
+# Requirement: run-id 形式バリデーション (edge cases)
+# ===========================================================================
+
+
+class TestRunIdFormat:
+    """Auto-generated run-id が <unix-timestamp>_<4文字ランダム> 形式であることを確認"""
+
+    def test_auto_run_id_matches_pattern(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        audit = _import_audit()
+        result = audit.audit_on(project_root=project_dir)
+        run_id = result["run_id"]
+        pattern = re.compile(r"^\d{10,}_[a-zA-Z0-9]{4}$")
+        assert pattern.match(run_id), \
+            f"run_id '{run_id}' does not match <unix_timestamp>_<4char>"
+
+    def test_auto_run_id_timestamp_is_recent(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """Edge case: 自動生成 run-id のタイムスタンプ部が現在時刻に近い"""
+        audit = _import_audit()
+        before = int(time.time())
+        result = audit.audit_on(project_root=project_dir)
+        after = int(time.time())
+        run_id = result["run_id"]
+        ts_part = int(run_id.split("_")[0])
+        assert before <= ts_part <= after + 1, \
+            f"Timestamp {ts_part} is not in range [{before}, {after}]"

--- a/cli/twl/tests/test_audit_state_integration.py
+++ b/cli/twl/tests/test_audit_state_integration.py
@@ -1,0 +1,319 @@
+"""Tests for audit integration in state.py write methods (issue-642).
+
+Covers:
+- state 変更のログ記録: audit 有効時に変更フィールド・変更前後の値を state-log.jsonl に追記
+- 変更なし時はログ不記録: 同一値を設定した場合は JSONL への追記なし
+- ログエントリのスキーマ: {ts, issue, field, old, new, role}
+
+Scenarios from: spec.md Requirement: state 遷移ログ
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from twl.autopilot.state import StateManager
+
+
+def _write_active(project_dir: Path, run_id: str = "state-test-run") -> Path:
+    """Write .audit/.active and return the audit run directory."""
+    audit_dir = project_dir / ".audit"
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    run_dir = audit_dir / run_id
+    run_dir.mkdir(exist_ok=True)
+    payload = {
+        "run_id": run_id,
+        "started_at": "2024-01-01T00:00:00Z",
+        "audit_dir": str(run_dir),
+    }
+    (audit_dir / ".active").write_text(json.dumps(payload), encoding="utf-8")
+    return run_dir
+
+
+def _create_autopilot_dir(tmp_path: Path, issue: str = "1") -> tuple[Path, Path]:
+    """Create autopilot dir with issues subdir and return (autopilot_dir, issues_dir)."""
+    ap_dir = tmp_path / ".autopilot"
+    issues_dir = ap_dir / "issues"
+    issues_dir.mkdir(parents=True)
+    return ap_dir, issues_dir
+
+
+def _init_issue(state: StateManager, issue: str = "1") -> None:
+    state.write(type_="issue", role="worker", issue=issue, init=True)
+
+
+def _read_state_log(run_dir: Path) -> list[dict]:
+    """Read all JSONL entries from state-log.jsonl."""
+    log_file = run_dir / "state-log.jsonl"
+    if not log_file.exists():
+        return []
+    entries = []
+    for line in log_file.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line:
+            entries.append(json.loads(line))
+    return entries
+
+
+# ===========================================================================
+# Requirement: state 遷移ログ
+# ===========================================================================
+
+
+class TestStateAuditLog:
+    """Scenario: state 変更のログ記録"""
+
+    def test_field_change_appended_to_state_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN audit が有効な状態で state.write() がフィールドを変更する
+        THEN {ts, issue, field, old, new, role} が state-log.jsonl に追記される"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="state-log-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="42")
+        state.write(
+            type_="issue", role="worker", issue="42",
+            sets=["current_step=phase-review"],
+        )
+
+        entries = _read_state_log(run_dir)
+        assert len(entries) >= 1, f"Expected at least 1 log entry, got {entries}"
+
+        entry = next(
+            (e for e in entries if e.get("field") == "current_step"),
+            None
+        )
+        assert entry is not None, \
+            f"No log entry for field=current_step, got: {entries}"
+
+        assert "ts" in entry
+        assert entry["field"] == "current_step"
+        assert entry["new"] == "phase-review"
+        assert "old" in entry
+        assert "role" in entry
+        assert entry["role"] in ("worker", "pilot")
+        assert "issue" in entry
+
+    def test_log_entry_schema_complete(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: ログエントリに必須フィールド {ts, issue, field, old, new, role} が全て含まれる"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="schema-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="7")
+        state.write(
+            type_="issue", role="worker", issue="7",
+            sets=["current_step=merge-gate"],
+        )
+
+        entries = _read_state_log(run_dir)
+        assert entries, "No log entries written"
+        entry = entries[-1]
+        for required_key in ("ts", "issue", "field", "old", "new", "role"):
+            assert required_key in entry, \
+                f"Missing required key '{required_key}' in log entry: {entry}"
+
+    def test_no_change_no_log_entry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """WHEN audit が有効な状態で write が既存値と同一の値を設定する
+        THEN state-log.jsonl への追記は行われない"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="no-change-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="5")
+        # Set initial value
+        state.write(
+            type_="issue", role="worker", issue="5",
+            sets=["current_step=phase-review"],
+        )
+        entries_after_first = _read_state_log(run_dir)
+        count_after_first = len(entries_after_first)
+
+        # Set same value again
+        state.write(
+            type_="issue", role="worker", issue="5",
+            sets=["current_step=phase-review"],
+        )
+        entries_after_second = _read_state_log(run_dir)
+        assert len(entries_after_second) == count_after_first, \
+            f"Expected no new log entries for unchanged field. " \
+            f"Before: {count_after_first}, After: {len(entries_after_second)}"
+
+    def test_multiple_fields_each_logged(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: 複数フィールドを一度に変更した場合、それぞれがログに記録される"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="multi-field-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="10")
+        state.write(
+            type_="issue", role="worker", issue="10",
+            sets=["current_step=phase-review", "retry_count=1"],
+        )
+
+        entries = _read_state_log(run_dir)
+        fields_logged = {e.get("field") for e in entries}
+        assert "current_step" in fields_logged, \
+            f"current_step not logged. Entries: {entries}"
+
+    def test_role_recorded_in_log(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: ログエントリの role が write 呼び出し時の role と一致する"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="role-log-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="20")
+        state.write(
+            type_="issue", role="worker", issue="20",
+            sets=["current_step=worker-step"],
+        )
+
+        entries = _read_state_log(run_dir)
+        entry = next(
+            (e for e in entries if e.get("field") == "current_step"),
+            None
+        )
+        assert entry is not None
+        assert entry["role"] == "worker"
+
+    def test_log_is_valid_jsonl(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: state-log.jsonl の各行が有効な JSON"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+        run_dir = _write_active(tmp_path, run_id="jsonl-valid-run")
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: True
+            )
+            monkeypatch.setattr(
+                audit_mod, "resolve_audit_dir",
+                lambda project_root=None: run_dir
+            )
+        except ImportError:
+            pytest.skip("twl.autopilot.audit not yet implemented")
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="99")
+        state.write(type_="issue", role="worker", issue="99", sets=["current_step=a"])
+        state.write(type_="issue", role="worker", issue="99", sets=["current_step=b"])
+
+        log_file = run_dir / "state-log.jsonl"
+        if not log_file.exists():
+            pytest.skip("state-log.jsonl not created (audit integration not implemented)")
+
+        for i, line in enumerate(log_file.read_text(encoding="utf-8").splitlines()):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                json.loads(line)
+            except json.JSONDecodeError as e:
+                pytest.fail(f"Line {i+1} is not valid JSON: {line!r} — {e}")
+
+    def test_audit_inactive_no_log_written(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: audit が無効な場合は state-log.jsonl に書き込まない"""
+        ap_dir, _ = _create_autopilot_dir(tmp_path)
+
+        try:
+            import twl.autopilot.audit as audit_mod  # type: ignore[import]
+            monkeypatch.setattr(
+                audit_mod, "is_audit_active",
+                lambda project_root=None: False
+            )
+        except ImportError:
+            pass  # audit not implemented: no integration, test still validates no crash
+
+        state = StateManager(autopilot_dir=ap_dir)
+        _init_issue(state, issue="3")
+        state.write(type_="issue", role="worker", issue="3", sets=["current_step=x"])
+
+        # No .audit directory or state-log.jsonl should appear
+        audit_base = tmp_path / ".audit"
+        for run_dir in (audit_base.iterdir() if audit_base.exists() else []):
+            log = run_dir / "state-log.jsonl"
+            assert not log.exists(), \
+                f"state-log.jsonl should not exist when audit is inactive: {log}"

--- a/deltaspec/changes/issue-642/.deltaspec.yaml
+++ b/deltaspec/changes/issue-642/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-13
+issue: 642
+name: issue-642
+status: pending

--- a/deltaspec/changes/issue-642/design.md
+++ b/deltaspec/changes/issue-642/design.md
@@ -1,0 +1,59 @@
+## Context
+
+twill の autopilot パイプラインは現在、中間成果物を揮発性ストレージ（/tmp の specialist manifest）または上書き型ストレージ（checkpoint.json）に保存している。bare repo 構造（`.bare/` + `main/` worktree + `worktrees/<branch>/`）では `git rev-parse --show-toplevel` がworktreeのルートを返すため、プロジェクトルートの特定には同コマンドを使用する。
+
+audit 機能は「opt-in」設計（環境変数 `TWL_AUDIT=1` または `.audit/.active` ファイルの存在）で有効化し、無効時は既存動作に一切影響しない。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `twl audit on/off/status` サブコマンドで audit セッションを管理する
+- `TWL_AUDIT=1` OR `.audit/.active` 存在時に中間成果物を永続化する
+- specialist manifest、checkpoint、state 遷移履歴を `.audit/<run-id>/` に保全する
+- `audit.py` を循環依存なしの独立モジュールとして設計する
+- Worker セッションへ `TWL_AUDIT_DIR`（絶対パス）を launcher 経由で伝搬する
+
+**Non-Goals:**
+
+- `twl audit report` レポート生成（後続 Issue）
+- observer による `.audit/<run-id>/` 分析・Issue 起票（後続 Issue）
+- `TWL_CHAIN_TRACE` の変更
+- `audit_history.py`（既存 Layer 1 empirical audit）の変更
+
+## Decisions
+
+### D1: audit.py の循環依存回避
+
+`audit.py` は `checkpoint.py` / `state.py` に依存しない（stdlib のみ使用）。`checkpoint.py` と `state.py` が `audit.py` を import する一方向依存とする。これにより既存モジュールの import チェーンを汚染しない。
+
+### D2: 有効化判定は OR ロジック
+
+`TWL_AUDIT=1` 環境変数または `.audit/.active` ファイル存在のいずれかで audit を有効化する。環境変数は一時的な有効化（CI・テスト）、`.active` ファイルは永続的な有効化（通常利用）に対応する。
+
+### D3: `_project_root()` は git rev-parse 依存
+
+`git rev-parse --show-toplevel` でプロジェクトルートを特定する。bare repo の worktree でも正しいパスが返る。git 管理外のディレクトリでの実行はサポート外とする。
+
+### D4: audit_dir 解決は TWL_AUDIT_DIR 優先
+
+`TWL_AUDIT_DIR` env var → `.audit/.active` の順で解決する。Worker セッションでは launcher が `resolve_audit_dir()` を呼び出した結果（絶対パス）を `TWL_AUDIT_DIR` に設定して env_flags 経由で渡す。環境変数の単純引き継ぎではなく、launcher が解決責任を持つ。
+
+### D5: checkpoint 保全は上書き前コピー
+
+`checkpoint.write()` 内で `is_audit_active()` が true の場合、既存ファイルを `<step>-<ISO8601>.json` としてコピーしてから上書きする。タイムスタンプは `datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")` で生成する。
+
+### D6: state-log.jsonl はフィールド単位の追記
+
+state write 系メソッドで変更が生じた場合、変更フィールド・変更前後の値・ロール（worker/pilot）・タイムスタンプを JSONL で追記する。state file 全体の diff ではなく、フィールド単位の変更レコードとする。
+
+### D7: check-specialist-completeness.sh のコピーは削除より前
+
+既存の `rm -f /tmp/.specialist-*` より前に audit コピーを実行する。既存の削除処理を後回しにすることで、コピーの失敗が削除をブロックしないよう `|| true` でエラーを無視する。
+
+## Risks / Trade-offs
+
+- **ディスク使用量**: audit 有効時に checkpoint が step ごとに蓄積される。長時間の autopilot run では数 MB 程度になる可能性がある。`.audit/` は `.gitignore` で追跡除外するため、リポジトリへの影響はない。
+- **パフォーマンス**: `is_audit_active()` は毎回 `os.path.isfile()` を呼び出す。頻繁な state write がある場合にわずかな I/O オーバーヘッドが生じる。許容範囲内と判断する。
+- **race condition**: 複数の Worker が同一 audit dir に並行書き込みする場合、state-log.jsonl の行が混在する可能性がある。JSONL 追記は行単位でアトミックなため、読み取り時に問題は生じない。
+- **audit off 未実行のまま終了**: `.audit/.active` が残存し続ける。`twl audit status` で確認可能。将来的に autopilot 終了時の自動 off を検討するが、本 Issue では対応しない。

--- a/deltaspec/changes/issue-642/proposal.md
+++ b/deltaspec/changes/issue-642/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+autopilot パイプラインの中間成果物（specialist manifest、checkpoint、state 遷移）が揮発性（/tmp）または上書き型で保管されており、実行の全体像を事後追跡できない。Wave 16-18 で 17 Issue を実装した際、specialist の spawn 完了・checkpoint のパス不整合・state stall 検知が困難であることが発覚した（#640 の根本原因）。
+
+## What Changes
+
+- `cli/twl/src/twl/cli.py` — `twl audit <on|off|status>` サブコマンドのディスパッチ追加
+- `cli/twl/src/twl/autopilot/audit.py` — 新規モジュール（on/off/status ロジック + ヘルパー関数）
+- `cli/twl/src/twl/autopilot/checkpoint.py` — `write()` に audit 分岐追加（上書き前にタイムスタンプ付きコピー）
+- `cli/twl/src/twl/autopilot/state.py` — write 系メソッドに audit 分岐追加（変更前後 diff を state-log.jsonl に追記）
+- `cli/twl/src/twl/autopilot/launcher.py` — `env_flags` に `TWL_AUDIT` / `TWL_AUDIT_DIR` を追加
+- `plugins/twl/scripts/hooks/check-specialist-completeness.sh` — TWL_AUDIT 時に /tmp の specialist ファイルを audit dir にコピー（既存削除処理より前）
+- `.gitignore` — `.audit/` 追加
+- `deps.yaml` — `audit.py` 新規モジュールのエントリ追加
+
+## Capabilities
+
+### New Capabilities
+
+- `twl audit on [--run-id ID]` — `.audit/<run-id>/` ディレクトリを作成し `.audit/.active` ファイルを書き出す
+- `twl audit off` — `.audit/.active` を削除し `.audit/<run-id>/index.json`（保全ファイル一覧）を生成する
+- `twl audit status` — 現在の audit 状態（active/inactive、run-id）を表示する
+- `is_audit_active()` — `TWL_AUDIT=1` env var または `.audit/.active` 存在で audit 有効を判定する
+- `resolve_audit_dir()` — `TWL_AUDIT_DIR` env var → `.audit/.active` の順で audit ディレクトリを解決する
+- specialist ファイルの自動保全 — PostToolUse hook 内で `/tmp/.specialist-*` を `.audit/<run-id>/specialists/` にコピー
+- checkpoint 自動保全 — checkpoint write 時に既存ファイルをタイムスタンプ付きで `.audit/<run-id>/checkpoints/` にコピー
+- state 遷移ログ — state write 時に変更前後 diff を `.audit/<run-id>/state-log.jsonl` に JSONL で追記
+
+### Modified Capabilities
+
+- `checkpoint.write()` — audit 有効時に上書き前コピーを追加実行
+- `state.py` write 系メソッド — audit 有効時に state-log.jsonl へ追記
+- `launcher.py` `env_flags` 生成 — `resolve_audit_dir()` で解決した絶対パスを `TWL_AUDIT_DIR` として Worker に伝搬
+- `check-specialist-completeness.sh` — audit コピー処理を既存削除処理より前に追加
+
+## Impact
+
+- 影響コード: `cli/twl/src/twl/cli.py`、`autopilot/` 配下 4 モジュール、`plugins/twl/scripts/hooks/check-specialist-completeness.sh`
+- 新規 API: `twl audit` サブコマンド（3 サブコマンド）、`audit.py` の `is_audit_active()` / `resolve_audit_dir()` / `_project_root()`
+- 依存方向: `audit.py` → stdlib のみ（循環依存なし）。`checkpoint.py` / `state.py` → `audit.py`（一方向）
+- `.audit/` ディレクトリは `.gitignore` で追跡除外

--- a/deltaspec/changes/issue-642/specs/audit-subcommand/spec.md
+++ b/deltaspec/changes/issue-642/specs/audit-subcommand/spec.md
@@ -1,0 +1,125 @@
+## ADDED Requirements
+
+### Requirement: twl audit on サブコマンド
+
+`twl audit on [--run-id ID]` を実行すると、`.audit/<run-id>/` ディレクトリが作成され、`.audit/.active` ファイルが書き出されなければならない（SHALL）。`--run-id` を省略した場合は `<unix-timestamp>_<4文字ランダム>` 形式の run-id が自動生成される。
+
+#### Scenario: run-id 自動生成で audit on
+- **WHEN** `twl audit on` を引数なしで実行する
+- **THEN** `.audit/<timestamp>_<random>/` ディレクトリが作成され、`.audit/.active` に `{"run_id":...,"started_at":...,"audit_dir":...}` が JSON で書き出される
+
+#### Scenario: 指定 run-id で audit on
+- **WHEN** `twl audit on --run-id my-run-001` を実行する
+- **THEN** `.audit/my-run-001/` ディレクトリが作成され、`.audit/.active` の `run_id` が `"my-run-001"` になる
+
+### Requirement: twl audit off サブコマンド
+
+`twl audit off` を実行すると、`.audit/.active` が削除され、`.audit/<run-id>/index.json` が生成されなければならない（SHALL）。audit が有効でない場合はエラーメッセージを表示して終了する。
+
+#### Scenario: 正常な audit off
+- **WHEN** `.audit/.active` が存在する状態で `twl audit off` を実行する
+- **THEN** `.audit/.active` が削除され、`.audit/<run-id>/index.json` に `{run_id, started_at, ended_at, files}` が書き出される
+
+#### Scenario: audit 未開始での off
+- **WHEN** `.audit/.active` が存在しない状態で `twl audit off` を実行する
+- **THEN** `audit is not active` エラーメッセージを表示して終了する
+
+### Requirement: twl audit status サブコマンド
+
+`twl audit status` を実行すると、現在の audit 状態（active/inactive、run-id）が表示されなければならない（SHALL）。
+
+#### Scenario: audit active 時の status
+- **WHEN** `.audit/.active` が存在する状態で `twl audit status` を実行する
+- **THEN** `active: true, run_id: <id>, audit_dir: <path>` を含む情報が表示される
+
+#### Scenario: audit inactive 時の status
+- **WHEN** `.audit/.active` が存在しない状態で `twl audit status` を実行する
+- **THEN** `active: false` が表示される
+
+### Requirement: is_audit_active() ヘルパー
+
+`is_audit_active()` は `TWL_AUDIT=1` 環境変数または `.audit/.active` ファイルの存在のいずれかで `True` を返さなければならない（SHALL）。両方とも存在しない場合は `False` を返す。
+
+#### Scenario: 環境変数での有効化
+- **WHEN** `TWL_AUDIT=1` 環境変数が設定されている
+- **THEN** `is_audit_active()` が `True` を返す
+
+#### Scenario: ファイルでの有効化
+- **WHEN** `.audit/.active` ファイルが存在する
+- **THEN** `is_audit_active()` が `True` を返す（環境変数なしでも）
+
+#### Scenario: 無効状態
+- **WHEN** `TWL_AUDIT` が未設定かつ `.audit/.active` が存在しない
+- **THEN** `is_audit_active()` が `False` を返す
+
+### Requirement: resolve_audit_dir() ヘルパー
+
+`resolve_audit_dir()` は `TWL_AUDIT_DIR` 環境変数 → `.audit/.active` の順で audit ディレクトリを解決し、`Path` を返さなければならない（SHALL）。いずれも存在しない場合は `None` を返す。
+
+#### Scenario: 環境変数からの解決
+- **WHEN** `TWL_AUDIT_DIR=/abs/path/to/audit` が設定されている
+- **THEN** `resolve_audit_dir()` が `Path("/abs/path/to/audit")` を返す
+
+#### Scenario: .active ファイルからの解決
+- **WHEN** `TWL_AUDIT_DIR` が未設定で `.audit/.active` が存在する
+- **THEN** `resolve_audit_dir()` が `.audit/.active` の `audit_dir` フィールドをプロジェクトルート相対で解決した絶対パスを返す
+
+### Requirement: specialist ファイルの自動保全
+
+`TWL_AUDIT=1` かつ `TWL_AUDIT_DIR` が設定されている場合、`check-specialist-completeness.sh` は `/tmp/.specialist-*` ファイルを `.audit/<run-id>/specialists/` にコピーしなければならない（SHALL）。このコピーは既存の削除処理より前に実行される。
+
+#### Scenario: audit 有効時の specialist 保全
+- **WHEN** `TWL_AUDIT=1` かつ `TWL_AUDIT_DIR` が設定された状態で `check-specialist-completeness.sh` が実行される
+- **THEN** `/tmp/.specialist-manifest-*.txt` および `/tmp/.specialist-spawned-*.txt` が `.audit/<run-id>/specialists/` にコピーされた後に削除される
+
+#### Scenario: audit 無効時の動作不変
+- **WHEN** `TWL_AUDIT` が未設定の状態で `check-specialist-completeness.sh` が実行される
+- **THEN** 既存の動作と同一（コピーなしで削除のみ実行）
+
+### Requirement: checkpoint 自動保全
+
+`is_audit_active()` が true の場合、`checkpoint.write()` は既存の checkpoint ファイルをタイムスタンプ付きで `.audit/<run-id>/checkpoints/` にコピーしてから上書きしなければならない（SHALL）。
+
+#### Scenario: checkpoint 保全コピー
+- **WHEN** audit が有効な状態で `checkpoint.write("phase-review", data)` を実行する
+- **THEN** 既存の `phase-review.json` が `.audit/<run-id>/checkpoints/phase-review-<ISO8601>.json` にコピーされてから新データで上書きされる
+
+#### Scenario: checkpoint 初回 write は保全不要
+- **WHEN** audit が有効な状態で既存ファイルなしに `checkpoint.write()` を実行する
+- **THEN** コピーなしで通常通り新規書き込みされる
+
+### Requirement: state 遷移ログ
+
+`is_audit_active()` が true の場合、state.py の write 系メソッドは変更フィールド・変更前後の値・ロール・タイムスタンプを `.audit/<run-id>/state-log.jsonl` に追記しなければならない（SHALL）。
+
+#### Scenario: state 変更のログ記録
+- **WHEN** audit が有効な状態で `state.py` の write メソッドがフィールドを変更する
+- **THEN** `{"ts":...,"issue":N,"field":"<field>","old":"<before>","new":"<after>","role":"worker"|"pilot"}` が `state-log.jsonl` に追記される
+
+#### Scenario: 変更なし時はログ不記録
+- **WHEN** audit が有効な状態で write メソッドが既存値と同一の値を設定する
+- **THEN** `state-log.jsonl` への追記は行われない
+
+### Requirement: launcher による TWL_AUDIT_DIR 伝搬
+
+`TWL_AUDIT=1` の場合、`launcher.py` は `resolve_audit_dir()` を呼び出して解決した絶対パスを `TWL_AUDIT_DIR` として Worker の `env_flags` に設定しなければならない（SHALL）。環境変数の単純引き継ぎではなく、launcher が解決責任を持つ。
+
+#### Scenario: Worker への audit 環境変数伝搬
+- **WHEN** `TWL_AUDIT=1` が設定された状態で `launcher.py` が Worker を起動する
+- **THEN** Worker の env_flags に `TWL_AUDIT=1` と `TWL_AUDIT_DIR=<絶対パス>` が設定される
+
+### Requirement: .gitignore への .audit/ 追加
+
+`.gitignore` に `.audit/` エントリが追加されなければならない（SHALL）。audit ディレクトリはリポジトリに追跡されない。
+
+#### Scenario: .audit/ の gitignore 確認
+- **WHEN** `.audit/` ディレクトリが作成される
+- **THEN** `git status` に `.audit/` が untracked として表示されない（gitignore によって除外される）
+
+### Requirement: deps.yaml への audit.py エントリ追加
+
+`deps.yaml` に `audit.py` 新規モジュールのエントリが追加されなければならない（SHALL）。deps.yaml は SSOT として依存関係を管理する。
+
+#### Scenario: deps.yaml の audit.py エントリ
+- **WHEN** `loom --check` を実行する
+- **THEN** `audit.py` が deps.yaml に登録されており、チェックが通る

--- a/deltaspec/changes/issue-642/tasks.md
+++ b/deltaspec/changes/issue-642/tasks.md
@@ -1,0 +1,37 @@
+## 1. audit.py 新規モジュール作成
+
+- [ ] 1.1 `cli/twl/src/twl/autopilot/audit.py` を新規作成し `_project_root()` ヘルパーを実装する
+- [ ] 1.2 `is_audit_active()` を実装する（TWL_AUDIT=1 OR .audit/.active 存在で True）
+- [ ] 1.3 `resolve_audit_dir()` を実装する（TWL_AUDIT_DIR env → .audit/.active → None）
+- [ ] 1.4 `audit_on(run_id=None)` を実装する（.audit/<run-id>/ 作成 + .audit/.active 書き出し）
+- [ ] 1.5 `audit_off()` を実装する（.audit/.active 削除 + index.json 生成）
+- [ ] 1.6 `audit_status()` を実装する（現在状態を dict で返す）
+
+## 2. CLI ディスパッチ追加
+
+- [ ] 2.1 `cli/twl/src/twl/cli.py` に `twl audit` サブコマンドのディスパッチを追加する（on/off/status）
+
+## 3. checkpoint.py の audit 分岐追加
+
+- [ ] 3.1 `cli/twl/src/twl/autopilot/checkpoint.py` の `write()` に audit 分岐を追加する（上書き前に既存ファイルをタイムスタンプ付きで .audit/<run-id>/checkpoints/ にコピー）
+
+## 4. state.py の audit 分岐追加
+
+- [ ] 4.1 `cli/twl/src/twl/autopilot/state.py` の write 系メソッドに audit 分岐を追加する（変更フィールド・前後値・role・ts を state-log.jsonl に JSONL 追記）
+
+## 5. launcher.py の env_flags 追加
+
+- [ ] 5.1 `cli/twl/src/twl/autopilot/launcher.py` の `env_flags` 生成に `resolve_audit_dir()` を呼び出して `TWL_AUDIT=1` + `TWL_AUDIT_DIR=<絶対パス>` を追加する
+
+## 6. check-specialist-completeness.sh の修正
+
+- [ ] 6.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に TWL_AUDIT 有効時の /tmp/.specialist-* コピー処理を既存削除処理より前に追加する
+
+## 7. gitignore と deps.yaml の更新
+
+- [ ] 7.1 `.gitignore` に `.audit/` を追加する
+- [ ] 7.2 `deps.yaml` に `audit.py` モジュールのエントリを追加する
+
+## 8. テスト確認
+
+- [ ] 8.1 既存テスト `pytest tests/` が全て PASS することを確認する

--- a/deltaspec/changes/issue-642/tasks.md
+++ b/deltaspec/changes/issue-642/tasks.md
@@ -1,37 +1,37 @@
 ## 1. audit.py 新規モジュール作成
 
-- [ ] 1.1 `cli/twl/src/twl/autopilot/audit.py` を新規作成し `_project_root()` ヘルパーを実装する
-- [ ] 1.2 `is_audit_active()` を実装する（TWL_AUDIT=1 OR .audit/.active 存在で True）
-- [ ] 1.3 `resolve_audit_dir()` を実装する（TWL_AUDIT_DIR env → .audit/.active → None）
-- [ ] 1.4 `audit_on(run_id=None)` を実装する（.audit/<run-id>/ 作成 + .audit/.active 書き出し）
-- [ ] 1.5 `audit_off()` を実装する（.audit/.active 削除 + index.json 生成）
-- [ ] 1.6 `audit_status()` を実装する（現在状態を dict で返す）
+- [x] 1.1 `cli/twl/src/twl/autopilot/audit.py` を新規作成し `_project_root()` ヘルパーを実装する
+- [x] 1.2 `is_audit_active()` を実装する（TWL_AUDIT=1 OR .audit/.active 存在で True）
+- [x] 1.3 `resolve_audit_dir()` を実装する（TWL_AUDIT_DIR env → .audit/.active → None）
+- [x] 1.4 `audit_on(run_id=None)` を実装する（.audit/<run-id>/ 作成 + .audit/.active 書き出し）
+- [x] 1.5 `audit_off()` を実装する（.audit/.active 削除 + index.json 生成）
+- [x] 1.6 `audit_status()` を実装する（現在状態を dict で返す）
 
 ## 2. CLI ディスパッチ追加
 
-- [ ] 2.1 `cli/twl/src/twl/cli.py` に `twl audit` サブコマンドのディスパッチを追加する（on/off/status）
+- [x] 2.1 `cli/twl/src/twl/cli.py` に `twl audit` サブコマンドのディスパッチを追加する（on/off/status）
 
 ## 3. checkpoint.py の audit 分岐追加
 
-- [ ] 3.1 `cli/twl/src/twl/autopilot/checkpoint.py` の `write()` に audit 分岐を追加する（上書き前に既存ファイルをタイムスタンプ付きで .audit/<run-id>/checkpoints/ にコピー）
+- [x] 3.1 `cli/twl/src/twl/autopilot/checkpoint.py` の `write()` に audit 分岐を追加する（上書き前に既存ファイルをタイムスタンプ付きで .audit/<run-id>/checkpoints/ にコピー）
 
 ## 4. state.py の audit 分岐追加
 
-- [ ] 4.1 `cli/twl/src/twl/autopilot/state.py` の write 系メソッドに audit 分岐を追加する（変更フィールド・前後値・role・ts を state-log.jsonl に JSONL 追記）
+- [x] 4.1 `cli/twl/src/twl/autopilot/state.py` の write 系メソッドに audit 分岐を追加する（変更フィールド・前後値・role・ts を state-log.jsonl に JSONL 追記）
 
 ## 5. launcher.py の env_flags 追加
 
-- [ ] 5.1 `cli/twl/src/twl/autopilot/launcher.py` の `env_flags` 生成に `resolve_audit_dir()` を呼び出して `TWL_AUDIT=1` + `TWL_AUDIT_DIR=<絶対パス>` を追加する
+- [x] 5.1 `cli/twl/src/twl/autopilot/launcher.py` の `env_flags` 生成に `resolve_audit_dir()` を呼び出して `TWL_AUDIT=1` + `TWL_AUDIT_DIR=<絶対パス>` を追加する
 
 ## 6. check-specialist-completeness.sh の修正
 
-- [ ] 6.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に TWL_AUDIT 有効時の /tmp/.specialist-* コピー処理を既存削除処理より前に追加する
+- [x] 6.1 `plugins/twl/scripts/hooks/check-specialist-completeness.sh` に TWL_AUDIT 有効時の /tmp/.specialist-* コピー処理を既存削除処理より前に追加する
 
 ## 7. gitignore と deps.yaml の更新
 
-- [ ] 7.1 `.gitignore` に `.audit/` を追加する
-- [ ] 7.2 `deps.yaml` に `audit.py` モジュールのエントリを追加する
+- [x] 7.1 `.gitignore` に `.audit/` を追加する
+- [x] 7.2 `deps.yaml` に `audit.py` モジュールのエントリを追加する
 
 ## 8. テスト確認
 
-- [ ] 8.1 既存テスト `pytest tests/` が全て PASS することを確認する
+- [x] 8.1 既存テスト `pytest tests/` が全て PASS することを確認する（pre-existing 失敗 127 件と同数、新規失敗なし）

--- a/deltaspec/changes/issue-642/test-mapping.yaml
+++ b/deltaspec/changes/issue-642/test-mapping.yaml
@@ -1,0 +1,267 @@
+change_id: issue-642
+generated_at: "2026-04-13T14:34:44Z"
+test_framework: pytest
+scenarios:
+  # ---------------------------------------------------------------------------
+  # Requirement: is_audit_active() ヘルパー
+  # ---------------------------------------------------------------------------
+  - id: "is-audit-active-env-var"
+    name: "環境変数での有効化"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 43
+    requirement: "is_audit_active() ヘルパー"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestIsAuditActive::test_env_var_twl_audit_1_returns_true"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "is-audit-active-file"
+    name: "ファイルでの有効化"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 47
+    requirement: "is_audit_active() ヘルパー"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestIsAuditActive::test_active_file_returns_true_without_env"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "is-audit-active-neither"
+    name: "無効状態"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 51
+    requirement: "is_audit_active() ヘルパー"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestIsAuditActive::test_neither_env_nor_file_returns_false"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: resolve_audit_dir() ヘルパー
+  # ---------------------------------------------------------------------------
+  - id: "resolve-audit-dir-env-var"
+    name: "環境変数からの解決"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 59
+    requirement: "resolve_audit_dir() ヘルパー"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestResolveAuditDir::test_env_var_twl_audit_dir_returned"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "resolve-audit-dir-active-file"
+    name: ".active ファイルからの解決"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 63
+    requirement: "resolve_audit_dir() ヘルパー"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestResolveAuditDir::test_active_file_audit_dir_returned"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: twl audit on サブコマンド
+  # ---------------------------------------------------------------------------
+  - id: "audit-on-auto-run-id"
+    name: "run-id 自動生成で audit on"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 7
+    requirement: "twl audit on サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditOn::test_auto_generated_run_id_creates_dir_and_active"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "audit-on-explicit-run-id"
+    name: "指定 run-id で audit on"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 11
+    requirement: "twl audit on サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditOn::test_explicit_run_id_creates_named_dir"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: twl audit off サブコマンド
+  # ---------------------------------------------------------------------------
+  - id: "audit-off-normal"
+    name: "正常な audit off"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 19
+    requirement: "twl audit off サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditOff::test_normal_off_removes_active_and_creates_index"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "audit-off-not-active"
+    name: "audit 未開始での off"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 23
+    requirement: "twl audit off サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditOff::test_off_without_active_raises_error"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: twl audit status サブコマンド
+  # ---------------------------------------------------------------------------
+  - id: "audit-status-active"
+    name: "audit active 時の status"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 31
+    requirement: "twl audit status サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditStatus::test_status_active_returns_true_with_run_id"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "audit-status-inactive"
+    name: "audit inactive 時の status"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 35
+    requirement: "twl audit status サブコマンド"
+    test_file: "tests/test_audit_module.py"
+    test_name: "TestAuditStatus::test_status_inactive_returns_false"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: checkpoint 自動保全
+  # ---------------------------------------------------------------------------
+  - id: "checkpoint-preservation-copy"
+    name: "checkpoint 保全コピー"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 83
+    requirement: "checkpoint 自動保全"
+    test_file: "tests/test_audit_checkpoint_integration.py"
+    test_name: "TestCheckpointAuditPreservation::test_existing_checkpoint_copied_before_overwrite"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "checkpoint-first-write-no-copy"
+    name: "checkpoint 初回 write は保全不要"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 87
+    requirement: "checkpoint 自動保全"
+    test_file: "tests/test_audit_checkpoint_integration.py"
+    test_name: "TestCheckpointAuditPreservation::test_first_write_no_archive_created"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: state 遷移ログ
+  # ---------------------------------------------------------------------------
+  - id: "state-log-on-change"
+    name: "state 変更のログ記録"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 95
+    requirement: "state 遷移ログ"
+    test_file: "tests/test_audit_state_integration.py"
+    test_name: "TestStateAuditLog::test_field_change_appended_to_state_log"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "state-log-no-change-no-entry"
+    name: "変更なし時はログ不記録"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 99
+    requirement: "state 遷移ログ"
+    test_file: "tests/test_audit_state_integration.py"
+    test_name: "TestStateAuditLog::test_no_change_no_log_entry"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: launcher による TWL_AUDIT_DIR 伝搬
+  # ---------------------------------------------------------------------------
+  - id: "launcher-audit-env-propagation"
+    name: "Worker への audit 環境変数伝搬"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 107
+    requirement: "launcher による TWL_AUDIT_DIR 伝搬"
+    test_file: "tests/test_audit_launcher_integration.py"
+    test_name: "TestLauncherAuditEnvPropagation::test_audit_env_flags_set_when_twl_audit_is_1"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ---------------------------------------------------------------------------
+  # Requirement: .gitignore への .audit/ 追加
+  # ---------------------------------------------------------------------------
+  - id: "gitignore-audit-dir"
+    name: ".audit/ の gitignore 確認"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 115
+    requirement: ".gitignore への .audit/ 追加"
+    test_file: "tests/test_audit_gitignore.py"
+    test_name: "TestGitignoreAuditDir::test_audit_dir_in_gitignore"
+    type: unit
+    criteria: []
+    status: failing
+    last_run: "2026-04-13T14:34:44Z"
+    failure_reason: ".audit/ not in .gitignore — implementation pending"
+
+  # ---------------------------------------------------------------------------
+  # Requirement: deps.yaml への audit.py エントリ追加
+  # ---------------------------------------------------------------------------
+  - id: "deps-yaml-audit-entry"
+    name: "deps.yaml の audit.py エントリ"
+    spec_file: "specs/audit-subcommand/spec.md"
+    spec_line: 123
+    requirement: "deps.yaml への audit.py エントリ追加"
+    test_file: "tests/test_audit_gitignore.py"
+    test_name: "TestDepsYamlAuditEntry::test_audit_py_entry_in_deps_yaml"
+    type: unit
+    criteria: []
+    status: passing
+    last_run: "2026-04-13T14:34:44Z"
+    failure_reason: null

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2639,6 +2639,11 @@ scripts:
       - script: resolve-issue-num
     description: "PR review 系 specialist 選択の動的マニフェスト（phase-review / merge-gate / post-fix-verify）。phase-review/merge-gate モードで Issue 番号が解決可能な場合 worker-issue-pr-alignment を出力に含める。merge-gate モードで chain 関連ファイル (deps.yaml/SKILL.md/chain-runner.sh) 変更時は worker-workflow-integrity を追加"
 
+  audit:
+    type: script
+    path: ../../cli/twl/src/twl/autopilot/audit.py
+    description: "autopilot 実行履歴の永続化（twl audit on/off/status + is_audit_active/resolve_audit_dir ヘルパー）"
+
   checkpoint-write:
     type: script
     path: ../../cli/twl/src/twl/autopilot/checkpoint.py

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -115,10 +115,22 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
         rm -f "$SESSION_LOCK"
       fi
     fi
-    # audit コピー: 削除前に audit dir へ保全（TWL_AUDIT 有効時）
-    if [[ "${TWL_AUDIT:-}" == "1" && -n "${TWL_AUDIT_DIR:-}" ]]; then
-      mkdir -p "${TWL_AUDIT_DIR}/specialists"
-      cp "$MANIFEST_FILE" "$SPAWNED_FILE" "${TWL_AUDIT_DIR}/specialists/" 2>/dev/null || true
+    # audit コピー: 削除前に audit dir へ保全（TWL_AUDIT=1 OR .audit/.active 存在時）
+    _AUDIT_DIR_RESOLVED="${TWL_AUDIT_DIR:-}"
+    if [[ "${TWL_AUDIT:-}" != "1" || -z "${_AUDIT_DIR_RESOLVED}" ]]; then
+      # .audit/.active ファイルから audit_dir を解決
+      _PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
+      _ACTIVE_FILE="${_PROJECT_ROOT}/.audit/.active"
+      if [[ -n "${_PROJECT_ROOT}" && -f "${_ACTIVE_FILE}" ]]; then
+        _AUDIT_DIR_REL="$(python3 -c "import json,sys; d=json.load(open('${_ACTIVE_FILE}')); print(d.get('audit_dir',''))" 2>/dev/null || echo "")"
+        if [[ -n "${_AUDIT_DIR_REL}" ]]; then
+          _AUDIT_DIR_RESOLVED="${_PROJECT_ROOT}/${_AUDIT_DIR_REL}"
+        fi
+      fi
+    fi
+    if [[ -n "${_AUDIT_DIR_RESOLVED}" ]]; then
+      mkdir -p "${_AUDIT_DIR_RESOLVED}/specialists"
+      cp "$MANIFEST_FILE" "$SPAWNED_FILE" "${_AUDIT_DIR_RESOLVED}/specialists/" 2>/dev/null || true
     fi
     # Clean up manifest and spawned tracking files
     rm -f "$MANIFEST_FILE" "$SPAWNED_FILE"

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -115,6 +115,11 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
         rm -f "$SESSION_LOCK"
       fi
     fi
+    # audit コピー: 削除前に audit dir へ保全（TWL_AUDIT 有効時）
+    if [[ "${TWL_AUDIT:-}" == "1" && -n "${TWL_AUDIT_DIR:-}" ]]; then
+      mkdir -p "${TWL_AUDIT_DIR}/specialists"
+      cp "$MANIFEST_FILE" "$SPAWNED_FILE" "${TWL_AUDIT_DIR}/specialists/" 2>/dev/null || true
+    fi
     # Clean up manifest and spawned tracking files
     rm -f "$MANIFEST_FILE" "$SPAWNED_FILE"
     continue

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -124,7 +124,12 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
       if [[ -n "${_PROJECT_ROOT}" && -f "${_ACTIVE_FILE}" ]]; then
         _AUDIT_DIR_REL="$(python3 -c "import json,sys; d=json.load(open('${_ACTIVE_FILE}')); print(d.get('audit_dir',''))" 2>/dev/null || echo "")"
         if [[ -n "${_AUDIT_DIR_REL}" ]]; then
-          _AUDIT_DIR_RESOLVED="${_PROJECT_ROOT}/${_AUDIT_DIR_REL}"
+          # audit_dir は絶対パスまたは相対パスの両方に対応
+          if [[ "${_AUDIT_DIR_REL}" == /* ]]; then
+            _AUDIT_DIR_RESOLVED="${_AUDIT_DIR_REL}"
+          else
+            _AUDIT_DIR_RESOLVED="${_PROJECT_ROOT}/${_AUDIT_DIR_REL}"
+          fi
         fi
       fi
     fi

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -117,7 +117,7 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
     fi
     # audit コピー: 削除前に audit dir へ保全（TWL_AUDIT=1 OR .audit/.active 存在時）
     _AUDIT_DIR_RESOLVED="${TWL_AUDIT_DIR:-}"
-    if [[ "${TWL_AUDIT:-}" != "1" || -z "${_AUDIT_DIR_RESOLVED}" ]]; then
+    if [[ -z "${_AUDIT_DIR_RESOLVED}" ]]; then
       # .audit/.active ファイルから audit_dir を解決
       _PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
       _ACTIVE_FILE="${_PROJECT_ROOT}/.audit/.active"

--- a/plugins/twl/scripts/hooks/check-specialist-completeness.sh
+++ b/plugins/twl/scripts/hooks/check-specialist-completeness.sh
@@ -122,7 +122,7 @@ for MANIFEST_FILE in "${MANIFEST_FILES[@]}"; do
       _PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "")"
       _ACTIVE_FILE="${_PROJECT_ROOT}/.audit/.active"
       if [[ -n "${_PROJECT_ROOT}" && -f "${_ACTIVE_FILE}" ]]; then
-        _AUDIT_DIR_REL="$(python3 -c "import json,sys; d=json.load(open('${_ACTIVE_FILE}')); print(d.get('audit_dir',''))" 2>/dev/null || echo "")"
+        _AUDIT_DIR_REL="$(AUDIT_ACTIVE_FILE="${_ACTIVE_FILE}" python3 -c "import json,os; f=os.environ.get('AUDIT_ACTIVE_FILE',''); d=json.load(open(f)) if f else {}; print(d.get('audit_dir',''))" 2>/dev/null || echo "")"
         if [[ -n "${_AUDIT_DIR_REL}" ]]; then
           # audit_dir は絶対パスまたは相対パスの両方に対応
           if [[ "${_AUDIT_DIR_REL}" == /* ]]; then


### PR DESCRIPTION
fix(642): simplify OR-condition in audit dir resolution

Condition was: TWL_AUDIT != 1 || TWL_AUDIT_DIR empty
Problem: always true when TWL_AUDIT unset, spuriously re-entering fallback
Fixed: enter fallback only when TWL_AUDIT_DIR is not already set

Closes #642