### PR TITLE
fix(issue-lifecycle): Worker早期killレースコンディション3点修正 (#697)

### DIFF
--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -386,20 +386,33 @@ wait_for_batch() {
           local inject_count=0
           [[ -f "$inject_count_file" ]] && inject_count=$(cat "$inject_count_file" 2>/dev/null | tr -d '[:space:]')
 
-          if [[ ("$current_state" == "fixing" || "$current_state" == "reviewing") && "$inject_count" -lt 3 ]]; then
-            # STATE=fixing/reviewing → Worker が中断状態。auto-inject で継続を促す (#672)
+          if [[ "$current_state" == "done" || "$current_state" == "failed" || "$current_state" == "circuit_broken" ]]; then
+            # terminal state → fallback 生成 + kill (#697)
+            local reason="input_waiting_terminal_${current_state}"
+            echo "[issue-lifecycle-orchestrator] ${subdir##*/}: input-waiting (STATE=$current_state terminal) — フォールバック生成" >&2
+            mkdir -p "${subdir}/OUT"
+            _generate_fallback_report "$subdir" "$reason"
+            tmux kill-window -t "$window_name" 2>/dev/null || true
+          elif [[ "$inject_count" -lt 3 ]]; then
+            # non-terminal + input-waiting → auto-inject で継続を促す (#672, #697)
             inject_count=$((inject_count + 1))
             echo "$inject_count" > "$inject_count_file"
+            # workflow 別に inject メッセージを分岐 (#697)
+            local inject_msg
+            if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
+              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 5: arch-drift → Step 6': gh issue edit → refined ラベル付与 → Step 7: STATE=done + OUT/report.json 書き込み。"
+            else
+              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 5: arch-drift → Step 6: gh issue create → Step 6.5: project-board-sync → Step 7: STATE=done + OUT/report.json 書き込み。"
+            fi
             echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=$current_state + input-waiting — auto-inject ($inject_count/3)" >&2
             "${SCRIPTS_ROOT}/../../session/scripts/session-comm.sh" inject "$window_name" \
-              "Step 5-7 を継続してください。findings に基づく修正(fixing) → Issue body 更新(gh issue edit) → refined ラベル付与 → STATE=done → OUT/report.json 書き込みを完了すること。" \
+              "$inject_msg" \
               2>/dev/null || true
             all_done=false
           else
-            # STATE=done / unknown / inject 3回失敗 → fallback (#647)
-            local reason="input_waiting_no_report"
-            [[ "$inject_count" -ge 3 ]] && reason="inject_exhausted_${inject_count}"
-            echo "[issue-lifecycle-orchestrator] ${subdir##*/}: input-waiting (STATE=$current_state, inject=$inject_count) — フォールバック生成" >&2
+            # inject 3 回失敗 → fallback (#647)
+            local reason="inject_exhausted_${inject_count}"
+            echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject exhausted (STATE=$current_state, inject=$inject_count) — フォールバック生成" >&2
             mkdir -p "${subdir}/OUT"
             _generate_fallback_report "$subdir" "$reason"
             tmux kill-window -t "$window_name" 2>/dev/null || true

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -400,9 +400,9 @@ wait_for_batch() {
             # workflow 別に inject メッセージを分岐 (#697)
             local inject_msg
             if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
-              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 5: arch-drift → Step 6': gh issue edit → refined ラベル付与 → Step 7: STATE=done + OUT/report.json 書き込み。"
+              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 4.5: refined ラベル判定 → Step 5: arch-drift → Step 6': gh issue edit（body更新 + labels_hint 一括ラベル付与）→ Step 7: STATE=done + OUT/report.json 書き込み。"
             else
-              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 5: arch-drift → Step 6: gh issue create → Step 6.5: project-board-sync → Step 7: STATE=done + OUT/report.json 書き込み。"
+              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 4.5: refined ラベル判定 → Step 5: arch-drift → Step 6: gh issue create → Step 6.5: project-board-sync → Step 7: STATE=done + OUT/report.json 書き込み。"
             fi
             echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=$current_state + input-waiting — auto-inject ($inject_count/3)" >&2
             "${SCRIPTS_ROOT}/../../session/scripts/session-comm.sh" inject "$window_name" \

--- a/plugins/twl/scripts/spec-review-manifest.sh
+++ b/plugins/twl/scripts/spec-review-manifest.sh
@@ -5,13 +5,8 @@
 # specialist の追加・削除はこのファイルの編集のみで反映される。
 # LLM が「どの specialist を呼ぶか」を判断する余地をなくす。
 
-# 常時必須
+# 常時必須（環境に依存しない — #697）
+# worker-codex-reviewer は codex 不在時に graceful skip（status: PASS, findings: []）する
 echo "twl:twl:issue-critic"
 echo "twl:twl:issue-feasibility"
-
-# codex 環境チェック（auth.json ベース）
-# codex login status は auth.json/keyring を確認する。
-# 各環境で事前に `codex login --with-api-key` を実行しておくこと。
-if command -v codex &>/dev/null && codex login status 2>&1 | grep -qi "logged in"; then
-  echo "twl:twl:worker-codex-reviewer"
-fi
+echo "twl:twl:worker-codex-reviewer"

--- a/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-lifecycle/SKILL.md
@@ -121,11 +121,15 @@ mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
 - `depth`: policies.depth（デフォルト: normal）
 - 結果を `rounds/<round>/findings.yaml` に書き込む
 
+**4a 完了後、中断せず直ちに 4b を実行すること（MUST — AskUserQuestion 禁止）。**
+
 #### 4b: aggregate
 
 `/twl:issue-review-aggregate` を Skill tool で呼び出す:
 - 入力: findings.yaml の内容
 - 結果を `rounds/<round>/aggregate.yaml` に書き込む
+
+**4b 完了後、中断せず直ちに 4c を実行すること（MUST）。**
 
 #### 4c: codex gate
 

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -132,11 +132,15 @@ mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
 - `depth`: policies.depth（デフォルト: normal）
 - 結果を `rounds/<round>/findings.yaml` に書き込む
 
+**4a 完了後、中断せず直ちに 4b を実行すること（MUST — AskUserQuestion 禁止）。**
+
 #### 4b: aggregate
 
 `/twl:issue-review-aggregate` を Skill tool で呼び出す:
 - 入力: findings.yaml の内容
 - 結果を `rounds/<round>/aggregate.yaml` に書き込む
+
+**4b 完了後、中断せず直ちに 4c を実行すること（MUST）。**
 
 #### 4c: codex gate
 


### PR DESCRIPTION
fix(issue-lifecycle): Worker早期killレースコンディション3点修正 (#697)

バグ1: wait_for_batch() STATE誤判定修正
- terminal state(done/failed/circuit_broken)のみfallback生成
- 空文字・running・pending等はnon-terminalとして待機継続
- Worker spawn直後の空STATE → early kill を防止

バグ2: spec-review-manifest.sh 常時3 specialist出力
- codex環境チェック条件を削除
- worker-codex-reviewerはcodex不在時にgraceful skip済み

バグ3: Worker停止防止の2層対応
- SKILL.md Step 4a/4b完了後に「直ちに次Step実行(MUST)」追記
- orchestratorのauto-injectテキストをworkflow別に分岐
  - workflow-issue-refine: gh issue edit フロー
  - workflow-issue-lifecycle: gh issue create フロー

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #697