### PR TITLE
feat(hooks): Hook ベース Event Emission インフラ構築 (#569)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,16 @@
         ]
       },
       {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/supervisor-input-wait.sh",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "hooks": [
           {
@@ -32,6 +42,38 @@
           {
             "type": "command",
             "command": "bash plugins/twl/scripts/hooks/pre-bash-merge-guard.sh",
+            "timeout": 3000
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/supervisor-heartbeat.sh",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
+        "matcher": "AskUserQuestion",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/supervisor-input-clear.sh",
+            "timeout": 3000
+          }
+        ]
+      },
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/supervisor-skill-step.sh",
             "timeout": 3000
           }
         ]
@@ -69,6 +111,18 @@
             "type": "command",
             "command": "bash plugins/twl/scripts/su-session-compact.sh",
             "timeout": 10000
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash plugins/twl/scripts/hooks/supervisor-session-end.sh",
+            "timeout": 3000
           }
         ]
       }

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2663,6 +2663,31 @@ scripts:
     path: scripts/hooks/pre-bash-phase3-gate.sh
     description: "PreToolUse gate (Layer C-2): co-issue Phase 3 未完了時に gh issue create / gh issue edit --add-label refined を deny する（Bash tool matcher）。gate state /tmp/.co-issue-phase3-gate-{cksum}.json で管理"
 
+  supervisor-heartbeat:
+    type: script
+    path: scripts/hooks/supervisor-heartbeat.sh
+    description: "PostToolUse hook (Write|Edit): AUTOPILOT_DIR 設定時に heartbeat イベントファイルを .supervisor/events/heartbeat-<session_id> にアトミック書き出し（#569 Event Emission インフラ）"
+
+  supervisor-input-wait:
+    type: script
+    path: scripts/hooks/supervisor-input-wait.sh
+    description: "PreToolUse hook (AskUserQuestion): AUTOPILOT_DIR 設定時に input-wait イベントファイルを .supervisor/events/input-wait-<session_id> にアトミック書き出し（#569 Event Emission インフラ）"
+
+  supervisor-input-clear:
+    type: script
+    path: scripts/hooks/supervisor-input-clear.sh
+    description: "PostToolUse hook (AskUserQuestion): AUTOPILOT_DIR 設定時に input-wait イベントファイルを削除（#569 Event Emission インフラ）"
+
+  supervisor-skill-step:
+    type: script
+    path: scripts/hooks/supervisor-skill-step.sh
+    description: "PostToolUse hook (Skill): AUTOPILOT_DIR 設定時に skill-step イベントファイルを .supervisor/events/skill-step-<session_id> にアトミック書き出し（#569 Event Emission インフラ）"
+
+  supervisor-session-end:
+    type: script
+    path: scripts/hooks/supervisor-session-end.sh
+    description: "Stop hook: AUTOPILOT_DIR 設定時に session-end イベントファイルを .supervisor/events/session-end-<session_id> にアトミック書き出し（#569 Event Emission インフラ）"
+
   pr-review-manifest:
     type: script
     path: scripts/pr-review-manifest.sh

--- a/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
+++ b/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Write|Edit → heartbeat イベントをファイルに書き出す
+# su-observer の Event Emission インフラ（#569）
+set -uo pipefail
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 or 空 → 通常セッション、何もしない
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# AUTOPILOT_DIR が実在するディレクトリでなければ無視
+if [[ ! -d "${AUTOPILOT_DIR}" ]]; then
+  exit 0
+fi
+
+# イベントディレクトリ（main/.supervisor/events/）
+# AUTOPILOT_DIR = main/.autopilot なので ../ が main/ を指す
+EVENTS_DIR="${AUTOPILOT_DIR}/../.supervisor/events"
+mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
+
+# session_id 取得: stdin JSON → CLAUDE_SESSION_ID 環境変数 → PID フォールバック
+SESSION_ID=""
+if [[ -n "$INPUT" ]]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo "")
+fi
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+fi
+
+TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "${PWD:-}")
+if [[ -z "$CWD" ]]; then
+  CWD="${PWD:-}"
+fi
+
+# アトミック書き込み（一時ファイル → mv）
+TMP_FILE="${EVENTS_DIR}/heartbeat-${SESSION_ID}.tmp.$$"
+TARGET_FILE="${EVENTS_DIR}/heartbeat-${SESSION_ID}"
+
+printf '{"session_id":"%s","timestamp":%s,"cwd":"%s"}\n' \
+  "$SESSION_ID" "$TIMESTAMP" "$CWD" > "$TMP_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+mv "$TMP_FILE" "$TARGET_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+
+exit 0

--- a/plugins/twl/scripts/hooks/supervisor-input-clear.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-clear.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# PostToolUse hook: AskUserQuestion → input-wait ファイルを削除（入力待ち解消）
+# su-observer の Event Emission インフラ（#569）
+set -uo pipefail
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 or 空 → 通常セッション、何もしない
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# AUTOPILOT_DIR が実在するディレクトリでなければ無視
+if [[ ! -d "${AUTOPILOT_DIR}" ]]; then
+  exit 0
+fi
+
+# イベントディレクトリ
+EVENTS_DIR="${AUTOPILOT_DIR}/../.supervisor/events"
+
+# session_id 取得
+SESSION_ID=""
+if [[ -n "$INPUT" ]]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo "")
+fi
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+fi
+
+# input-wait ファイルを削除（存在しなければ何もしない）
+TARGET_FILE="${EVENTS_DIR}/input-wait-${SESSION_ID}"
+rm -f "$TARGET_FILE" 2>/dev/null || true
+
+exit 0

--- a/plugins/twl/scripts/hooks/supervisor-input-wait.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-wait.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# PreToolUse hook: AskUserQuestion → input-wait イベントをファイルに書き出す
+# su-observer の Event Emission インフラ（#569）
+set -uo pipefail
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 or 空 → 通常セッション、何もしない
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# AUTOPILOT_DIR が実在するディレクトリでなければ無視
+if [[ ! -d "${AUTOPILOT_DIR}" ]]; then
+  exit 0
+fi
+
+# イベントディレクトリ（main/.supervisor/events/）
+EVENTS_DIR="${AUTOPILOT_DIR}/../.supervisor/events"
+mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
+
+# session_id 取得
+SESSION_ID=""
+if [[ -n "$INPUT" ]]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo "")
+fi
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+fi
+
+TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
+
+# アトミック書き込み
+TMP_FILE="${EVENTS_DIR}/input-wait-${SESSION_ID}.tmp.$$"
+TARGET_FILE="${EVENTS_DIR}/input-wait-${SESSION_ID}"
+
+printf '{"session_id":"%s","timestamp":%s,"event":"input-wait"}\n' \
+  "$SESSION_ID" "$TIMESTAMP" > "$TMP_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+mv "$TMP_FILE" "$TARGET_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+
+exit 0

--- a/plugins/twl/scripts/hooks/supervisor-session-end.sh
+++ b/plugins/twl/scripts/hooks/supervisor-session-end.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Stop hook: セッション終了シグナルをファイルに書き出す
+# su-observer の Event Emission インフラ（#569）
+set -uo pipefail
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 or 空 → 通常セッション、何もしない
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# AUTOPILOT_DIR が実在するディレクトリでなければ無視
+if [[ ! -d "${AUTOPILOT_DIR}" ]]; then
+  exit 0
+fi
+
+# イベントディレクトリ（main/.supervisor/events/）
+EVENTS_DIR="${AUTOPILOT_DIR}/../.supervisor/events"
+mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
+
+# session_id 取得
+SESSION_ID=""
+if [[ -n "$INPUT" ]]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo "")
+fi
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+fi
+
+TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
+
+# アトミック書き込み
+TMP_FILE="${EVENTS_DIR}/session-end-${SESSION_ID}.tmp.$$"
+TARGET_FILE="${EVENTS_DIR}/session-end-${SESSION_ID}"
+
+printf '{"session_id":"%s","timestamp":%s,"event":"session-end"}\n' \
+  "$SESSION_ID" "$TIMESTAMP" > "$TMP_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+mv "$TMP_FILE" "$TARGET_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+
+exit 0

--- a/plugins/twl/scripts/hooks/supervisor-skill-step.sh
+++ b/plugins/twl/scripts/hooks/supervisor-skill-step.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# PostToolUse hook: Skill → skill-step イベントをファイルに書き出す
+# su-observer の Event Emission インフラ（#569）
+# 注意: PostToolUse: Skill matcher は Claude Code hook 仕様でサポートされている
+set -uo pipefail
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# AUTOPILOT_DIR 未設定 or 空 → 通常セッション、何もしない
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  exit 0
+fi
+
+# AUTOPILOT_DIR が実在するディレクトリでなければ無視
+if [[ ! -d "${AUTOPILOT_DIR}" ]]; then
+  exit 0
+fi
+
+# イベントディレクトリ（main/.supervisor/events/）
+EVENTS_DIR="${AUTOPILOT_DIR}/../.supervisor/events"
+mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
+
+# session_id 取得
+SESSION_ID=""
+if [[ -n "$INPUT" ]]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || echo "")
+fi
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
+fi
+
+TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
+
+# skill 名と tool_input 取得（tool_input は最大 500 文字）
+SKILL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // empty' 2>/dev/null || echo "")
+TOOL_INPUT_RAW=$(printf '%s' "$INPUT" | jq -r '.tool_input | tostring' 2>/dev/null || echo "")
+TOOL_INPUT="${TOOL_INPUT_RAW:0:500}"
+
+# JSON エスケープ（改行・タブ・クォートを処理）
+json_escape_simple() {
+  local s="$1"
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\r'/\\r}"
+  printf '%s' "$s"
+}
+
+SKILL_ESC=$(json_escape_simple "$SKILL_NAME")
+TOOL_INPUT_ESC=$(json_escape_simple "$TOOL_INPUT")
+
+# アトミック書き込み
+TMP_FILE="${EVENTS_DIR}/skill-step-${SESSION_ID}.tmp.$$"
+TARGET_FILE="${EVENTS_DIR}/skill-step-${SESSION_ID}"
+
+printf '{"session_id":"%s","timestamp":%s,"skill":"%s","tool_input":"%s"}\n' \
+  "$SESSION_ID" "$TIMESTAMP" "$SKILL_ESC" "$TOOL_INPUT_ESC" > "$TMP_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+mv "$TMP_FILE" "$TARGET_FILE" 2>/dev/null || { rm -f "$TMP_FILE" 2>/dev/null; exit 0; }
+
+exit 0

--- a/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
+++ b/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Functional Tests: supervisor-event-emission-hooks
+# Tests the behavior of scripts/hooks/supervisor-*.sh
+# Coverage: AUTOPILOT_DIR 設定あり/なし、JSON フォーマット検証、exit 0 保証
+# =============================================================================
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+HOOKS_DIR="${PROJECT_ROOT}/scripts/hooks"
+
+PASS=0
+FAIL=0
+ERRORS=()
+
+SANDBOX=""
+AUTOPILOT_DIR_TEST=""
+EVENTS_DIR_TEST=""
+SUPERVISOR_DIR_TEST=""
+
+setup_sandbox() {
+  SANDBOX=$(mktemp -d)
+  AUTOPILOT_DIR_TEST="${SANDBOX}/.autopilot"
+  SUPERVISOR_DIR_TEST="${SANDBOX}/.supervisor"
+  EVENTS_DIR_TEST="${SUPERVISOR_DIR_TEST}/events"
+  mkdir -p "$AUTOPILOT_DIR_TEST"
+  mkdir -p "$EVENTS_DIR_TEST"
+}
+
+teardown_sandbox() {
+  if [[ -n "$SANDBOX" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+  SANDBOX=""
+  AUTOPILOT_DIR_TEST=""
+  EVENTS_DIR_TEST=""
+  SUPERVISOR_DIR_TEST=""
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result
+  setup_sandbox
+  result=0
+  $func || result=$?
+  teardown_sandbox
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ERRORS+=("$name")
+    ((FAIL++)) || true
+  fi
+}
+
+# --- ヘルパー ---
+
+# AUTOPILOT_DIR を sandbox に向けて hook を実行（EVENTS_DIR を上書き）
+# hook のパス解決: AUTOPILOT_DIR/../.supervisor/events を使うため
+# sandbox 構造: ${SANDBOX}/.autopilot + ${SANDBOX}/.supervisor/events
+run_hook_with_autopilot() {
+  local hook_script="$1"
+  local input_json="${2-}"
+  [[ -z "$input_json" ]] && input_json="{}"
+  local override_autopilot_dir="${3:-$AUTOPILOT_DIR_TEST}"
+  printf '%s' "$input_json" | AUTOPILOT_DIR="$override_autopilot_dir" \
+    bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
+}
+
+run_hook_without_autopilot() {
+  local hook_script="$1"
+  local input_json="${2-}"
+  [[ -z "$input_json" ]] && input_json="{}"
+  printf '%s' "$input_json" | bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
+}
+
+# =============================================================================
+# supervisor-heartbeat.sh テスト
+# =============================================================================
+
+test_heartbeat_no_autopilot_dir() {
+  local exit_code
+  run_hook_without_autopilot "supervisor-heartbeat.sh" '{}' || exit_code=$?
+  exit_code="${exit_code:-0}"
+  [[ "$exit_code" -eq 0 ]] || return 1
+  # ファイルが生成されていないことを確認（EVENTS_DIR は存在しない）
+  [[ -z "$(find "${SANDBOX}" -name "heartbeat-*" 2>/dev/null)" ]] || return 1
+}
+
+test_heartbeat_creates_event_file() {
+  local session_json='{"session_id":"test-sess-01","cwd":"/tmp/test"}'
+  run_hook_with_autopilot "supervisor-heartbeat.sh" "$session_json"
+  local event_file="${EVENTS_DIR_TEST}/heartbeat-test-sess-01"
+  [[ -f "$event_file" ]] || return 1
+  # JSON フォーマット検証
+  jq -e '.session_id == "test-sess-01"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e 'has("cwd")' "$event_file" > /dev/null 2>&1 || return 1
+}
+
+test_heartbeat_exit_zero_on_failure() {
+  # 書き込み不可なディレクトリでも exit 0
+  local bad_dir="${SANDBOX}/.autopilot-bad"
+  mkdir -p "$bad_dir"
+  chmod 000 "$bad_dir" 2>/dev/null || true
+  run_hook_with_autopilot "supervisor-heartbeat.sh" '{"session_id":"x"}' "$bad_dir"
+  local ec=$?
+  chmod 755 "$bad_dir" 2>/dev/null || true
+  [[ "$ec" -eq 0 ]] || return 1
+}
+
+test_heartbeat_no_stdout() {
+  local session_json='{"session_id":"test-stdout","cwd":"/tmp"}'
+  local output
+  output=$(run_hook_with_autopilot "supervisor-heartbeat.sh" "$session_json")
+  [[ -z "$output" ]] || return 1
+}
+
+# =============================================================================
+# supervisor-input-wait.sh テスト
+# =============================================================================
+
+test_input_wait_no_autopilot_dir() {
+  local exit_code
+  run_hook_without_autopilot "supervisor-input-wait.sh" '{}' || exit_code=$?
+  exit_code="${exit_code:-0}"
+  [[ "$exit_code" -eq 0 ]] || return 1
+}
+
+test_input_wait_creates_event_file() {
+  local session_json='{"session_id":"wait-sess-01"}'
+  run_hook_with_autopilot "supervisor-input-wait.sh" "$session_json"
+  local event_file="${EVENTS_DIR_TEST}/input-wait-wait-sess-01"
+  [[ -f "$event_file" ]] || return 1
+  jq -e '.session_id == "wait-sess-01"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.event == "input-wait"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || return 1
+}
+
+test_input_wait_no_stdout() {
+  local output
+  output=$(run_hook_with_autopilot "supervisor-input-wait.sh" '{"session_id":"sw"}')
+  [[ -z "$output" ]] || return 1
+}
+
+# =============================================================================
+# supervisor-input-clear.sh テスト
+# =============================================================================
+
+test_input_clear_removes_file() {
+  local session_id="clear-sess-01"
+  local event_file="${EVENTS_DIR_TEST}/input-wait-${session_id}"
+  # ファイルを先に作成
+  echo '{"event":"input-wait"}' > "$event_file"
+  [[ -f "$event_file" ]] || return 1
+  local session_json="{\"session_id\":\"${session_id}\"}"
+  run_hook_with_autopilot "supervisor-input-clear.sh" "$session_json"
+  [[ ! -f "$event_file" ]] || return 1
+}
+
+test_input_clear_no_file_ok() {
+  # ファイルが存在しなくても exit 0
+  run_hook_with_autopilot "supervisor-input-clear.sh" '{"session_id":"nonexistent"}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+test_input_clear_no_autopilot_dir() {
+  run_hook_without_autopilot "supervisor-input-clear.sh" '{}' || true
+  [[ $? -eq 0 ]] || return 1
+}
+
+# =============================================================================
+# supervisor-skill-step.sh テスト
+# =============================================================================
+
+test_skill_step_no_autopilot_dir() {
+  local exit_code
+  run_hook_without_autopilot "supervisor-skill-step.sh" '{}' || exit_code=$?
+  exit_code="${exit_code:-0}"
+  [[ "$exit_code" -eq 0 ]] || return 1
+}
+
+test_skill_step_creates_event_file() {
+  local session_json='{"session_id":"skill-sess-01","tool_input":{"skill":"workflow-setup","args":"#123"}}'
+  run_hook_with_autopilot "supervisor-skill-step.sh" "$session_json"
+  local event_file="${EVENTS_DIR_TEST}/skill-step-skill-sess-01"
+  [[ -f "$event_file" ]] || return 1
+  jq -e '.session_id == "skill-sess-01"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e 'has("skill")' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e 'has("tool_input")' "$event_file" > /dev/null 2>&1 || return 1
+}
+
+test_skill_step_no_stdout() {
+  local output
+  output=$(run_hook_with_autopilot "supervisor-skill-step.sh" '{"session_id":"ss"}')
+  [[ -z "$output" ]] || return 1
+}
+
+# =============================================================================
+# supervisor-session-end.sh テスト
+# =============================================================================
+
+test_session_end_no_autopilot_dir() {
+  local exit_code
+  run_hook_without_autopilot "supervisor-session-end.sh" '{}' || exit_code=$?
+  exit_code="${exit_code:-0}"
+  [[ "$exit_code" -eq 0 ]] || return 1
+}
+
+test_session_end_creates_event_file() {
+  local session_json='{"session_id":"end-sess-01"}'
+  run_hook_with_autopilot "supervisor-session-end.sh" "$session_json"
+  local event_file="${EVENTS_DIR_TEST}/session-end-end-sess-01"
+  [[ -f "$event_file" ]] || return 1
+  jq -e '.session_id == "end-sess-01"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.event == "session-end"' "$event_file" > /dev/null 2>&1 || return 1
+  jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || return 1
+}
+
+test_session_end_no_stdout() {
+  local output
+  output=$(run_hook_with_autopilot "supervisor-session-end.sh" '{"session_id":"se"}')
+  [[ -z "$output" ]] || return 1
+}
+
+# =============================================================================
+# 実行
+# =============================================================================
+
+echo "=== supervisor-event-emission-hooks tests ==="
+
+# heartbeat
+run_test "heartbeat: AUTOPILOT_DIR 未設定で exit 0" test_heartbeat_no_autopilot_dir
+run_test "heartbeat: イベントファイル生成と JSON フォーマット" test_heartbeat_creates_event_file
+run_test "heartbeat: 書き込み失敗でも exit 0" test_heartbeat_exit_zero_on_failure
+run_test "heartbeat: stdout に何も出力しない" test_heartbeat_no_stdout
+
+# input-wait
+run_test "input-wait: AUTOPILOT_DIR 未設定で exit 0" test_input_wait_no_autopilot_dir
+run_test "input-wait: イベントファイル生成と JSON フォーマット" test_input_wait_creates_event_file
+run_test "input-wait: stdout に何も出力しない" test_input_wait_no_stdout
+
+# input-clear
+run_test "input-clear: input-wait ファイルを削除" test_input_clear_removes_file
+run_test "input-clear: ファイル不在でも exit 0" test_input_clear_no_file_ok
+run_test "input-clear: AUTOPILOT_DIR 未設定で exit 0" test_input_clear_no_autopilot_dir
+
+# skill-step
+run_test "skill-step: AUTOPILOT_DIR 未設定で exit 0" test_skill_step_no_autopilot_dir
+run_test "skill-step: イベントファイル生成と JSON フォーマット" test_skill_step_creates_event_file
+run_test "skill-step: stdout に何も出力しない" test_skill_step_no_stdout
+
+# session-end
+run_test "session-end: AUTOPILOT_DIR 未設定で exit 0" test_session_end_no_autopilot_dir
+run_test "session-end: イベントファイル生成と JSON フォーマット" test_session_end_creates_event_file
+run_test "session-end: stdout に何も出力しない" test_session_end_no_stdout
+
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo "Failed tests:"
+  for e in "${ERRORS[@]}"; do
+    echo "  - $e"
+  done
+fi
+
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
feat(hooks): Hook ベース Event Emission インフラ構築 (#569)

- supervisor-heartbeat.sh: PostToolUse Write|Edit で heartbeat イベント書き出し
- supervisor-input-wait.sh: PreToolUse AskUserQuestion で input-wait イベント書き出し
- supervisor-input-clear.sh: PostToolUse AskUserQuestion で input-wait ファイル削除
- supervisor-skill-step.sh: PostToolUse Skill で skill-step イベント書き出し
- supervisor-session-end.sh: Stop で session-end イベント書き出し

全 hook:
- AUTOPILOT_DIR 未設定時は即 exit 0（通常セッション無影響）
- stdout に何も出力しない（トークン影響ゼロ）
- 失敗時も exit 0（Worker の動作をブロックしない）
- アトミック書き込み（tmp ファイル + mv）

.claude/settings.json に PostToolUse / Stop キーを新規追加
PreToolUse に AskUserQuestion matcher 追加
deps.yaml に 5 コンポーネント登録
テスト: 16 件 PASS

Closes #569