### PR TITLE
fix(merge-gate): quick モードでも specialist review を強制実行

### DIFF
--- a/plugins/twl/commands/merge-gate.md
+++ b/plugins/twl/commands/merge-gate.md
@@ -49,7 +49,7 @@ echo "$SPECIALISTS" > "$MANIFEST_FILE"
 trap 'rm -f "$MANIFEST_FILE" "$SPAWNED_FILE"' EXIT
 ```
 
-マニフェスト各行を Task spawn 対象とする（手動追加・削除は MUST NOT）。出力 0 行は自動 PASS。結果収集後 `rm -f "$MANIFEST_FILE"` 等で削除（trap でも可）。
+マニフェスト各行を Task spawn 対象とする（手動追加・削除は MUST NOT）。**quick ラベルが付与されていても specialist マニフェスト生成・spawn を省略してはならない（MUST NOT）**。quick が影響するのは DeltaSpec のスキップと phase-review checkpoint チェックのスキップのみであり、specialist review の実行には影響しない。`pr-review-manifest.sh` は merge-gate モードで最低限 `worker-code-reviewer` と `worker-security-reviewer` を必ず出力するため、マニフェスト 0 行は自動 PASS としない。結果収集後 `rm -f "$MANIFEST_FILE"` 等で削除（trap でも可）。
 
 ### 並列 specialist 実行（MUST: 全 specialist 一括 spawn）
 

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -154,6 +154,13 @@ if [[ "$MODE" == "merge-gate" ]]; then
   fi
 fi
 
+# merge-gate モード: 最低限必須 specialist（quick ラベル含む全ケースで保証）
+# quick ラベルでも specialist review は省略不可（Issue #657）
+if [[ "$MODE" == "merge-gate" ]]; then
+  SPECIALISTS["worker-code-reviewer"]=1
+  SPECIALISTS["worker-security-reviewer"]=1
+fi
+
 # phase-review / merge-gate モード: architecture/ 配下の .md 変更 → worker-arch-doc-reviewer
 if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
   for f in "${FILES[@]}"; do


### PR DESCRIPTION
fix(merge-gate): quick モードでも specialist review を強制実行

- merge-gate.md: quick ラベルでも specialist マニフェスト生成・spawn は
  省略してはならない（MUST NOT）を明記。マニフェスト 0 行の自動 PASS を廃止
- pr-review-manifest.sh: merge-gate モードでは quick ラベル含む全ケースで
  worker-code-reviewer + worker-security-reviewer を最低限必須化 (Issue #657)

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #657