### PR TITLE
fix(autopilot): nohup 起動前に PROJECT_DIR へ cd して CWD を固定

### DIFF
--- a/plugins/twl/commands/autopilot-pilot-wakeup-loop.md
+++ b/plugins/twl/commands/autopilot-pilot-wakeup-loop.md
@@ -22,6 +22,7 @@ Pilot の Bash context 外で持続実行するため **nohup/disown** を使用
 ```bash
 mkdir -p "${AUTOPILOT_DIR}/trace"
 _ORCH_LOG="${AUTOPILOT_DIR}/trace/orchestrator-phase-${PHASE_NUM}.log"
+cd "${PROJECT_DIR}/main" 2>/dev/null || cd "${PROJECT_DIR}" || true
 nohup bash autopilot-orchestrator.sh \
   --plan "${AUTOPILOT_DIR}/plan.yaml" \
   --phase "$PHASE_NUM" \


### PR DESCRIPTION
fix(autopilot): nohup 起動前に PROJECT_DIR へ cd して CWD を固定

orchestrator を nohup 起動する際、Pilot の起動元ディレクトリが CWD に
なっていると worktree 作成が失敗する問題を修正。

nohup 直前に `cd "${PROJECT_DIR}/main" 2>/dev/null || cd "${PROJECT_DIR}" || true`
を追加し、CWD を確実にプロジェクトディレクトリに固定する。

Closes #705

Co-Authored-By: Claude <noreply@anthropic.com>