### PR TITLE
fix: implement observer_window field for reliable AC-5/AC-6 window validation

### DIFF
--- a/deltaspec/changes/issue-613/.deltaspec.yaml
+++ b/deltaspec/changes/issue-613/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-14
+issue: 613
+name: issue-613
+status: pending

--- a/deltaspec/changes/issue-613/design.md
+++ b/deltaspec/changes/issue-613/design.md
@@ -1,0 +1,62 @@
+## Context
+
+su-observer は長時間常駐する Claude Code セッション（observer ウィンドウ）を管理する。セッション状態は `.supervisor/session.json` に保存されるが、現状 Claude Code session ID は記録されていない。ユーザーが observer ウィンドウに戻る際、session ID がわからず `claude --resume` による復帰が困難。
+
+`cld` スクリプトは現状 `set -euo pipefail` + `exec claude ...` 構成で、全引数をそのまま `claude` にパススルーする。引数パースロジックがないため、`--observer` フラグの intercept には引数ループでの事前チェックが必要。
+
+## Goals / Non-Goals
+
+**Goals:**
+- Claude Code session ID を `su-observer` 起動時に `.supervisor/session.json` へ保存
+- `cld --observer` で保存済み session ID を使って `claude --resume` を自動実行
+- session ID の有効性確認（tmux window 存在・Claude Code プロセス生存）
+- compaction 後の session ID 更新（AC-0 の検証結果次第で `su-postcompact.sh` に追加）
+- `SupervisorSession` エンティティへの `claude_session_id` フィールド追加
+- エラーケース（session.json 不在・ID 空・window 不在・プロセス終了）の適切なメッセージ
+
+**Non-Goals:**
+- `cld-ch` への `--observer` フラグ追加（tmux window 切り替え用で別レイヤー）
+- 複数プロジェクト間の observer 切り替え UI
+- session ID の自動ローテーション
+
+## Decisions
+
+### Session ID 取得方法（AC-0 で検証後に確定）
+
+優先順で試行:
+1. **環境変数** `CLAUDE_SESSION_ID`（Claude Code が設定している場合）
+2. **JSONL ファイル推定**: `~/.claude/projects/<project-hash>/` 配下の最新 `.jsonl` ファイル名から抽出
+3. **Hook stdin**: SessionStart hook の stdin JSON（実測で確認）
+
+co-issue の `pre-bash-phase3-gate.sh` では `${CLAUDE_SESSION_ID:-${SESSION_ID:-unknown}}` と使用されており、常に利用可能とは限らない。**実装前に AC-0 検証を必須とする。**
+
+### `cld --observer` 引数パース設計
+
+`--observer` を `exec` の前で intercept する:
+```bash
+PASS_ARGS=()
+OBSERVER_MODE=false
+for arg in "$@"; do
+  if [[ "$arg" == "--observer" ]]; then
+    OBSERVER_MODE=true
+  else
+    PASS_ARGS+=("$arg")
+  fi
+done
+```
+`--observer` 検出時は `exec claude` に到達せず、代わりに `claude --resume <claude_session_id>` を exec する分岐を設ける。
+
+### session-state.sh 活用
+
+有効性確認では `session-state.sh list --json` で window 一覧を取得し、`session-state.sh state <window>` で状態を判定する。`session-state.sh` は `plugins/session/scripts/` に配置され、symlink 経由で PATH 上に存在する。
+
+### su-postcompact.sh の責務拡張
+
+session ID 更新の追加は責務の拡張となるため、PostCompact hook 内で別スクリプトに分離するか、明確なセクション分離を設ける。AC-0 の検証結果に依存するため、compaction 後に ID が変わる場合のみ実装する。
+
+## Risks / Trade-offs
+
+- **Session ID 取得の不安定性**: `CLAUDE_SESSION_ID` が常に利用可能とは限らない → AC-0 検証で安定する方法を確定する
+- **JSONL ファイル推定の精度**: 最新ファイルが必ずしも現在のセッションとは限らない
+- **Compaction 時の ID 変更**: `/compact` 後に session ID が変わる場合、`--observer` での resume が失敗する可能性 → AC-0 で検証
+- **cld の引数パース導入**: 現状のシンプルな全パススルー設計から変更するため、既存フラグ互換性を確認する（AC-8）

--- a/deltaspec/changes/issue-613/proposal.md
+++ b/deltaspec/changes/issue-613/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+su-observer セッションは長時間常駐するが、ユーザーが observer ウィンドウに戻ろうとしたときに Claude Code session ID がわからず `cld --resume <session-id>` での復帰が困難。現状は `.jsonl` ファイル名から手動で推定するしかない。
+
+## What Changes
+
+- `su-observer SKILL.md` Step 0 で Claude Code session ID を取得し `.supervisor/session.json` の `claude_session_id` フィールドに保存するロジックを追加
+- `cld` スクリプトに `--observer` フラグを追加し、保存された session ID で自動的に `claude --resume` を実行
+- `su-postcompact.sh` に compaction 後の session ID 更新ロジックを追加（AC-0 検証結果に依存）
+- `supervision.md` の `SupervisorSession` エンティティに `claude_session_id` フィールドを追加
+- `plugins/twl/tests/scenarios/` に session resume のテストを追加
+
+## Capabilities
+
+### New Capabilities
+
+- `cld --observer` コマンドで observer セッションに即座に resume できる
+- su-observer セッションの Claude Code session ID が `.supervisor/session.json` に自動保存される
+- session ID の有効性確認（tmux window 存在・プロセス生存チェック）
+
+### Modified Capabilities
+
+- `su-observer SKILL.md` Step 0 が session ID を取得・保存するようになる
+- `cld` スクリプトが `--observer` フラグを認識し、引数ループで intercept する
+
+## Impact
+
+- `plugins/twl/skills/su-observer/SKILL.md`: Step 0 に `claude_session_id` 保存ロジック追加
+- `plugins/session/scripts/cld`: `--observer` フラグ追加、引数パースロジック挿入
+- `plugins/twl/scripts/su-postcompact.sh`: compaction 後の session ID 更新（AC-0 依存）
+- `plugins/twl/architecture/domain/contexts/supervision.md`: `SupervisorSession` エンティティに `claude_session_id` 追加
+- `plugins/twl/deps.yaml`: su-observer の dependencies に session plugin エンティティを追加
+- `plugins/twl/tests/scenarios/su-observer-session-resume.test.sh`: 新規 bats テスト

--- a/deltaspec/changes/issue-613/specs/session-id-persistence/spec.md
+++ b/deltaspec/changes/issue-613/specs/session-id-persistence/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Session ID 保存
+
+su-observer セッション起動時に Claude Code session ID を `.supervisor/session.json` の `claude_session_id` フィールドに保存しなければならない（SHALL）。
+
+#### Scenario: 新規 observer セッション起動時の session ID 保存
+- **WHEN** `su-observer` SKILL.md Step 0 で SupervisorSession を新規作成するとき
+- **THEN** Claude Code session ID が `.supervisor/session.json` の `claude_session_id` フィールドに書き込まれること
+
+#### Scenario: observer セッション復帰時の session ID 更新
+- **WHEN** `su-observer` SKILL.md Step 0 で status=active の既存セッションに復帰するとき
+- **THEN** 既存の `claude_session_id` が検証され、変更がある場合は更新されること
+
+### Requirement: SupervisorSession エンティティ拡張
+
+`supervision.md` の `SupervisorSession` エンティティに `claude_session_id` フィールドを追加しなければならない（SHALL）。
+
+#### Scenario: アーキテクチャドキュメントへのフィールド追加
+- **WHEN** `plugins/twl/architecture/domain/contexts/supervision.md` を参照するとき
+- **THEN** `SupervisorSession` エンティティのフィールド一覧に `claude_session_id: string | null` が含まれること
+
+## MODIFIED Requirements
+
+### Requirement: cld --observer フラグ
+
+`cld` スクリプトは `--observer` フラグを認識し、`.supervisor/session.json` に保存された session ID で `claude --resume` を実行しなければならない（MUST）。
+
+#### Scenario: 有効な observer session への resume
+- **WHEN** `cld --observer` を実行し、有効な session ID と tmux window が存在するとき
+- **THEN** `claude --resume <claude_session_id>` が実行されること
+
+#### Scenario: session.json が存在しない場合のエラー
+- **WHEN** `cld --observer` を実行し、`.supervisor/session.json` が存在しないとき
+- **THEN** `"No active observer session. Start one with: cld → /su-observer"` メッセージが表示されること
+
+#### Scenario: session ID が空の場合のエラー
+- **WHEN** `cld --observer` を実行し、`claude_session_id` が null または空のとき
+- **THEN** `"Observer session found but no Claude session ID recorded"` メッセージが表示されること
+
+#### Scenario: tmux window が存在しない場合のエラー
+- **WHEN** `cld --observer` を実行し、対応する tmux window が存在しないとき
+- **THEN** `"Observer window not found. Session may have ended"` メッセージが表示されること
+
+#### Scenario: Claude Code プロセスが終了している場合のエラー
+- **WHEN** `cld --observer` を実行し、Claude Code プロセスが exited 状態のとき
+- **THEN** `"Observer session has ended. Start a new one with: cld → /su-observer"` メッセージが表示されること
+
+#### Scenario: 既存フラグの互換性維持
+- **WHEN** `cld` を `--observer` フラグなしで実行するとき
+- **THEN** 既存動作（全引数を `claude` にパススルー）に影響がないこと
+
+### Requirement: Compaction 後の Session ID 更新
+
+compaction 後も session ID が正しく維持されなければならない（SHALL）。ID が変わる場合は `su-postcompact.sh` で更新する。
+
+#### Scenario: compaction 後の session ID 更新（ID 変更ケース）
+- **WHEN** Claude Code の `/compact` 実行後に session ID が変わったとき
+- **THEN** `su-postcompact.sh` が新しい session ID を取得し `.supervisor/session.json` を更新すること

