### PR TITLE
fix(co-issue): specialist review session が OUT/report.json を書き込まずに終了するバグを修正

### DIFF
--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -223,8 +223,14 @@ _build_worker_prompt() {
     "【自律実行指示】" \
     "- 全 Step を中断なく自律的に完了すること" \
     "- 途中で AskUserQuestion を使用しないこと" \
+    "- /twl:issue-spec-review 完了後も停止せず、直ちに次のステップ（issue-review-aggregate）を実行すること" \
     "- エラー発生時は OUT/report.json に status: failed を書き込んで exit すること" \
     "- policies.json の設定に従い specialist review を実行すること" \
+    "" \
+    "【完了条件（MUST）】" \
+    "- 全ステップ完了後、または失敗時を問わず、必ず以下の絶対パスに report.json を書き込んでから停止すること" \
+    "- ${subdir}/OUT/report.json" \
+    "- このファイルを書き込まずに ❯ プロンプトを表示して停止することは禁止" \
     "" \
     "【policies.json 主要フィールド】" \
     "- max_rounds: ${max_rounds}" \
@@ -362,6 +368,9 @@ spawn_session() {
 wait_for_batch() {
   local -a batch_subdirs=("$@")
   local poll_count=0
+  local SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
+  # アイドル連続カウント（キー: window_name）
+  declare -A _wfb_idle_counts
 
   while true; do
     local all_done=true
@@ -377,14 +386,27 @@ wait_for_batch() {
           echo "[issue-lifecycle-orchestrator] ${subdir##*/}: ウィンドウ消失・report.json なし — フォールバック生成" >&2
           mkdir -p "${subdir}/OUT"
           _generate_fallback_report "$subdir" "window_lost"
-        elif "${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" check "$window_name" input-waiting 2>/dev/null; then
-          # Window 存在 + input-waiting → specialist 完了済みだが report.json 未書き出し (#647)
-          echo "[issue-lifecycle-orchestrator] ${subdir##*/}: input-waiting + report.json なし — フォールバック生成" >&2
-          mkdir -p "${subdir}/OUT"
-          _generate_fallback_report "$subdir" "input_waiting_no_report"
-          tmux kill-window -t "$window_name" 2>/dev/null || true
         else
-          all_done=false
+          # ウィンドウ生存中: session-state.sh state で input-waiting 検出 (#647)
+          local _wfb_session_state="processing"
+          if [[ -f "${SESSION_SCRIPTS}/session-state.sh" ]]; then
+            _wfb_session_state=$("${SESSION_SCRIPTS}/session-state.sh" state "$window_name" 2>/dev/null || echo "processing")
+          fi
+          if [[ "$_wfb_session_state" == "input-waiting" ]]; then
+            _wfb_idle_counts["$window_name"]=$(( ${_wfb_idle_counts["$window_name"]:-0} + 1 ))
+            if [[ "${_wfb_idle_counts["$window_name"]}" -ge 3 ]]; then
+              # 3ポーリング連続アイドル（≥30秒）→ specialist 完了済みだが report.json 未書き出しと判断
+              echo "[issue-lifecycle-orchestrator] ${subdir##*/}: input-waiting 検出 (${_wfb_idle_counts["$window_name"]}回連続) — fallback report.json 生成" >&2
+              mkdir -p "${subdir}/OUT"
+              _generate_fallback_report "$subdir" "input_waiting_no_report"
+              tmux kill-window -t "$window_name" 2>/dev/null || true
+            else
+              all_done=false
+            fi
+          else
+            _wfb_idle_counts["$window_name"]=0
+            all_done=false
+          fi
         fi
       fi
     done

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -4,14 +4,6 @@
 # per-issue dir 配下の各 subdir に対して /twl:workflow-issue-lifecycle を
 # tmux cld セッションで並列起動する。
 #
-# spec-review-orchestrator.sh のコードパターンを流用:
-#   - tmux new-window + cld セッション並列起動
-#   - MAX_PARALLEL バッチ制御
-#   - ポーリング完了検知（OUT/report.json の存在確認）
-#   - flock による window 名衝突回避
-#   - || continue による失敗局所化
-#   - Resume 対応（done スキップ / failed リセット）
-#
 # Usage:
 #   bash issue-lifecycle-orchestrator.sh --per-issue-dir <abs-path>
 #
@@ -131,9 +123,7 @@ fi
 
 echo "[issue-lifecycle-orchestrator] サブディレクトリ数: ${TOTAL}, MAX_PARALLEL: ${MAX_PARALLEL}"
 
-# ADR-017 IM-7: N=1 不変量は各 Worker（workflow-issue-lifecycle）が個別に
-# spec-review-session-init.sh 1 を呼び出すことで保証する。
-# orchestrator はセッション初期化を行わない（state file 競合防止）。
+# ADR-017 IM-7: N=1 不変量 — 各 Worker が spec-review-session-init.sh 1 を呼び出す（state file 競合防止）
 
 # =============================================================================
 # sid 抽出ユーティリティ
@@ -289,9 +279,7 @@ _spawn_tmux_window_with_prompt() {
   local subdir="$1" window_name="$2" prompt_file="$3"
   local SESSION_SCRIPTS="${SCRIPTS_ROOT}/../../session/scripts"
   echo "[issue-lifecycle-orchestrator] ${subdir##*/}: spawn (window=${window_name})" >&2
-  # TWL_AUDIT / TWL_AUDIT_DIR を export して cld-spawn 子プロセスに継承させる (Wave 23)
-  # cld-spawn は CLD_ENV_FILE を自動 source するが、TWL_AUDIT は ~/.cld-env に含まれないため明示的に export
-  # export はシェルグローバルに波及するが、orchestrator プロセス内で一貫して有効にする意図
+  # TWL_AUDIT を export して cld-spawn に継承（~/.cld-env 非掲載のため明示 export）— Wave 23
   if [[ "${TWL_AUDIT:-}" == "1" ]]; then
     export TWL_AUDIT
     [[ -n "${TWL_AUDIT_DIR:-}" ]] && export TWL_AUDIT_DIR

--- a/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
@@ -121,6 +121,8 @@ mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
 - `depth`: policies.depth（デフォルト: normal）
 - 結果を `rounds/<round>/findings.yaml` に書き込む
 
+**MUST**: Skill 返却後は findings テーブルをテキストのみで表示して `❯` 停止してはならない。Write ツールで `rounds/<round>/findings.yaml` を書き込み直ちに Step 4b に進むこと。
+
 #### 4b: aggregate
 
 `/twl:issue-review-aggregate` を Skill tool で呼び出す:
@@ -238,3 +240,4 @@ printf 'done\n' > "$PER_ISSUE_DIR/STATE"
 - N=1 ガード呼び出しを省略してはならない
 - STATE ファイルへの書き込みを省略してはならない
 - OUT/report.json の書き込みを省略してはならない（正常・異常どちらの終了でも必須）
+- `/twl:issue-spec-review` Skill 返却後にテキスト応答のみで `❯` 停止してはならない（Step 4b に直進すること）

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -132,6 +132,8 @@ mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
 - `depth`: policies.depth（デフォルト: normal）
 - 結果を `rounds/<round>/findings.yaml` に書き込む
 
+**MUST**: Skill 返却後は findings テーブルをテキストのみで表示して `❯` 停止してはならない。Write ツールで `rounds/<round>/findings.yaml` を書き込み直ちに Step 4b に進むこと。
+
 #### 4b: aggregate
 
 `/twl:issue-review-aggregate` を Skill tool で呼び出す:
@@ -272,5 +274,6 @@ printf 'done\n' > "$PER_ISSUE_DIR/STATE"
 - N=1 ガード呼び出しを省略してはならない
 - STATE ファイルへの書き込みを省略してはならない
 - OUT/report.json の書き込みを省略してはならない（正常・異常どちらの終了でも必須）
+- `/twl:issue-spec-review` Skill 返却後にテキスト応答のみで `❯` 停止してはならない（Step 4b に直進すること）
 - 既存 Issue の title を変更してはならない
 - 既存 Issue のラベルを削除してはならない（追加のみ許可）


### PR DESCRIPTION
fix(co-issue): specialist review session が OUT/report.json を書き込まずに終了するバグを修正

- issue-lifecycle-orchestrator.sh: ワーカープロンプトに OUT/report.json の絶対パスと
  完了条件を明示（/twl:issue-spec-review 完了後の停止禁止指示を追加）
- issue-lifecycle-orchestrator.sh: wait_for_batch() にセッションアイドル検出を追加。
  session-state.sh で input-waiting を検知し、3ポーリング連続アイドル時に
  report.json fallback（status: incomplete）を書き込む
- workflow-issue-lifecycle/SKILL.md: Step 4a に /twl:issue-spec-review 返却後の
  即座継続 MUST 制約を追加、禁止事項にも同制約を追加
- workflow-issue-refine/SKILL.md: 同上

Closes #647