### PR TITLE
fix: merge-gate と workflow-pr-verify に PR 存在確認ガードを追加

### DIFF
--- a/plugins/twl/commands/merge-gate.md
+++ b/plugins/twl/commands/merge-gate.md
@@ -24,7 +24,7 @@ if [[ -z "$PR_NUM" || "$PR_NUM" == "none" ]]; then
   python3 -m twl.autopilot.checkpoint write \
     --step merge-gate \
     --status REJECT \
-    --findings '[{"severity":"CRITICAL","category":"process","message":"PR が存在しない状態で merge-gate が実行されました。PR を作成してから再実行してください","confidence":100}]'
+    --findings '[{"severity":"CRITICAL","category":"chain-integrity-drift","message":"PR が存在しない状態で merge-gate が実行されました。PR を作成してから再実行してください","confidence":100}]'
   exit 1
 fi
 ```

--- a/plugins/twl/commands/merge-gate.md
+++ b/plugins/twl/commands/merge-gate.md
@@ -13,6 +13,25 @@ chain Step 8（composite）。chain ライフサイクルは deps.yaml を参照
 
 ## ドメインルール
 
+### PR 存在確認（MUST — 最初に実行）
+
+merge-gate は PR が存在しない状態で実行してはならない（Issue #649）。動的レビュアー構築より先に実行すること。
+
+```bash
+PR_NUM=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+if [[ -z "$PR_NUM" || "$PR_NUM" == "none" ]]; then
+  echo "REJECT: PR が存在しません。PR を作成してから merge-gate を実行してください" >&2
+  python3 -m twl.autopilot.checkpoint write \
+    --step merge-gate \
+    --status REJECT \
+    --findings '[{"severity":"CRITICAL","category":"process","message":"PR が存在しない状態で merge-gate が実行されました。PR を作成してから再実行してください","confidence":100}]'
+  exit 1
+fi
+```
+
+PR が存在しない場合、merge-gate は即座に REJECT を返し以降の処理を行わない。
+Supervisor / Pilot が PR を作成（`intervene-auto --pattern pr-create`）してから merge-gate を再実行すること。
+
 ### 動的レビュアー構築
 
 ```bash

--- a/plugins/twl/skills/workflow-pr-verify/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-verify/SKILL.md
@@ -44,6 +44,22 @@ CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
 [[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
 ```
 
+### 前提: PR 存在確認（MUST — 全ステップより先に実行）
+
+workflow-pr-verify は PR が存在する状態で実行しなければならない（Issue #649）。
+
+```bash
+PR_NUM=$(gh pr list --head "$(git branch --show-current)" --json number -q '.[0].number' 2>/dev/null || echo "")
+if [[ -z "$PR_NUM" ]]; then
+  echo "ERROR: PR が存在しません。PR を作成してから workflow-pr-verify を実行してください" >&2
+  echo "  git push origin HEAD が完了していることを確認し、gh pr create を実行してください" >&2
+  exit 1
+fi
+echo "✓ PR #${PR_NUM} 確認済み"
+```
+
+PR が存在しない場合はここで停止する。PR 作成後に改めて workflow-pr-verify を実行すること。
+
 ### Step 0.5: prompt-compliance（refined_by ハッシュ整合性）【機械的 → runner】
 ```bash
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/chain-runner.sh" prompt-compliance


### PR DESCRIPTION
fix: merge-gate と workflow-pr-verify に PR 存在確認ガードを追加

PR が存在しない状態で specialist review が実行され、merge-gate が
PASS してしまう問題を修正（Issue #649）。

- merge-gate.md: 動的レビュアー構築より先に PR 存在確認ガードを追加。
  PR 未作成の場合は即座に REJECT を返し checkpoint を書き込む。
- workflow-pr-verify/SKILL.md: 全ステップより先に PR 存在確認ガードを追加。
  PR 未作成の場合はエラーメッセージを出力して停止する。

Closes #649