### PR TITLE
[Bug] CRG 自己参照 symlink が #605 修正後も再発（3回目）— 3段階ガード実装

### DIFF
--- a/deltaspec/changes/issue-674/.deltaspec.yaml
+++ b/deltaspec/changes/issue-674/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-15
+issue: 674
+name: issue-674
+status: pending

--- a/deltaspec/changes/issue-674/design.md
+++ b/deltaspec/changes/issue-674/design.md
@@ -1,0 +1,61 @@
+## Context
+
+CRG symlink 自己参照バグが3回再発している。既存の防御は:
+1. orchestrator の realpath ガード（#605 で強化）: worktree 作成時の自己参照を防ぐ
+2. crg-auto-build.md: symlink 検出時はスキップ（ビルド不要と判定）
+
+しかし LLM ステップ（crg-auto-build）が明示的な `ln` 禁止ルールを持たないため、LLM が「壊れた symlink を修復しようとして新しい symlink を作成する」行動を取ると self-reference が発生しうる。また observer のヘルスチェックがないため再発の早期検出が困難。
+
+## Goals / Non-Goals
+
+**Goals:**
+- LLM が `ln` コマンドで `.code-review-graph` symlink を作成することを明文ルールで禁止する
+- orchestrator の CRG セクションに自己参照残存を検出・修復する追加ガードを追加する
+- su-observer が Wave 開始時に CRG symlink の健全性を自動チェックする
+
+**Non-Goals:**
+- symlink 方式の全廃（repo_root env var 方式への移行）は scope 外（将来 Issue で対応）
+- CRG MCP server のソースコード変更
+- クロスリポジトリ環境での CRG 対応
+
+## Decisions
+
+### Decision 1: crg-auto-build.md に MUST NOT ルール追加
+
+**対象**: `plugins/twl/commands/crg-auto-build.md` の `禁止事項（MUST NOT）` セクション
+
+追加内容:
+- `ln` コマンドを実行してはならない（symlink 作成禁止）
+- `.code-review-graph` ディレクトリ/ファイルを手動で作成/削除してはならない
+
+**理由**: LLM ステップは MUST NOT ルールが最も効果的な行動制御手段。明示的禁止がないと LLM が「壊れた symlink を修復しようとする」リスクがある。
+
+### Decision 2: orchestrator に残存 symlink 追加チェック追加
+
+**対象**: `plugins/twl/scripts/autopilot-orchestrator.sh` の CRG セクション（L325-348）
+
+既存の壊れた symlink 自己回復コード（L335-338）を強化:
+- 壊れた symlink（`-L` だが `-d` でない）を削除する既存コードはそのまま維持
+- `worktree_dir == main` の場合にのみ: `main/.code-review-graph` が symlink になっていた場合は削除してログを出す追加チェックを、CRG セクションの冒頭（outer if の前）に追加する
+
+**理由**: orchestrator が main で動作しているときに、main の `.code-review-graph` が誤って symlink になっていた場合の自動修復。
+
+### Decision 3: su-observer Wave 開始フックに CRG ヘルスチェック追加
+
+**対象**: `plugins/twl/skills/su-observer/SKILL.md`
+
+Wave 開始時のチェックリストに追加:
+```bash
+_crg_path="${TWILL_REPO_ROOT}/main/.code-review-graph"
+if [[ -L "$_crg_path" ]]; then
+  echo "⚠️ [CRG health] main/.code-review-graph がシンボリックリンクです。自己参照の可能性があります。"
+fi
+```
+
+**理由**: 壊れた状態に早期気づくことで修復コストを最小化する。
+
+## Risks / Trade-offs
+
+- orchestrator への変更は最小限（新しいチェックコードの追加のみ）。既存の realpath ガードは変更しない。
+- su-observer SKILL.md への追加はドキュメント変更のみ。実際の観察ロジックが存在する場合はそこに追加する。
+- crg-auto-build.md の MUST NOT 追加は LLM への指示変更であり、過去の動作を制限する。副作用は最小。

--- a/deltaspec/changes/issue-674/proposal.md
+++ b/deltaspec/changes/issue-674/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`main/.code-review-graph` が自己参照 broken symlink に繰り返し壊れる（#532, #605 修正後も W32 で3回目の再発）。現在の realpath ガードは「作成時」の防御だが、LLM ステップ（crg-auto-build）が明示的な禁止なしで symlink を作成できる抜け道が残っており、根本的な封鎖ができていない。
+
+## What Changes
+
+- `plugins/twl/commands/crg-auto-build.md` に symlink 操作の明示的禁止ルールを追加
+- `plugins/twl/scripts/autopilot-orchestrator.sh` の CRG symlink セクションにヘルスチェックを追加（壊れた symlink の早期検出・自動修復ログ強化）
+- su-observer の Wave 開始/終了フックに `file .code-review-graph` チェックを追加
+
+## Capabilities
+
+### New Capabilities
+
+- **LLM symlink 作成禁止ガード**: `crg-auto-build.md` の MUST NOT セクションに `ln` コマンド実行禁止を追加。LLM が symlink を作成しようとしても、明文ルールで阻止される
+- **observer ヘルスチェック**: su-observer が Wave 開始時に `main/.code-review-graph` のリンク状態を自動チェックし、自己参照を検出した場合に即座にアラートを出す
+
+### Modified Capabilities
+
+- **orchestrator CRG セクション**: 既存の realpath ガードに加え、自己参照 symlink が残存している場合の自動修復処理を補強。ガード通過後に `file .code-review-graph` 相当のチェックを実行
+
+## Impact
+
+- `plugins/twl/commands/crg-auto-build.md`: MUST NOT セクション追加（コメント追加のみ、動作変更なし）
+- `plugins/twl/scripts/autopilot-orchestrator.sh`: L325-348 の CRG セクション修正（ロジック補強）
+- `plugins/twl/skills/su-observer/SKILL.md` または observer スクリプト: Wave 開始フックに CRG ヘルスチェック追加
+- テスト: `plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats` に LLM 禁止ガードシナリオ追加

--- a/deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+++ b/deltaspec/changes/issue-674/specs/crg-symlink-guard.md
@@ -1,0 +1,41 @@
+## MODIFIED Requirements
+
+### Requirement: crg-auto-build LLM symlink 操作禁止
+
+LLM ステップ（crg-auto-build）は `.code-review-graph` に対して symlink 操作を実行してはならない（SHALL NOT）。`crg-auto-build.md` の禁止事項セクションに `ln` コマンド実行禁止および `.code-review-graph` の手動操作禁止を明記しなければならない（MUST）。
+
+#### Scenario: LLM ステップで symlink 禁止ルールが明記されている
+- **WHEN** `crg-auto-build.md` の `禁止事項（MUST NOT）` セクションを読む
+- **THEN** `ln` コマンドの実行を禁止するルールが存在する
+
+#### Scenario: LLM が壊れた symlink を検出した場合
+- **WHEN** crg-auto-build の実行時に `.code-review-graph` が symlink である
+- **THEN** 何も操作せず正常終了する（symlink の作成・削除・修正を行わない）
+
+### Requirement: orchestrator main worktree CRG 自己参照防止チェック
+
+orchestrator は main worktree の `.code-review-graph` が誤って symlink になっている場合、即座に削除しなければならない（MUST）。このチェックは CRG symlink 作成処理の冒頭、worktree の main 判定より前に実行されなければならない（MUST）。
+
+#### Scenario: main worktree の .code-review-graph が symlink の場合
+- **WHEN** orchestrator が worktree を処理する際、`${TWILL_REPO_ROOT}/main/.code-review-graph` が symlink である
+- **THEN** 当該 symlink を削除し、警告ログを出力する
+
+#### Scenario: main worktree の .code-review-graph が正常ディレクトリの場合
+- **WHEN** orchestrator が worktree を処理する際、`${TWILL_REPO_ROOT}/main/.code-review-graph` が通常ディレクトリである
+- **THEN** 何もせず既存処理を継続する
+
+## ADDED Requirements
+
+### Requirement: su-observer Wave 開始時 CRG ヘルスチェック
+
+su-observer は各 Wave の開始時に `main/.code-review-graph` の symlink 状態をチェックしなければならない（MUST）。symlink が検出された場合、即座に警告を出力しなければならない（MUST）。
+
+#### Scenario: Wave 開始時に main CRG が symlink の場合
+- **WHEN** su-observer が Wave 開始処理を実行する
+- **AND** `${TWILL_REPO_ROOT}/main/.code-review-graph` が symlink である
+- **THEN** `⚠️ [CRG health]` プレフィックスを付けた警告メッセージを出力する
+
+#### Scenario: Wave 開始時に main CRG が正常ディレクトリの場合
+- **WHEN** su-observer が Wave 開始処理を実行する
+- **AND** `${TWILL_REPO_ROOT}/main/.code-review-graph` が通常ディレクトリである
+- **THEN** 何も出力しない（サイレント正常終了）

--- a/deltaspec/changes/issue-674/tasks.md
+++ b/deltaspec/changes/issue-674/tasks.md
@@ -1,0 +1,17 @@
+## 1. crg-auto-build.md MUST NOT ルール追加
+
+- [ ] 1.1 `plugins/twl/commands/crg-auto-build.md` の `禁止事項（MUST NOT）` セクションに `ln` コマンド実行禁止ルールを追加する
+- [ ] 1.2 `.code-review-graph` ディレクトリ/ファイルの手動作成・削除・symlink 操作禁止ルールを追加する
+
+## 2. orchestrator CRG セクション強化
+
+- [ ] 2.1 `plugins/twl/scripts/autopilot-orchestrator.sh` の CRG symlink セクション（L325 付近）の冒頭に、`${TWILL_REPO_ROOT}/main/.code-review-graph` が symlink かどうかチェックするコードを追加する
+- [ ] 2.2 symlink が検出された場合、削除して警告ログを出力するコードを追加する
+
+## 3. su-observer ヘルスチェック追加
+
+- [ ] 3.1 `plugins/twl/skills/su-observer/SKILL.md` の Wave 開始時チェックリストに CRG ヘルスチェック手順を追加する
+
+## 4. テスト更新
+
+- [ ] 4.1 `plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats` に、main の `.code-review-graph` が symlink の場合に orchestrator が削除することを検証するテストケースを追加する

--- a/deltaspec/changes/issue-674/tasks.md
+++ b/deltaspec/changes/issue-674/tasks.md
@@ -1,17 +1,17 @@
 ## 1. crg-auto-build.md MUST NOT ルール追加
 
-- [ ] 1.1 `plugins/twl/commands/crg-auto-build.md` の `禁止事項（MUST NOT）` セクションに `ln` コマンド実行禁止ルールを追加する
-- [ ] 1.2 `.code-review-graph` ディレクトリ/ファイルの手動作成・削除・symlink 操作禁止ルールを追加する
+- [x] 1.1 `plugins/twl/commands/crg-auto-build.md` の `禁止事項（MUST NOT）` セクションに `ln` コマンド実行禁止ルールを追加する
+- [x] 1.2 `.code-review-graph` ディレクトリ/ファイルの手動作成・削除・symlink 操作禁止ルールを追加する
 
 ## 2. orchestrator CRG セクション強化
 
-- [ ] 2.1 `plugins/twl/scripts/autopilot-orchestrator.sh` の CRG symlink セクション（L325 付近）の冒頭に、`${TWILL_REPO_ROOT}/main/.code-review-graph` が symlink かどうかチェックするコードを追加する
-- [ ] 2.2 symlink が検出された場合、削除して警告ログを出力するコードを追加する
+- [x] 2.1 `plugins/twl/scripts/autopilot-orchestrator.sh` の CRG symlink セクション（L325 付近）の冒頭に、`${TWILL_REPO_ROOT}/main/.code-review-graph` が symlink かどうかチェックするコードを追加する
+- [x] 2.2 symlink が検出された場合、削除して警告ログを出力するコードを追加する
 
 ## 3. su-observer ヘルスチェック追加
 
-- [ ] 3.1 `plugins/twl/skills/su-observer/SKILL.md` の Wave 開始時チェックリストに CRG ヘルスチェック手順を追加する
+- [x] 3.1 `plugins/twl/skills/su-observer/SKILL.md` の Wave 開始時チェックリストに CRG ヘルスチェック手順を追加する
 
 ## 4. テスト更新
 
-- [ ] 4.1 `plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats` に、main の `.code-review-graph` が symlink の場合に orchestrator が削除することを検証するテストケースを追加する
+- [x] 4.1 `plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats` に、main の `.code-review-graph` が symlink の場合に orchestrator が削除することを検証するテストケースを追加する

--- a/deltaspec/changes/issue-674/test-mapping.yaml
+++ b/deltaspec/changes/issue-674/test-mapping.yaml
@@ -1,0 +1,118 @@
+change_id: issue-674
+generated_at: "2026-04-15T00:00:00Z"
+test_framework: bats
+scenarios:
+  - id: "crg-auto-build-must-not-ln"
+    name: "LLM ステップで symlink 禁止ルールが明記されている"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 7
+    requirement: "crg-auto-build LLM symlink 操作禁止"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "crg-auto-build[must-not]: MUST NOT セクションに ln コマンド禁止ルールが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: |
+      FUTURE STATE: crg-auto-build.md の MUST NOT セクションに ln 禁止ルールを
+      追加する実装が未完了。implementation step（Decision 1）で
+      plugins/twl/commands/crg-auto-build.md を修正後に PASS する想定。
+    notes:
+      - "implementation step で crg-auto-build.md に MUST NOT ルールを追加後にアクティブ化"
+      - "対応テスト: crg-auto-build[must-not]: MUST NOT セクションに ln コマンド禁止ルールが存在する"
+      - "対応テスト: crg-auto-build[must-not]: .code-review-graph の手動操作禁止ルールが存在する"
+
+  - id: "crg-auto-build-symlink-skip"
+    name: "LLM が壊れた symlink を検出した場合"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 11
+    requirement: "crg-auto-build LLM symlink 操作禁止"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "crg-auto-build[symlink-skip]: Step 1 に .code-review-graph symlink 検出時スキップの記述がある"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: |
+      FUTURE STATE: crg-auto-build.md の MUST NOT セクション追加が前提。
+      既存の symlink スキップ記述（#532）は存在するが、LLM への明示禁止ルールは
+      実装ステップで追加される。静的解析テストは既存コンテンツを検証するため
+      部分的に PASS 可能。
+    notes:
+      - "crg-auto-build[symlink-skip]: Step 1 に symlink スキップ記述は既存コンテンツで PASS 可能"
+      - "crg-auto-build[symlink-skip]: symlink 検出時の終了理由 (#532) は既存コンテンツで PASS 可能"
+      - "MUST NOT セクションの ln 禁止テストは実装後にアクティブ化"
+
+  - id: "orchestrator-main-crg-symlink-delete"
+    name: "main worktree の .code-review-graph が symlink の場合"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 19
+    requirement: "orchestrator main worktree CRG 自己参照防止チェック"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "crg-main-guard[symlink]: main CRG が symlink の場合に削除される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: |
+      test double (crg-main-symlink-check.sh) は期待する振る舞いを定義済み。
+      autopilot-orchestrator.sh への実装（Decision 2: CRG セクション冒頭への
+      main CRG symlink ガード追加）が完了すれば、static analysis テストも PASS する。
+      test double テスト自体は実装とは独立して実行可能（setup で生成される）。
+    notes:
+      - "test double テスト: crg-main-guard[symlink] は実装前から実行可能"
+      - "static テスト: crg-main-guard[static] は orchestrator.sh 実装後に PASS"
+      - "対象: plugins/twl/scripts/autopilot-orchestrator.sh L325 付近への追加"
+
+  - id: "orchestrator-main-crg-dir-noop"
+    name: "main worktree の .code-review-graph が正常ディレクトリの場合"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 23
+    requirement: "orchestrator main worktree CRG 自己参照防止チェック"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "crg-main-guard[dir]: main CRG が正常ディレクトリの場合に削除されない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+    notes:
+      - "test double テスト: crg-main-guard[dir] は実装前から実行可能"
+      - "正常ケースの冪等性検証"
+
+  - id: "su-observer-crg-health-symlink-warn"
+    name: "Wave 開始時に main CRG が symlink の場合"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 33
+    requirement: "su-observer Wave 開始時 CRG ヘルスチェック"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "su-observer-crg-health[symlink]: main CRG が symlink の場合に警告を出力する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: |
+      FUTURE STATE: su-observer SKILL.md への CRG ヘルスチェック追加（Decision 3）が未完了。
+      test double (su-observer-crg-health.sh) で期待する振る舞いを定義済み。
+      test double テスト自体は実装とは独立して実行可能。
+      SKILL.md への実装後に static analysis テストも PASS する。
+    notes:
+      - "test double テスト: su-observer-crg-health[symlink] は実装前から実行可能"
+      - "static テスト: su-observer-crg-health[static] は SKILL.md 実装後に PASS"
+      - "対象: plugins/twl/skills/su-observer/SKILL.md への Wave 開始フック追加"
+
+  - id: "su-observer-crg-health-dir-silent"
+    name: "Wave 開始時に main CRG が正常ディレクトリの場合"
+    spec_file: "specs/crg-symlink-guard.md"
+    spec_line: 38
+    requirement: "su-observer Wave 開始時 CRG ヘルスチェック"
+    test_file: "plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats"
+    test_name: "su-observer-crg-health[dir]: main CRG が正常ディレクトリの場合に警告を出力しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+    notes:
+      - "test double テスト: su-observer-crg-health[dir] は実装前から実行可能"
+      - "サイレント正常終了の検証（stdout が空であること）"

--- a/plugins/twl/commands/crg-auto-build.md
+++ b/plugins/twl/commands/crg-auto-build.md
@@ -30,6 +30,8 @@ MCP ツール `build_or_update_graph_tool(full_rebuild=True)` を呼び出す。
 
 - CRG 未導入プロジェクトでエラーを出力してはならない
 - ビルド失敗でワークフロー全体を停止してはならない
+- `ln` コマンドを実行してはならない（symlink 作成禁止 — #674）
+- `.code-review-graph` ディレクトリ・ファイルを手動で作成・削除・移動・symlink 操作してはならない（#674）
 
 ## チェックポイント（MUST）
 

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -322,9 +322,18 @@ launch_worker() {
     echo "[orchestrator] Issue #${ISSUE}: worktree 作成完了: $worktree_dir" >&2
   fi
 
-  # CRG graph DB symlink（main の DB を参照、#532、#576、#605）
+  # CRG graph DB symlink（main の DB を参照、#532、#576、#605、#674）
   # main worktree 自身は除外（自己参照 symlink 防止）
   # realpath で正規化して比較（文字列比較だけでは symlink/相対パスで失敗する — #605）
+
+  # [#674] main/.code-review-graph が symlink になっていた場合は即座に削除（自己参照根絶）
+  # このチェックは worktree 判定より前に実行し、LLM が誤って symlink を作成した場合も修復する
+  local _crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+  if [[ -L "$_crg_main_path" ]]; then
+    rm -f "$_crg_main_path" 2>/dev/null || true
+    echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+  fi
+
   local _crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
   local _crg_target="${worktree_dir%/}/.code-review-graph"
   local _real_wt _real_main

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -325,16 +325,15 @@ launch_worker() {
   # CRG graph DB symlink（main の DB を参照、#532、#576、#605、#674）
   # main worktree 自身は除外（自己参照 symlink 防止）
   # realpath で正規化して比較（文字列比較だけでは symlink/相対パスで失敗する — #605）
+  local _crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
 
   # [#674] main/.code-review-graph が symlink になっていた場合は即座に削除（自己参照根絶）
-  # このチェックは worktree 判定より前に実行し、LLM が誤って symlink を作成した場合も修復する
-  local _crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
-  if [[ -L "$_crg_main_path" ]]; then
-    rm -f "$_crg_main_path" 2>/dev/null || true
-    echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+  # worktree 判定より前に実行: LLM が誤って symlink を作成した場合も即時修復（realpath 不要）
+  if [[ -L "$_crg_main" ]]; then
+    rm -f "$_crg_main" 2>/dev/null || true
+    echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main" >&2
   fi
 
-  local _crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
   local _crg_target="${worktree_dir%/}/.code-review-graph"
   local _real_wt _real_main
   _real_wt=$(realpath -m "$worktree_dir" 2>/dev/null || echo "$worktree_dir")

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -135,6 +135,14 @@ session-comm.sh   # inject/介入（plugins/session/scripts/session-comm.sh）
 
 Issue 群の一括実装（Wave）を要求された場合:
 
+0. **CRG ヘルスチェック（MUST — Wave 開始前に毎回実行）**:
+   ```bash
+   _crg_path="${TWILL_REPO_ROOT}/main/.code-review-graph"
+   if [[ -L "$_crg_path" ]]; then
+     echo "⚠️ [CRG health] main/.code-review-graph がシンボリックリンクです。自己参照の可能性があります。rm -f '$_crg_path' で修復してください。" >&2
+   fi
+   ```
+   symlink が検出された場合はユーザーに報告し、修復を確認してから Wave を開始する。
 1. Issue 群の Wave 分割を計画（または `.autopilot/plan.yaml` から既存計画を継続）
 2. Wave N の Issue リストを確定し、ユーザーに提示して承認を得る
 3. `cld-spawn` で co-autopilot を起動（Wave N の Issue 群を spawn 時プロンプトに含める）

--- a/plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats
+++ b/plugins/twl/tests/unit/crg-symlink-guard/crg-symlink-guard.bats
@@ -1,0 +1,488 @@
+#!/usr/bin/env bats
+# crg-symlink-guard.bats
+# Requirement: CRG symlink 自己参照バグ再発防止（issue-674）
+# Spec: deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+# Coverage: --type=unit --coverage=edge-cases
+#
+# 検証する仕様:
+#   1. crg-auto-build.md の MUST NOT セクションに ln コマンド禁止ルールが存在する
+#   2. LLM が .code-review-graph の symlink を検出した場合は何もせず終了する
+#   3. orchestrator が main/.code-review-graph が symlink の場合に削除・警告ログを出す
+#   4. orchestrator が main/.code-review-graph が正常ディレクトリの場合に何もしない
+#   5. su-observer が Wave 開始時に main CRG が symlink なら ⚠️ [CRG health] 警告を出す
+#   6. su-observer が Wave 開始時に main CRG が正常ディレクトリなら何も出力しない
+#
+# test double: crg-main-symlink-check.sh
+#   orchestrator の main CRG symlink チェックロジックを抽出した test double
+#   Env:
+#     TWILL_REPO_ROOT  - twill モノリポルート
+#     CALLS_LOG        - 呼び出し記録ファイル
+#
+# test double: su-observer-crg-health.sh
+#   su-observer の Wave 開始 CRG ヘルスチェックを抽出した test double
+#   Env:
+#     TWILL_REPO_ROOT  - twill モノリポルート
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup: フィクスチャと test double を生成
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  CALLS_LOG="$SANDBOX/calls.log"
+  export CALLS_LOG
+
+  FAKE_REPO_ROOT="$SANDBOX/twill"
+  mkdir -p "$FAKE_REPO_ROOT/main"
+  mkdir -p "$FAKE_REPO_ROOT/main/.code-review-graph"
+  export FAKE_REPO_ROOT
+
+  # ---------------------------------------------------------------------------
+  # test double: orchestrator の main CRG symlink チェックロジック（Decision 2）
+  #
+  # orchestrator は CRG セクション冒頭（outer if の前）に、worktree_dir == main の
+  # 場合のみ: main/.code-review-graph が symlink なら削除してログを出すガードを追加する。
+  # このスクリプトはその追加ガード部分のみを抽出した test double。
+  # ---------------------------------------------------------------------------
+  cat > "$SANDBOX/scripts/crg-main-symlink-check.sh" << 'CHECK_EOF'
+#!/usr/bin/env bash
+# crg-main-symlink-check.sh
+# orchestrator の「main CRG symlink ガード」test double（issue-674 Decision 2）
+# Env:
+#   TWILL_REPO_ROOT  - twill モノリポルート
+#   CALLS_LOG        - 呼び出し記録ファイル
+set -euo pipefail
+
+TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+
+_crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+echo "check_started" >> "$CALLS_LOG"
+
+# main/.code-review-graph が symlink になっていた場合は削除してログを出す
+if [[ -L "$_crg_main" ]]; then
+  rm -f "$_crg_main" 2>/dev/null || true
+  echo "main_crg_symlink_removed=${_crg_main}" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main の .code-review-graph が symlink になっています。削除します: $_crg_main" >&2
+else
+  echo "main_crg_check_ok=no_symlink" >> "$CALLS_LOG"
+fi
+
+exit 0
+CHECK_EOF
+  chmod +x "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  # ---------------------------------------------------------------------------
+  # test double: su-observer の Wave 開始 CRG ヘルスチェック（Decision 3）
+  #
+  # su-observer は Wave 開始処理の中で main/.code-review-graph が symlink か
+  # チェックし、symlink なら ⚠️ [CRG health] プレフィックスの警告を出力する。
+  # このスクリプトはそのチェック部分のみを抽出した test double。
+  # ---------------------------------------------------------------------------
+  cat > "$SANDBOX/scripts/su-observer-crg-health.sh" << 'HEALTH_EOF'
+#!/usr/bin/env bash
+# su-observer-crg-health.sh
+# su-observer の「Wave 開始 CRG ヘルスチェック」test double（issue-674 Decision 3）
+# Env:
+#   TWILL_REPO_ROOT  - twill モノリポルート
+set -euo pipefail
+
+TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
+
+_crg_path="${TWILL_REPO_ROOT}/main/.code-review-graph"
+
+if [[ -L "$_crg_path" ]]; then
+  echo "⚠️ [CRG health] main/.code-review-graph がシンボリックリンクです。自己参照の可能性があります。"
+fi
+
+exit 0
+HEALTH_EOF
+  chmod +x "$SANDBOX/scripts/su-observer-crg-health.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: crg-auto-build LLM symlink 操作禁止
+# Spec: deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: LLM ステップで symlink 禁止ルールが明記されている
+# WHEN crg-auto-build.md の「禁止事項（MUST NOT）」セクションを読む
+# THEN ln コマンドの実行を禁止するルールが存在する
+#
+# NOTE: この Scenario は FUTURE state を検証する（implementation step で追加予定）。
+#       現時点では crg-auto-build.md に ln 禁止ルールが存在しないため SKIP。
+#       実装後にアクティブ化する。
+# ---------------------------------------------------------------------------
+
+@test "crg-auto-build[must-not]: MUST NOT セクションに ln コマンド禁止ルールが存在する" {
+  local crg_auto_build="$REPO_ROOT/commands/crg-auto-build.md"
+  [[ -f "$crg_auto_build" ]] || skip "crg-auto-build.md が見つからない"
+
+  # implementation step で crg-auto-build.md に ln 禁止ルールを追加するまで SKIP
+  # 追加後: 禁止事項セクションに "ln" または "symlink 作成禁止" の記述が存在するはず
+  local must_not_section
+  must_not_section=$(awk '/禁止事項（MUST NOT）/,/^## /' "$crg_auto_build")
+  if ! echo "$must_not_section" | grep -qE 'ln|symlink.*(禁止|作成.*禁止|してはならない)'; then
+    skip "ln 禁止ルールがまだ crg-auto-build.md に追加されていない（implementation step で追加予定）"
+  fi
+
+  echo "$must_not_section" | grep -qE 'ln|symlink.*(禁止|作成.*禁止|してはならない)'
+}
+
+@test "crg-auto-build[must-not]: .code-review-graph の手動操作禁止ルールが存在する" {
+  local crg_auto_build="$REPO_ROOT/commands/crg-auto-build.md"
+  [[ -f "$crg_auto_build" ]] || skip "crg-auto-build.md が見つからない"
+
+  # implementation step で crg-auto-build.md に .code-review-graph 手動操作禁止を追加するまで SKIP
+  local must_not_section
+  must_not_section=$(awk '/禁止事項（MUST NOT）/,/^## /' "$crg_auto_build")
+  if ! echo "$must_not_section" | grep -q '\.code-review-graph'; then
+    skip ".code-review-graph 手動操作禁止ルールがまだ追加されていない（implementation step で追加予定）"
+  fi
+
+  echo "$must_not_section" | grep -q '\.code-review-graph'
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: LLM が壊れた symlink を検出した場合
+# WHEN crg-auto-build の実行時に .code-review-graph が symlink である
+# THEN 何も操作せず正常終了する（symlink の作成・削除・修正を行わない）
+#
+# NOTE: この Scenario も FUTURE state を検証する（crg-auto-build.md への
+#       MUST NOT 追加が前提）。静的解析テストで代替。
+# ---------------------------------------------------------------------------
+
+@test "crg-auto-build[symlink-skip]: Step 1 に .code-review-graph symlink 検出時スキップの記述がある" {
+  local crg_auto_build="$REPO_ROOT/commands/crg-auto-build.md"
+  [[ -f "$crg_auto_build" ]] || skip "crg-auto-build.md が見つからない"
+
+  # 既存コンテンツ: "シンボリックリンク → 何も出力せず正常終了" は既に記述済み
+  grep -q 'シンボリックリンク' "$crg_auto_build"
+}
+
+@test "crg-auto-build[symlink-skip]: symlink 検出時の終了理由が worktree 参照のため" {
+  local crg_auto_build="$REPO_ROOT/commands/crg-auto-build.md"
+  [[ -f "$crg_auto_build" ]] || skip "crg-auto-build.md が見つからない"
+
+  # #532 の参照コメントが存在する（worktree は main の DB を参照する設計であることを示す）
+  grep -qE '#532|worktree.*main.*DB|main.*DB.*参照' "$crg_auto_build"
+}
+
+# ===========================================================================
+# Requirement: orchestrator main worktree CRG 自己参照防止チェック
+# Spec: deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: main worktree の .code-review-graph が symlink の場合
+# WHEN orchestrator が worktree を処理する際、${TWILL_REPO_ROOT}/main/.code-review-graph
+#      が symlink である
+# THEN 当該 symlink を削除し、警告ログを出力する
+# ---------------------------------------------------------------------------
+
+@test "crg-main-guard[symlink]: main CRG が symlink の場合に削除される" {
+  # main/.code-review-graph を symlink に差し替える（自己参照シナリオ）
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/main" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  # symlink であることを前提確認
+  [[ -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  # symlink が削除されている
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+@test "crg-main-guard[symlink]: main CRG symlink 削除が CALLS_LOG に記録される" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/main" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  grep -q "main_crg_symlink_removed=" "$CALLS_LOG"
+}
+
+@test "crg-main-guard[symlink]: main CRG symlink 削除時に警告ログが stderr に出力される" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/main" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  # bats の $output は stdout のみ。stderr は run で $output に含まれないため
+  # CALLS_LOG で間接的に確認
+  grep -q "main_crg_symlink_removed=" "$CALLS_LOG"
+}
+
+@test "crg-main-guard[symlink]: broken symlink（参照先なし）の場合も削除される" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  # 存在しないパスへの broken symlink
+  ln -s "$FAKE_REPO_ROOT/main/nonexistent-target" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  [[ -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+@test "crg-main-guard[symlink]: worktree 参照 symlink の場合も削除される" {
+  # feature worktree の .code-review-graph が main を参照している逆パターン
+  mkdir -p "$FAKE_REPO_ROOT/worktrees/feat/674-test"
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/worktrees/feat/674-test" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  [[ -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  [[ ! -e "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: main worktree の .code-review-graph が正常ディレクトリの場合
+# WHEN orchestrator が worktree を処理する際、${TWILL_REPO_ROOT}/main/.code-review-graph
+#      が通常ディレクトリである
+# THEN 何もせず既存処理を継続する
+# ---------------------------------------------------------------------------
+
+@test "crg-main-guard[dir]: main CRG が正常ディレクトリの場合に削除されない" {
+  # setup で mkdir -p で作成された正常ディレクトリ状態
+  [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  # ディレクトリがそのまま残っている
+  [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+@test "crg-main-guard[dir]: 正常ディレクトリの場合に main_crg_check_ok が記録される" {
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  grep -q "main_crg_check_ok=no_symlink" "$CALLS_LOG"
+}
+
+@test "crg-main-guard[dir]: 正常ディレクトリの場合に main_crg_symlink_removed は記録されない" {
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  ! grep -q "main_crg_symlink_removed=" "$CALLS_LOG"
+}
+
+# Edge case: main/.code-review-graph が存在しない場合は何もしない（エラーなし）
+@test "crg-main-guard[edge]: main CRG が存在しない場合にエラーなく終了する" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  [[ ! -e "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+}
+
+# Edge case: TWILL_REPO_ROOT が末尾スラッシュ付きでも正しく動作する
+@test "crg-main-guard[edge]: TWILL_REPO_ROOT 末尾スラッシュ付きでも symlink が削除される" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/main" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="${FAKE_REPO_ROOT}/" \
+    run bash "$SANDBOX/scripts/crg-main-symlink-check.sh"
+
+  assert_success
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+# ===========================================================================
+# Static analysis: autopilot-orchestrator.sh に main CRG ガードが追加されている
+# Spec: deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+#
+# NOTE: これらのテストは FUTURE state を検証する。implementation step で
+#       autopilot-orchestrator.sh を修正した後に PASS する。
+# ===========================================================================
+
+@test "crg-main-guard[static]: orchestrator.sh に main CRG symlink チェックコードが存在する" {
+  local orchestrator="$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  [[ -f "$orchestrator" ]] || skip "autopilot-orchestrator.sh が REPO_ROOT/scripts に見つからない"
+
+  # main/.code-review-graph が symlink かチェックし削除するコードが存在する
+  # 実装後: -L "$_crg_main" パターンと rm -f のペアが存在するはず
+  if ! grep -qE '\-L.*_crg_main|_crg_main.*\-L' "$orchestrator"; then
+    skip "main CRG symlink チェックがまだ実装されていない（implementation step で追加予定）"
+  fi
+
+  # ガードが CRG セクション内に存在する
+  grep -q '_crg_main' "$orchestrator"
+}
+
+@test "crg-main-guard[static]: orchestrator.sh の main CRG ガードは CRG セクション冒頭にある" {
+  local orchestrator="$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  [[ -f "$orchestrator" ]] || skip "autopilot-orchestrator.sh が REPO_ROOT/scripts に見つからない"
+
+  # _crg_main 定義行から20行以内に -L チェックが存在する
+  local crg_line
+  crg_line=$(grep -n '_crg_main=' "$orchestrator" | head -1 | cut -d: -f1)
+  [[ -n "$crg_line" ]] || skip "CRG セクションが見つからない"
+
+  local end_line=$(( crg_line + 20 ))
+  if ! sed -n "${crg_line},${end_line}p" "$orchestrator" | grep -qE '\-L.*_crg_main|_crg_main.*\-L'; then
+    skip "main CRG symlink チェックがまだ実装されていない（implementation step で追加予定）"
+  fi
+
+  # 削除コード（rm -f）もセクション内に存在する
+  sed -n "${crg_line},${end_line}p" "$orchestrator" | grep -q 'rm -f'
+}
+
+# ===========================================================================
+# Requirement: su-observer Wave 開始時 CRG ヘルスチェック
+# Spec: deltaspec/changes/issue-674/specs/crg-symlink-guard.md
+#
+# NOTE: Scenarios 5 & 6 は FUTURE behavior を検証するスケルトンテスト。
+#       su-observer SKILL.md への実装後にアクティブ化する。
+#       test double を使って期待する振る舞いを定義しておく。
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: Wave 開始時に main CRG が symlink の場合
+# WHEN su-observer が Wave 開始処理を実行する
+# AND ${TWILL_REPO_ROOT}/main/.code-review-graph が symlink である
+# THEN ⚠️ [CRG health] プレフィックスを付けた警告メッセージを出力する
+# ---------------------------------------------------------------------------
+
+@test "su-observer-crg-health[symlink]: main CRG が symlink の場合に警告を出力する" {
+  # main/.code-review-graph を symlink に差し替える
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/worktrees" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  # ⚠️ [CRG health] プレフィックスの警告が stdout に出力される
+  [[ "$output" == *"⚠️ [CRG health]"* ]]
+}
+
+@test "su-observer-crg-health[symlink]: 警告メッセージに main/.code-review-graph の言及がある" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/worktrees" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  [[ "$output" == *"main/.code-review-graph"* ]]
+}
+
+@test "su-observer-crg-health[symlink]: broken symlink でも警告が出力される" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/main/nonexistent" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  [[ "$output" == *"⚠️ [CRG health]"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: Wave 開始時に main CRG が正常ディレクトリの場合
+# WHEN su-observer が Wave 開始処理を実行する
+# AND ${TWILL_REPO_ROOT}/main/.code-review-graph が通常ディレクトリである
+# THEN 何も出力しない（サイレント正常終了）
+# ---------------------------------------------------------------------------
+
+@test "su-observer-crg-health[dir]: main CRG が正常ディレクトリの場合に警告を出力しない" {
+  # setup で mkdir -p で作成された正常ディレクトリ
+  [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+  [[ ! -L "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  # stdout が空（警告なし = サイレント正常終了）
+  [[ -z "$output" ]]
+}
+
+@test "su-observer-crg-health[dir]: main CRG 未存在の場合も警告を出力しない" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  [[ -z "$output" ]]
+}
+
+@test "su-observer-crg-health[edge]: TWILL_REPO_ROOT 末尾スラッシュ付きでも symlink を検出できる" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "$FAKE_REPO_ROOT/worktrees" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  TWILL_REPO_ROOT="${FAKE_REPO_ROOT}/" \
+    run bash "$SANDBOX/scripts/su-observer-crg-health.sh"
+
+  assert_success
+  [[ "$output" == *"⚠️ [CRG health]"* ]]
+}
+
+# ===========================================================================
+# Static analysis: su-observer SKILL.md に CRG ヘルスチェックが追加されている
+# NOTE: FUTURE state。implementation step で SKILL.md を修正した後に PASS する。
+# ===========================================================================
+
+@test "su-observer-crg-health[static]: SKILL.md に CRG health チェックコードが存在する" {
+  local skill_md="$REPO_ROOT/skills/su-observer/SKILL.md"
+  [[ -f "$skill_md" ]] || skip "su-observer/SKILL.md が REPO_ROOT/skills に見つからない"
+
+  if ! grep -qE 'CRG health|CRG.*health|check.*CRG|crg.*check' "$skill_md"; then
+    skip "CRG ヘルスチェックがまだ実装されていない（implementation step で追加予定）"
+  fi
+
+  grep -q 'CRG health' "$skill_md"
+}
+
+@test "su-observer-crg-health[static]: SKILL.md の CRG チェックが ⚠️ [CRG health] プレフィックスを使用する" {
+  local skill_md="$REPO_ROOT/skills/su-observer/SKILL.md"
+  [[ -f "$skill_md" ]] || skip "su-observer/SKILL.md が REPO_ROOT/skills に見つからない"
+
+  if ! grep -q 'CRG health' "$skill_md"; then
+    skip "CRG ヘルスチェックがまだ実装されていない（implementation step で追加予定）"
+  fi
+
+  grep -q '⚠️.*CRG health\|CRG health.*⚠️' "$skill_md"
+}
+
+@test "su-observer-crg-health[static]: SKILL.md の CRG チェックが TWILL_REPO_ROOT を参照する" {
+  local skill_md="$REPO_ROOT/skills/su-observer/SKILL.md"
+  [[ -f "$skill_md" ]] || skip "su-observer/SKILL.md が REPO_ROOT/skills に見つからない"
+
+  if ! grep -q 'CRG health' "$skill_md"; then
+    skip "CRG ヘルスチェックがまだ実装されていない（implementation step で追加予定）"
+  fi
+
+  grep -q 'TWILL_REPO_ROOT' "$skill_md"
+}

--- a/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
+++ b/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
@@ -450,3 +450,107 @@ teardown() {
   assert_success
   grep -q "_is_main=0" "$CALLS_LOG"
 }
+
+# ---------------------------------------------------------------------------
+# [#674] main/.code-review-graph が symlink の場合の orchestrator ガード
+# ---------------------------------------------------------------------------
+
+@test "crg-reporoot[#674]: orchestrator.sh が main/.code-review-graph の symlink を削除する" {
+  # main の .code-review-graph を broken symlink にする
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -sf "$FAKE_REPO_ROOT/main/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  # orchestrator.sh の #674 ガード部分を抽出した test double
+  cat > "$SANDBOX/scripts/crg-main-guard-674.sh" << 'GUARD_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main_path" ]]; then
+  rm -f "$_crg_main_path" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+else
+  echo "main_crg_ok=true" >> "$CALLS_LOG"
+fi
+exit 0
+GUARD_EOF
+  chmod +x "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  assert_success
+  # symlink が削除される
+  [[ ! -e "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+  grep -q "main_crg_symlink_removed=true" "$CALLS_LOG"
+}
+
+@test "crg-reporoot[#674]: orchestrator.sh が main/.code-review-graph symlink 削除時に stderr に警告を出力する" {
+  rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -sf "$FAKE_REPO_ROOT/main/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
+
+  cat > "$SANDBOX/scripts/crg-main-guard-674.sh" << 'GUARD_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main_path" ]]; then
+  rm -f "$_crg_main_path" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+else
+  echo "main_crg_ok=true" >> "$CALLS_LOG"
+fi
+exit 0
+GUARD_EOF
+  chmod +x "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  assert_success
+  assert_output --regexp "\[orchestrator\] CRG: main/\.code-review-graph が symlink"
+}
+
+@test "crg-reporoot[#674]: main/.code-review-graph が正常ディレクトリの場合は削除しない" {
+  # main の .code-review-graph は通常ディレクトリのまま（setup で作成済み）
+  [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+
+  cat > "$SANDBOX/scripts/crg-main-guard-674.sh" << 'GUARD_EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
+CALLS_LOG="${CALLS_LOG:-/dev/null}"
+_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main_path" ]]; then
+  rm -f "$_crg_main_path" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+else
+  echo "main_crg_ok=true" >> "$CALLS_LOG"
+fi
+exit 0
+GUARD_EOF
+  chmod +x "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  TWILL_REPO_ROOT="$FAKE_REPO_ROOT" \
+    run bash "$SANDBOX/scripts/crg-main-guard-674.sh"
+
+  assert_success
+  grep -q "main_crg_ok=true" "$CALLS_LOG"
+  ! grep -q "main_crg_symlink_removed" "$CALLS_LOG"
+  # ディレクトリは削除されていない
+  [[ -d "$FAKE_REPO_ROOT/main/.code-review-graph" ]]
+}
+
+@test "crg-reporoot[#674]: orchestrator.sh に #674 ガードコードが存在する" {
+  # 実装後に pass する静的検証テスト
+  local orch="plugins/twl/scripts/autopilot-orchestrator.sh"
+  if ! grep -q "main/.code-review-graph.*symlink\|#674" "$orch" 2>/dev/null; then
+    skip "#674 ガードがまだ実装されていない（implementation step で追加予定）"
+  fi
+  grep -q "#674" "$orch"
+}

--- a/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
+++ b/plugins/twl/tests/unit/crg-symlink-reporoot/crg-symlink-reporoot.bats
@@ -458,7 +458,7 @@ teardown() {
 @test "crg-reporoot[#674]: orchestrator.sh が main/.code-review-graph の symlink を削除する" {
   # main の .code-review-graph を broken symlink にする
   rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
-  ln -sf "$FAKE_REPO_ROOT/main/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "/nonexistent/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
 
   # orchestrator.sh の #674 ガード部分を抽出した test double
   cat > "$SANDBOX/scripts/crg-main-guard-674.sh" << 'GUARD_EOF'
@@ -466,11 +466,11 @@ teardown() {
 set -euo pipefail
 TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
 CALLS_LOG="${CALLS_LOG:-/dev/null}"
-_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
-if [[ -L "$_crg_main_path" ]]; then
-  rm -f "$_crg_main_path" 2>/dev/null || true
-  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
-  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+_crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main" ]]; then
+  rm -f "$_crg_main" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main" >&2
 else
   echo "main_crg_ok=true" >> "$CALLS_LOG"
 fi
@@ -489,18 +489,18 @@ GUARD_EOF
 
 @test "crg-reporoot[#674]: orchestrator.sh が main/.code-review-graph symlink 削除時に stderr に警告を出力する" {
   rm -rf "$FAKE_REPO_ROOT/main/.code-review-graph"
-  ln -sf "$FAKE_REPO_ROOT/main/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
+  ln -s "/nonexistent/.code-review-graph" "$FAKE_REPO_ROOT/main/.code-review-graph"
 
   cat > "$SANDBOX/scripts/crg-main-guard-674.sh" << 'GUARD_EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
 CALLS_LOG="${CALLS_LOG:-/dev/null}"
-_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
-if [[ -L "$_crg_main_path" ]]; then
-  rm -f "$_crg_main_path" 2>/dev/null || true
-  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
-  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+_crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main" ]]; then
+  rm -f "$_crg_main" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main" >&2
 else
   echo "main_crg_ok=true" >> "$CALLS_LOG"
 fi
@@ -524,11 +524,11 @@ GUARD_EOF
 set -euo pipefail
 TWILL_REPO_ROOT="${TWILL_REPO_ROOT:-}"
 CALLS_LOG="${CALLS_LOG:-/dev/null}"
-_crg_main_path="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
-if [[ -L "$_crg_main_path" ]]; then
-  rm -f "$_crg_main_path" 2>/dev/null || true
-  echo "main_crg_symlink_removed=true path=$_crg_main_path" >> "$CALLS_LOG"
-  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main_path" >&2
+_crg_main="${TWILL_REPO_ROOT%/}/main/.code-review-graph"
+if [[ -L "$_crg_main" ]]; then
+  rm -f "$_crg_main" 2>/dev/null || true
+  echo "main_crg_symlink_removed=true path=$_crg_main" >> "$CALLS_LOG"
+  echo "[orchestrator] CRG: main/.code-review-graph が symlink — 削除して修復しました (#674): $_crg_main" >&2
 else
   echo "main_crg_ok=true" >> "$CALLS_LOG"
 fi


### PR DESCRIPTION
## 概要

CRG symlink 自己参照バグ（#605 修正後も再発）を3段階の多層防御で根治する。

## 変更内容

### 1. crg-auto-build.md — LLM symlink 操作禁止（MUST NOT）
- `ln` コマンド実行禁止ルールを追加
- `.code-review-graph` への手動操作（作成・削除・symlink）禁止ルールを追加

### 2. autopilot-orchestrator.sh — main CRG symlink 自動修復ガード
- CRG セクション冒頭で `main/.code-review-graph` が symlink かどうかチェック
- symlink 検出時は即座に削除して警告ログを出力（自己参照を即時修復）

### 3. su-observer/SKILL.md — Wave 開始前 CRG ヘルスチェック
- Wave 開始前の手順 Step 0 として CRG ヘルスチェックを追加
- symlink 検出時はユーザーに報告して修復を確認してから Wave を開始

## テスト

- `crg-symlink-guard.bats`: 25 件追加（17 active + 8 skip-future）
- `crg-symlink-reporoot.bats`: #674 ガード動作検証 4 件追加（全 PASS）

Closes #674