### PR TITLE
fix(plugins/twl): 自動起票 Issue の Board Status In Progress 残留を防止

### DIFF
--- a/plugins/twl/commands/prompt-audit-apply.md
+++ b/plugins/twl/commands/prompt-audit-apply.md
@@ -72,6 +72,7 @@ FAIL コンポーネントがある場合:
    ラベル: tech-debt
    本文: findings の内容
    ```
+   作成成功時: 出力 URL（`https://github.com/<owner>/<repo>/issues/<N>` 形式）から issue_number を抽出し、`/twl:project-board-sync <issue_number>` を Skill tool で呼び出す（Board Status を "Todo" に設定。失敗は非ブロッキング）。
 
 ## 完了出力
 

--- a/plugins/twl/commands/scope-judge.md
+++ b/plugins/twl/commands/scope-judge.md
@@ -29,10 +29,12 @@
 スコープ外かつ `severity in [CRITICAL, WARNING]` の finding について:
 
 ```
-gh issue create --title "tech-debt: ${finding.message}" \
+ISSUE_URL=$(gh issue create --title "tech-debt: ${finding.message}" \
   --body "## 検出元\nPR #${PR_NUM} のレビューで検出\n\n## 詳細\n${finding}" \
-  --label "tech-debt"
+  --label "tech-debt")
 ```
+
+作成成功時: 出力 URL（`https://github.com/<owner>/<repo>/issues/<N>` 形式）から issue_number を抽出し、`/twl:project-board-sync <issue_number>` を Skill tool で呼び出す（Board Status を "Todo" に設定。失敗は非ブロッキング）。
 
 ### Step 3: 結果報告
 

--- a/plugins/twl/commands/warning-fix.md
+++ b/plugins/twl/commands/warning-fix.md
@@ -39,9 +39,11 @@ severity=INFO は対象外
 修正できなかった WARNING は tech-debt Issue として起票:
 
 ```
-gh issue create --title "tech-debt: ${finding.message}" \
-  --label "tech-debt"
+ISSUE_URL=$(gh issue create --title "tech-debt: ${finding.message}" \
+  --label "tech-debt")
 ```
+
+作成成功時: 出力 URL（`https://github.com/<owner>/<repo>/issues/<N>` 形式）から issue_number を抽出し、`/twl:project-board-sync <issue_number>` を Skill tool で呼び出す（Board Status を "Todo" に設定。失敗は非ブロッキング）。
 
 ### 制約
 

--- a/plugins/twl/refs/ref-auto-issue-board-ops.md
+++ b/plugins/twl/refs/ref-auto-issue-board-ops.md
@@ -1,0 +1,61 @@
+---
+type: reference
+---
+
+# 自動起票 Issue の Board Status 運用ガイド
+
+## 背景
+
+autopilot Worker が実装中に自動起票した Issue（tech-debt / self-improve / warning-fix / scope-judge / prompt-audit-apply 経由）は、
+Board Status が **"Todo"** で追加されるべきである。
+これらの Issue は実装が完了していないため、In Progress にしてはならない。
+
+仕様制約（`deltaspec/specs/issue-lifecycle.md`）:
+> `chain-runner.sh board-status-update` を直接呼ばない（デフォルトが In Progress のため）
+
+## 自動起票フローの正しい Board Status
+
+| 自動起票フロー | 使用コマンド | 期待 Status |
+|-------------|------------|-------------|
+| scope-judge（Deferred Issue） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
+| warning-fix（未修正 WARNING） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
+| prompt-audit-apply（FAIL Issue） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
+| workflow-issue-lifecycle | `issue-create` + `project-board-sync` (Step 6.5) | **Todo** |
+
+## 既存の In Progress 放置 Issue を検出する手順
+
+以下のコマンドで Board 上の "In Progress" Issue を一覧表示し、自動起票ラベル（`tech-debt`, `self-improve` 等）が付いているものを確認する。
+
+```bash
+# Board の In Progress アイテムを取得（プロジェクト番号とオーナーは CLAUDE.md を参照）
+gh project item-list 6 --owner shuu5 --format json --limit 200 \
+  | jq -r '.items[] | select(.status == "In Progress") | "\(.content.number) \(.content.title)"'
+
+# In Progress + tech-debt ラベルを持つ Issue を確認
+gh issue list --label "tech-debt" --state open --json number,title,labels \
+  | jq -r '.[] | "\(.number) \(.title)"'
+```
+
+## 自動起票 Issue の Board Status を修正する手順
+
+誤って In Progress になっている自動起票 Issue を "Todo" に戻す:
+
+```bash
+# chain-runner.sh board-status-update の第2引数に "Todo" を指定
+CR="$(git rev-parse --show-toplevel)/scripts/chain-runner.sh"
+bash "$CR" board-status-update <ISSUE_NUM> "Todo"
+```
+
+または `/twl:project-board-sync <ISSUE_NUM>` を Skill tool で実行する（常に "Todo" で設定する）。
+
+## 関連ファイル
+
+| ファイル | 役割 |
+|---------|------|
+| `scripts/chain-runner.sh:402-466` | `board-status-update` 実装（第2引数で Status 指定可） |
+| `commands/project-board-sync.md` | `project-board-sync` 実装（常に "Todo"） |
+| `commands/scope-judge.md` | Deferred Issue 作成後 `project-board-sync` を呼ぶ |
+| `commands/warning-fix.md` | 未修正 WARNING Issue 作成後 `project-board-sync` を呼ぶ |
+| `commands/prompt-audit-apply.md` | FAIL Issue 作成後 `project-board-sync` を呼ぶ |
+| `deltaspec/specs/issue-lifecycle.md:93` | 自動起票時の仕様制約 |
+| `tests/bats/scripts/board-merge-done-transition.bats` | Done 遷移テスト（自動起票 Issue は Done に遷移しない） |

--- a/plugins/twl/refs/ref-auto-issue-board-ops.md
+++ b/plugins/twl/refs/ref-auto-issue-board-ops.md
@@ -20,6 +20,7 @@ Board Status が **"Todo"** で追加されるべきである。
 | scope-judge（Deferred Issue） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
 | warning-fix（未修正 WARNING） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
 | prompt-audit-apply（FAIL Issue） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
+| co-self-improve（from-observation） | `gh issue create` + `/twl:project-board-sync` | **Todo** |
 | workflow-issue-lifecycle | `issue-create` + `project-board-sync` (Step 6.5) | **Todo** |
 
 ## 既存の In Progress 放置 Issue を検出する手順

--- a/plugins/twl/skills/co-self-improve/SKILL.md
+++ b/plugins/twl/skills/co-self-improve/SKILL.md
@@ -131,7 +131,7 @@ workflow が完了（検出 0 件 or ユーザー停止 or タイムアウト）
 2. AskUserQuestion で「Issue draft 生成しますか?」（全件 / 一部 / なし）
 3. 承認時のみ `commands/issue-draft-from-observation.md` を呼ぶ
 4. draft をユーザーに見せて最終確認（MUST）
-5. 承認時のみ `gh issue create` で起票（label: `from-observation`, `ctx/observation` 必須）
+5. 承認時のみ `gh issue create` で起票（label: `from-observation`, `ctx/observation` 必須）。起票成功時: 出力 URL から issue_number を抽出し、`/twl:project-board-sync <issue_number>` を Skill tool で呼び出す（Board Status を "Todo" に設定。失敗は非ブロッキング）。
 
 ## 禁止事項（MUST NOT）
 

--- a/plugins/twl/tests/bats/scripts/board-merge-done-transition.bats
+++ b/plugins/twl/tests/bats/scripts/board-merge-done-transition.bats
@@ -318,3 +318,57 @@ GHSTUB_FAIL_BODY
   ! grep -q "project item-edit" "$GH_LOG"
   ! grep -q "project item-archive" "$GH_LOG"
 }
