### PR TITLE
feat(audit): audit_snapshot API + CLI サブコマンド追加 (#646)

### DIFF
--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -199,6 +199,39 @@ def audit_status(project_root: Path | None = None) -> dict:
     }
 
 
+def audit_snapshot(
+    source_dir: Path | str,
+    label: str,
+    project_root: Path | None = None,
+) -> Path | None:
+    """Copy source_dir to .audit/<run-id>/<label>/ for persistence.
+
+    Returns the destination path, or None if audit is not active (no-op).
+    D1 compliant: audit.py does not know the internal structure of source_dir.
+    """
+    if not is_audit_active(project_root):
+        return None
+
+    audit_dir = resolve_audit_dir(project_root)
+    if audit_dir is None:
+        return None
+
+    source = Path(source_dir)
+    if not source.is_dir():
+        return None
+
+    # Validate label (same rules as run_id)
+    if not _VALID_RUN_ID_RE.match(label.replace("/", "_")):
+        raise ValueError(f"Invalid label {label!r}: use alphanumeric, hyphens, underscores, or slashes")
+
+    dest = audit_dir / label
+    dest.mkdir(parents=True, exist_ok=True)
+
+    import shutil
+    shutil.copytree(source, dest, dirs_exist_ok=True)
+    return dest
+
+
 # ---------------------------------------------------------------------------
 # CLI entry point
 # ---------------------------------------------------------------------------
@@ -213,6 +246,10 @@ def main(argv: list[str] | None = None) -> int:
 
     sub.add_parser("off", help="Stop audit session and write index.json")
     sub.add_parser("status", help="Show current audit status")
+
+    snap_p = sub.add_parser("snapshot", help="Copy directory to audit for persistence")
+    snap_p.add_argument("--source-dir", dest="source_dir", required=True, help="Directory to snapshot")
+    snap_p.add_argument("--label", required=True, help="Label for the snapshot (e.g. co-issue/1)")
 
     args = parser.parse_args(argv if argv is not None else sys.argv[1:])
 
@@ -245,6 +282,18 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print("active: false")
         return 0
+
+    if args.cmd == "snapshot":
+        try:
+            dest = audit_snapshot(args.source_dir, args.label)
+            if dest:
+                print(f"snapshot saved: {dest}")
+            else:
+                print("audit not active — snapshot skipped")
+            return 0
+        except ValueError as e:
+            print(f"error: {e}", file=sys.stderr)
+            return 1
 
     parser.print_help()
     return 1


### PR DESCRIPTION
## 概要

audit.py に汎用 `audit_snapshot()` API を追加。co-issue の中間成果物を `.audit/<run-id>/` に永続化。

## 修正内容

### audit_snapshot(source_dir, label, project_root)
- `source_dir` を `.audit/<run-id>/<label>/` に `shutil.copytree` でコピー
- audit 非アクティブ時は no-op (None 返却)
- D1 準拠: stdlib のみ使用、source_dir の内部構造を知らない

### CLI: `twl audit snapshot --source-dir <path> --label <label>`
- audit アクティブ時: コピーしてパスを表示
- audit 非アクティブ時: "snapshot skipped" を表示

### env 伝搬
Wave 23 PR #659 で実装済み（autopilot-launch.sh + issue-lifecycle-orchestrator.sh）

Closes #646