--- a/deltaspec/changes/issue-613/tasks.md
+++ b/deltaspec/changes/issue-613/tasks.md
@@ -1,0 +1,47 @@
+## 1. AC-0: Session ID 取得方法の検証
+
+- [ ] 1.1 `CLAUDE_SESSION_ID` 環境変数が su-observer 起動時に利用可能か実測で確認する
+- [ ] 1.2 JSONL ファイル推定方式（`~/.claude/projects/<hash>/` 最新ファイル名）の実測確認
+- [ ] 1.3 compaction 後に session ID が変わるかどうかを実測確認
+- [ ] 1.4 検証結果を Issue コメントまたは PR description に記録する
+
+## 2. アーキテクチャドキュメント更新
+
+- [ ] 2.1 `plugins/twl/architecture/domain/contexts/supervision.md` の `SupervisorSession` エンティティに `claude_session_id: string | null` フィールドを追加する
+
+## 3. su-observer SKILL.md の session ID 保存ロジック追加
+
+- [ ] 3.1 AC-0 で確定した取得方法で session ID を取得するロジックを実装する
+- [ ] 3.2 Step 0 新規セッション作成分岐（step 0-2）に `claude_session_id` を `session.json` へ書き込むロジックを追加する
+- [ ] 3.3 Step 0 復帰分岐（status=active）に既存 `claude_session_id` の検証・更新ロジックを追加する
+
+## 4. cld --observer フラグの実装
+
+- [ ] 4.1 `plugins/session/scripts/cld` に引数ループで `--observer` を検出するロジックを追加する
+- [ ] 4.2 `--observer` 検出時のプロジェクトルート検出ロジックを実装する（`git rev-parse` または bare repo 構造検出）
+- [ ] 4.3 `.supervisor/session.json` の存在確認・`claude_session_id` 読み取りロジックを実装する
+- [ ] 4.4 `session-state.sh list --json` + `session-state.sh state <window>` で有効性確認ロジックを実装する
+- [ ] 4.5 4 エラーケース（session.json 不在・ID 空・window 不在・プロセス終了）のメッセージを実装する
+- [ ] 4.6 有効時に `exec claude --resume <claude_session_id>` を実行するロジックを実装する
+
+## 5. su-postcompact.sh の session ID 更新（AC-0 結果に依存）
+
+- [ ] 5.1 AC-0 で compaction 後 ID が変わる場合のみ: session ID 更新ロジックを `su-postcompact.sh` に追加する（明確なセクション分離または別スクリプトに分離）
+
+## 6. deps.yaml 更新
+
+- [ ] 6.1 `plugins/twl/deps.yaml` の su-observer エントリに session plugin への依存を追加する
+- [ ] 6.2 `plugins/session/deps.yaml` の cld エントリを `--observer` フラグ追加に合わせて更新する
+
+## 7. テスト追加
+
+- [ ] 7.1 `plugins/twl/tests/scenarios/su-observer-session-resume.test.sh` を bats 形式で新規作成する
+- [ ] 7.2 session ID 保存テスト（AC-1）を実装する
+- [ ] 7.3 `cld --observer` resume テスト（AC-2）を実装する
+- [ ] 7.4 4 エラーケーステスト（AC-3〜AC-6）を実装する
+- [ ] 7.5 引数互換性テスト（AC-8）を実装する
+
+## 8. 最終確認
+
+- [ ] 8.1 `twl --check` が PASS することを確認する
+- [ ] 8.2 `cld` の既存フラグ（`--help` 等）および引数パススルー動作に影響がないことを確認する

--- a/deltaspec/changes/issue-613/tasks.md
+++ b/deltaspec/changes/issue-613/tasks.md
@@ -1,47 +1,47 @@
 ## 1. AC-0: Session ID 取得方法の検証
 
-- [ ] 1.1 `CLAUDE_SESSION_ID` 環境変数が su-observer 起動時に利用可能か実測で確認する
-- [ ] 1.2 JSONL ファイル推定方式（`~/.claude/projects/<hash>/` 最新ファイル名）の実測確認
-- [ ] 1.3 compaction 後に session ID が変わるかどうかを実測確認
-- [ ] 1.4 検証結果を Issue コメントまたは PR description に記録する
+- [x] 1.1 `CLAUDE_SESSION_ID` 環境変数が su-observer 起動時に利用可能か実測で確認する
+- [x] 1.2 JSONL ファイル推定方式（`~/.claude/projects/<hash>/` 最新ファイル名）の実測確認
+- [x] 1.3 compaction 後に session ID が変わるかどうかを実測確認
+- [x] 1.4 検証結果を Issue コメントまたは PR description に記録する
 
 ## 2. アーキテクチャドキュメント更新
 
-- [ ] 2.1 `plugins/twl/architecture/domain/contexts/supervision.md` の `SupervisorSession` エンティティに `claude_session_id: string | null` フィールドを追加する
+- [x] 2.1 `plugins/twl/architecture/domain/contexts/supervision.md` の `SupervisorSession` エンティティに `claude_session_id: string | null` フィールドを追加する
 
 ## 3. su-observer SKILL.md の session ID 保存ロジック追加
 
-- [ ] 3.1 AC-0 で確定した取得方法で session ID を取得するロジックを実装する
-- [ ] 3.2 Step 0 新規セッション作成分岐（step 0-2）に `claude_session_id` を `session.json` へ書き込むロジックを追加する
-- [ ] 3.3 Step 0 復帰分岐（status=active）に既存 `claude_session_id` の検証・更新ロジックを追加する
+- [x] 3.1 AC-0 で確定した取得方法で session ID を取得するロジックを実装する
+- [x] 3.2 Step 0 新規セッション作成分岐（step 0-2）に `claude_session_id` を `session.json` へ書き込むロジックを追加する
+- [x] 3.3 Step 0 復帰分岐（status=active）に既存 `claude_session_id` の検証・更新ロジックを追加する
 
 ## 4. cld --observer フラグの実装
 
-- [ ] 4.1 `plugins/session/scripts/cld` に引数ループで `--observer` を検出するロジックを追加する
-- [ ] 4.2 `--observer` 検出時のプロジェクトルート検出ロジックを実装する（`git rev-parse` または bare repo 構造検出）
-- [ ] 4.3 `.supervisor/session.json` の存在確認・`claude_session_id` 読み取りロジックを実装する
-- [ ] 4.4 `session-state.sh list --json` + `session-state.sh state <window>` で有効性確認ロジックを実装する
-- [ ] 4.5 4 エラーケース（session.json 不在・ID 空・window 不在・プロセス終了）のメッセージを実装する
-- [ ] 4.6 有効時に `exec claude --resume <claude_session_id>` を実行するロジックを実装する
+- [x] 4.1 `plugins/session/scripts/cld` に引数ループで `--observer` を検出するロジックを追加する
+- [x] 4.2 `--observer` 検出時のプロジェクトルート検出ロジックを実装する（`git rev-parse` または bare repo 構造検出）
+- [x] 4.3 `.supervisor/session.json` の存在確認・`claude_session_id` 読み取りロジックを実装する
+- [x] 4.4 `session-state.sh list --json` + `session-state.sh state <window>` で有効性確認ロジックを実装する
+- [x] 4.5 4 エラーケース（session.json 不在・ID 空・window 不在・プロセス終了）のメッセージを実装する
+- [x] 4.6 有効時に `exec claude --resume <claude_session_id>` を実行するロジックを実装する
 
 ## 5. su-postcompact.sh の session ID 更新（AC-0 結果に依存）
 
-- [ ] 5.1 AC-0 で compaction 後 ID が変わる場合のみ: session ID 更新ロジックを `su-postcompact.sh` に追加する（明確なセクション分離または別スクリプトに分離）
+- [x] 5.1 AC-0 で compaction 後 ID が変わる場合のみ: session ID 更新ロジックを `su-postcompact.sh` に追加する（明確なセクション分離または別スクリプトに分離）
 
 ## 6. deps.yaml 更新
 
-- [ ] 6.1 `plugins/twl/deps.yaml` の su-observer エントリに session plugin への依存を追加する
-- [ ] 6.2 `plugins/session/deps.yaml` の cld エントリを `--observer` フラグ追加に合わせて更新する
+- [x] 6.1 `plugins/twl/deps.yaml` の su-observer エントリに session plugin への依存を追加する
+- [x] 6.2 `plugins/session/deps.yaml` の cld エントリを `--observer` フラグ追加に合わせて更新する
 
 ## 7. テスト追加
 
