### PR TITLE
fix: observer/su-observer が audit を自動有効化しない (#724)

### DIFF
--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -68,6 +68,14 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/python-env.sh"
 
 これにより `cli/twl/src` の絶対パスが `PYTHONPATH` に追加される（python-env.sh が BASH_SOURCE から絶対パスを自動解決）。省略すると `python3 -m twl.autopilot.*` 呼び出し時に `ModuleNotFoundError` が発生する。
 
+**条件付き audit on（MUST）:** PYTHONPATH 設定後、audit が非アクティブな場合のみ audit を開始する（二重呼び出しによるセッション上書きを防止）:
+
+```bash
+if ! twl audit status 2>/dev/null | grep -q "^active: true"; then
+  twl audit on
+fi
+```
+
 `commands/autopilot-init.md` を Read → 実行。出力: SESSION_ID, PHASE_COUNT, SESSION_STATE_FILE。
 
 **AUTOPILOT_DIR 一致確認（MUST）:** `autopilot-init` 実行前に、`AUTOPILOT_DIR` が `plan.yaml` と同じディレクトリを指していることを確認する。bare repo レイアウトでは `autopilot-plan.sh` が `.bare/` を検出して `main/.autopilot/` に plan.yaml を配置するため、Pilot も同じパスを使用すること。不一致はパストラバーサルエラーの原因になる (#660)。
@@ -110,6 +118,14 @@ TaskUpdate Phase P → completed。`python3 -m twl.autopilot.audit snapshot ...`
 bash "${CLAUDE_PLUGIN_ROOT}/scripts/autopilot-cleanup.sh" --autopilot-dir "$AUTOPILOT_DIR"
 ```
 done state file を即座にアーカイブし、TTL 超過の failed state file もアーカイブ。孤立 worktree を検出・削除する。`--dry-run` で事前確認も可能。
+
+**条件付き audit off（MUST）:** クリーンアップ後、audit がアクティブな場合のみ停止する（非 active 時の RuntimeError を防止）:
+
+```bash
+if twl audit status 2>/dev/null | grep -q "^active: true"; then
+  twl audit off
+fi
+```
 
 ## 再開機能
 

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -45,6 +45,12 @@ spawnable_by:
      OBSERVER_WINDOW_NAME=$(tmux display-message -p '#W' 2>/dev/null || echo "")
      # session.json に claude_session_id + observer_window フィールドを含めて書き込む
      # 例: {"session_id": "<uuid>", "claude_session_id": "<CLAUDE_SESSION_ID_VAL>", "observer_window": "<OBSERVER_WINDOW_NAME>", "status": "active", ...}
+     # audit on（新規セッション。CLAUDE_SESSION_ID_VAL を run-id として使用）
+     if [[ -n "$CLAUDE_SESSION_ID_VAL" ]]; then
+       twl audit on --run-id "$CLAUDE_SESSION_ID_VAL"
+     else
+       twl audit on
+     fi
      ```
 2.5. `.supervisor/budget-pause.json` の存在確認:
    - 存在かつ `status: "paused"` → budget 回復シーケンスを実行してから常駐ループへ:
@@ -360,6 +366,7 @@ Issue 群の一括実装（Wave）を要求された場合:
 5. Wave 完了を検知したら:
    - `commands/wave-collect.md` を Read → 実行（`WAVE_NUM=<N>`）
    - `commands/externalize-state.md` を Read → 実行（`--trigger wave_complete`）
+   - **audit snapshot（SHOULD）**: `twl audit snapshot --source-dir "${AUTOPILOT_DIR:-.autopilot}" --label "wave/${WAVE_NUM}"` を実行する（audit 非アクティブ時は自動 no-op）
    - **イベントファイル一括クリーンアップ（MUST）**: externalize-state 実行後に `.supervisor/events/` 配下の全ファイルを削除する:
      ```bash
      rm -f .supervisor/events/* 2>/dev/null || true


### PR DESCRIPTION
fix: observer/su-observer が audit を自動有効化しない (#724)

- su-observer Step 0（新規セッション）: twl audit on --run-id CLAUDE_SESSION_ID_VAL を追加
- co-autopilot Step 3: 条件付き audit on を追加（twl audit status で非 active 時のみ実行）
- co-autopilot Step 5: 条件付き audit off を追加（active 時のみ実行し RuntimeError を防止）
- su-observer Wave 完了ステップ: twl audit snapshot 追加（非 active 時は自動 no-op）
- launcher.py:185-193 の Worker 伝播コード動作を確認（変更不要）

Closes #724