+
+# ---------------------------------------------------------------------------
+# Scenario: 自動起票 Issue は Done に遷移しない
+#
+# WHEN merge-gate-execute.sh が primary issue (#193) の merge を実行する
+# THEN primary issue (#193) のみ Board Status が Done に更新され、
+#      自動起票 Issue (#200) は Done に遷移しない
+# ---------------------------------------------------------------------------
+
+@test "merge-gate-execute: 自動起票 Issue は primary issue merge で Done に遷移しない" {
+  create_issue_json 193 "merge-ready"
+  create_issue_json 200 "running"  # 自動起票 Issue（In Progress 放置を模擬）
+  export ISSUE=193 PR_NUMBER=42 BRANCH="feat/193-test"
+
+  local item_calls_log="$SANDBOX/item-add-calls.log"
+
+  cat > "$STUB_BIN/gh" <<GHSTUB_HEAD
+#!/usr/bin/env bash
+echo "\$*" >> "${GH_LOG}"
+GHSTUB_HEAD
+  cat >> "$STUB_BIN/gh" <<GHSTUB_BODY
+case "\$*" in
+  *"pr merge"*)
+    exit 0 ;;
+  *"issue view"*)
+    echo "CLOSED" ;;
+  *"project list"*)
+    echo '{"projects": [{"number": 5, "title": "loom-plugin-dev board"}]}' ;;
+  *"repo view"*"--json nameWithOwner"*)
+    echo '{"nameWithOwner": "shuu5/loom-plugin-dev", "owner": {"login": "shuu5"}}' ;;
+  *"api graphql"*)
+    echo '{"data": {"user": {"projectV2": {"id": "PVT_abc", "title": "loom-plugin-dev board", "repositories": {"nodes": [{"nameWithOwner": "shuu5/loom-plugin-dev"}]}}}}}' ;;
+  *"project item-add"*)
+    echo "\$*" >> "${item_calls_log}"
+    echo '{"id": "PVTI_item193"}' ;;
+  *"project field-list"*)
+    echo '{"fields": [{"id": "FIELD_STATUS", "name": "Status", "options": [{"id": "OPT_TODO", "name": "Todo"}, {"id": "OPT_DONE", "name": "Done"}]}]}' ;;
+  *"project item-edit"*)
+    echo '{}' ;;
+  *)
+    echo '{}' ;;
+esac
+GHSTUB_BODY
+  chmod +x "$STUB_BIN/gh"
+
+  run bash "$SANDBOX/scripts/merge-gate-execute.sh"
+
+  assert_success
+
+  # primary issue #193 の URL で item-add が呼ばれた
+  grep -q "issues/193" "$item_calls_log"
+  # 自動起票 Issue #200 の URL で item-add は呼ばれない（Done 遷移対象外）
+  ! grep -q "issues/200" "$item_calls_log"
+}


### PR DESCRIPTION
fix(plugins/twl): 自動起票 Issue の Board Status In Progress 残留を防止

自動起票フロー（scope-judge / warning-fix / prompt-audit-apply）で
gh issue create 後に /twl:project-board-sync を呼び出し、
Board Status を In Progress ではなく Todo に設定する。

- commands/scope-judge.md: Deferred Issue 作成後に project-board-sync を呼ぶ
- commands/warning-fix.md: 未修正 WARNING Issue 作成後に project-board-sync を呼ぶ
- commands/prompt-audit-apply.md: FAIL Issue 作成後に project-board-sync を呼ぶ
- tests/bats/scripts/board-merge-done-transition.bats: 自動起票 Issue は
  primary issue merge で Done に遷移しないシナリオを追加
- refs/ref-auto-issue-board-ops.md: In Progress 放置 Issue の検出・修正手順を文書化

Closes #611