### PR TITLE
fix(autopilot): bare repo パス修正 + audit_snapshot 統合 (Wave 28, #660)

### DIFF
--- a/plugins/twl/scripts/autopilot-plan.sh
+++ b/plugins/twl/scripts/autopilot-plan.sh
@@ -85,7 +85,13 @@ if [[ -n "$REPOS_JSON" ]]; then
 fi
 
 SESSION_ID=$(uuidgen | cut -c1-8)
-AUTOPILOT_DIR="${PROJECT_DIR}/.autopilot"
+# bare repo レイアウト検出: .bare/ が存在する場合、state ファイルは main worktree に配置 (#660)
+# PROJECT_DIR 自体は bare repo root のまま維持（orchestrator の worktree 作成パスに必要）
+if [[ -d "${PROJECT_DIR}/.bare" ]]; then
+  AUTOPILOT_DIR="${PROJECT_DIR}/main/.autopilot"
+else
+  AUTOPILOT_DIR="${PROJECT_DIR}/.autopilot"
+fi
 mkdir -p "$AUTOPILOT_DIR"
 PLAN_FILE="${AUTOPILOT_DIR}/plan.yaml"
 

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -445,6 +445,15 @@ while [[ "$BATCH_START" -lt "$TOTAL" ]]; do
     tmux kill-window -t "$window_name" 2>/dev/null || true
   done
 
+  # audit_snapshot fallback: Worker が snapshot を書かなかった場合に orchestrator 側で保全
+  for subdir in "${local_batch[@]}"; do
+    if [[ "${TWL_AUDIT:-}" == "1" ]]; then
+      local _snap_label="co-issue/$(basename "$subdir")"
+      python3 -m twl.autopilot.audit snapshot \
+        --source-dir "$subdir" --label "$_snap_label" 2>/dev/null || true
+    fi
+  done
+
   echo "[issue-lifecycle-orchestrator] バッチ完了: ${COMPLETED}/${TOTAL} subdirs 処理済み"
 done
 

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -448,7 +448,7 @@ while [[ "$BATCH_START" -lt "$TOTAL" ]]; do
   # audit_snapshot fallback: Worker が snapshot を書かなかった場合に orchestrator 側で保全
   for subdir in "${local_batch[@]}"; do
     if [[ "${TWL_AUDIT:-}" == "1" ]]; then
-      local _snap_label="co-issue/$(basename "$subdir")"
+      _snap_label="co-issue/$(basename "$subdir")"
       python3 -m twl.autopilot.audit snapshot \
         --source-dir "$subdir" --label "$_snap_label" 2>/dev/null || true
     fi

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -70,6 +70,8 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/python-env.sh"
 
 `commands/autopilot-init.md` を Read → 実行。出力: SESSION_ID, PHASE_COUNT, SESSION_STATE_FILE。
 
+**AUTOPILOT_DIR 一致確認（MUST）:** `autopilot-init` 実行前に、`AUTOPILOT_DIR` が `plan.yaml` と同じディレクトリを指していることを確認する。bare repo レイアウトでは `autopilot-plan.sh` が `.bare/` を検出して `main/.autopilot/` に plan.yaml を配置するため、Pilot も同じパスを使用すること。不一致はパストラバーサルエラーの原因になる (#660)。
+
 ## Step 3.5: su-observer からの監視受入
 
 co-autopilot は su-observer から spawn・監視される設計になっている（ADR-014 Decision 2）。
@@ -197,6 +199,13 @@ PHASE_COMPLETE 受信後、以下の順序で実行する（各 atomic の処理
 `PILOT_ACTIVE_REVIEW_DISABLE=1` の場合、手順 2-4 はスキップされる（各 atomic 内で opt-out 処理）。
 
 TaskUpdate Phase P → completed。
+
+audit_snapshot でセッション状態を保全（audit 非アクティブ時は no-op）:
+```bash
+python3 -m twl.autopilot.audit snapshot \
+  --source-dir "$AUTOPILOT_DIR" \
+  --label "co-autopilot/${SESSION_ID}" 2>/dev/null || true
+```
 
 ## Step 5: 完了サマリー（orchestrator 委譲）
 

--- a/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
@@ -192,13 +192,15 @@ Step 6 の `/twl:issue-create` 出力 URL（`https://github.com/<owner>/<repo>/i
 - issue_number: issue_url の末尾パスセグメント（`/issues/(\d+)` でマッチ）
 - 失敗時は `OUT/report.json` の `warnings_acknowledged` リストに warning エントリを追加（非ブロッキング）。STATE は変更しない
 
-### Step 7: 完了
+### Step 7: 完了（MUST — 最終ステップ）
+
+**report.json 書き込みは最終ステップとして必須。書き込み完了まで終了してはならない（MUST）。**
 
 ```bash
 printf 'done\n' > "$PER_ISSUE_DIR/STATE"
 ```
 
-`OUT/report.json` に以下を書き込む:
+`OUT/report.json` に以下を書き込む（**省略不可**）:
 ```json
 {
   "status": "done",
@@ -207,6 +209,13 @@ printf 'done\n' > "$PER_ISSUE_DIR/STATE"
   "findings_final": <最終 aggregate.yaml の内容>,
   "warnings_acknowledged": <WARNING findings のリスト>
 }
+```
+
+report.json 書き込み後、audit snapshot を実行する（audit 非アクティブ時は no-op）:
+```bash
+python3 -m twl.autopilot.audit snapshot \
+  --source-dir "$PER_ISSUE_DIR" \
+  --label "co-issue/$(basename "$PER_ISSUE_DIR")" 2>/dev/null || true
 ```
 
 ## STATE 遷移


### PR DESCRIPTION
## 概要

Wave 28: co-autopilot 起動ブロッカー修正 + audit_snapshot workflow 統合。

## #660: bare repo パス不一致修正

autopilot-plan.sh が PROJECT_DIR (bare repo root) を使って AUTOPILOT_DIR を構築するため、
main/ で動く Pilot の AUTOPILOT_DIR と不一致 → パストラバーサルエラー。

**修正**: `.bare/` ディレクトリ検出で `AUTOPILOT_DIR` を `main/.autopilot` に誘導。
PROJECT_DIR は bare repo root のまま維持（worktree 作成パスに必要）。

## audit_snapshot 統合（二重防御）

- **Primary**: workflow-issue-lifecycle Step 7 で audit_snapshot 呼び出し
- **Secondary**: orchestrator バッチ完了後 + co-autopilot Step 4.5 で fallback snapshot

## report.json MUST 強化

workflow-issue-lifecycle Step 7 の report.json 書き込みを「最終ステップとして必須（MUST）」に強化。

Closes #660