### PR TITLE
fix(autopilot): CLD_ENV_FILE source + TWL_AUDIT env 伝搬 (Wave 23)

### DIFF
--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -352,7 +352,7 @@ if [[ -f "$_CLD_ENV_FILE" ]]; then
   CLD_ENV_FILE_ENV="CLD_ENV_FILE=$(printf '%q' "$_CLD_ENV_FILE")"
 fi
 if [[ -n "${CLAUDE_CODE_EFFORT_LEVEL:-}" ]]; then
-  EFFORT_ENV="CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL}"
+  EFFORT_ENV="CLAUDE_CODE_EFFORT_LEVEL=$(printf '%q' "${CLAUDE_CODE_EFFORT_LEVEL}")"
 fi
 
 # --- TWL_AUDIT 環境変数構築 (Wave 23) ---

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -339,11 +339,31 @@ else
   PYTHONPATH_ENV=""
 fi
 
-# --- CLD_ENV_FILE 環境変数構築 (#652) ---
-# cld-spawn のデフォルトは autopilot Worker には効かないため、autopilot-launch.sh でも伝搬する
+# --- CLD_ENV_FILE source + 環境変数構築 (#652, Wave 23 修正) ---
+# autopilot-launch.sh は tmux new-window + cld を直接起動するため、cld-spawn の
+# CLD_ENV_FILE 自動 source が効かない。ここで明示的に source し、中の変数
+# （CLAUDE_CODE_EFFORT_LEVEL 等）を env string に含める。
 CLD_ENV_FILE_ENV=""
-if [[ -n "${CLD_ENV_FILE:-}" ]]; then
-  CLD_ENV_FILE_ENV="CLD_ENV_FILE=$(printf '%q' "$CLD_ENV_FILE")"
+EFFORT_ENV=""
+_CLD_ENV_FILE="${CLD_ENV_FILE:-$HOME/.cld-env}"
+if [[ -f "$_CLD_ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$_CLD_ENV_FILE"
+  CLD_ENV_FILE_ENV="CLD_ENV_FILE=$(printf '%q' "$_CLD_ENV_FILE")"
+fi
+if [[ -n "${CLAUDE_CODE_EFFORT_LEVEL:-}" ]]; then
+  EFFORT_ENV="CLAUDE_CODE_EFFORT_LEVEL=${CLAUDE_CODE_EFFORT_LEVEL}"
+fi
+
+# --- TWL_AUDIT 環境変数構築 (Wave 23) ---
+# audit hook（checkpoint コピー、state-log、specialist manifest コピー）が
+# Worker 内で動作するために TWL_AUDIT / TWL_AUDIT_DIR を伝搬する
+AUDIT_ENV=""
+if [[ "${TWL_AUDIT:-}" == "1" ]]; then
+  AUDIT_ENV="TWL_AUDIT=1"
+  if [[ -n "${TWL_AUDIT_DIR:-}" ]]; then
+    AUDIT_ENV="${AUDIT_ENV} TWL_AUDIT_DIR=$(printf '%q' "$TWL_AUDIT_DIR")"
+  fi
 fi
 
 # --- コンテキスト引数構築 (Task 1.9) ---
@@ -370,7 +390,7 @@ QUOTED_CLD=$(printf '%q' "$CLD_PATH")
 QUOTED_PROMPT=$(printf '%q' "$PROMPT")
 # プロンプトは positional arg で渡す。-p/--print は禁止（非対話モードで即終了する）
 tmux new-window -d -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
-  "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} ${PYTHONPATH_ENV} ${CLD_ENV_FILE_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
+  "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} ${PYTHONPATH_ENV} ${CLD_ENV_FILE_ENV} ${EFFORT_ENV} ${AUDIT_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
 
 # --- クラッシュ検知フック設定 (Task 1.10) ---
 tmux set-option -t "$WINDOW_NAME" remain-on-exit on

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -243,7 +243,11 @@ _spawn_tmux_window_with_prompt() {
   echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
   # TWL_AUDIT / TWL_AUDIT_DIR を export して cld-spawn 子プロセスに継承させる (Wave 23)
   # cld-spawn は CLD_ENV_FILE を自動 source するが、TWL_AUDIT は ~/.cld-env に含まれないため明示的に export
-  [[ "${TWL_AUDIT:-}" == "1" ]] && export TWL_AUDIT TWL_AUDIT_DIR
+  # export はシェルグローバルに波及するが、orchestrator プロセス内で一貫して有効にする意図
+  if [[ "${TWL_AUDIT:-}" == "1" ]]; then
+    export TWL_AUDIT
+    [[ -n "${TWL_AUDIT_DIR:-}" ]] && export TWL_AUDIT_DIR
+  fi
   # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
   # env-file は CLD_ENV_FILE 環境変数のフォールバックに委譲（cld-spawn が自動検出）
   "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" --model "${WORKER_MODEL}" || {

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -241,6 +241,9 @@ _spawn_tmux_window_with_prompt() {
   local subdir="$1" window_name="$2" prompt_file="$3"
   local SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
   echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
+  # TWL_AUDIT / TWL_AUDIT_DIR を export して cld-spawn 子プロセスに継承させる (Wave 23)
+  # cld-spawn は CLD_ENV_FILE を自動 source するが、TWL_AUDIT は ~/.cld-env に含まれないため明示的に export
+  [[ "${TWL_AUDIT:-}" == "1" ]] && export TWL_AUDIT TWL_AUDIT_DIR
   # cld-spawn: 対話モードで起動（one-shot モード stdout 問題を回避 — #541）
   # env-file は CLD_ENV_FILE 環境変数のフォールバックに委譲（cld-spawn が自動検出）
   "${SESSION_SCRIPTS}/cld-spawn" --cd "$(pwd)" --window-name "${window_name}" --model "${WORKER_MODEL}" || {


### PR DESCRIPTION
## 概要

Wave 23 の残作業: autopilot Worker への環境変数伝搬修正。

## 修正内容

### autopilot-launch.sh (#652 完全修正 + TWL_AUDIT)

1. **CLD_ENV_FILE sourcing**: `CLD_ENV_FILE` を env var として渡すだけでなく、`source` して中の変数 (`CLAUDE_CODE_EFFORT_LEVEL=max`) を Worker の env string に直接含める
   - 修正前: Worker が medium effort で動作（`cld` は CLD_ENV_FILE を読まないため）
   - 修正後: `CLAUDE_CODE_EFFORT_LEVEL=max` が直接 env に設定される

2. **TWL_AUDIT env**: `TWL_AUDIT` / `TWL_AUDIT_DIR` を Worker に伝搬。Wave 24 から audit hook（checkpoint コピー、state-log、specialist manifest コピー）が Worker 内で動作するために必要。

### issue-lifecycle-orchestrator.sh (TWL_AUDIT)

- `_spawn_tmux_window_with_prompt()` で `TWL_AUDIT` / `TWL_AUDIT_DIR` を `export` して `cld-spawn` 子プロセスに継承させる

## テスト

- `autopilot-launch.sh` の env string に `CLAUDE_CODE_EFFORT_LEVEL` と `TWL_AUDIT` が含まれることを確認
- orchestrator の cld-spawn 呼び出し前に TWL_AUDIT が export されることを確認

## 関連

- #652 (autopilot-launch.sh CLD_ENV_FILE 伝搬 — 本 PR で完全修正)
- #646 (audit co-issue 対応 — TWL_AUDIT env はこの一部)

Closes #652