### PR TITLE
fix(co-issue): fallback [D] direct specialist spawn とcompleteness guard を追加 (#723)

### DIFF
--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -273,11 +273,36 @@ fi
 
 #### Step 4c: failure 対話
 
-failure または circuit_broken が 1 件以上の場合、AskUserQuestion で以下を確認:
+failure または circuit_broken が 1 件以上の場合、まず `report.json` の `reason` フィールドで失敗原因を判定する:
 
-- `[retry subset]` → `bash scripts/issue-lifecycle-orchestrator.sh --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet` で非 done のみ再実行
-- `[manual fix]` → 手動修正を依頼してユーザーに案内
-- `[accept partial]` → このまま完了
+**inject_exhausted 起因の場合（[D] 自動適用）:**
+
+`reason` が `inject_exhausted_*` にマッチする場合、[D] を自動実行する（ユーザー確認不要）。
+
+**[D] direct specialist spawn — 実行手順（MUST）:**
+
+1. **policies.json バリデーション**: 各非 done issue の `per-issue/<index>/IN/policies.json` について以下を検証する。バリデーション失敗時は `[A] retry` に切り替える:
+   - `specialists` キーが存在すること（必須）
+   - 値が文字列配列（`string[]`）であること
+   - 重複がないこと
+   - 各要素が既知の specialist 名（`"worker-codex-reviewer"`, `"issue-critic"`, `"issue-feasibility"`）に含まれること
+
+2. **全 specialist を並列 spawn**: `policies.json` の `specialists` 配列を読み込み、全 specialist を Agent tool で単一メッセージで並列 spawn する（省略・スキップ禁止）
+
+3. **完了待ちとタイムアウト**: 全 specialist の完了を待つ（タイムアウト: specialist あたり 300 秒）。タイムアウトした specialist は `timed_out` として記録する
+
+4. **completeness guard（MUST）**: 完了した specialist 名の集合（actual）と `policies.json["specialists"]` の集合（expected）を名前ベースで比較する:
+   - `missing = expected - actual` が空でない場合: 不足 specialist を 1 回リトライ spawn する
+   - リトライ後も不足の場合: `status: "failed"` として記録し、不足 specialist 名をユーザーに報告する
+   - **禁止**: `len(findings) >= len(specialists)` 等の findings 数による代替判定（findings=0 は正常実行と実行漏れを区別できないため）
+
+5. **findings 統合**: 完了した specialist の findings を `rounds/<round>/findings.yaml` に統合し、aggregate（Step 4b）フローを継続する
+
+**inject_exhausted 以外の failure の場合（AskUserQuestion）:**
+
+- `[A] retry subset` → `bash scripts/issue-lifecycle-orchestrator.sh --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet` で非 done のみ再実行
+- `[B] manual fix` → 手動修正を依頼してユーザーに案内
+- `[C] accept partial` → このまま完了（**ユーザーの明示的承認を確認してから実行すること**。デフォルト選択禁止）
 
 ## 終了時クリーンアップ（Phase 4 完了後）
 

--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -254,6 +254,7 @@ fi
 
 | 分類 | 判定条件 |
 |------|---------|
+| `fallback_inject_exhausted` | `status: "done"` かつ `fallback: true` かつ `reason` が `inject_exhausted_*` にマッチ（`done` より先に評価すること） |
 | `done` | `status: "done"` |
 | `warned` | `status: "done"` かつ `warnings_acknowledged` が非空 |
 | `failed` | `status: "failed"` または `status: "codex_unreliable"` |
@@ -268,37 +269,41 @@ fi
 |---|----------------------|--------|-----|
 | 1 | ...                  | done   | ... |
 ...
-合計: done=N / warned=W / failed=F / circuit_broken=C
+合計: done=N / warned=W / failed=F / circuit_broken=C / fallback_inject_exhausted=I
 ```
 
 #### Step 4c: failure 対話
 
-failure または circuit_broken が 1 件以上の場合、まず `report.json` の `reason` フィールドで失敗原因を判定する:
+`failure`・`circuit_broken`・`fallback_inject_exhausted` が 1 件以上の場合、以下のフローで対応する:
 
-**inject_exhausted 起因の場合（[D] 自動適用）:**
+**fallback_inject_exhausted の場合（[D] 自動適用）:**
 
-`reason` が `inject_exhausted_*` にマッチする場合、[D] を自動実行する（ユーザー確認不要）。
+Step 4a で `fallback_inject_exhausted` に分類された issue が存在する場合、[D] を自動実行する（ユーザー確認不要）。
 
-**[D] direct specialist spawn — 実行手順（MUST）:**
+**[D] direct specialist spawn — アーキテクチャ注記:**
 
-1. **policies.json バリデーション**: 各非 done issue の `per-issue/<index>/IN/policies.json` について以下を検証する。バリデーション失敗時は `[A] retry` に切り替える:
+[D] は inject_exhausted により Worker セッションが起動不能な場合の回復機構として、co-issue コントローラーが直接 Agent tool で specialist を spawn する。これは ADR-017 の通常 Pilot/Worker 隔離モデルの例外であり、inject_exhausted フォールバック時に限り許可される設計意図の下で実行する。spec-review-session-init.sh / PreToolUse gate（IM-7 層(b)）は適用されないが、以下の completeness guard が代替保証として機能する。
+
+**[D] 実行手順（MUST）:**
+
+1. **policies.json バリデーション**: 各 fallback_inject_exhausted issue の `per-issue/<index>/IN/policies.json` について以下を検証する。バリデーション失敗時は `[B] manual fix` に切り替える:
    - `specialists` キーが存在すること（必須）
    - 値が文字列配列（`string[]`）であること
    - 重複がないこと
    - 各要素が既知の specialist 名（`"worker-codex-reviewer"`, `"issue-critic"`, `"issue-feasibility"`）に含まれること
 
-2. **全 specialist を並列 spawn**: `policies.json` の `specialists` 配列を読み込み、全 specialist を Agent tool で単一メッセージで並列 spawn する（省略・スキップ禁止）
+2. **全 specialist を並列 spawn**: `policies.json` の `specialists` 配列を読み込み、全 specialist を Agent tool で単一メッセージで並列 spawn する（省略・スキップ禁止）。`per-issue/<index>/IN/draft.md` を入力として各 specialist に渡す
 
 3. **完了待ちとタイムアウト**: 全 specialist の完了を待つ（タイムアウト: specialist あたり 300 秒）。タイムアウトした specialist は `timed_out` として記録する
 
 4. **completeness guard（MUST）**: 完了した specialist 名の集合（actual）と `policies.json["specialists"]` の集合（expected）を名前ベースで比較する:
    - `missing = expected - actual` が空でない場合: 不足 specialist を 1 回リトライ spawn する
-   - リトライ後も不足の場合: `status: "failed"` として記録し、不足 specialist 名をユーザーに報告する
+   - リトライ後も不足の場合: `per-issue/<index>/OUT/report.json` に `{"status":"failed","reason":"specialist_missing","missing":[...]}` を書き込み `[B] manual fix` に移行する
    - **禁止**: `len(findings) >= len(specialists)` 等の findings 数による代替判定（findings=0 は正常実行と実行漏れを区別できないため）
 
-5. **findings 統合**: 完了した specialist の findings を `rounds/<round>/findings.yaml` に統合し、aggregate（Step 4b）フローを継続する
+5. **aggregate 実行**: 収集した specialist outputs を入力として `/twl:issue-review-aggregate` を Skill tool で呼び出す。結果を `per-issue/<index>/OUT/report.json` に書き込み（`status: "done"` または `circuit_broken`）、Step 4a の `done` / `failed` と同様に処理する
 
-**inject_exhausted 以外の failure の場合（AskUserQuestion）:**
+**failure / circuit_broken の場合（AskUserQuestion）:**
 
 - `[A] retry subset` → `bash scripts/issue-lifecycle-orchestrator.sh --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet` で非 done のみ再実行
 - `[B] manual fix` → 手動修正を依頼してユーザーに案内

--- a/plugins/twl/skills/workflow-issue-refine/SKILL.md
+++ b/plugins/twl/skills/workflow-issue-refine/SKILL.md
@@ -132,6 +132,11 @@ mkdir -p "$PER_ISSUE_DIR/rounds/${round}"
 - `depth`: policies.depth（デフォルト: normal）
 - 結果を `rounds/<round>/findings.yaml` に書き込む
 
+**completeness guard（MUST）**: `issue-spec-review` の返却値 `specialist_results` のキー集合と `policies.specialists` 配列の集合を名前ベースで比較する:
+- `missing = Set(policies.specialists) - Set(specialist_results.keys())` が空でない場合: 不足 specialist を 1 回再実行する
+- 再実行後も不足の場合: STATE ← failed → `OUT/report.json` に `{"status":"failed","reason":"specialist_missing","missing":[...]}` を書き込んで exit 0
+- **禁止**: findings 数による completeness 判定（findings=0 は正常実行と実行漏れを区別できないため）
+
 **4a 完了後、中断せず直ちに 4b を実行すること（MUST — AskUserQuestion 禁止）。**
 
 #### 4b: aggregate


### PR DESCRIPTION
## 概要

co-issue fallback 時に worker-codex-reviewer が spawn されない問題を修正。

## 変更内容

- co-issue SKILL.md Phase 4c に [D] direct specialist spawn 選択肢を追加
- specialist completeness guard: 名前集合の一致で検証（findings 数ではなく）
- policies.json のバリデーション追加
- workflow-issue-refine SKILL.md との整合

Closes #723

Co-Authored-By: Claude <noreply@anthropic.com>