### PR TITLE
feat(#726): PostToolUse Write hook で explore-summary を自動 Issue リンク

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/supervisor-input-wait.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/supervisor-input-wait.sh\"",
             "timeout": 3000
           }
         ]
@@ -26,22 +26,22 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/pre-bash-commit-validate.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-commit-validate.sh\"",
             "timeout": 5000
           },
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/pre-bash-refined-label-gate.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-refined-label-gate.sh\"",
             "timeout": 5000
           },
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/pre-bash-phase3-gate.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-phase3-gate.sh\"",
             "timeout": 5000
           },
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/pre-bash-merge-guard.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-merge-guard.sh\"",
             "timeout": 3000
           }
         ]
@@ -53,8 +53,13 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/supervisor-heartbeat.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/supervisor-heartbeat.sh\"",
             "timeout": 3000
+          },
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/explore-summary-link.sh\"",
+            "timeout": 5000
           }
         ]
       },
@@ -63,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/supervisor-input-clear.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/supervisor-input-clear.sh\"",
             "timeout": 3000
           }
         ]
@@ -73,7 +78,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/supervisor-skill-step.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/supervisor-skill-step.sh\"",
             "timeout": 3000
           }
         ]
@@ -121,7 +126,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash plugins/twl/scripts/hooks/supervisor-session-end.sh",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/supervisor-session-end.sh\"",
             "timeout": 3000
           }
         ]

--- a/cli/twl/src/twl/cli_dispatch.py
+++ b/cli/twl/src/twl/cli_dispatch.py
@@ -502,8 +502,11 @@ def handle_explore_link(argv):
             print(f"Error: '{source_path}' not found", file=sys.stderr)
             return 1
         explore_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(str(source_path), str(summary_path))
-        print(f"Copied {source_path} -> {summary_path}")
+        if source_path.resolve() != summary_path.resolve():
+            shutil.copy2(str(source_path), str(summary_path))
+            print(f"Copied {source_path} -> {summary_path}")
+        else:
+            print(f"Source and destination are the same file, skipping copy: {source_path}")
 
         # gh issue comment
         try:

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2697,6 +2697,11 @@ scripts:
     path: scripts/hooks/supervisor-session-end.sh
     description: "Stop hook: AUTOPILOT_DIR 設定時に session-end イベントファイルを .supervisor/events/session-end-<session_id> にアトミック書き出し（#569 Event Emission インフラ）"
 
+  explore-summary-link:
+    type: script
+    path: scripts/hooks/explore-summary-link.sh
+    description: "PostToolUse hook (Write|Edit): .explore/<N>/summary.md への書き込みを検知し gh issue comment で explore-summary リンクを自動追加。冪等チェック付き（#726）"
+
   pr-review-manifest:
     type: script
     path: scripts/pr-review-manifest.sh

--- a/plugins/twl/scripts/hooks/explore-summary-link.sh
+++ b/plugins/twl/scripts/hooks/explore-summary-link.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# PostToolUse Write|Edit hook: .explore/<N>/summary.md への書き込みを検知し
+# gh issue comment で explore-summary リンクを追加する（#726）
+set -uo pipefail
+
+LOG_FILE="/tmp/explore-link-hook.log"
+
+log() {
+  echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" >> "$LOG_FILE"
+}
+
+# stdin を消費
+INPUT=$(cat 2>/dev/null || echo "")
+
+# FILE_PATH 取得: env var 優先、stdin JSON フォールバック
+FILE_PATH="${TOOL_INPUT_file_path:-}"
+if [[ -z "$FILE_PATH" && -n "$INPUT" ]]; then
+  FILE_PATH=$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || echo "")
+fi
+
+# /.explore/<N>/summary.md パターンにマッチするか確認（スラッシュプレフィックス必須）
+if [[ -z "$FILE_PATH" ]] || ! printf '%s' "$FILE_PATH" | grep -qE '/.explore/[0-9]+/summary\.md$'; then
+  exit 0
+fi
+
+# Issue 番号を抽出
+ISSUE_NUM=$(printf '%s' "$FILE_PATH" | sed -n 's|.*/.explore/\([0-9][0-9]*\)/summary\.md$|\1|p')
+if [[ -z "$ISSUE_NUM" ]]; then
+  exit 0
+fi
+
+# git リポジトリ内でなければ終了
+if ! git rev-parse --git-common-dir &>/dev/null; then
+  exit 0
+fi
+
+# gh コマンド確認
+if ! command -v gh &>/dev/null; then
+  log "WARNING: gh command not found"
+  exit 0
+fi
+
+# 冪等性チェック: 既存の explore-summary リンクコメントを確認
+EXISTING_COUNT=0
+EXISTING_COUNT=$(gh issue view "$ISSUE_NUM" --json comments 2>>"$LOG_FILE" \
+  | jq -r '[.comments[].body | select(contains("explore-summary linked:"))] | length' 2>>"$LOG_FILE") || true
+
+if [[ "${EXISTING_COUNT:-0}" -gt 0 ]]; then
+  log "WARNING: explore-summary already linked for Issue #${ISSUE_NUM} (check-then-act race condition possible)"
+  exit 0
+fi
+
+# gh issue comment（stderr はログファイルに出力）
+if ! gh issue comment "$ISSUE_NUM" --body "explore-summary linked: \`${FILE_PATH}\`" 2>>"$LOG_FILE"; then
+  log "ERROR: failed to comment on Issue #${ISSUE_NUM}"
+fi
+
+exit 0


### PR DESCRIPTION
feat(#726): PostToolUse Write hook で explore-summary を自動 Issue リンク

- settings.json: 全 hook パスを git-common-dir ベースの絶対パスに変更
  (worktree Worker で PreToolUse/PostToolUse ガードが無効化される問題を修正)
- settings.json: PostToolUse Write|Edit に explore-summary-link.sh hook を追加
- plugins/twl/scripts/hooks/explore-summary-link.sh: 新規作成
  - /.explore/<N>/summary.md への Write を検知して gh issue comment を実行
  - 冪等性チェック: 既存コメント確認し、リンク済みならスキップ
  - gh API エラーは /tmp/explore-link-hook.log に記録
- cli_dispatch.py L505: explore-link set の SameFileError 対応
  (src == dst の場合は copy をスキップし comment のみ実行)

Closes #726