### PR TITLE
fix(audit): TWL_AUDIT_DIR env path に .resolve() と containment チェックを追加

### DIFF
--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -107,6 +107,8 @@ def resolve_audit_dir(project_root: Path | None = None) -> Path | None:
                 if not resolved.is_relative_to(root_resolved):
                     raise ValueError(f"audit_dir is outside project root: {resolved}")
                 return resolved
+    except ValueError:
+        raise
     except Exception:
         pass
     return None

--- a/cli/twl/src/twl/autopilot/audit.py
+++ b/cli/twl/src/twl/autopilot/audit.py
@@ -87,7 +87,12 @@ def resolve_audit_dir(project_root: Path | None = None) -> Path | None:
     """Resolve audit directory: TWL_AUDIT_DIR env → .audit/.active → None."""
     env = os.environ.get("TWL_AUDIT_DIR")
     if env:
-        return Path(env)
+        root = _resolve_root(project_root)
+        resolved = Path(env).resolve()
+        root_resolved = root.resolve()
+        if not resolved.is_relative_to(root_resolved):
+            raise ValueError(f"TWL_AUDIT_DIR is outside project root: {resolved}")
+        return resolved
     try:
         active = _active_file(project_root)
         if active.is_file():

--- a/cli/twl/tests/test_audit_module.py
+++ b/cli/twl/tests/test_audit_module.py
@@ -150,12 +150,22 @@ class TestResolveAuditDir:
     def test_env_var_twl_audit_dir_returned(
         self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
     ) -> None:
-        """WHEN TWL_AUDIT_DIR=/abs/path THEN resolve_audit_dir() が Path を返す"""
+        """WHEN TWL_AUDIT_DIR=<project 内パス> THEN resolve_audit_dir() が resolved Path を返す"""
         audit = _import_audit()
-        expected = "/abs/path/to/audit"
-        monkeypatch.setenv("TWL_AUDIT_DIR", expected)
+        expected = project_dir / "audit-session"
+        expected.mkdir()
+        monkeypatch.setenv("TWL_AUDIT_DIR", str(expected))
         result = audit.resolve_audit_dir(project_root=project_dir)
-        assert result == Path(expected)
+        assert result == expected.resolve()
+
+    def test_env_var_outside_project_raises(
+        self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
+    ) -> None:
+        """WHEN TWL_AUDIT_DIR が project root 外 THEN ValueError を raise する"""
+        audit = _import_audit()
+        monkeypatch.setenv("TWL_AUDIT_DIR", "/tmp/evil-path")
+        with pytest.raises(ValueError, match="TWL_AUDIT_DIR is outside project root"):
+            audit.resolve_audit_dir(project_root=project_dir)
 
     def test_active_file_audit_dir_returned(
         self, monkeypatch: pytest.MonkeyPatch, project_dir: Path
@@ -184,11 +194,12 @@ class TestResolveAuditDir:
     ) -> None:
         """Edge case: TWL_AUDIT_DIR が .active より優先される"""
         audit = _import_audit()
-        env_path = "/env/path/audit"
-        monkeypatch.setenv("TWL_AUDIT_DIR", env_path)
+        env_dir = project_dir / "env-audit"
+        env_dir.mkdir()
+        monkeypatch.setenv("TWL_AUDIT_DIR", str(env_dir))
         _write_active(project_dir, run_id="other-run")
         result = audit.resolve_audit_dir(project_root=project_dir)
-        assert result == Path(env_path)
+        assert result == env_dir.resolve()
 
     def test_active_file_relative_audit_dir_resolved_to_absolute(
         self, monkeypatch: pytest.MonkeyPatch, project_dir: Path


### PR DESCRIPTION
fix(audit): TWL_AUDIT_DIR env path に .resolve() と containment チェックを追加

resolve_audit_dir() で TWL_AUDIT_DIR 環境変数のパスが .resolve() されず
containment チェックも行われていなかった問題を修正。
.active からのパスと同様に project root 内に限定するよう統一。

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #643