### PR TITLE
fix(session): CLD_ENV_FILE 未設定時に ~/.cld-env をデフォルト source する

### DIFF
--- a/plugins/session/scripts/cld-spawn
+++ b/plugins/session/scripts/cld-spawn
@@ -69,8 +69,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-# --env-file 未指定時は CLD_ENV_FILE 環境変数をデフォルトとして使用
-ENV_FILE="${ENV_FILE:-${CLD_ENV_FILE:-}}"
+# --env-file 未指定時は CLD_ENV_FILE 環境変数、次に ~/.cld-env をデフォルトとして使用
+ENV_FILE="${ENV_FILE:-${CLD_ENV_FILE:-$HOME/.cld-env}}"
 # --env-file のチルダ展開（存在チェックは不要: 不在時は source が 2>/dev/null で無視）
 if [[ -n "$ENV_FILE" ]]; then
     ENV_FILE="${ENV_FILE/#\~/$HOME}"

--- a/plugins/session/tests/cld-spawn-env-file.bats
+++ b/plugins/session/tests/cld-spawn-env-file.bats
@@ -188,19 +188,20 @@ _run_spawn() {
 # ---------------------------------------------------------------------------
 # Scenario 5: --env-file も CLD_ENV_FILE も未設定の場合
 # WHEN: --env-file 引数も CLD_ENV_FILE 環境変数も未指定で cld-spawn を実行する
-# THEN: 既存動作に変更なく、ランチャースクリプトに source 行が追加されない
+# THEN: ~/.cld-env をデフォルトとして LAUNCHER に source 行が追加される
 # ---------------------------------------------------------------------------
-@test "env-file: --env-file も CLD_ENV_FILE も未設定なら LAUNCHER に source 行が含まれない" {
+@test "env-file: --env-file も CLD_ENV_FILE も未設定なら ~/.cld-env をデフォルトとして LAUNCHER に source 行が含まれる" {
     unset CLD_ENV_FILE 2>/dev/null || true
     _run_spawn
     [[ "$status" -eq 0 ]]
     [[ -n "$LAUNCHER_CONTENT" ]]
-    # env file 用の source 行が LAUNCHER に含まれていない
-    # （通常の bash や cld の実行行は含まれうるが、ファイルのsourceは含まれない）
+    # ~/.cld-env をデフォルトとして source 行が LAUNCHER に含まれる
+    # （存在しない場合は 2>/dev/null で無視される）
     local env_source_lines
     env_source_lines=$(printf '%s\n' "$LAUNCHER_CONTENT" \
         | grep -E '^(source |[[:space:]]*\. )' \
         | grep -v '^#!/' \
         || true)
-    [[ -z "$env_source_lines" ]]
+    [[ -n "$env_source_lines" ]]
+    echo "$env_source_lines" | grep -q '\.cld-env'
 }


### PR DESCRIPTION
fix(session): CLD_ENV_FILE 未設定時に ~/.cld-env をデフォルト source する

--env-file 未指定かつ CLD_ENV_FILE 未設定の場合、~/.cld-env が存在すれば
自動的に source するようデフォルト値を追加。
compact 後やセッション再開時に環境変数が消失しても effort=max が維持される。

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #645