### PR TITLE
fix(issue-lifecycle-orchestrator): inject debounce + 上限緩和 + progressive delay (#709)

### DIFF
--- a/deltaspec/changes/issue-709/.deltaspec.yaml
+++ b/deltaspec/changes/issue-709/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-15
+issue: 709
+name: issue-709
+status: pending

--- a/deltaspec/changes/issue-709/design.md
+++ b/deltaspec/changes/issue-709/design.md
@@ -1,0 +1,42 @@
+## Context
+
+`issue-lifecycle-orchestrator.sh` の `wait_for_batch()` 関数内 inject ロジック（L380-L419）が対象。`session-state.sh` が processing 中の Worker を `input-waiting` と誤報告する false positive（#708）により、実際には不要な inject が連続実行され、inject 上限（3回）を使い切って `inject_exhausted` に陥る。
+
+現在の問題点：
+1. L380 で `input-waiting` 検出後、即座に inject フローへ進む（debounce なし）
+2. inject 上限が 3 回と低い
+3. inject 間に待機なし（progressive delay なし）
+4. inject 実行直前の再確認なし
+5. inject メッセージが詳細すぎる（chain-runner の自律判断を妨げるリスク）
+
+## Goals / Non-Goals
+
+**Goals:**
+- transient false positive を debounce で排除し、inject が本当に必要な場合のみ実行する
+- inject 上限を 5 回に緩和して、false positive 消費後も本来の inject を届けられるようにする
+- inject 間に progressive delay を設けて Worker の処理時間を確保する
+- inject 直前再確認で unnecessary inject をさらに抑制する
+- inject メッセージを簡潔にして Worker の chain 自律判断を妨げない
+
+**Non-Goals:**
+- `session-state.sh` の false positive 自体の修正（#708 が担当）
+- `autopilot-orchestrator.sh` の inject 修正（#707 が担当）
+- inject ロジックの共通 lib 化（機構が異なるため見送り）
+
+## Decisions
+
+**1. debounce 実装**: `input-waiting` 検出直後に `sleep 5` を挿入し、`session-state.sh` を再度呼び出す。再確認が `input-waiting` でない場合は `all_done=false` で次ポーリングサイクルへ。再確認も `input-waiting` なら inject フロー継続。
+
+**2. inject 上限 3 → 5**: `inject_count -lt 3` を `-lt 5` に変更。エラーメッセージ内の `3` も `5` に更新。
+
+**3. progressive delay**: inject 実行後に `sleep $((5 * inject_count))` を追加（1回目: 5秒、2回目: 10秒、3回目: 15秒…）。
+
+**4. inject 前再確認**: inject 実行直前（session-comm.sh 呼び出し前）に `session-state.sh` で状態を再取得し、`input-waiting` でなければ `continue`。
+
+**5. inject メッセージ簡素化**: ワークフロー分岐（`existing-issue.json` 有無）を廃止し、単一メッセージ `"処理を続行してください。"` に統一。
+
+## Risks / Trade-offs
+
+- debounce の `sleep 5` はポーリング全体を遅延させるが、false positive 排除の効果の方が大きい
+- inject 上限を 5 に増やすと genuine stagnation の検出が遅くなるが、false positive 対策として許容範囲内
+- progressive delay により recovery 時間が伸びるが、Worker への過剰 inject 防止を優先

--- a/deltaspec/changes/issue-709/proposal.md
+++ b/deltaspec/changes/issue-709/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+`issue-lifecycle-orchestrator.sh` のポーリングループで、`session-state.sh` の false positive（#708）による `input-waiting` 誤検出を即座に inject してしまい、debounce がないため transient な誤検出を全て消費して `inject_exhausted` に到達する。inject 上限が 3 回と低く、false positive 消費後に本来必要な inject が送れなくなる。
+
+## What Changes
+
+- `input-waiting` 検出後に 5 秒の debounce（再確認待ち）を追加し、transient false positive を排除する
+- inject 上限を 3 → 5 に緩和する
+- inject 間に progressive delay（`sleep $((5 * inject_count))`）を適用する
+- inject 実行直前に session-state.sh で再確認し、`input-waiting` でなければスキップする
+- inject メッセージを簡潔化（「処理を続行してください。」）
+
+## Capabilities
+
+### New Capabilities
+
+なし
+
+### Modified Capabilities
+
+- **issue-lifecycle-orchestrator.sh inject ロジック**: debounce・上限緩和・progressive delay・pre-inject 再確認・メッセージ簡素化による inject_exhausted 発生防止
+
+## Impact
+
+- `plugins/twl/scripts/issue-lifecycle-orchestrator.sh` L370-L419（inject ロジック）のみ変更
+- `autopilot-orchestrator.sh` および `session-state.sh` は変更しない（各自 #707/#708 で対応済み）

--- a/deltaspec/changes/issue-709/specs/inject-resilience.md
+++ b/deltaspec/changes/issue-709/specs/inject-resilience.md
@@ -1,0 +1,48 @@
+## MODIFIED Requirements
+
+### Requirement: input-waiting debounce
+`issue-lifecycle-orchestrator.sh` の `wait_for_batch()` は、`session-state.sh` が `input-waiting` を返した直後に、5 秒の debounce を設け `session-state.sh` で再確認しなければならない（SHALL）。再確認が `input-waiting` でない場合、inject をスキップしてポーリングサイクルを継続しなければならない（MUST）。
+
+#### Scenario: transient false positive を排除する
+- **WHEN** `session-state.sh` が `input-waiting` を返し、5 秒後の再確認が `input-waiting` 以外を返す
+- **THEN** inject を実行せず `all_done=false` で次のポーリングサイクルへ進む
+
+#### Scenario: 真の input-waiting を受理する
+- **WHEN** `session-state.sh` が `input-waiting` を返し、5 秒後の再確認も `input-waiting` を返す
+- **THEN** inject フローを継続する
+
+### Requirement: inject 上限緩和
+inject 上限は 5 回でなければならない（MUST）。`inject_count -lt 3` の条件を `-lt 5` に変更し、ログメッセージ内の上限値も 5 に更新しなければならない（SHALL）。
+
+#### Scenario: inject 5 回未満で継続する
+- **WHEN** `inject_count` が 5 未満かつ non-terminal state で `input-waiting` が確認される
+- **THEN** inject を実行し `inject_count` をインクリメントする
+
+#### Scenario: inject 5 回到達で fallback に移行する
+- **WHEN** `inject_count` が 5 以上になる
+- **THEN** fallback report を生成してウィンドウを kill する
+
+### Requirement: inject 間の progressive delay
+inject 実行後に `sleep $((5 * inject_count))` を挿入しなければならない（MUST）。これにより inject 間隔が回数に応じて増加し（5秒・10秒・15秒・20秒・25秒）、Worker の処理時間を確保しなければならない（SHALL）。
+
+#### Scenario: inject 後に progressive delay が適用される
+- **WHEN** inject が実行される
+- **THEN** `sleep $((5 * inject_count))` が inject の直後に実行される
+
+### Requirement: inject 直前の状態再確認
+inject 実行直前（`session-comm.sh` 呼び出し前）に `session-state.sh` で状態を再確認しなければならない（MUST）。再確認が `input-waiting` でない場合は inject をスキップしなければならない（SHALL）。
+
+#### Scenario: inject 直前に状態が変化していれば注入しない
+- **WHEN** inject 実行直前の再確認で `session-state.sh` が `input-waiting` 以外を返す
+- **THEN** inject を実行せず `continue` でポーリングサイクルへ戻る
+
+#### Scenario: inject 直前も input-waiting なら注入する
+- **WHEN** inject 実行直前の再確認でも `session-state.sh` が `input-waiting` を返す
+- **THEN** `session-comm.sh inject` を実行する
+
+### Requirement: inject メッセージ簡素化
+inject メッセージは `"処理を続行してください。"` に統一しなければならない（MUST）。ワークフロー分岐（`existing-issue.json` 有無による分岐）を削除しなければならない（SHALL）。
+
+#### Scenario: inject メッセージが簡潔である
+- **WHEN** inject が実行される
+- **THEN** `session-comm.sh inject` に渡すメッセージが `"処理を続行してください。"` である

--- a/deltaspec/changes/issue-709/tasks.md
+++ b/deltaspec/changes/issue-709/tasks.md
@@ -1,13 +1,13 @@
 ## 1. issue-lifecycle-orchestrator.sh inject ロジック修正
 
-- [ ] 1.1 L380 の `input-waiting` 検出直後に `sleep 5` + `session-state.sh` 再確認ロジックを追加し、再確認が `input-waiting` 以外なら `all_done=false; continue` でスキップする
-- [ ] 1.2 inject 上限を 3 → 5 に変更（`-lt 3` → `-lt 5`）
-- [ ] 1.3 inject ログメッセージ内の上限値 `3` を `5` に更新
-- [ ] 1.4 inject 実行直前（`session-comm.sh` 前）に `session-state.sh` 再確認を追加し、`input-waiting` でなければ `continue`
-- [ ] 1.5 inject 実行後に `sleep $((5 * inject_count))` の progressive delay を追加
-- [ ] 1.6 inject メッセージを `"処理を続行してください。"` に簡素化（`existing-issue.json` 分岐を削除）
+- [x] 1.1 L380 の `input-waiting` 検出直後に `sleep 5` + `session-state.sh` 再確認ロジックを追加し、再確認が `input-waiting` 以外なら `all_done=false; continue` でスキップする
+- [x] 1.2 inject 上限を 3 → 5 に変更（`-lt 3` → `-lt 5`）
+- [x] 1.3 inject ログメッセージ内の上限値 `3` を `5` に更新
+- [x] 1.4 inject 実行直前（`session-comm.sh` 前）に `session-state.sh` 再確認を追加し、`input-waiting` でなければ `continue`
+- [x] 1.5 inject 実行後に `sleep $((5 * inject_count))` の progressive delay を追加
+- [x] 1.6 inject メッセージを `"処理を続行してください。"` に簡素化（`existing-issue.json` 分岐を削除）
 
 ## 2. 検証
 
-- [ ] 2.1 `plugins/twl/scripts/issue-lifecycle-orchestrator.sh` の変更箇所を手動レビューし、Issue #709 の受け入れ基準を全て満たすことを確認する
-- [ ] 2.2 `twl --check` でバリデーション通過を確認する
+- [x] 2.1 `plugins/twl/scripts/issue-lifecycle-orchestrator.sh` の変更箇所を手動レビューし、Issue #709 の受け入れ基準を全て満たすことを確認する
+- [x] 2.2 `twl --check` でバリデーション通過を確認する

--- a/deltaspec/changes/issue-709/tasks.md
+++ b/deltaspec/changes/issue-709/tasks.md
@@ -1,0 +1,13 @@
+## 1. issue-lifecycle-orchestrator.sh inject ロジック修正
+
+- [ ] 1.1 L380 の `input-waiting` 検出直後に `sleep 5` + `session-state.sh` 再確認ロジックを追加し、再確認が `input-waiting` 以外なら `all_done=false; continue` でスキップする
+- [ ] 1.2 inject 上限を 3 → 5 に変更（`-lt 3` → `-lt 5`）
+- [ ] 1.3 inject ログメッセージ内の上限値 `3` を `5` に更新
+- [ ] 1.4 inject 実行直前（`session-comm.sh` 前）に `session-state.sh` 再確認を追加し、`input-waiting` でなければ `continue`
+- [ ] 1.5 inject 実行後に `sleep $((5 * inject_count))` の progressive delay を追加
+- [ ] 1.6 inject メッセージを `"処理を続行してください。"` に簡素化（`existing-issue.json` 分岐を削除）
+
+## 2. 検証
+
+- [ ] 2.1 `plugins/twl/scripts/issue-lifecycle-orchestrator.sh` の変更箇所を手動レビューし、Issue #709 の受け入れ基準を全て満たすことを確認する
+- [ ] 2.2 `twl --check` でバリデーション通過を確認する

--- a/deltaspec/changes/issue-709/test-mapping.yaml
+++ b/deltaspec/changes/issue-709/test-mapping.yaml
@@ -1,0 +1,283 @@
+change_id: issue-709
+generated_at: "2026-04-15T14:38:01Z"
+test_framework: bash
+scenarios:
+  # ==========================================================================
+  # Requirement: input-waiting debounce
+  # ==========================================================================
+
+  - id: "transient-false-positive-排除"
+    name: "transient false positive を排除する"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 6
+    requirement: "input-waiting debounce"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "debounce: sleep 5 が wait_for_batch() に実装されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "transient-false-positive-排除-recheck"
+    name: "transient false positive を排除する（再確認呼び出し）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 6
+    requirement: "input-waiting debounce"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "debounce: wait_for_batch() に session-state.sh の再確認呼び出しが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "transient-false-positive-排除-order"
+    name: "transient false positive を排除する（sleep 順序）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 6
+    requirement: "input-waiting debounce"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "debounce: sleep 5 が inject_count インクリメントより前に存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "真の-input-waiting-受理"
+    name: "真の input-waiting を受理する"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 10
+    requirement: "input-waiting debounce"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "debounce: 再確認が input-waiting でも inject フロー継続パスが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ==========================================================================
+  # Requirement: inject 上限緩和
+  # ==========================================================================
+
+  - id: "inject-5回未満-継続"
+    name: "inject 5 回未満で継続する"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 17
+    requirement: "inject 上限緩和"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 上限: inject_count -lt 5 の条件が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-5回未満-継続-no-old-limit"
+    name: "inject 5 回未満で継続する（旧上限 -lt 3 不在）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 17
+    requirement: "inject 上限緩和"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 上限 [edge]: inject_count -lt 3 （旧上限）が存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-5回到達-fallback"
+    name: "inject 5 回到達で fallback に移行する"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 21
+    requirement: "inject 上限緩和"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject exhausted: fallback report 生成呼び出しが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-5回到達-log-5"
+    name: "inject 5 回到達（ログメッセージ上限値 /5）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 21
+    requirement: "inject 上限緩和"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject exhausted [edge]: ログメッセージの上限値が /5 になっている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-5回到達-log-no-3"
+    name: "inject 5 回到達（ログメッセージに旧上限 /3 不在）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 21
+    requirement: "inject 上限緩和"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject exhausted [edge]: ログメッセージに旧上限 /3 が含まれない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ==========================================================================
+  # Requirement: inject 間の progressive delay
+  # ==========================================================================
+
+  - id: "inject後-progressive-delay"
+    name: "inject 後に progressive delay が適用される"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 28
+    requirement: "inject 間の progressive delay"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "progressive delay: sleep $((5 * inject_count)) が wait_for_batch() に存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject後-progressive-delay-order"
+    name: "inject 後に progressive delay が適用される（sleep 順序）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 28
+    requirement: "inject 間の progressive delay"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "progressive delay: sleep が session-comm.sh inject 呼び出しの後に存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject後-progressive-delay-updated-count"
+    name: "inject 後に progressive delay が適用される（インクリメント後に sleep）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 28
+    requirement: "inject 間の progressive delay"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "progressive delay [edge]: inject_count インクリメント後に sleep が実行される"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ==========================================================================
+  # Requirement: inject 直前の状態再確認
+  # ==========================================================================
+
+  - id: "inject直前-状態変化-スキップ"
+    name: "inject 直前に状態が変化していれば注入しない"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 35
+    requirement: "inject 直前の状態再確認"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 前再確認: session-state.sh が session-comm.sh inject より前に呼ばれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject直前-状態変化-continue"
+    name: "inject 直前に状態が変化していれば注入しない（continue でスキップ）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 35
+    requirement: "inject 直前の状態再確認"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 前再確認: continue でスキップするパスが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject直前-input-waiting-注入"
+    name: "inject 直前も input-waiting なら注入する"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 39
+    requirement: "inject 直前の状態再確認"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 直前再確認: session-comm.sh inject 呼び出しが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject直前-独立チェック"
+    name: "inject 直前の状態再確認は debounce と独立している"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 39
+    requirement: "inject 直前の状態再確認"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject 直前再確認 [edge]: session-state.sh 呼び出しが 2 回以上存在する（debounce と直前確認）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # ==========================================================================
+  # Requirement: inject メッセージ簡素化
+  # ==========================================================================
+
+  - id: "inject-メッセージ簡潔"
+    name: "inject メッセージが簡潔である"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 46
+    requirement: "inject メッセージ簡素化"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject メッセージ: \"処理を続行してください。\" が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-メッセージ-分岐削除"
+    name: "inject メッセージが簡潔である（existing-issue.json 分岐削除）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 46
+    requirement: "inject メッセージ簡素化"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject メッセージ [edge]: existing-issue.json による分岐が存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-メッセージ-旧メッセージ不在"
+    name: "inject メッセージが簡潔である（旧詳細メッセージ不在）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 46
+    requirement: "inject メッセージ簡素化"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject メッセージ [edge]: 旧メッセージ（4b: issue-review-aggregate）が存在しない"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "inject-メッセージ-単一代入"
+    name: "inject メッセージが簡潔である（inject_msg 代入が 1 行のみ）"
+    spec_file: "specs/inject-resilience.md"
+    spec_line: 46
+    requirement: "inject メッセージ簡素化"
+    test_file: "plugins/twl/tests/scenarios/inject-resilience.test.sh"
+    test_name: "inject メッセージ [edge]: inject_msg の代入が 1 行のみ（分岐なし）"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -378,7 +378,15 @@ wait_for_batch() {
           mkdir -p "${subdir}/OUT"
           _generate_fallback_report "$subdir" "window_lost"
         elif [[ "$("${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" state "$window_name" 2>/dev/null)" == "input-waiting" ]]; then
-          # Window 存在 + input-waiting → STATE ファイルを確認して判断 (#672)
+          # Window 存在 + input-waiting → debounce で transient false positive を排除 (#709)
+          sleep 5
+          local _recheck
+          _recheck=$("${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" state "$window_name" 2>/dev/null)
+          if [[ "$_recheck" != "input-waiting" ]]; then
+            all_done=false
+            continue
+          fi
+          # STATE ファイルを確認して判断 (#672)
           local state_file="${subdir}/STATE"
           local current_state=""
           [[ -f "$state_file" ]] && current_state=$(cat "$state_file" 2>/dev/null | tr -d '[:space:]')
@@ -393,24 +401,25 @@ wait_for_batch() {
             mkdir -p "${subdir}/OUT"
             _generate_fallback_report "$subdir" "$reason"
             tmux kill-window -t "$window_name" 2>/dev/null || true
-          elif [[ "$inject_count" -lt 3 ]]; then
-            # non-terminal + input-waiting → auto-inject で継続を促す (#672, #697)
+          elif [[ "$inject_count" -lt 5 ]]; then
+            # inject 直前再確認 — 状態が変化していれば inject をスキップ (#709)
+            local _pre_inject_state
+            _pre_inject_state=$("${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" state "$window_name" 2>/dev/null)
+            if [[ "$_pre_inject_state" != "input-waiting" ]]; then
+              continue
+            fi
+            # non-terminal + input-waiting → auto-inject で継続を促す (#672, #697, #709)
             inject_count=$((inject_count + 1))
             echo "$inject_count" > "$inject_count_file"
-            # workflow 別に inject メッセージを分岐 (#697)
-            local inject_msg
-            if [[ -f "${subdir}/IN/existing-issue.json" ]]; then
-              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 4.5: refined ラベル判定 → Step 5: arch-drift → Step 6': gh issue edit（body更新 + labels_hint 一括ラベル付与）→ Step 7: STATE=done + OUT/report.json 書き込み。"
-            else
-              inject_msg="直ちに次の Step を継続してください。4b: issue-review-aggregate Skill 呼び出し → 4c/4d: findings 判定 → body 修正(STATE=fixing) → Step 4.5: refined ラベル判定 → Step 5: arch-drift → Step 6: gh issue create → Step 6.5: project-board-sync → Step 7: STATE=done + OUT/report.json 書き込み。"
-            fi
-            echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=$current_state + input-waiting — auto-inject ($inject_count/3)" >&2
+            local inject_msg="処理を続行してください。"
+            echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=$current_state + input-waiting — auto-inject ($inject_count/5)" >&2
             "${SCRIPTS_ROOT}/../../session/scripts/session-comm.sh" inject "$window_name" \
               "$inject_msg" \
               2>/dev/null || true
+            sleep $((5 * inject_count))
             all_done=false
           else
-            # inject 3 回失敗 → fallback (#647)
+            # inject 5 回失敗 → fallback (#647, #709)
             local reason="inject_exhausted_${inject_count}"
             echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject exhausted (STATE=$current_state, inject=$inject_count) — フォールバック生成" >&2
             mkdir -p "${subdir}/OUT"

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -393,6 +393,7 @@ wait_for_batch() {
           local inject_count_file="${subdir}/.inject_count"
           local inject_count=0
           [[ -f "$inject_count_file" ]] && inject_count=$(cat "$inject_count_file" 2>/dev/null | tr -d '[:space:]')
+          [[ "$inject_count" =~ ^[0-9]+$ ]] || inject_count=0
 
           if [[ "$current_state" == "done" || "$current_state" == "failed" || "$current_state" == "circuit_broken" ]]; then
             # terminal state → fallback 生成 + kill (#697)
@@ -406,6 +407,7 @@ wait_for_batch() {
             local _pre_inject_state
             _pre_inject_state=$("${SCRIPTS_ROOT}/../../session/scripts/session-state.sh" state "$window_name" 2>/dev/null)
             if [[ "$_pre_inject_state" != "input-waiting" ]]; then
+              all_done=false
               continue
             fi
             # non-terminal + input-waiting → auto-inject で継続を促す (#672, #697, #709)

--- a/plugins/twl/tests/scenarios/inject-resilience.test.sh
+++ b/plugins/twl/tests/scenarios/inject-resilience.test.sh
@@ -1,0 +1,478 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Unit Tests: inject resilience improvements (issue-709)
+# Generated from: deltaspec/changes/issue-709/specs/inject-resilience.md
+# change-id: issue-709
+# Coverage level: edge-cases
+#
+# Verifies: plugins/twl/scripts/issue-lifecycle-orchestrator.sh の
+#   wait_for_batch() 内 inject ロジック改善
+#   - input-waiting debounce（5 秒 + 再確認）
+#   - inject 上限 3 → 5 への緩和
+#   - inject 後 progressive delay (sleep $((5 * inject_count)))
+#   - inject 直前の状態再確認
+#   - inject メッセージ簡素化（"処理を続行してください。"）
+# =============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ORCHESTRATOR_REL="scripts/issue-lifecycle-orchestrator.sh"
+ORCHESTRATOR="${PROJECT_ROOT}/${ORCHESTRATOR_REL}"
+
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result=0
+  "$func" || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "$file" ]]
+}
+
+# wait_for_batch() 関数本体のみを抽出する（関数定義開始行〜閉じ "^}" まで）
+extract_wait_for_batch() {
+  awk '/^wait_for_batch\(\)[ \t]*\{/,/^\}/' "$ORCHESTRATOR"
+}
+
+wait_for_batch_contains() {
+  local pattern="$1"
+  local body
+  body=$(extract_wait_for_batch)
+  echo "$body" | grep -qE -- "$pattern"
+}
+
+wait_for_batch_not_contains() {
+  local pattern="$1"
+  local body
+  body=$(extract_wait_for_batch)
+  if echo "$body" | grep -qE -- "$pattern"; then
+    return 1
+  fi
+  return 0
+}
+
+# wait_for_batch() 内で pattern_a が pattern_b より先に現れることを確認する
+wait_for_batch_order() {
+  local pattern_a="$1"
+  local pattern_b="$2"
+  local body
+  body=$(extract_wait_for_batch)
+  local line_a line_b
+  line_a=$(echo "$body" | grep -nE -- "$pattern_a" | head -1 | cut -d: -f1)
+  line_b=$(echo "$body" | grep -nE -- "$pattern_b" | head -1 | cut -d: -f1)
+  if [[ -z "$line_a" || -z "$line_b" ]]; then
+    return 1
+  fi
+  [[ "$line_a" -lt "$line_b" ]]
+}
+
+# ---------------------------------------------------------------------------
+# ファイル存在確認
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Prerequisite: orchestrator スクリプト存在確認 ---"
+
+test_orchestrator_exists() {
+  assert_file_exists "$ORCHESTRATOR"
+}
+run_test "issue-lifecycle-orchestrator.sh が存在する" test_orchestrator_exists
+
+# ---------------------------------------------------------------------------
+# =============================================================================
+# Requirement: input-waiting debounce
+# =============================================================================
+echo ""
+echo "--- Requirement: input-waiting debounce ---"
+
+# ---------------------------------------------------------------------------
+# Scenario: transient false positive を排除する (spec line 6)
+# WHEN: session-state.sh が input-waiting を返し、5 秒後の再確認が input-waiting 以外を返す
+# THEN: inject を実行せず all_done=false で次のポーリングサイクルへ進む
+# ---------------------------------------------------------------------------
+
+# debounce: input-waiting 検出後に sleep 5 が実装されていること
+test_debounce_sleep_exists() {
+  wait_for_batch_contains 'sleep 5'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "debounce: sleep 5 が wait_for_batch() に実装されている" test_debounce_sleep_exists
+else
+  run_test_skip "debounce: sleep 5 が wait_for_batch() に実装されている" "${ORCHESTRATOR_REL} not found"
+fi
+
+# debounce: input-waiting 検出後に session-state.sh が再呼び出しされること
+# (1回目の input-waiting 検出 + sleep 5 の後にもう1回 session-state.sh が呼ばれる)
+test_debounce_recheck_exists() {
+  local body
+  body=$(extract_wait_for_batch)
+  # session-state.sh の呼び出しが2回以上あること
+  local count
+  count=$(echo "$body" | grep -cE 'session-state\.sh.*state' || true)
+  [[ "$count" -ge 2 ]]
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "debounce: wait_for_batch() に session-state.sh の再確認呼び出しが存在する" test_debounce_recheck_exists
+else
+  run_test_skip "debounce: wait_for_batch() に session-state.sh の再確認呼び出しが存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# debounce: sleep 5 が最初の input-waiting 分岐内にあること（progressive delay の sleep より前に存在）
+test_debounce_sleep_before_inject() {
+  wait_for_batch_order 'sleep 5' 'inject_count=\$\(\(inject_count \+ 1\)\)'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "debounce: sleep 5 が inject_count インクリメントより前に存在する" test_debounce_sleep_before_inject
+else
+  run_test_skip "debounce: sleep 5 が inject_count インクリメントより前に存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario: 真の input-waiting を受理する (spec line 10)
+# WHEN: session-state.sh が input-waiting を返し、5 秒後の再確認も input-waiting を返す
+# THEN: inject フローを継続する
+# ---------------------------------------------------------------------------
+
+# 再確認が input-waiting の場合に inject フロー（inject_count インクリメント）へ続く構造
+test_debounce_true_positive_continues() {
+  # inject_count インクリメント（inject フロー継続）と session-state.sh 再確認が共存すること
+  wait_for_batch_contains 'inject_count=\$\(\(inject_count \+ 1\)\)'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "debounce: 再確認が input-waiting でも inject フロー継続パスが存在する" test_debounce_true_positive_continues
+else
+  run_test_skip "debounce: 再確認が input-waiting でも inject フロー継続パスが存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# エッジケース: debounce 再確認が input-waiting 以外のとき all_done=false で継続する分岐がある
+test_debounce_false_positive_alldonef() {
+  # all_done=false が wait_for_batch() 内に存在し、inject_count インクリメントとは別に現れること
+  local body
+  body=$(extract_wait_for_batch)
+  local alldonef_count
+  alldonef_count=$(echo "$body" | grep -cE 'all_done=false' || true)
+  # inject フロー内（継続）と debounce スキップ後の2箇所以上に存在することを期待
+  [[ "$alldonef_count" -ge 1 ]]
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "debounce [edge]: all_done=false が wait_for_batch() に存在する" test_debounce_false_positive_alldonef
+else
+  run_test_skip "debounce [edge]: all_done=false が wait_for_batch() に存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# =============================================================================
+# Requirement: inject 上限緩和
+# =============================================================================
+echo ""
+echo "--- Requirement: inject 上限緩和 ---"
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 5 回未満で継続する (spec line 17)
+# WHEN: inject_count が 5 未満かつ non-terminal state で input-waiting が確認される
+# THEN: inject を実行し inject_count をインクリメントする
+# ---------------------------------------------------------------------------
+
+# 上限が 5 (-lt 5) に変更されていること
+test_inject_limit_5() {
+  wait_for_batch_contains 'inject_count.*-lt 5'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 上限: inject_count -lt 5 の条件が存在する" test_inject_limit_5
+else
+  run_test_skip "inject 上限: inject_count -lt 5 の条件が存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# 旧上限 (-lt 3) が残っていないこと
+test_no_inject_limit_3() {
+  wait_for_batch_not_contains 'inject_count.*-lt 3'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 上限 [edge]: inject_count -lt 3 （旧上限）が存在しない" test_no_inject_limit_3
+else
+  run_test_skip "inject 上限 [edge]: inject_count -lt 3 （旧上限）が存在しない" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 5 回到達で fallback に移行する (spec line 21)
+# WHEN: inject_count が 5 以上になる
+# THEN: fallback report を生成してウィンドウを kill する
+# ---------------------------------------------------------------------------
+
+# fallback 生成 + tmux kill-window が存在すること
+test_inject_exhausted_fallback() {
+  wait_for_batch_contains '_generate_fallback_report'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject exhausted: fallback report 生成呼び出しが存在する" test_inject_exhausted_fallback
+else
+  run_test_skip "inject exhausted: fallback report 生成呼び出しが存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+test_inject_exhausted_kill() {
+  wait_for_batch_contains 'tmux kill-window'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject exhausted: tmux kill-window が存在する" test_inject_exhausted_kill
+else
+  run_test_skip "inject exhausted: tmux kill-window が存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ログメッセージ内の上限値が 5 に更新されていること
+test_inject_exhausted_log_msg_5() {
+  local body
+  body=$(extract_wait_for_batch)
+  # inject exhausted のログメッセージ行に /5 が含まれること
+  echo "$body" | grep -E 'inject.*exhausted|auto-inject' | grep -qE '/5'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject exhausted [edge]: ログメッセージの上限値が /5 になっている" test_inject_exhausted_log_msg_5
+else
+  run_test_skip "inject exhausted [edge]: ログメッセージの上限値が /5 になっている" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ログメッセージに旧上限 /3 が残っていないこと
+test_inject_log_no_3() {
+  local body
+  body=$(extract_wait_for_batch)
+  # auto-inject ログ行に "/3" が含まれていないこと
+  if echo "$body" | grep -E 'auto-inject' | grep -qE '\(/3\)|/3\b'; then
+    return 1
+  fi
+  return 0
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject exhausted [edge]: ログメッセージに旧上限 /3 が含まれない" test_inject_log_no_3
+else
+  run_test_skip "inject exhausted [edge]: ログメッセージに旧上限 /3 が含まれない" "${ORCHESTRATOR_REL} not found"
+fi
+
+# =============================================================================
+# Requirement: inject 間の progressive delay
+# =============================================================================
+echo ""
+echo "--- Requirement: inject 間の progressive delay ---"
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 後に progressive delay が適用される (spec line 28)
+# WHEN: inject が実行される
+# THEN: sleep $((5 * inject_count)) が inject の直後に実行される
+# ---------------------------------------------------------------------------
+
+# progressive delay の sleep 式が存在すること
+test_progressive_delay_exists() {
+  wait_for_batch_contains 'sleep \$\(\(5 \* inject_count\)\)'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "progressive delay: sleep \$((5 * inject_count)) が wait_for_batch() に存在する" test_progressive_delay_exists
+else
+  run_test_skip "progressive delay: sleep \$((5 * inject_count)) が wait_for_batch() に存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# progressive delay が session-comm.sh inject 呼び出しの後にあること
+test_progressive_delay_after_inject() {
+  wait_for_batch_order 'session-comm\.sh.*inject' 'sleep \$\(\(5 \* inject_count\)\)'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "progressive delay: sleep が session-comm.sh inject 呼び出しの後に存在する" test_progressive_delay_after_inject
+else
+  run_test_skip "progressive delay: sleep が session-comm.sh inject 呼び出しの後に存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# エッジケース: inject_count インクリメント後に progressive delay があること
+# （遅延計算で最新の inject_count が使われること）
+test_progressive_delay_uses_updated_count() {
+  wait_for_batch_order 'inject_count=\$\(\(inject_count \+ 1\)\)' 'sleep \$\(\(5 \* inject_count\)\)'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "progressive delay [edge]: inject_count インクリメント後に sleep が実行される" test_progressive_delay_uses_updated_count
+else
+  run_test_skip "progressive delay [edge]: inject_count インクリメント後に sleep が実行される" "${ORCHESTRATOR_REL} not found"
+fi
+
+# =============================================================================
+# Requirement: inject 直前の状態再確認
+# =============================================================================
+echo ""
+echo "--- Requirement: inject 直前の状態再確認 ---"
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 直前に状態が変化していれば注入しない (spec line 35)
+# WHEN: inject 実行直前の再確認で session-state.sh が input-waiting 以外を返す
+# THEN: inject を実行せず continue でポーリングサイクルへ戻る
+# ---------------------------------------------------------------------------
+
+# inject 直前再確認: session-state.sh が session-comm.sh より前に呼ばれていること
+test_preinjection_check_order() {
+  wait_for_batch_order 'session-state\.sh.*state' 'session-comm\.sh.*inject'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 前再確認: session-state.sh が session-comm.sh inject より前に呼ばれる" test_preinjection_check_order
+else
+  run_test_skip "inject 前再確認: session-state.sh が session-comm.sh inject より前に呼ばれる" "${ORCHESTRATOR_REL} not found"
+fi
+
+# inject 前再確認: continue でスキップする分岐が存在すること
+test_preinjection_check_continue() {
+  wait_for_batch_contains 'continue'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 前再確認: continue でスキップするパスが存在する" test_preinjection_check_continue
+else
+  run_test_skip "inject 前再確認: continue でスキップするパスが存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ---------------------------------------------------------------------------
+# Scenario: inject 直前も input-waiting なら注入する (spec line 39)
+# WHEN: inject 実行直前の再確認でも session-state.sh が input-waiting を返す
+# THEN: session-comm.sh inject を実行する
+# ---------------------------------------------------------------------------
+
+# session-comm.sh inject の呼び出しが存在すること
+test_sessioncomm_inject_exists() {
+  wait_for_batch_contains 'session-comm\.sh.*inject'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 直前再確認: session-comm.sh inject 呼び出しが存在する" test_sessioncomm_inject_exists
+else
+  run_test_skip "inject 直前再確認: session-comm.sh inject 呼び出しが存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# エッジケース: inject 前再確認が debounce 再確認とは別の変数または条件を使うこと
+# (inject 直前チェックは debounce とは独立したコードパスであること)
+test_preinjection_check_independent() {
+  local body
+  body=$(extract_wait_for_batch)
+  # session-state.sh の呼び出し行数が 2 以上（debounce 1 + 直前確認 1）
+  local count
+  count=$(echo "$body" | grep -cE '"?\$\{?SCRIPTS_ROOT\}?.*session-state\.sh' || true)
+  [[ "$count" -ge 2 ]]
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject 直前再確認 [edge]: session-state.sh 呼び出しが 2 回以上存在する（debounce と直前確認）" test_preinjection_check_independent
+else
+  run_test_skip "inject 直前再確認 [edge]: session-state.sh 呼び出しが 2 回以上存在する（debounce と直前確認）" "${ORCHESTRATOR_REL} not found"
+fi
+
+# =============================================================================
+# Requirement: inject メッセージ簡素化
+# =============================================================================
+echo ""
+echo "--- Requirement: inject メッセージ簡素化 ---"
+
+# ---------------------------------------------------------------------------
+# Scenario: inject メッセージが簡潔である (spec line 46)
+# WHEN: inject が実行される
+# THEN: session-comm.sh inject に渡すメッセージが "処理を続行してください。" である
+# ---------------------------------------------------------------------------
+
+test_inject_message_simplified() {
+  wait_for_batch_contains '処理を続行してください。'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject メッセージ: \"処理を続行してください。\" が存在する" test_inject_message_simplified
+else
+  run_test_skip "inject メッセージ: \"処理を続行してください。\" が存在する" "${ORCHESTRATOR_REL} not found"
+fi
+
+# ワークフロー分岐（existing-issue.json 有無による分岐）が削除されていること
+test_no_existing_issue_json_branch() {
+  wait_for_batch_not_contains 'existing-issue\.json'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject メッセージ [edge]: existing-issue.json による分岐が存在しない" test_no_existing_issue_json_branch
+else
+  run_test_skip "inject メッセージ [edge]: existing-issue.json による分岐が存在しない" "${ORCHESTRATOR_REL} not found"
+fi
+
+# 旧メッセージ（詳細な Step 指示）が残っていないこと
+test_no_old_inject_message_4b() {
+  wait_for_batch_not_contains '4b: issue-review-aggregate'
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject メッセージ [edge]: 旧メッセージ（4b: issue-review-aggregate）が存在しない" test_no_old_inject_message_4b
+else
+  run_test_skip "inject メッセージ [edge]: 旧メッセージ（4b: issue-review-aggregate）が存在しない" "${ORCHESTRATOR_REL} not found"
+fi
+
+# エッジケース: inject_msg 変数が1種類のみに統一されていること
+# (分岐削除後は単一の inject_msg 代入のみ存在する)
+test_inject_msg_single_assignment() {
+  local body
+  body=$(extract_wait_for_batch)
+  local assign_count
+  assign_count=$(echo "$body" | grep -cE 'inject_msg=' || true)
+  # 1 行のみ（分岐なし）
+  [[ "$assign_count" -eq 1 ]]
+}
+
+if assert_file_exists "$ORCHESTRATOR"; then
+  run_test "inject メッセージ [edge]: inject_msg の代入が 1 行のみ（分岐なし）" test_inject_msg_single_assignment
+else
+  run_test_skip "inject メッセージ [edge]: inject_msg の代入が 1 行のみ（分岐なし）" "${ORCHESTRATOR_REL} not found"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
fix(issue-lifecycle-orchestrator): inject debounce + 上限緩和 + progressive delay (#709)

- input-waiting 検出後に 5 秒 debounce を追加（transient false positive 排除）
- inject 上限を 3 → 5 に緩和
- inject 後に progressive delay（sleep $((5 * inject_count))）を追加
- inject 直前の session-state.sh 再確認でスキップ機構を追加
- inject メッセージを「処理を続行してください。」に簡素化
- existing-issue.json による分岐を削除

Closes #709