### PR TITLE
fix(ac-verify): Step 0 冒頭で python-env.sh を source し PYTHONPATH を設定

### DIFF
--- a/plugins/twl/commands/ac-verify.md
+++ b/plugins/twl/commands/ac-verify.md
@@ -33,6 +33,7 @@ PR diff・テスト結果・レビュー結果を Issue の受け入れ基準（
 ### Step 0: 入力収集
 
 ```bash
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/python-env.sh" 2>/dev/null || true
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-.dev-session}"
 AC_FILE="${SNAPSHOT_DIR}/01.5-ac-checklist.md"
 


### PR DESCRIPTION
fix(ac-verify): Step 0 冒頭で python-env.sh を source し PYTHONPATH を設定

Worker の checkpoint write で PYTHONPATH 未設定により ModuleNotFoundError が
発生していた問題を修正。

既存パターン（chain-runner.sh L18-19, worker-terminal-guard.sh 等）に合わせて
Step 0 冒頭に source 行を追加する。

Refs #706

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #706