### PR TITLE
feat(autopilot): findings/fix report テンプレート化 + report.json フォールバック (#655, #647)

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1118,19 +1118,31 @@ step_pr_comment_findings() {
   warning_count=$(echo "$combined_findings" | jq '[.[] | select(.severity == "WARNING")] | length' 2>/dev/null || echo "0")
   info_count=$(echo "$combined_findings" | jq '[.[] | select(.severity == "INFO")] | length' 2>/dev/null || echo "0")
 
+  # --- findings テンプレート (#655) ---
+  # severity 別にグループ化。Reviewer/File:Line/Finding/Confidence カラム。
   local body
   body="## Specialist Review Findings"$'\n\n'
+  body+="**Summary**: ${critical_count} CRITICAL / ${warning_count} WARNING / ${info_count} INFO (total ${findings_count})"$'\n\n'
 
   if [[ "$findings_count" -gt 0 ]]; then
-    body+="| Severity | Category | File | Message |"$'\n'
-    body+="|----------|----------|------|---------|"$'\n'
-    body+=$(echo "$combined_findings" | jq -r '.[] | "| \(.severity) | \(.category) | \(.file // "-"):\(.line // "-") | \(.message[:120]) |"' 2>/dev/null || echo "| - | - | - | parse error |")
-    body+=$'\n\n'
+    local sev
+    for sev in CRITICAL WARNING INFO; do
+      local sev_findings sev_count
+      sev_findings=$(echo "$combined_findings" | jq -c "[.[] | select(.severity == \"$sev\")]" 2>/dev/null || echo "[]")
+      sev_count=$(echo "$sev_findings" | jq 'length' 2>/dev/null || echo "0")
+      if [[ "$sev_count" -gt 0 ]]; then
+        body+="### ${sev} (${sev_count})"$'\n\n'
+        body+="| Reviewer | File:Line | Finding | Conf |"$'\n'
+        body+="|----------|-----------|---------|------|"$'\n'
+        body+=$(echo "$sev_findings" | jq -r '.[] | "| \(.source // "-") | \(.file // "-"):\(.line // "-") | \(.message[:150]) | \(.confidence // "-") |"' 2>/dev/null || echo "| - | - | parse error | - |")
+        body+=$'\n\n'
+      fi
+    done
   else
-    body+="_No findings._"$'\n\n'
+    body+="全 specialist が findings なしで完了。"$'\n\n'
   fi
 
-  body+="**Decision**: ${mg_status} (${critical_count} CRITICAL, ${warning_count} WARNING, ${info_count} INFO)"
+  body+="**Decision**: ${mg_status}"
 
   gh pr comment "$pr_num" --body "$body" 2>/dev/null || {
     skip "pr-comment-findings" "PR コメント投稿失敗"
@@ -1153,16 +1165,59 @@ step_pr_comment_fix_summary() {
     return 0
   fi
 
-  local summary=""
+  # --- fix report テンプレート (#655) ---
+  # stdin から JSON 配列を読み取り、Fixed/Deferred/Acknowledged に分類。
+  # JSON 形式: [{"finding":"...","action":"fixed|deferred|acknowledged","detail":"...","tech_debt":true|false}]
+  local raw_input=""
   if [[ ! -t 0 ]]; then
-    summary=$(cat)
+    raw_input=$(cat)
   fi
 
-  if [[ -z "$summary" ]]; then
-    summary="_No fixes applied (no CRITICAL/WARNING findings required fixing)._"
-  fi
+  local body="## Fix Report"$'\n\n'
 
-  local body="## Fix Summary"$'\n\n'"${summary}"
+  # JSON parse を試行。失敗時は raw テキストとして扱う
+  if echo "$raw_input" | jq empty 2>/dev/null && [[ -n "$raw_input" ]]; then
+    local fixed_items deferred_items ack_items
+    fixed_items=$(echo "$raw_input" | jq -c '[.[] | select(.action == "fixed")]' 2>/dev/null || echo "[]")
+    deferred_items=$(echo "$raw_input" | jq -c '[.[] | select(.action == "deferred")]' 2>/dev/null || echo "[]")
+    ack_items=$(echo "$raw_input" | jq -c '[.[] | select(.action == "acknowledged")]' 2>/dev/null || echo "[]")
+
+    local fc dc ac
+    fc=$(echo "$fixed_items" | jq 'length' 2>/dev/null || echo "0")
+    dc=$(echo "$deferred_items" | jq 'length' 2>/dev/null || echo "0")
+    ac=$(echo "$ack_items" | jq 'length' 2>/dev/null || echo "0")
+
+    body+="**Summary**: ${fc} fixed / ${dc} deferred / ${ac} acknowledged"$'\n\n'
+
+    if [[ "$fc" -gt 0 ]]; then
+      body+="### Fixed"$'\n\n'
+      body+="| Finding | Detail |"$'\n'
+      body+="|---------|--------|"$'\n'
+      body+=$(echo "$fixed_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) |"' 2>/dev/null)
+      body+=$'\n\n'
+    fi
+
+    if [[ "$dc" -gt 0 ]]; then
+      body+="### Deferred (tech-debt candidates)"$'\n\n'
+      body+="| Finding | Reason | Tech-Debt |"$'\n'
+      body+="|---------|--------|-----------|"$'\n'
+      body+=$(echo "$deferred_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) | \(if .tech_debt then "候補" else "-" end) |"' 2>/dev/null)
+      body+=$'\n\n'
+    fi
+
+    if [[ "$ac" -gt 0 ]]; then
+      body+="### Acknowledged (no action needed)"$'\n\n'
+      body+="| Finding | Reason |"$'\n'
+      body+="|---------|--------|"$'\n'
+      body+=$(echo "$ack_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) |"' 2>/dev/null)
+      body+=$'\n\n'
+    fi
+  elif [[ -n "$raw_input" ]]; then
+    # 非 JSON: raw テキストをそのまま使用（後方互換）
+    body+="${raw_input}"$'\n\n'
+  else
+    body+="No findings required fixing."$'\n\n'
+  fi
 
   gh pr comment "$pr_num" --body "$body" 2>/dev/null || {
     skip "pr-comment-fix-summary" "PR コメント投稿失敗"

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1193,7 +1193,7 @@ step_pr_comment_fix_summary() {
       body+="### Fixed"$'\n\n'
       body+="| Finding | Detail |"$'\n'
       body+="|---------|--------|"$'\n'
-      body+=$(echo "$fixed_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) |"' 2>/dev/null)
+      body+=$(echo "$fixed_items" | jq -r '.[] | "| \((.finding // "-")[:100]) | \((.detail // "-")[:100]) |"' 2>/dev/null)
       body+=$'\n\n'
     fi
 
@@ -1201,7 +1201,7 @@ step_pr_comment_fix_summary() {
       body+="### Deferred (tech-debt candidates)"$'\n\n'
       body+="| Finding | Reason | Tech-Debt |"$'\n'
       body+="|---------|--------|-----------|"$'\n'
-      body+=$(echo "$deferred_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) | \(if .tech_debt then "候補" else "-" end) |"' 2>/dev/null)
+      body+=$(echo "$deferred_items" | jq -r '.[] | "| \((.finding // "-")[:100]) | \((.detail // "-")[:100]) | \(if .tech_debt then "候補" else "-" end) |"' 2>/dev/null)
       body+=$'\n\n'
     fi
 
@@ -1209,7 +1209,7 @@ step_pr_comment_fix_summary() {
       body+="### Acknowledged (no action needed)"$'\n\n'
       body+="| Finding | Reason |"$'\n'
       body+="|---------|--------|"$'\n'
-      body+=$(echo "$ack_items" | jq -r '.[] | "| \(.finding[:100]) | \(.detail[:100]) |"' 2>/dev/null)
+      body+=$(echo "$ack_items" | jq -r '.[] | "| \((.finding // "-")[:100]) | \((.detail // "-")[:100]) |"' 2>/dev/null)
       body+=$'\n\n'
     fi
   elif [[ -n "$raw_input" ]]; then

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -247,37 +247,30 @@ _generate_fallback_report() {
   local findings_file="${subdir}/OUT/findings.yaml"
 
   if [[ -f "$aggregate_file" ]]; then
-    # aggregate.yaml → report.json 変換
-    python3 -c "
-import yaml, json, sys
-with open('${aggregate_file}') as f:
+    # aggregate.yaml → report.json 変換（環境変数経由でパスを渡す — CWE-78 対策）
+    _FB_INPUT="$aggregate_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="aggregate" \
+      python3 -c '
+import yaml, json, os, sys
+with open(os.environ["_FB_INPUT"]) as f:
     data = yaml.safe_load(f) or {}
-report = {
-    'status': 'done',
-    'fallback': True,
-    'reason': '${reason}',
-    'findings_count': len(data.get('findings', [])),
-    'aggregate': data
-}
-with open('${report_file}', 'w') as f:
+report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
+          "findings_count": len(data.get("findings", [])), os.environ["_FB_KEY"]: data}
+with open(os.environ["_FB_OUTPUT"], "w") as f:
     json.dump(report, f, ensure_ascii=False, indent=2)
-" 2>/dev/null && return 0
+' 2>/dev/null && return 0
   fi
 
   if [[ -f "$findings_file" ]]; then
-    python3 -c "
-import yaml, json, sys
-with open('${findings_file}') as f:
+    _FB_INPUT="$findings_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="findings" \
+      python3 -c '
+import yaml, json, os, sys
+with open(os.environ["_FB_INPUT"]) as f:
     data = yaml.safe_load(f) or {}
-report = {
-    'status': 'done',
-    'fallback': True,
-    'reason': '${reason}',
-    'findings': data
-}
-with open('${report_file}', 'w') as f:
+report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
+          os.environ["_FB_KEY"]: data}
+with open(os.environ["_FB_OUTPUT"], "w") as f:
     json.dump(report, f, ensure_ascii=False, indent=2)
-" 2>/dev/null && return 0
+' 2>/dev/null && return 0
   fi
 
   # 中間ファイルもない場合は最小限のフォールバック

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -235,6 +235,55 @@ _build_worker_prompt() {
     > "$_bwp_prompt_file"
 }
 
+# report.json フォールバック生成 (#647)
+# specialist が report.json を書かずに完了した場合に、
+# findings.yaml / aggregate.yaml から report.json を構築する
+_generate_fallback_report() {
+  local subdir="$1" reason="$2"
+  local report_file="${subdir}/OUT/report.json"
+
+  # findings.yaml / aggregate.yaml がある場合はそこから構築
+  local aggregate_file="${subdir}/OUT/aggregate.yaml"
+  local findings_file="${subdir}/OUT/findings.yaml"
+
+  if [[ -f "$aggregate_file" ]]; then
+    # aggregate.yaml → report.json 変換
+    python3 -c "
+import yaml, json, sys
+with open('${aggregate_file}') as f:
+    data = yaml.safe_load(f) or {}
+report = {
+    'status': 'done',
+    'fallback': True,
+    'reason': '${reason}',
+    'findings_count': len(data.get('findings', [])),
+    'aggregate': data
+}
+with open('${report_file}', 'w') as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+" 2>/dev/null && return 0
+  fi
+
+  if [[ -f "$findings_file" ]]; then
+    python3 -c "
+import yaml, json, sys
+with open('${findings_file}') as f:
+    data = yaml.safe_load(f) or {}
+report = {
+    'status': 'done',
+    'fallback': True,
+    'reason': '${reason}',
+    'findings': data
+}
+with open('${report_file}', 'w') as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+" 2>/dev/null && return 0
+  fi
+
+  # 中間ファイルもない場合は最小限のフォールバック
+  printf '{"status":"done","fallback":true,"reason":"%s","error":"no_intermediate_files"}\n' "$reason" > "$report_file"
+}
+
 # cld-spawn でウィンドウを起動し inject-file でプロンプトを送達する
 # 引数: subdir window_name prompt_file
 _spawn_tmux_window_with_prompt() {
@@ -331,9 +380,16 @@ wait_for_batch() {
         local window_name
         window_name="$(window_name_for_subdir "$subdir")"
         if ! tmux list-windows -F '#{window_name}' 2>/dev/null | grep -qxF "$window_name"; then
-          echo "[issue-lifecycle-orchestrator] ${subdir##*/}: ウィンドウ消失・report.json なし — タイムアウト扱い" >&2
+          # Window 消失 → fallback report.json 生成 (#647)
+          echo "[issue-lifecycle-orchestrator] ${subdir##*/}: ウィンドウ消失・report.json なし — フォールバック生成" >&2
           mkdir -p "${subdir}/OUT"
-          printf '{"status":"timeout","error":"window_lost"}\n' > "$report_file"
+          _generate_fallback_report "$subdir" "window_lost"
+        elif "${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" check "$window_name" input-waiting 2>/dev/null; then
+          # Window 存在 + input-waiting → specialist 完了済みだが report.json 未書き出し (#647)
+          echo "[issue-lifecycle-orchestrator] ${subdir##*/}: input-waiting + report.json なし — フォールバック生成" >&2
+          mkdir -p "${subdir}/OUT"
+          _generate_fallback_report "$subdir" "input_waiting_no_report"
+          tmux kill-window -t "$window_name" 2>/dev/null || true
         else
           all_done=false
         fi


### PR DESCRIPTION
## 概要

Wave 24: PR cycle の出力品質標準化 + co-issue Phase 遷移修復。

## #655: findings/fix report テンプレート化

### step_pr_comment_findings
- severity 別グループ化（CRITICAL → WARNING → INFO）
- カラム: Reviewer / File:Line / Finding / Confidence
- `_No findings._` を廃止、「全 specialist が findings なしで完了」に変更

### step_pr_comment_fix_summary
- JSON 入力: Fixed/Deferred/Acknowledged セクション分類
- Deferred に tech-debt 候補カラム
- 非 JSON 入力の後方互換

## #647: co-issue report.json フォールバック

### _generate_fallback_report()
- specialist が report.json を書かずに完了した場合のフォールバック
- findings.yaml / aggregate.yaml から report.json を構築
- 中間ファイルもない場合は最小限フォールバック

### wait_for_batch() 改善
- Window 存在 + input-waiting + report.json なし → フォールバック生成 + window kill
- 既存の window 消失検知も _generate_fallback_report() に統一

Closes #655
Closes #647