-- [ ] 7.1 `plugins/twl/tests/scenarios/su-observer-session-resume.test.sh` を bats 形式で新規作成する
-- [ ] 7.2 session ID 保存テスト（AC-1）を実装する
-- [ ] 7.3 `cld --observer` resume テスト（AC-2）を実装する
-- [ ] 7.4 4 エラーケーステスト（AC-3〜AC-6）を実装する
-- [ ] 7.5 引数互換性テスト（AC-8）を実装する
+- [x] 7.1 `plugins/twl/tests/scenarios/su-observer-session-resume.test.sh` を bats 形式で新規作成する
+- [x] 7.2 session ID 保存テスト（AC-1）を実装する
+- [x] 7.3 `cld --observer` resume テスト（AC-2）を実装する
+- [x] 7.4 4 エラーケーステスト（AC-3〜AC-6）を実装する
+- [x] 7.5 引数互換性テスト（AC-8）を実装する
 
 ## 8. 最終確認
 
-- [ ] 8.1 `twl --check` が PASS することを確認する
-- [ ] 8.2 `cld` の既存フラグ（`--help` 等）および引数パススルー動作に影響がないことを確認する
+- [x] 8.1 `twl --check` が PASS することを確認する
+- [x] 8.2 `cld` の既存フラグ（`--help` 等）および引数パススルー動作に影響がないことを確認する

--- a/deltaspec/changes/issue-613/test-mapping.yaml
+++ b/deltaspec/changes/issue-613/test-mapping.yaml
@@ -1,0 +1,151 @@
+change_id: issue-613
+generated_at: "2026-04-14T00:00:00Z"
+test_framework: bats-shell
+test_file: plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
+
+scenarios:
+  # ============================================================
+  # Requirement: Session ID 保存 (ADDED)
+  # ============================================================
+
+  - id: "new-observer-session-id-save"
+    name: "新規 observer セッション起動時の session ID 保存"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 7
+    requirement: "Session ID 保存"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "SKILL.md Step 0: 新規作成パスで claude_session_id 保存が定義されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "observer-session-resume-id-update"
+    name: "observer セッション復帰時の session ID 更新"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 11
+    requirement: "Session ID 保存"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "SKILL.md Step 0: 復帰パスで claude_session_id の検証・更新が定義されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ============================================================
+  # Requirement: SupervisorSession エンティティ拡張 (ADDED)
+  # ============================================================
+
+  - id: "supervision-md-claude-session-id-field"
+    name: "アーキテクチャドキュメントへのフィールド追加"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 19
+    requirement: "SupervisorSession エンティティ拡張"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "supervision.md: SupervisorSession に claude_session_id フィールドが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ============================================================
+  # Requirement: cld --observer フラグ (MODIFIED)
+  # ============================================================
+
+  - id: "cld-observer-valid-session-resume"
+    name: "有効な observer session への resume"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 29
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: claude --resume <session_id> 呼び出しが実装されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "cld-observer-no-session-json-error"
+    name: "session.json が存在しない場合のエラー"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 33
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: session.json 不在時エラーメッセージ 'No active observer session' が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "cld-observer-empty-session-id-error"
+    name: "session ID が空の場合のエラー"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 37
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: session ID 空時エラーメッセージが定義されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "cld-observer-no-tmux-window-error"
+    name: "tmux window が存在しない場合のエラー"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 41
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: tmux window 不在エラーメッセージ 'Observer window not found' が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "cld-observer-process-exited-error"
+    name: "Claude Code プロセスが終了している場合のエラー"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 45
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: プロセス終了エラーメッセージ 'Observer session has ended' が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "cld-observer-existing-flags-compat"
+    name: "既存フラグの互換性維持"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 49
+    requirement: "cld --observer フラグ"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "cld スクリプト: --observer なし時の全引数パススルーが維持されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ============================================================
+  # Requirement: Compaction 後の Session ID 更新 (MODIFIED)
+  # ============================================================
+
+  - id: "postcompact-session-id-update"
+    name: "compaction 後の session ID 更新（ID 変更ケース）"
+    spec_file: "specs/session-id-persistence/spec.md"
+    spec_line: 57
+    requirement: "Compaction 後の Session ID 更新"
+    test_file: "plugins/twl/tests/scenarios/su-observer-session-resume.test.sh"
+    test_name: "su-postcompact.sh: claude_session_id 更新処理が実装されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -46,7 +46,7 @@ scripts:
   cld:
     type: script
     path: scripts/cld
-    description: "Claude Code ランチャー（plugin 自動検出 + systemd-run）"
+    description: "Claude Code ランチャー（plugin 自動検出 + systemd-run）。--observer フラグ: .supervisor/session.json の claude_session_id で claude --resume を実行"
 
   cld-spawn:
     type: script

--- a/plugins/session/scripts/cld
+++ b/plugins/session/scripts/cld
@@ -7,6 +7,95 @@ if ! command -v claude &>/dev/null; then
     exit 1
 fi
 
+# --observer フラグ事前検出（exec claude の前に intercept）
+OBSERVER_MODE=false
+PASS_ARGS=()
+for arg in "$@"; do
+    if [[ "$arg" == "--observer" ]]; then
+        OBSERVER_MODE=true
+    else
+        PASS_ARGS+=("$arg")
+    fi
+done
+
+if [[ "$OBSERVER_MODE" == "true" ]]; then
+    # プロジェクトルート検出（bare repo 構造 or git toplevel）
+    PROJECT_ROOT=""
+    if git rev-parse --show-toplevel &>/dev/null 2>&1; then
+        GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+        # bare repo 構造: worktree 内の場合は bare repo root を探す
+        if [[ -f "${GIT_ROOT}/.git" ]]; then
+            # .git がファイル（worktree）→ bare repo root を参照
+            GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+            if [[ -n "$GIT_COMMON" && -d "${GIT_COMMON%/.bare*}" ]]; then
+                BARE_ROOT="${GIT_COMMON%/.bare*}"
+                PROJECT_ROOT="${BARE_ROOT}/main"
+            else
+                PROJECT_ROOT="$GIT_ROOT"
+            fi
+        else
+            PROJECT_ROOT="$GIT_ROOT"
+        fi
+    fi
+
+    SESSION_JSON=""
+    if [[ -n "$PROJECT_ROOT" ]]; then
+        SESSION_JSON="${PROJECT_ROOT}/.supervisor/session.json"
+    fi
+
+    # session.json 存在確認
+    if [[ -z "$SESSION_JSON" || ! -f "$SESSION_JSON" ]]; then
+        echo "No active observer session. Start one with: cld → /su-observer" >&2
+        exit 1
+    fi
+
+    # claude_session_id 読み取り
+    CLAUDE_SESSION_ID_VAL=$(python3 -c "
+import json, sys
+try:
+    data = json.load(open('${SESSION_JSON}'))
+    sid = data.get('claude_session_id', None)
+    print(sid if sid else '')
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+    if [[ -z "$CLAUDE_SESSION_ID_VAL" || "$CLAUDE_SESSION_ID_VAL" == "null" ]]; then
+        echo "Observer session found but no Claude session ID recorded" >&2
+        exit 1
+    fi
+
+    # tmux window 有効性確認（session-state.sh が PATH 上にある場合）
+    if command -v session-state.sh &>/dev/null; then
+        WINDOW_LIST=$(session-state.sh list --json 2>/dev/null || echo "[]")
+        OBSERVER_WINDOW=$(python3 -c "
+import json, sys
+try:
+    windows = json.loads('''${WINDOW_LIST}''')
+    for w in windows:
+        if w.get('window', '') == 'observer':
+            print(w.get('window', ''))
+            break
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+
+        if [[ -z "$OBSERVER_WINDOW" ]]; then
+            echo "Observer window not found. Session may have ended" >&2
+            exit 1
+        fi
+
+        OBSERVER_STATE=$(session-state.sh state observer 2>/dev/null || echo "exited")
+        if [[ "$OBSERVER_STATE" == "exited" ]]; then
+            echo "Observer session has ended. Start a new one with: cld → /su-observer" >&2
+            exit 1
+        fi
+    fi
+
+    # 有効な session ID で resume
+    exec claude --resume "$CLAUDE_SESSION_ID_VAL" "${PASS_ARGS[@]}"
+fi
+
 PLUGINS_BASE="$HOME/.claude/plugins"
 PLUGIN_ARGS=()
 
@@ -25,4 +114,4 @@ done < <(env | grep '^DEV_')
 
 exec systemd-run --user --scope -p MemoryMax=12G \
     "${ENV_ARGS[@]}" \
-    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "$@"
+    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]}"

--- a/plugins/session/scripts/cld
+++ b/plugins/session/scripts/cld
@@ -21,16 +21,22 @@ done
 if [[ "$OBSERVER_MODE" == "true" ]]; then
     # プロジェクトルート検出（bare repo 構造 or git toplevel）
     PROJECT_ROOT=""
-    if git rev-parse --show-toplevel &>/dev/null 2>&1; then
+    if git rev-parse --show-toplevel &>/dev/null; then
         GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
         # bare repo 構造: worktree 内の場合は bare repo root を探す
         if [[ -f "${GIT_ROOT}/.git" ]]; then
-            # .git がファイル（worktree）→ bare repo root を参照
+            # .git がファイル（worktree）→ bare repo root の main/ を参照
             GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
-            if [[ -n "$GIT_COMMON" && -d "${GIT_COMMON%/.bare*}" ]]; then
-                BARE_ROOT="${GIT_COMMON%/.bare*}"
-                PROJECT_ROOT="${BARE_ROOT}/main"
-            else
+            # GIT_COMMON は typically <bare-root>/.bare を指す
+            # <bare-root>/.bare → <bare-root>/main を構築
+            if [[ -n "$GIT_COMMON" ]]; then
+                BARE_ROOT="${GIT_COMMON%/.bare}"
+                if [[ "$BARE_ROOT" != "$GIT_COMMON" && -d "${BARE_ROOT}/main" ]]; then
+                    PROJECT_ROOT="${BARE_ROOT}/main"
+                fi
+            fi
+            # fallback: git toplevel 自体を使用
+            if [[ -z "$PROJECT_ROOT" ]]; then
                 PROJECT_ROOT="$GIT_ROOT"
             fi
         else
@@ -49,51 +55,25 @@ if [[ "$OBSERVER_MODE" == "true" ]]; then
         exit 1
     fi
 
-    # claude_session_id 読み取り
-    CLAUDE_SESSION_ID_VAL=$(python3 -c "
-import json, sys
+    # claude_session_id 読み取り（環境変数経由で Python に渡す — injection 防止）
+    CLAUDE_SESSION_ID_VAL=$(SESSION_JSON_PATH="$SESSION_JSON" python3 -c "
+import os, json
 try:
-    data = json.load(open('${SESSION_JSON}'))
-    sid = data.get('claude_session_id', None)
-    print(sid if sid else '')
+    with open(os.environ['SESSION_JSON_PATH']) as f:
+        data = json.load(f)
+    sid = data.get('claude_session_id') or ''
+    print(sid)
 except Exception:
     print('')
 " 2>/dev/null || echo "")
 
-    if [[ -z "$CLAUDE_SESSION_ID_VAL" || "$CLAUDE_SESSION_ID_VAL" == "null" ]]; then
+    if [[ -z "$CLAUDE_SESSION_ID_VAL" ]]; then
         echo "Observer session found but no Claude session ID recorded" >&2
         exit 1
     fi
 
-    # tmux window 有効性確認（session-state.sh が PATH 上にある場合）
-    if command -v session-state.sh &>/dev/null; then
-        WINDOW_LIST=$(session-state.sh list --json 2>/dev/null || echo "[]")
-        OBSERVER_WINDOW=$(python3 -c "
-import json, sys
-try:
-    windows = json.loads('''${WINDOW_LIST}''')
-    for w in windows:
-        if w.get('window', '') == 'observer':
-            print(w.get('window', ''))
-            break
-except Exception:
-    pass
-" 2>/dev/null || echo "")
-
-        if [[ -z "$OBSERVER_WINDOW" ]]; then
-            echo "Observer window not found. Session may have ended" >&2
-            exit 1
-        fi
-
-        OBSERVER_STATE=$(session-state.sh state observer 2>/dev/null || echo "exited")
-        if [[ "$OBSERVER_STATE" == "exited" ]]; then
-            echo "Observer session has ended. Start a new one with: cld → /su-observer" >&2
-            exit 1
-        fi
-    fi
-
-    # 有効な session ID で resume
-    exec claude --resume "$CLAUDE_SESSION_ID_VAL" "${PASS_ARGS[@]}"
+    # 有効な session ID で resume（ウィンドウ有効性確認は claude --resume に委ねる）
+    exec claude --resume "$CLAUDE_SESSION_ID_VAL" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"
 fi
 
 PLUGINS_BASE="$HOME/.claude/plugins"
@@ -114,4 +94,4 @@ done < <(env | grep '^DEV_')
 
 exec systemd-run --user --scope -p MemoryMax=12G \
     "${ENV_ARGS[@]}" \
-    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]}"
+    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"

--- a/plugins/session/scripts/cld
+++ b/plugins/session/scripts/cld
@@ -28,10 +28,10 @@ if [[ "$OBSERVER_MODE" == "true" ]]; then
             # .git がファイル（worktree）→ bare repo root の main/ を参照
             GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
             # GIT_COMMON は typically <bare-root>/.bare を指す
-            # <bare-root>/.bare → <bare-root>/main を構築
-            if [[ -n "$GIT_COMMON" ]]; then
+            # /.bare サフィックスを正確に除去して <bare-root>/main を構築
+            if [[ -n "$GIT_COMMON" && "${GIT_COMMON%/.bare}" != "$GIT_COMMON" ]]; then
                 BARE_ROOT="${GIT_COMMON%/.bare}"
-                if [[ "$BARE_ROOT" != "$GIT_COMMON" && -d "${BARE_ROOT}/main" ]]; then
+                if [[ -d "${BARE_ROOT}/main" ]]; then
                     PROJECT_ROOT="${BARE_ROOT}/main"
                 fi
             fi
@@ -55,24 +55,45 @@ if [[ "$OBSERVER_MODE" == "true" ]]; then
         exit 1
     fi
 
-    # claude_session_id 読み取り（環境変数経由で Python に渡す — injection 防止）
-    CLAUDE_SESSION_ID_VAL=$(SESSION_JSON_PATH="$SESSION_JSON" python3 -c "
+    # claude_session_id と observer_window を読み取り（環境変数経由で Python に渡す）
+    SESSION_DATA=$(SESSION_JSON_PATH="$SESSION_JSON" python3 -c "
 import os, json
 try:
     with open(os.environ['SESSION_JSON_PATH']) as f:
         data = json.load(f)
     sid = data.get('claude_session_id') or ''
+    win = data.get('observer_window') or ''
     print(sid)
+    print(win)
 except Exception:
     print('')
-" 2>/dev/null || echo "")
+    print('')
+" 2>/dev/null || printf '\n')
+
+    CLAUDE_SESSION_ID_VAL=$(echo "$SESSION_DATA" | head -1)
+    OBSERVER_WINDOW_NAME=$(echo "$SESSION_DATA" | tail -1)
 
     if [[ -z "$CLAUDE_SESSION_ID_VAL" ]]; then
         echo "Observer session found but no Claude session ID recorded" >&2
         exit 1
     fi
 
-    # 有効な session ID で resume（ウィンドウ有効性確認は claude --resume に委ねる）
+    # tmux ウィンドウ有効性確認（observer_window が記録されており session-state.sh が利用可能な場合）
+    if [[ -n "$OBSERVER_WINDOW_NAME" ]] && command -v session-state.sh &>/dev/null; then
+        OBSERVER_STATE=$(session-state.sh state "$OBSERVER_WINDOW_NAME" 2>/dev/null || echo "exited")
+        case "$OBSERVER_STATE" in
+            "exited")
+                echo "Observer session has ended. Start a new one with: cld → /su-observer" >&2
+                exit 1
+                ;;
+            "")
+                echo "Observer window not found. Session may have ended" >&2
+                exit 1
+                ;;
+        esac
+    fi
+
+    # 有効な session ID で resume
     exec claude --resume "$CLAUDE_SESSION_ID_VAL" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"
 fi
 

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -21,6 +21,7 @@ su-observer のプロジェクト常駐セッション。
 | status | `active` \| `compacting` \| `paused` \| `ended` | セッション状態 |
 | started_at | string (ISO 8601) | 開始時刻 |
 | claude_session_id | string \| null | Claude Code セッション ID（`cld --observer` での resume 用）。null = 未取得。JSONL ファイル名から取得（AC-0 で確定）。compaction 後は su-postcompact.sh が更新する（SHALL） |
+| observer_window | string \| null | su-observer が起動している tmux ウィンドウ名。`cld --observer` のウィンドウ有効性確認に使用。null = 未記録 |
 | supervised_controllers | SupervisedController[] | 監視中の controller リスト |
 | current_wave | WaveState \| null | 現在の Wave 状態（autopilot 実行時） |
 | memory_budget | MemoryBudget | 三層記憶の消費量追跡 |

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -20,7 +20,7 @@ su-observer のプロジェクト常駐セッション。
 | main_dir | string | bare repo の main ディレクトリパス |
 | status | `active` \| `compacting` \| `paused` \| `ended` | セッション状態 |
 | started_at | string (ISO 8601) | 開始時刻 |
-| claude_session_id | string \| null | Claude Code セッション ID（resume 用）。JSONL ファイル名から取得 |
+| claude_session_id | string \| null | Claude Code セッション ID（`cld --observer` での resume 用）。null = 未取得。JSONL ファイル名から取得（AC-0 で確定）。compaction 後は su-postcompact.sh が更新する（SHALL） |
 | supervised_controllers | SupervisedController[] | 監視中の controller リスト |
 | current_wave | WaveState \| null | 現在の Wave 状態（autopilot 実行時） |
 | memory_budget | MemoryBudget | 三層記憶の消費量追跡 |

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -20,6 +20,7 @@ su-observer のプロジェクト常駐セッション。
 | main_dir | string | bare repo の main ディレクトリパス |
 | status | `active` \| `compacting` \| `paused` \| `ended` | セッション状態 |
 | started_at | string (ISO 8601) | 開始時刻 |
+| claude_session_id | string \| null | Claude Code セッション ID（resume 用）。JSONL ファイル名から取得 |
 | supervised_controllers | SupervisedController[] | 監視中の controller リスト |
 | current_wave | WaveState \| null | 現在の Wave 状態（autopilot 実行時） |
 | memory_budget | MemoryBudget | 三層記憶の消費量追跡 |

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -325,6 +325,8 @@ skills:
       - atomic: su-compact  # SU-6b: context 逼迫時またはユーザー指示時にユーザーへ提案（SHOULD）
       - atomic: wave-collect        # SU-6a: Wave 完了時の結果収集
       - atomic: externalize-state   # SU-6a: Wave 完了時の外部化
+    dependencies:
+      - plugin: session  # cld --observer: session.json の claude_session_id 読み取りに session plugin の session-state.sh を使用
     description: "メタ認知レイヤー: 全 controller の監視・介入。テストシナリオ実行は co-self-improve に委譲"
 
   workflow-setup:

--- a/plugins/twl/scripts/su-postcompact.sh
+++ b/plugins/twl/scripts/su-postcompact.sh
@@ -3,6 +3,33 @@ set -euo pipefail
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
 [ -d "$SUPERVISOR_DIR" ] || exit 0
 
+# =============================================================================
+# Section: Session ID 更新（compaction 後に session ID が変わるため）
+# =============================================================================
+SESSION_JSON="${SUPERVISOR_DIR}/session.json"
+if [[ -f "$SESSION_JSON" ]]; then
+    PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
+    NEW_SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
+    if [[ -n "$NEW_SESSION_ID" ]]; then
+        python3 - <<PYEOF
+import json
+path = "${SESSION_JSON}"
+new_id = "${NEW_SESSION_ID}"
+try:
+    with open(path) as f:
+        data = json.load(f)
+    old_id = data.get("claude_session_id", "")
+    if old_id != new_id:
+        data["claude_session_id"] = new_id
+        with open(path, "w") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+except Exception:
+    pass
+PYEOF
+    fi
+fi
+# =============================================================================
+
 echo "## [POST-COMPACT RESTORE] Compaction 完了 — 以下の Working Memory で作業を再開せよ"
 echo ""
 echo "### 復帰手順（必須）"

--- a/plugins/twl/scripts/su-postcompact.sh
+++ b/plugins/twl/scripts/su-postcompact.sh
@@ -9,12 +9,19 @@ SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
 SESSION_JSON="${SUPERVISOR_DIR}/session.json"
 if [[ -f "$SESSION_JSON" ]]; then
     PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
-    NEW_SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
+    # ls -t で最新 JSONL ファイルから session ID を取得
+    NEW_SESSION_ID=""
+    if compgen -G "${HOME}/.claude/projects/${PROJECT_HASH}/*.jsonl" > /dev/null 2>&1; then
+        NEW_SESSION_ID=$(ls -t "${HOME}/.claude/projects/${PROJECT_HASH}/"*.jsonl 2>/dev/null \
+            | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
+    fi
     if [[ -n "$NEW_SESSION_ID" ]]; then
-        python3 - <<PYEOF
-import json
-path = "${SESSION_JSON}"
-new_id = "${NEW_SESSION_ID}"
+        # 変数を環境変数経由で渡す（heredoc への文字列展開 injection を防止）
+        # ヒアドキュメントのデリミタをシングルクォートで囲みシェル展開を無効化
+        SESSION_JSON_PATH="$SESSION_JSON" NEW_SESSION_ID_VAL="$NEW_SESSION_ID" python3 - <<'PYEOF'
+import json, os
+path = os.environ["SESSION_JSON_PATH"]
+new_id = os.environ["NEW_SESSION_ID_VAL"]
 try:
     with open(path) as f:
         data = json.load(f)

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -38,12 +38,13 @@ spawnable_by:
      NEW_SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||')
      # session.json の claude_session_id と比較し、差異があれば上書き
      ```
-   - 存在しない → 新規 SupervisorSession 作成。Claude Code session ID を取得して `claude_session_id` に保存:
+   - 存在しない → 新規 SupervisorSession 作成。Claude Code session ID と tmux ウィンドウ名を取得して保存:
      ```bash
      PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
-     CLAUDE_SESSION_ID_VAL=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||')
-     # session.json に claude_session_id フィールドを含めて書き込む
-     # 例: {"session_id": "<uuid>", "claude_session_id": "<CLAUDE_SESSION_ID_VAL>", "status": "active", ...}
+     CLAUDE_SESSION_ID_VAL=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
+     OBSERVER_WINDOW_NAME=$(tmux display-message -p '#W' 2>/dev/null || echo "")
+     # session.json に claude_session_id + observer_window フィールドを含めて書き込む
+     # 例: {"session_id": "<uuid>", "claude_session_id": "<CLAUDE_SESSION_ID_VAL>", "observer_window": "<OBSERVER_WINDOW_NAME>", "status": "active", ...}
      ```
 3. Project Board から現在の状態を取得（Todo/In Progress の Issue 一覧）
 4. `mcp__doobidoo__memory_search` でプロジェクトの直近記憶を検索（プロジェクト全体像の復元）

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -32,8 +32,19 @@ spawnable_by:
 
 1. bare repo 構造を検証（main/ で起動されていることを確認）
 2. `.supervisor/session.json` の存在確認:
-   - 存在 + status=active → 前回セッションの復帰。PostCompact 相当の外部化ファイル読み込み
-   - 存在しない → 新規 SupervisorSession 作成
+   - 存在 + status=active → 前回セッションの復帰。PostCompact 相当の外部化ファイル読み込み。既存 `claude_session_id` を検証し変更があれば更新:
+     ```bash
+     PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
+     NEW_SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||')
+     # session.json の claude_session_id と比較し、差異があれば上書き
+     ```
+   - 存在しない → 新規 SupervisorSession 作成。Claude Code session ID を取得して `claude_session_id` に保存:
+     ```bash
+     PROJECT_HASH=$(pwd | sed 's|/|-|g; s|^-||')
+     CLAUDE_SESSION_ID_VAL=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||')
+     # session.json に claude_session_id フィールドを含めて書き込む
+     # 例: {"session_id": "<uuid>", "claude_session_id": "<CLAUDE_SESSION_ID_VAL>", "status": "active", ...}
+     ```
 3. Project Board から現在の状態を取得（Todo/In Progress の Issue 一覧）
 4. `mcp__doobidoo__memory_search` でプロジェクトの直近記憶を検索（プロジェクト全体像の復元）
 5. `refs/monitor-channel-catalog.md` を Read して Monitor チャネル定義を把握（Wave 管理時のチャネル選択に使用）

--- a/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
+++ b/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
@@ -1,0 +1,828 @@
+#!/usr/bin/env bash
+# =============================================================================
+# BDD Scenario Tests: su-observer session ID persistence & cld --observer resume
+# Generated from: deltaspec/changes/issue-613/specs/session-id-persistence/spec.md
+# Coverage level: edge-cases
+# =============================================================================
+set -uo pipefail
+
+# Project root (relative to test file location)
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SESSION_PLUGIN_ROOT="$(cd "${PROJECT_ROOT}/../../plugins/session" && pwd 2>/dev/null)" || SESSION_PLUGIN_ROOT=""
+CLD_SCRIPT="${SESSION_PLUGIN_ROOT:+${SESSION_PLUGIN_ROOT}/scripts/cld}"
+SU_OBSERVER_SKILL="${PROJECT_ROOT}/skills/su-observer/SKILL.md"
+SUPERVISION_MD="${PROJECT_ROOT}/architecture/domain/contexts/supervision.md"
+SU_POSTCOMPACT="${PROJECT_ROOT}/scripts/su-postcompact.sh"
+
+# Counters
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# --- Test Helpers ---
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "$file" ]]
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "$file" ]] && grep -qP -- "$pattern" "$file"
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "$file" ]] || return 1
+  if grep -qP -- "$pattern" "$file"; then
+    return 1
+  fi
+  return 0
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+setup_sandbox() {
+  SANDBOX=$(mktemp -d)
+  mkdir -p "${SANDBOX}/.supervisor"
+}
+
+teardown_sandbox() {
+  if [[ -n "${SANDBOX:-}" && -d "${SANDBOX}" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+  SANDBOX=""
+}
+
+SANDBOX=""
+trap teardown_sandbox EXIT
+
+# =============================================================================
+# Requirement: Session ID 保存
+# Scenario: 新規 observer セッション起動時の session ID 保存 (spec line 7)
+# WHEN: su-observer SKILL.md Step 0 で SupervisorSession を新規作成するとき
+# THEN: Claude Code session ID が .supervisor/session.json の claude_session_id フィールドに書き込まれること
+# =============================================================================
+echo ""
+echo "--- Requirement: Session ID 保存 / Scenario: 新規 observer セッション起動時 ---"
+
+# Test: SKILL.md Step 0 に session.json への claude_session_id 書き込み指示が含まれる
+test_skillmd_step0_session_id_write() {
+  assert_file_exists "$SU_OBSERVER_SKILL" || return 1
+  assert_file_contains "$SU_OBSERVER_SKILL" "claude_session_id"
+}
+
+if [[ -f "$SU_OBSERVER_SKILL" ]]; then
+  run_test "SKILL.md Step 0: claude_session_id フィールドへの書き込み指示が存在する" test_skillmd_step0_session_id_write
+else
+  run_test_skip "SKILL.md Step 0: claude_session_id 書き込み指示" "SKILL.md が存在しない"
+fi
+
+# Test: SKILL.md が session.json への保存に言及している
+test_skillmd_session_json_reference() {
+  assert_file_exists "$SU_OBSERVER_SKILL" || return 1
+  assert_file_contains "$SU_OBSERVER_SKILL" "session\.json"
+}
+
+if [[ -f "$SU_OBSERVER_SKILL" ]]; then
+  run_test "SKILL.md: .supervisor/session.json への参照が存在する" test_skillmd_session_json_reference
+else
+  run_test_skip "SKILL.md: session.json 参照" "SKILL.md が存在しない"
+fi
+
+# Test: SKILL.md Step 0 に「新規作成」パスで session ID 保存に言及する
+test_skillmd_new_session_id_save() {
+  assert_file_exists "$SU_OBSERVER_SKILL" || return 1
+  # 新規 SupervisorSession 作成パスに claude_session_id への言及があること
+  python3 - "$SU_OBSERVER_SKILL" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# Step 0 セクションを抽出（Step 1 が現れる前まで）
+step0_match = re.search(r'(?:##+ Step\s*0|Step\s*0[:\s])(.*?)(?=##+ Step\s*1|Step\s*1[:\s]|\Z)', content, re.DOTALL | re.IGNORECASE)
+if not step0_match:
+    print("Step 0 section not found", file=sys.stderr)
+    sys.exit(1)
+
+step0_text = step0_match.group(0)
+
+# 新規作成パス + session ID の両方が含まれるか確認
+has_new_session = bool(re.search(r'新規.*SupervisorSession|SupervisorSession.*作成|新規.*セッション', step0_text))
+has_session_id = bool(re.search(r'claude_session_id', step0_text))
+
+if not (has_new_session and has_session_id):
+    print(f"Step 0 missing new-session+session_id: has_new_session={has_new_session}, has_session_id={has_session_id}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SU_OBSERVER_SKILL" ]]; then
+  run_test "SKILL.md Step 0: 新規作成パスで claude_session_id 保存が定義されている" test_skillmd_new_session_id_save
+else
+  run_test_skip "SKILL.md Step 0: 新規作成パスの session ID 保存" "SKILL.md が存在しない"
+fi
+
+# Edge case: session.json は .supervisor/ ディレクトリ内に作成されること
+test_skillmd_supervisor_dir_path() {
+  assert_file_exists "$SU_OBSERVER_SKILL" || return 1
+  assert_file_contains "$SU_OBSERVER_SKILL" "\.supervisor/session\.json"
+}
+
+if [[ -f "$SU_OBSERVER_SKILL" ]]; then
+  run_test "SKILL.md [edge: session.json パスが .supervisor/ 配下であること]" test_skillmd_supervisor_dir_path
+else
+  run_test_skip "SKILL.md [edge: .supervisor/session.json パス]" "SKILL.md が存在しない"
+fi
+
+# Edge case: session.json の JSON 構造に claude_session_id キーが含まれること（スキーマ検証）
+test_sandbox_session_json_schema() {
+  setup_sandbox
+  # session.json に claude_session_id が含まれる場合の JSON パース確認
+  cat > "${SANDBOX}/.supervisor/session.json" <<'JSON'
+{
+  "session_id": "test-session-001",
+  "claude_session_id": "claude-abc123",
+  "status": "active",
+  "started_at": "2026-04-14T00:00:00Z"
+}
+JSON
+  python3 -c "
+import json, sys
+with open('${SANDBOX}/.supervisor/session.json') as f:
+    data = json.load(f)
+if 'claude_session_id' not in data:
+    print('claude_session_id key missing', file=sys.stderr)
+    sys.exit(1)
+if not data['claude_session_id']:
+    print('claude_session_id is empty', file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+"
+  local result=$?
+  teardown_sandbox
+  return $result
+}
+run_test "session.json [edge: claude_session_id キーを含む JSON スキーマが有効]" test_sandbox_session_json_schema
+
+# =============================================================================
+# Requirement: Session ID 保存
+# Scenario: observer セッション復帰時の session ID 更新 (spec line 11)
+# WHEN: su-observer SKILL.md Step 0 で status=active の既存セッションに復帰するとき
+# THEN: 既存の claude_session_id が検証され、変更がある場合は更新されること
+# =============================================================================
+echo ""
+echo "--- Requirement: Session ID 保存 / Scenario: observer セッション復帰時の session ID 更新 ---"
+
+# Test: SKILL.md Step 0 に「復帰」パスで session ID 更新に言及する
+test_skillmd_resume_session_id_update() {
+  assert_file_exists "$SU_OBSERVER_SKILL" || return 1
+  python3 - "$SU_OBSERVER_SKILL" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# Step 0 セクションを抽出
+step0_match = re.search(r'(?:##+ Step\s*0|Step\s*0[:\s])(.*?)(?=##+ Step\s*1|Step\s*1[:\s]|\Z)', content, re.DOTALL | re.IGNORECASE)
+if not step0_match:
+    print("Step 0 section not found", file=sys.stderr)
+    sys.exit(1)
+
+step0_text = step0_match.group(0)
+
+# status=active 復帰パス + session ID 更新の両方が含まれるか
+has_resume = bool(re.search(r'status.*active|active.*復帰|復帰.*active|前回.*復帰', step0_text))
+has_update = bool(re.search(r'claude_session_id', step0_text))
+
+if not (has_resume and has_update):
+    print(f"Step 0 missing resume+update: has_resume={has_resume}, has_update={has_update}", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SU_OBSERVER_SKILL" ]]; then
+  run_test "SKILL.md Step 0: 復帰パスで claude_session_id の検証・更新が定義されている" test_skillmd_resume_session_id_update
+else
+  run_test_skip "SKILL.md Step 0: 復帰パスの session ID 更新" "SKILL.md が存在しない"
+fi
+
+# Edge case: session ID が変更なし → session.json を書き換えない（冪等性）
+test_sandbox_session_id_unchanged_idempotent() {
+  setup_sandbox
+  local original_id="claude-unchanged-999"
+  cat > "${SANDBOX}/.supervisor/session.json" <<JSON
+{
+  "session_id": "sup-001",
+  "claude_session_id": "${original_id}",
+  "status": "active",
+  "started_at": "2026-04-14T00:00:00Z"
+}
+JSON
+  # ファイル変更なし → 同じ値を書いても claude_session_id が変わらないこと
+  python3 -c "
+import json
+path = '${SANDBOX}/.supervisor/session.json'
+with open(path) as f:
+    data = json.load(f)
+# 変更なし（同値）
+if data['claude_session_id'] == '${original_id}':
+    # session.json は書き換え不要（更新不要フラグが立つはず）
+    import sys; sys.exit(0)
+import sys; sys.exit(1)
+"
+  local result=$?
+  teardown_sandbox
+  return $result
+}
+run_test "session.json [edge: session ID 変更なし時は書き換え不要（冪等性）]" test_sandbox_session_id_unchanged_idempotent
+
+# Edge case: session ID が変更あり → 新しい値で session.json が更新されること
+test_sandbox_session_id_update_on_change() {
+  setup_sandbox
+  local old_id="claude-old-111"
+  local new_id="claude-new-222"
+  cat > "${SANDBOX}/.supervisor/session.json" <<JSON
+{
+  "session_id": "sup-002",
+  "claude_session_id": "${old_id}",
+  "status": "active",
+  "started_at": "2026-04-14T00:00:00Z"
+}
+JSON
+  # 新しい session ID で上書き
+  python3 -c "
+import json
+path = '${SANDBOX}/.supervisor/session.json'
+with open(path) as f:
+    data = json.load(f)
+data['claude_session_id'] = '${new_id}'
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2)
+"
+  # 更新後の確認
+  python3 -c "
+import json
+path = '${SANDBOX}/.supervisor/session.json'
+with open(path) as f:
+    data = json.load(f)
+import sys
+if data['claude_session_id'] != '${new_id}':
+    print(f'Expected ${new_id}, got {data[\"claude_session_id\"]}', file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+"
+  local result=$?
+  teardown_sandbox
+  return $result
+}
+run_test "session.json [edge: session ID 変更時は新しい値で更新される]" test_sandbox_session_id_update_on_change
+
+# =============================================================================
+# Requirement: SupervisorSession エンティティ拡張
+# Scenario: アーキテクチャドキュメントへのフィールド追加 (spec line 19)
+# WHEN: plugins/twl/architecture/domain/contexts/supervision.md を参照するとき
+# THEN: SupervisorSession エンティティのフィールド一覧に claude_session_id: string | null が含まれること
+# =============================================================================
+echo ""
+echo "--- Requirement: SupervisorSession エンティティ拡張 / Scenario: アーキテクチャドキュメントへのフィールド追加 ---"
+
+# Test: supervision.md の SupervisorSession テーブルに claude_session_id フィールドが存在する
+test_supervision_md_has_claude_session_id() {
+  assert_file_exists "$SUPERVISION_MD" || return 1
+  python3 - "$SUPERVISION_MD" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# SupervisorSession セクションを抽出
+session_match = re.search(r'###\s*SupervisorSession(.*?)(?=###|\Z)', content, re.DOTALL)
+if not session_match:
+    print("SupervisorSession section not found", file=sys.stderr)
+    sys.exit(1)
+
+section_text = session_match.group(1)
+
+# claude_session_id フィールドが存在するか確認
+if not re.search(r'claude_session_id', section_text):
+    print("claude_session_id field not found in SupervisorSession section", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SUPERVISION_MD" ]]; then
+  run_test "supervision.md: SupervisorSession に claude_session_id フィールドが存在する" test_supervision_md_has_claude_session_id
+else
+  run_test_skip "supervision.md: SupervisorSession フィールド確認" "supervision.md が存在しない"
+fi
+
+# Test: claude_session_id の型が string | null または string \| null と定義されている
+test_supervision_md_field_type_nullable_string() {
+  assert_file_exists "$SUPERVISION_MD" || return 1
+  python3 - "$SUPERVISION_MD" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# SupervisorSession セクション内の claude_session_id 行を確認
+session_match = re.search(r'###\s*SupervisorSession(.*?)(?=###|\Z)', content, re.DOTALL)
+if not session_match:
+    print("SupervisorSession section not found", file=sys.stderr)
+    sys.exit(1)
+
+section_text = session_match.group(1)
+
+# claude_session_id を含む行を抽出
+lines = section_text.splitlines()
+field_line = next((l for l in lines if 'claude_session_id' in l), None)
+if not field_line:
+    print("claude_session_id line not found", file=sys.stderr)
+    sys.exit(1)
+
+# string | null または string \| null が含まれるか（テーブルのエスケープ考慮）
+if not re.search(r'string.*\|?\s*null|null.*\|?\s*string', field_line, re.IGNORECASE):
+    print(f"Type annotation 'string | null' not found in: {field_line.strip()}", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SUPERVISION_MD" ]]; then
+  run_test "supervision.md: claude_session_id の型が string | null と定義されている" test_supervision_md_field_type_nullable_string
+else
+  run_test_skip "supervision.md: claude_session_id 型定義確認" "supervision.md が存在しない"
+fi
+
+# Edge case: SupervisorSession テーブルの既存フィールド（session_id, status 等）が壊れていない
+test_supervision_md_existing_fields_intact() {
+  assert_file_exists "$SUPERVISION_MD" || return 1
+  python3 - "$SUPERVISION_MD" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+session_match = re.search(r'###\s*SupervisorSession(.*?)(?=###|\Z)', content, re.DOTALL)
+if not session_match:
+    print("SupervisorSession section not found", file=sys.stderr)
+    sys.exit(1)
+
+section_text = session_match.group(1)
+
+# 必須の既存フィールドが残っているか確認
+required_fields = ['session_id', 'project', 'status', 'started_at']
+missing = [f for f in required_fields if f not in section_text]
+if missing:
+    print(f"Missing required fields: {missing}", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SUPERVISION_MD" ]]; then
+  run_test "supervision.md [edge: 既存フィールド session_id/project/status/started_at が維持されている]" test_supervision_md_existing_fields_intact
+else
+  run_test_skip "supervision.md [edge: 既存フィールド確認]" "supervision.md が存在しない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: 有効な observer session への resume (spec line 29)
+# WHEN: cld --observer を実行し、有効な session ID と tmux window が存在するとき
+# THEN: claude --resume <claude_session_id> が実行されること
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: 有効な observer session への resume ---"
+
+# Test: cld スクリプトに --observer フラグの処理が含まれている
+test_cld_has_observer_flag_handling() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "\-\-observer"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: --observer フラグ処理が実装されている" test_cld_has_observer_flag_handling
+else
+  run_test_skip "cld スクリプト: --observer フラグ処理" "cld スクリプトが見つからない"
+fi
+
+# Test: cld スクリプトに claude --resume の呼び出しが含まれている
+test_cld_has_claude_resume_call() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "claude.*--resume|--resume.*claude"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: claude --resume <session_id> 呼び出しが実装されている" test_cld_has_claude_resume_call
+else
+  run_test_skip "cld スクリプト: claude --resume 呼び出し" "cld スクリプトが見つからない"
+fi
+
+# Test: cld スクリプトが session.json から claude_session_id を読み取る
+test_cld_reads_claude_session_id_from_json() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "claude_session_id"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: session.json から claude_session_id を読み取る処理がある" test_cld_reads_claude_session_id_from_json
+else
+  run_test_skip "cld スクリプト: claude_session_id 読み取り" "cld スクリプトが見つからない"
+fi
+
+# Edge case: --observer フラグ処理が他フラグ（--env-file, -p 等）より前に評価される
+test_cld_observer_flag_parse_order() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  python3 - "$CLD_SCRIPT" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+observer_match = re.search(r'--observer', content)
+resume_match = re.search(r'--resume', content)
+
+if not observer_match:
+    print("--observer not found in cld script", file=sys.stderr)
+    sys.exit(1)
+if not resume_match:
+    print("--resume not found in cld script", file=sys.stderr)
+    sys.exit(1)
+
+# --observer の処理が --resume よりも前に定義されているか
+if observer_match.start() > resume_match.start():
+    print("Warning: --observer handling appears after --resume call", file=sys.stderr)
+    # 警告のみ（FAIL ではなく）
+sys.exit(0)
+PYEOF
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: --observer フラグが正しい順序で解析される]" test_cld_observer_flag_parse_order
+else
+  run_test_skip "cld スクリプト [edge: フラグ解析順序]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: session.json が存在しない場合のエラー (spec line 33)
+# WHEN: cld --observer を実行し、.supervisor/session.json が存在しないとき
+# THEN: "No active observer session. Start one with: cld → /su-observer" メッセージが表示されること
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: session.json が存在しない場合のエラー ---"
+
+# Test: cld スクリプトに session.json 不在時のエラーメッセージが含まれる
+test_cld_no_session_json_error_msg() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "No active observer session"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: session.json 不在時エラーメッセージ 'No active observer session' が存在する" test_cld_no_session_json_error_msg
+else
+  run_test_skip "cld スクリプト: session.json 不在エラーメッセージ" "cld スクリプトが見つからない"
+fi
+
+# Test: エラーメッセージに su-observer 起動方法が含まれる
+test_cld_no_session_json_error_hint() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "su-observer"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: session.json 不在エラーに /su-observer 起動ヒントが含まれる" test_cld_no_session_json_error_hint
+else
+  run_test_skip "cld スクリプト: エラーヒント確認" "cld スクリプトが見つからない"
+fi
+
+# Edge case: session.json が存在するが壊れた JSON の場合もエラーが出ること
+test_cld_observer_broken_json_handled() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # スクリプトに JSON パースエラーハンドリングが存在するか
+  assert_file_contains "$CLD_SCRIPT" "jq\|python3\|parse" || \
+    assert_file_contains "$CLD_SCRIPT" "2>/dev/null\|2>&1"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: 破損 JSON に対してエラーハンドリングが存在する]" test_cld_observer_broken_json_handled
+else
+  run_test_skip "cld スクリプト [edge: 破損 JSON ハンドリング]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: session ID が空の場合のエラー (spec line 37)
+# WHEN: cld --observer を実行し、claude_session_id が null または空のとき
+# THEN: "Observer session found but no Claude session ID recorded" メッセージが表示されること
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: session ID が空の場合のエラー ---"
+
+# Test: cld スクリプトに session ID 空時のエラーメッセージが含まれる
+test_cld_empty_session_id_error_msg() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "Observer session found but no Claude session ID recorded"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: session ID 空時エラーメッセージが定義されている" test_cld_empty_session_id_error_msg
+else
+  run_test_skip "cld スクリプト: session ID 空エラーメッセージ" "cld スクリプトが見つからない"
+fi
+
+# Edge case: claude_session_id が "null" リテラル文字列の場合も空と同様に扱われること
+test_cld_null_literal_treated_as_empty() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # null または空の両方をチェックするパターンが存在するか
+  assert_file_contains "$CLD_SCRIPT" 'null\|-z\|empty\|^\s*$'
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: null リテラルと空文字列の両方をエラーとして扱う]" test_cld_null_literal_treated_as_empty
+else
+  run_test_skip "cld スクリプト [edge: null/空の両方チェック]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: tmux window が存在しない場合のエラー (spec line 41)
+# WHEN: cld --observer を実行し、対応する tmux window が存在しないとき
+# THEN: "Observer window not found. Session may have ended" メッセージが表示されること
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: tmux window が存在しない場合のエラー ---"
+
+# Test: cld スクリプトに tmux window 不在時のエラーメッセージが含まれる
+test_cld_no_tmux_window_error_msg() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "Observer window not found"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: tmux window 不在エラーメッセージ 'Observer window not found' が存在する" test_cld_no_tmux_window_error_msg
+else
+  run_test_skip "cld スクリプト: tmux window 不在エラーメッセージ" "cld スクリプトが見つからない"
+fi
+
+# Test: cld スクリプトが tmux window の存在確認を行っている
+test_cld_checks_tmux_window_existence() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "tmux.*list-windows\|tmux.*has-session\|tmux.*select-window"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: tmux window 存在確認コマンドが実装されている" test_cld_checks_tmux_window_existence
+else
+  run_test_skip "cld スクリプト: tmux window 存在確認" "cld スクリプトが見つからない"
+fi
+
+# Edge case: tmux が起動していない場合（TMUX 変数なし）でもエラーが適切に処理される
+test_cld_tmux_not_running_handled() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # tmux コマンド失敗時の || または 2>/dev/null が存在するか
+  assert_file_contains "$CLD_SCRIPT" "tmux.*2>/dev/null\|tmux.*\|\|"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: tmux 未起動時のエラーが適切に処理される]" test_cld_tmux_not_running_handled
+else
+  run_test_skip "cld スクリプト [edge: tmux 未起動時の処理]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: Claude Code プロセスが終了している場合のエラー (spec line 45)
+# WHEN: cld --observer を実行し、Claude Code プロセスが exited 状態のとき
+# THEN: "Observer session has ended. Start a new one with: cld → /su-observer" メッセージが表示されること
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: Claude Code プロセスが終了している場合のエラー ---"
+
+# Test: cld スクリプトにプロセス終了時のエラーメッセージが含まれる
+test_cld_process_exited_error_msg() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  assert_file_contains "$CLD_SCRIPT" "Observer session has ended"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: プロセス終了エラーメッセージ 'Observer session has ended' が存在する" test_cld_process_exited_error_msg
+else
+  run_test_skip "cld スクリプト: プロセス終了エラーメッセージ" "cld スクリプトが見つからない"
+fi
+
+# Test: cld スクリプトがプロセスの生存確認を行っている
+test_cld_checks_process_alive() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # プロセス確認: ps, kill -0, pgrep など
+  assert_file_contains "$CLD_SCRIPT" "ps\b.*claude\|pgrep.*claude\|kill\s*-0\|tmux.*capture-pane\|session.*exited\|exited"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: Claude Code プロセス生存確認が実装されている" test_cld_checks_process_alive
+else
+  run_test_skip "cld スクリプト: プロセス生存確認" "cld スクリプトが見つからない"
+fi
+
+# Edge case: session.json の status フィールドが ended/exited の場合もエラーを表示する
+test_cld_session_status_ended_detected() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # status=ended または exited の検出パターン
+  assert_file_contains "$CLD_SCRIPT" "ended\|exited\|status"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: session status=ended/exited を検出してエラー表示]" test_cld_session_status_ended_detected
+else
+  run_test_skip "cld スクリプト [edge: status=ended 検出]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: cld --observer フラグ
+# Scenario: 既存フラグの互換性維持 (spec line 49)
+# WHEN: cld を --observer フラグなしで実行するとき
+# THEN: 既存動作（全引数を claude にパススルー）に影響がないこと
+# =============================================================================
+echo ""
+echo "--- Requirement: cld --observer フラグ / Scenario: 既存フラグの互換性維持 ---"
+
+# Test: cld スクリプトに --observer なし時の exec/passthrough が維持されている
+test_cld_passthrough_preserved() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # exec claude ... "$@" または claude ... "$@" パターンが存在するか
+  assert_file_contains "$CLD_SCRIPT" 'exec.*claude.*"\$@"\|claude.*"\$@"'
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: --observer なし時の全引数パススルーが維持されている" test_cld_passthrough_preserved
+else
+  run_test_skip "cld スクリプト: 全引数パススルー維持" "cld スクリプトが見つからない"
+fi
+
+# Test: --observer フラグは --dangerously-skip-permissions 等の既存フラグと共存できる
+test_cld_observer_coexists_with_existing_flags() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # dangerously-skip-permissions が残っている
+  assert_file_contains "$CLD_SCRIPT" "dangerously-skip-permissions"
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト: --dangerously-skip-permissions 等の既存フラグが維持されている" test_cld_observer_coexists_with_existing_flags
+else
+  run_test_skip "cld スクリプト: 既存フラグ共存確認" "cld スクリプトが見つからない"
+fi
+
+# Edge case: -p フラグが --observer と共に渡された場合は拒否する（既存の cld-p-flag-prohibition）
+test_cld_p_flag_prohibition_with_observer() {
+  [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
+  # -p フラグに関する制約が存在するか（または --observer 時は明示的にチェックしないことを確認）
+  # この Edge case: --observer が -p フラグの既存禁止ロジックを壊さないこと
+  # cld スクリプト自体に -p 禁止ロジックがあれば OK
+  assert_file_contains "$CLD_SCRIPT" "\-p\b\|\-\-print\b" || return 0  # なければスキップ相当で OK
+}
+
+if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
+  run_test "cld スクリプト [edge: -p フラグ禁止ロジックが --observer によって壊されていない]" test_cld_p_flag_prohibition_with_observer
+else
+  run_test_skip "cld スクリプト [edge: -p フラグ禁止共存]" "cld スクリプトが見つからない"
+fi
+
+# =============================================================================
+# Requirement: Compaction 後の Session ID 更新
+# Scenario: compaction 後の session ID 更新（ID 変更ケース） (spec line 57)
+# WHEN: Claude Code の /compact 実行後に session ID が変わったとき
+# THEN: su-postcompact.sh が新しい session ID を取得し .supervisor/session.json を更新すること
+# =============================================================================
+echo ""
+echo "--- Requirement: Compaction 後の Session ID 更新 / Scenario: compaction 後の session ID 更新 ---"
+
+# Test: su-postcompact.sh スクリプトが存在する
+test_postcompact_script_exists() {
+  assert_file_exists "$SU_POSTCOMPACT"
+}
+run_test "su-postcompact.sh スクリプトが存在する" test_postcompact_script_exists
+
+# Test: su-postcompact.sh が session.json の claude_session_id 更新に言及している
+test_postcompact_updates_claude_session_id() {
+  assert_file_exists "$SU_POSTCOMPACT" || return 1
+  assert_file_contains "$SU_POSTCOMPACT" "claude_session_id"
+}
+
+if [[ -f "$SU_POSTCOMPACT" ]]; then
+  run_test "su-postcompact.sh: claude_session_id 更新処理が実装されている" test_postcompact_updates_claude_session_id
+else
+  run_test_skip "su-postcompact.sh: claude_session_id 更新" "su-postcompact.sh が存在しない"
+fi
+
+# Test: su-postcompact.sh が session.json を書き込む処理を持つ
+test_postcompact_writes_session_json() {
+  assert_file_exists "$SU_POSTCOMPACT" || return 1
+  assert_file_contains "$SU_POSTCOMPACT" "session\.json"
+}
+
+if [[ -f "$SU_POSTCOMPACT" ]]; then
+  run_test "su-postcompact.sh: .supervisor/session.json への書き込みが実装されている" test_postcompact_writes_session_json
+else
+  run_test_skip "su-postcompact.sh: session.json 書き込み" "su-postcompact.sh が存在しない"
+fi
+
+# Edge case: compaction 後も session_id（supervisor 側）は変わらず claude_session_id のみ更新される
+test_postcompact_only_claude_session_id_changes() {
+  assert_file_exists "$SU_POSTCOMPACT" || return 1
+  python3 - "$SU_POSTCOMPACT" <<'PYEOF'
+import re, sys
+
+with open(sys.argv[1]) as f:
+    content = f.read()
+
+# claude_session_id の更新処理が存在するか
+has_claude_session_update = bool(re.search(r'claude_session_id', content))
+
+if not has_claude_session_update:
+    print("claude_session_id update not found in su-postcompact.sh", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+
+if [[ -f "$SU_POSTCOMPACT" ]]; then
+  run_test "su-postcompact.sh [edge: claude_session_id のみを選択的に更新する]" test_postcompact_only_claude_session_id_changes
+else
+  run_test_skip "su-postcompact.sh [edge: 選択的更新]" "su-postcompact.sh が存在しない"
+fi
+
+# Edge case: su-postcompact.sh は SUPERVISOR_DIR 環境変数を尊重する（デフォルト: .supervisor）
+test_postcompact_respects_supervisor_dir_env() {
+  assert_file_exists "$SU_POSTCOMPACT" || return 1
+  assert_file_contains "$SU_POSTCOMPACT" "SUPERVISOR_DIR"
+}
+
+if [[ -f "$SU_POSTCOMPACT" ]]; then
+  run_test "su-postcompact.sh [edge: SUPERVISOR_DIR 環境変数を尊重する]" test_postcompact_respects_supervisor_dir_env
+else
+  run_test_skip "su-postcompact.sh [edge: SUPERVISOR_DIR 環境変数]" "su-postcompact.sh が存在しない"
+fi
+
+# Edge case: compaction 後 session.json が存在しない場合は何もしない（graceful）
+test_postcompact_graceful_no_session_json() {
+  assert_file_exists "$SU_POSTCOMPACT" || return 1
+  # session.json 不在時の exit 0 や存在チェックが定義されているか
+  assert_file_contains "$SU_POSTCOMPACT" "\[ -f.*session\.json\|session\.json.*-f\|\[ -d \$\{SUPERVISOR_DIR"
+}
+
+if [[ -f "$SU_POSTCOMPACT" ]]; then
+  run_test "su-postcompact.sh [edge: session.json 不在時は何もせずに終了する]" test_postcompact_graceful_no_session_json
+else
+  run_test_skip "su-postcompact.sh [edge: session.json 不在時の graceful exit]" "su-postcompact.sh が存在しない"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
fix: implement observer_window field for reliable AC-5/AC-6 window validation

- supervision.md: add observer_window field to SupervisorSession entity
- su-observer SKILL.md: store tmux window name (tmux display-message) in session.json
- cld --observer: read observer_window from session.json; use session-state.sh
  with actual window name (not hardcoded 'observer') for AC-5/AC-6 validation
  Validation skipped gracefully if observer_window not recorded (backward compat)

Closes #613