### PR TITLE
feat(#740): specialist completeness 自動監査システムを追加

### DIFF
--- a/deltaspec/changes/issue-740/.deltaspec.yaml
+++ b/deltaspec/changes/issue-740/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-20
+issue: 740
+name: issue-740
+status: pending

--- a/deltaspec/changes/issue-740/design.md
+++ b/deltaspec/changes/issue-740/design.md
@@ -1,0 +1,41 @@
+## Architecture
+
+### specialist-audit.sh の設計
+
+```
+specialist-audit.sh
+  ├── JSONL パス解決（--issue N → グロブ前方一致 → Issue 番号マッチ）
+  ├── 実行集合抽出（grep "subagent_type":"twl:twl:worker-*"）
+  ├── 期待集合生成（pr-review-manifest.sh --mode merge-gate）
+  ├── 突合（expected ⊆ actual 検証）
+  ├── 出力（JSON stdout）
+  └── audit ログ保存（.audit/<run_id>/specialist-audit-<issue>-<ts>-<pid>.json）
+```
+
+### JSONL パス解決の注意点
+
+1. **99 文字切り捨て**: Claude Code はプロジェクトディレクトリ名を 99 文字で切り捨てる → グロブ前方一致検索が必須
+2. **sequential JSONL 競合**: 複数 Issue を同一 worktree で処理すると複数 JSONL が蓄積 → Issue 番号マッチで絞り込み、フォールバックは最新 JSONL
+
+### bootstrapping 戦略
+
+| Stage | SPECIALIST_AUDIT_MODE | 動作 |
+|-------|----------------------|------|
+| 0-1 (初回 PR) | warn | 全 FAIL を WARN に降格、exit 0 |
+| 2 (本番) | strict | FAIL → exit 1、merge REJECT |
+
+### merge-gate-check-spawn.sh 統合
+
+```
+[既存] MANIFEST_FILE ブロック（LLM 自己申告検証）
+[新規] specialist-audit.sh 呼び出し（JSONL 独立検証、MANIFEST_FILE ブロック外）
+```
+
+`set -euo pipefail` 環境での exit code 捕捉: `|| audit_exit=$?` で明示的に取得。
+
+### su-observer 統合
+
+Wave 完了時に全 Issue の JSONL を一括監査:
+- `--warn-only` フラグで merge-gate の strict モードを経由せず監査
+- `.audit/wave-${WAVE_NUM}/specialist-audit.log` に追記
+- FAIL 行は次 Wave の観察対象（自動起票は行わない）

--- a/deltaspec/changes/issue-740/proposal.md
+++ b/deltaspec/changes/issue-740/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+`merge-gate-check-spawn.sh` は LLM 自己申告（SPAWNED_FILE）のみで specialist completeness を判定しており、Worker JSONL による独立検証がない。#722 で specialist review 0 件のまま自動 merge された事故が発生し、observer の手動 JSONL 監査に依存している状況が続いている。
+
+## What Changes
+
+- `plugins/twl/scripts/specialist-audit.sh` を新規作成: Worker JSONL を直読みして specialist completeness を独立検証するスクリプト
+- `plugins/twl/scripts/merge-gate-check-spawn.sh` を拡張: JSONL 独立検証ブロックを末尾追加（MANIFEST_FILE ブロック外）
+- `plugins/twl/skills/su-observer/SKILL.md` を更新: Wave 完了時に各 Issue の specialist completeness を自動監査
+
+## Capabilities
+
+### New Capabilities
+
+- **JSONL 独立検証**: Worker session JSONL から `twl:twl:worker-*` を抽出し、`pr-review-manifest.sh` が生成する期待集合と突合する
+- **bootstrapping 対応**: `SPECIALIST_AUDIT_MODE=warn` で全 FAIL を WARN に降格（initial deploy 時の誤検知を防止）
+- **緊急無効化**: `SKIP_SPECIALIST_AUDIT=1` で即座にスキップ可能
+- **merge-gate 統合**: `merge-gate-check-spawn.sh` が specialist-audit.sh を呼び出し、JSONL 独立検証を自動実行
+
+### Modified Capabilities
+
+- **merge-gate-check-spawn.sh**: MANIFEST_FILE ブロック外（スクリプト末尾）に specialist-audit.sh 呼び出しを追加
+- **su-observer Wave 完了処理**: twl audit snapshot 直後に全 Issue の specialist completeness を一括監査
+
+## Impact
+
+- `plugins/twl/scripts/specialist-audit.sh`: 新規作成（JSONL 直読み監査ツール）
+- `plugins/twl/scripts/merge-gate-check-spawn.sh`: 末尾に specialist-audit.sh 呼び出し追加
+- `plugins/twl/skills/su-observer/SKILL.md`: L369 直後に specialist-audit 呼び出し追加

--- a/deltaspec/changes/issue-740/specs/specialist-completeness.md
+++ b/deltaspec/changes/issue-740/specs/specialist-completeness.md
@@ -1,0 +1,62 @@
+## ADDED Requirements
+
+### Requirement: specialist-audit.sh スクリプト
+
+`plugins/twl/scripts/specialist-audit.sh` を新規作成し、Worker JSONL から specialist completeness を独立検証しなければならない（SHALL）。
+
+- 入力: `--issue <N>` または `--jsonl <path>`（排他）
+- 期待集合: `pr-review-manifest.sh --mode <phase>` を呼び出して動的生成しなければならない（SHALL）
+- 実行集合: JSONL から `"subagent_type":"twl:twl:worker-*"` を抽出しなければならない（SHALL）
+- 突合: `expected ⊆ actual` を検証し、missing 非空を FAIL としなければならない（SHALL）
+- exit code: `0=PASS/WARN`、`1=FAIL` の 2 値のみとしなければならない（SHALL）
+- 環境変数 `SPECIALIST_AUDIT_MODE=warn` で全 FAIL を WARN に降格しなければならない（SHALL）
+- `SKIP_SPECIALIST_AUDIT=1` で完全スキップしなければならない（SHALL）
+
+#### Scenario: JSONL に全期待 specialist が存在する場合
+- **WHEN** `specialist-audit.sh --issue 740 --mode merge-gate` を実行し、JSONL に全期待 specialist が存在する
+- **THEN** stdout に `{"status":"PASS",...}` を出力し exit 0
+
+#### Scenario: JSONL に missing specialist がある場合（strict モード）
+- **WHEN** `SPECIALIST_AUDIT_MODE=strict specialist-audit.sh --issue 740` を実行し、missing specialist がある
+- **THEN** stdout に `{"status":"FAIL","missing":[...]}` を出力し exit 1
+
+#### Scenario: warn モードで missing がある場合
+- **WHEN** `SPECIALIST_AUDIT_MODE=warn specialist-audit.sh --issue 740` を実行し、missing がある
+- **THEN** stdout に `{"status":"WARN",...}` を出力し exit 0
+
+#### Scenario: --warn-only フラグ使用
+- **WHEN** `specialist-audit.sh --issue 740 --warn-only` を実行し、missing がある
+- **THEN** exit 0 で終了する
+
+#### Scenario: JSONL 解決失敗
+- **WHEN** 対応プロジェクトディレクトリが存在しない Issue 番号を指定する
+- **THEN** `{"status":"WARN","reason":"jsonl_resolution_failed"}` を出力し exit 0
+
+### Requirement: merge-gate-check-spawn.sh JSONL 独立検証
+
+`merge-gate-check-spawn.sh` の末尾（MANIFEST_FILE ブロック外）に specialist-audit.sh 呼び出しを追加し、JSONL 独立検証を実行しなければならない（SHALL）。
+
+- `${CLAUDE_PLUGIN_ROOT:-plugins/twl}/scripts/specialist-audit.sh` で解決しなければならない（SHALL）
+- `set -euo pipefail` 下で `|| audit_exit=$?` で exit code を捕捉しなければならない（SHALL）
+- `--quick` フラグを呼び出し側が判定して渡さなければならない（SHALL）
+- FAIL 時は stderr に `REJECT: specialist-audit FAIL` を出力しなければならない（SHALL）
+- JSONL 解決失敗時は exit 0 で継続しなければならない（SHALL）
+
+#### Scenario: 正常な merge-gate 実行
+- **WHEN** `merge-gate-check-spawn.sh` が実行され、specialist-audit.sh が PASS を返す
+- **THEN** exit 0 で完了し、既存の MANIFEST_FILE 検証も維持される
+
+#### Scenario: specialist-audit FAIL（strict モード）
+- **WHEN** `SPECIALIST_AUDIT_MODE=strict` で specialist-audit.sh が FAIL を返す
+- **THEN** `REJECT: specialist-audit FAIL` を stderr に出力し exit 1
+
+### Requirement: su-observer Wave 完了時の自動監査
+
+`su-observer/SKILL.md` の Wave 完了セクション（L369 の `twl audit snapshot` 直後）に specialist-audit.sh 呼び出しを追加し、全 Issue の specialist completeness を一括監査しなければならない（SHALL）。
+
+- `--warn-only` フラグで merge を阻害しない形で監査しなければならない（SHALL）
+- 結果を `.audit/wave-${WAVE_NUM}/specialist-audit.log` に追記しなければならない（SHALL）
+
+#### Scenario: Wave 完了時の一括監査
+- **WHEN** Wave 完了を検知し、su-observer が Wave 完了処理を実行する
+- **THEN** 全 issue-*.json に対して specialist-audit.sh が --warn-only で実行される

--- a/deltaspec/changes/issue-740/tasks.md
+++ b/deltaspec/changes/issue-740/tasks.md
@@ -1,0 +1,17 @@
+## A. specialist-audit.sh 新規作成
+
+- [x] A.1 `plugins/twl/scripts/specialist-audit.sh` を新規作成（--issue/--jsonl/--mode/--manifest-file/--quick/--warn-only/--json/--summary オプション、exit 0/1 の 2 値）
+- [x] A.2 JSONL パス解決ロジック（グロブ前方一致 + Issue 番号マッチ + フォールバック）を実装
+- [x] A.3 期待集合生成（pr-review-manifest.sh 呼び出し、--manifest-file 再利用オプション）を実装
+- [x] A.4 実行集合抽出（JSONL から twl:twl:worker-* を grep）を実装
+- [x] A.5 突合ロジック（expected ⊆ actual、missing/extra 計算）と JSON 出力を実装
+- [x] A.6 SPECIALIST_AUDIT_MODE=warn|strict、SKIP_SPECIALIST_AUDIT=1 の環境変数対応を実装
+- [x] A.7 audit ログ保存（.audit/<run_id>/specialist-audit-<issue>-<ts>-<pid>.json）を実装
+
+## B. merge-gate-check-spawn.sh 拡張
+
+- [x] B.1 `merge-gate-check-spawn.sh` の末尾（MANIFEST_FILE ブロック外）に specialist-audit.sh 呼び出しを追加
+
+## C. su-observer SKILL.md 更新
+
+- [x] C.1 `su-observer/SKILL.md` の L369 `twl audit snapshot` 直後に specialist-audit.sh 一括呼び出しを追加（for issue_json ループ、--warn-only、.audit/wave-N/specialist-audit.log に追記）

--- a/deltaspec/changes/issue-740/test-mapping.yaml
+++ b/deltaspec/changes/issue-740/test-mapping.yaml
@@ -1,0 +1,7 @@
+change: issue-740
+schema: spec-driven
+mappings:
+  - spec: specs/specialist-completeness.md
+    tests:
+      - type: unit
+        path: tests/unit/specialist-audit.bats

--- a/plugins/twl/scripts/merge-gate-check-spawn.sh
+++ b/plugins/twl/scripts/merge-gate-check-spawn.sh
@@ -8,6 +8,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [[ -n "${MANIFEST_FILE:-}" && -f "${MANIFEST_FILE:-}" ]]; then
   MISSING=$(comm -23 \
     <(grep -v '^#' "$MANIFEST_FILE" | grep -v '^[[:space:]]*$' | sed 's|^twl:twl:||' | sort -u) \
@@ -19,4 +21,51 @@ if [[ -n "${MANIFEST_FILE:-}" && -f "${MANIFEST_FILE:-}" ]]; then
     exit 1
   fi
   echo "✓ 全 specialist spawn 完了確認済み"
+fi
+
+# --- JSONL 独立検証（LLM 自己申告に依存しない specialist completeness 確認）---
+# MANIFEST_FILE ブロック外に配置し、chain 外実行時にも specialist 監査を走らせる
+_audit_script="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}/scripts/specialist-audit.sh"
+if [[ -f "$_audit_script" ]]; then
+  # ISSUE_NUM を解決（resolve-issue-num.sh 経由、失敗時は空文字）
+  _issue_num="${ISSUE_NUM:-}"
+  if [[ -z "$_issue_num" ]]; then
+    _resolver="${SCRIPT_DIR}/resolve-issue-num.sh"
+    if [[ -f "$_resolver" ]]; then
+      # shellcheck disable=SC1090
+      source "$_resolver" 2>/dev/null || true
+      if declare -f resolve_issue_num >/dev/null 2>&1; then
+        _issue_num=$(resolve_issue_num 2>/dev/null || echo "")
+      fi
+    fi
+  fi
+
+  # quick ラベル判定（IS_QUICK 環境変数または .autopilot/issues/issue-N.json 参照）
+  _quick_flag=""
+  if [[ "${IS_QUICK:-false}" == "true" ]]; then
+    _quick_flag="--quick"
+  elif [[ -n "$_issue_num" ]]; then
+    _is_quick=$(python3 -m twl.autopilot.state read --type issue --issue "$_issue_num" --field is_quick 2>/dev/null || echo "false")
+    [[ "$_is_quick" == "true" ]] && _quick_flag="--quick"
+  fi
+
+  # --manifest-file を渡して pr-review-manifest.sh の二重呼び出しを回避
+  _manifest_arg=""
+  [[ -n "${MANIFEST_FILE:-}" && -f "${MANIFEST_FILE:-}" ]] && _manifest_arg="--manifest-file ${MANIFEST_FILE}"
+
+  _audit_exit=0
+  if [[ -n "$_issue_num" ]]; then
+    bash "$_audit_script" --issue "$_issue_num" --mode merge-gate \
+      ${_manifest_arg} ${_quick_flag} 2>/dev/null || _audit_exit=$?
+  else
+    echo "WARN: specialist-audit: Issue 番号が解決できないためスキップ" >&2
+  fi
+
+  if [[ $_audit_exit -ne 0 ]]; then
+    echo "REJECT: specialist-audit FAIL (exit=${_audit_exit})" >&2
+    exit $_audit_exit
+  fi
+  echo "✓ specialist-audit: PASS"
+else
+  echo "WARN: specialist-audit.sh が見つかりません: ${_audit_script}" >&2
 fi

--- a/plugins/twl/scripts/merge-gate-check-spawn.sh
+++ b/plugins/twl/scripts/merge-gate-check-spawn.sh
@@ -50,13 +50,16 @@ if [[ -f "$_audit_script" ]]; then
   fi
 
   # --manifest-file を渡して pr-review-manifest.sh の二重呼び出しを回避
-  _manifest_arg=""
-  [[ -n "${MANIFEST_FILE:-}" && -f "${MANIFEST_FILE:-}" ]] && _manifest_arg="--manifest-file ${MANIFEST_FILE}"
+  # 配列で引数を構築してワードスプリットを防止
+  _manifest_args=()
+  [[ -n "${MANIFEST_FILE:-}" && -f "${MANIFEST_FILE:-}" ]] && _manifest_args=(--manifest-file "${MANIFEST_FILE}")
+  _quick_args=()
+  [[ "$_quick_flag" == "--quick" ]] && _quick_args=(--quick)
 
   _audit_exit=0
   if [[ -n "$_issue_num" ]]; then
     bash "$_audit_script" --issue "$_issue_num" --mode merge-gate \
-      ${_manifest_arg} ${_quick_flag} 2>/dev/null || _audit_exit=$?
+      "${_manifest_args[@]+"${_manifest_args[@]}"}" "${_quick_args[@]+"${_quick_args[@]}"}" 2>/dev/null || _audit_exit=$?
   else
     echo "WARN: specialist-audit: Issue 番号が解決できないためスキップ" >&2
   fi

--- a/plugins/twl/scripts/specialist-audit.sh
+++ b/plugins/twl/scripts/specialist-audit.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# specialist-audit.sh - Worker JSONL から specialist completeness を独立検証
+#
+# 期待集合は pr-review-manifest.sh 経由で動的生成。
+# LLM 自己申告（SPAWNED_FILE）に依存しない独立検証パス。
+#
+# Usage:
+#   specialist-audit.sh --issue <N> [options]
+#   specialist-audit.sh --jsonl <path> [options]
+#
+# Options:
+#   --issue <N>             Issue 番号（JSONL パスを自動解決）
+#   --jsonl <path>          JSONL パスを直接指定（--issue と排他）
+#   --mode <phase>          pr-review-manifest.sh に渡すモード (default: merge-gate)
+#   --manifest-file <path>  既存 MANIFEST_FILE を再利用（pr-review-manifest.sh 二重呼び出しを回避）
+#   --quick                 FAIL を WARN に降格（quick ラベル用）
+#   --warn-only             常に exit 0（bootstrapping 期間用）
+#   --json                  JSON 形式で出力（default）
+#   --summary               サマリのみ出力
+#
+# 環境変数:
+#   SPECIALIST_AUDIT_MODE=warn|strict  (default: warn)
+#   SKIP_SPECIALIST_AUDIT=1            完全スキップ
+#
+# Exit codes:
+#   0 = PASS / WARN
+#   1 = FAIL (missing 非空 かつ strict モード かつ --quick なし かつ --warn-only なし)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- デフォルト値 ---
+ISSUE_NUM=""
+JSONL_PATH=""
+MODE="merge-gate"
+MANIFEST_FILE_ARG=""
+QUICK=false
+WARN_ONLY=false
+OUTPUT_FORMAT="json"
+AUDIT_MODE="${SPECIALIST_AUDIT_MODE:-warn}"
+
+# --- 引数パース ---
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)
+      ISSUE_NUM="$2"; shift 2 ;;
+    --jsonl)
+      JSONL_PATH="$2"; shift 2 ;;
+    --mode)
+      MODE="$2"; shift 2 ;;
+    --manifest-file)
+      MANIFEST_FILE_ARG="$2"; shift 2 ;;
+    --quick)
+      QUICK=true; shift ;;
+    --warn-only)
+      WARN_ONLY=true; shift ;;
+    --json)
+      OUTPUT_FORMAT="json"; shift ;;
+    --summary)
+      OUTPUT_FORMAT="summary"; shift ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      exit 1 ;;
+  esac
+done
+
+# --- SKIP_SPECIALIST_AUDIT チェック ---
+if [[ "${SKIP_SPECIALIST_AUDIT:-}" == "1" ]]; then
+  echo "WARNING: SKIP_SPECIALIST_AUDIT=1 のため specialist-audit をスキップします" >&2
+  mkdir -p ".audit/skip"
+  printf '{"status":"SKIP","reason":"SKIP_SPECIALIST_AUDIT=1"}\n' \
+    >> ".audit/skip/specialist-audit-skip-$(date +%s 2>/dev/null || echo 0)-$$.json"
+  printf '{"status":"SKIP","reason":"SKIP_SPECIALIST_AUDIT=1"}\n'
+  exit 0
+fi
+
+# --- --issue と --jsonl の排他チェック ---
+if [[ -n "$ISSUE_NUM" && -n "$JSONL_PATH" ]]; then
+  echo "ERROR: --issue と --jsonl は排他オプションです" >&2
+  exit 1
+fi
+if [[ -z "$ISSUE_NUM" && -z "$JSONL_PATH" ]]; then
+  echo "ERROR: --issue または --jsonl が必要です" >&2
+  exit 1
+fi
+
+# --- JSONL パス解決（--issue の場合）---
+resolve_jsonl() {
+  local issue="$1"
+
+  # 99文字切り捨て対応: グロブで前方一致検索（worktrees/fix と worktrees/feat の両方）
+  local proj_dir=""
+  for pattern in \
+    "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*-${issue}-*" \
+    "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*${issue}*"; do
+    local found
+    found=$(ls -td $pattern 2>/dev/null | head -1 || echo "")
+    if [[ -n "$found" ]]; then
+      proj_dir="$found"
+      break
+    fi
+  done
+
+  if [[ -z "$proj_dir" ]]; then
+    echo "WARN: プロジェクトディレクトリが見つかりません (issue=${issue})" >&2
+    return 1
+  fi
+
+  if [[ ! -d "$proj_dir" ]]; then
+    echo "WARN: プロジェクトディレクトリが存在しません: $proj_dir" >&2
+    return 1
+  fi
+
+  # Issue 番号を含む JSONL を選択（sequential 実行での競合対策）
+  local selected=""
+  while IFS= read -r jsonl; do
+    if grep -l "Issue #${issue}\|issue-${issue}\|\"#${issue}\"" "$jsonl" >/dev/null 2>&1; then
+      selected="$jsonl"
+      break
+    fi
+  done < <(ls -t "$proj_dir"/*.jsonl 2>/dev/null)
+
+  if [[ -z "$selected" ]]; then
+    # フォールバック: 最新の JSONL を使用
+    selected=$(ls -t "$proj_dir"/*.jsonl 2>/dev/null | head -1 || echo "")
+  fi
+
+  if [[ -z "$selected" ]]; then
+    echo "WARN: JSONL ファイルが見つかりません: $proj_dir" >&2
+    return 1
+  fi
+
+  echo "$selected"
+}
+
+# --- JSONL 解決 ---
+if [[ -n "$ISSUE_NUM" ]]; then
+  resolved_jsonl=""
+  if ! resolved_jsonl=$(resolve_jsonl "$ISSUE_NUM" 2>&1); then
+    warn_msg=$(echo "$resolved_jsonl" | grep -v '^WARN:' || echo "unknown error")
+    out_json="{\"status\":\"WARN\",\"reason\":\"jsonl_resolution_failed\",\"issue\":${ISSUE_NUM},\"detail\":\"${warn_msg}\"}"
+    echo "$out_json"
+    exit 0
+  fi
+  JSONL_PATH="$resolved_jsonl"
+fi
+
+if [[ ! -f "$JSONL_PATH" ]]; then
+  out_json="{\"status\":\"WARN\",\"reason\":\"jsonl_not_found\",\"jsonl\":\"${JSONL_PATH}\",\"issue\":${ISSUE_NUM:-null}}"
+  echo "$out_json"
+  exit 0
+fi
+
+# --- specialist 抽出（actual set）---
+mapfile -t ACTUAL_SPECIALISTS < <(
+  grep -oE '"subagent_type":"twl:twl:worker-[^"]+"' "$JSONL_PATH" 2>/dev/null \
+    | sort -u \
+    | sed 's|^"subagent_type":"twl:twl:||; s|"$||' \
+    || true
+)
+
+# --- 期待集合生成（expected set）---
+EXPECTED_SPECIALISTS=()
+if [[ -n "$MANIFEST_FILE_ARG" && -f "$MANIFEST_FILE_ARG" ]]; then
+  # --manifest-file 再利用（pr-review-manifest.sh 二重呼び出しを回避）
+  mapfile -t EXPECTED_SPECIALISTS < <(
+    grep -v '^#' "$MANIFEST_FILE_ARG" | grep -v '^[[:space:]]*$' | sed 's|^twl:twl:||' | sort -u || true
+  )
+else
+  manifest_script="${CLAUDE_PLUGIN_ROOT:-${SCRIPT_DIR}/..}/scripts/pr-review-manifest.sh"
+  if [[ ! -f "$manifest_script" ]]; then
+    echo "WARN: pr-review-manifest.sh が見つかりません: $manifest_script" >&2
+    out_json="{\"status\":\"WARN\",\"reason\":\"manifest_script_not_found\",\"issue\":${ISSUE_NUM:-null}}"
+    echo "$out_json"
+    exit 0
+  fi
+
+  # ISSUE_NUM を export して worker-issue-pr-alignment の動的判定を揃える
+  if [[ -n "${ISSUE_NUM:-}" ]]; then
+    export ISSUE_NUM
+  fi
+
+  mapfile -t EXPECTED_SPECIALISTS < <(
+    git diff --name-only origin/main 2>/dev/null \
+      | bash "$manifest_script" --mode "$MODE" 2>/dev/null \
+      || true
+  )
+fi
+
+# --- 突合: missing = expected - actual, extra = actual - expected ---
+MISSING=()
+for exp in "${EXPECTED_SPECIALISTS[@]+"${EXPECTED_SPECIALISTS[@]}"}"; do
+  found=false
+  for act in "${ACTUAL_SPECIALISTS[@]+"${ACTUAL_SPECIALISTS[@]}"}"; do
+    [[ "$exp" == "$act" ]] && found=true && break
+  done
+  $found || MISSING+=("$exp")
+done
+
+EXTRA=()
+for act in "${ACTUAL_SPECIALISTS[@]+"${ACTUAL_SPECIALISTS[@]}"}"; do
+  found=false
+  for exp in "${EXPECTED_SPECIALISTS[@]+"${EXPECTED_SPECIALISTS[@]}"}"; do
+    [[ "$act" == "$exp" ]] && found=true && break
+  done
+  $found || EXTRA+=("$act")
+done
+
+# --- status 判定 ---
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+if [[ ${#MISSING[@]} -eq 0 ]]; then
+  STATUS="PASS"
+  EXIT_CODE=0
+else
+  if [[ "$WARN_ONLY" == "true" || "$QUICK" == "true" || "$AUDIT_MODE" == "warn" ]]; then
+    STATUS="WARN"
+    EXIT_CODE=0
+  else
+    STATUS="FAIL"
+    EXIT_CODE=1
+  fi
+fi
+
+# --- JSON 生成（jq が利用可能な場合は使用、なければ手動構築）---
+issue_field="${ISSUE_NUM:-null}"
+
+if command -v jq &>/dev/null; then
+  expected_json=$(printf '%s\n' "${EXPECTED_SPECIALISTS[@]+"${EXPECTED_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+  actual_json=$(printf '%s\n' "${ACTUAL_SPECIALISTS[@]+"${ACTUAL_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+  missing_json=$(printf '%s\n' "${MISSING[@]+"${MISSING[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+  extra_json=$(printf '%s\n' "${EXTRA[@]+"${EXTRA[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+
+  RESULT_JSON=$(jq -n \
+    --arg status "$STATUS" \
+    --argjson issue "$issue_field" \
+    --arg jsonl "$JSONL_PATH" \
+    --arg mode "$MODE" \
+    --argjson expected "$expected_json" \
+    --argjson actual "$actual_json" \
+    --argjson missing "$missing_json" \
+    --argjson extra "$extra_json" \
+    --arg timestamp "$TIMESTAMP" \
+    --arg audit_mode "$AUDIT_MODE" \
+    '{status:$status,issue:$issue,jsonl:$jsonl,mode:$mode,expected:$expected,actual:$actual,missing:$missing,extra:$extra,timestamp:$timestamp,audit_mode:$audit_mode}' \
+    2>/dev/null || echo "{\"status\":\"${STATUS}\",\"error\":\"jq_failed\"}")
+else
+  # jq 非利用時のフォールバック（簡易 JSON）
+  RESULT_JSON="{\"status\":\"${STATUS}\",\"issue\":${issue_field},\"mode\":\"${MODE}\",\"timestamp\":\"${TIMESTAMP}\",\"audit_mode\":\"${AUDIT_MODE}\"}"
+fi
+
+# --- audit ログ保存 ---
+TIMESTAMP_NS=$(date +%s%N 2>/dev/null || date +%s 2>/dev/null || echo "0")
+RUN_ID="${AUDIT_RUN_ID:-$(date +%Y%m%d-%H%M%S 2>/dev/null || echo "unknown")}"
+AUDIT_DIR=".audit/${RUN_ID}"
+mkdir -p "$AUDIT_DIR"
+AUDIT_FILE="${AUDIT_DIR}/specialist-audit-${ISSUE_NUM:-unknown}-${TIMESTAMP_NS}-$$.json"
+echo "$RESULT_JSON" > "$AUDIT_FILE"
+
+# --- 出力 ---
+if [[ "$OUTPUT_FORMAT" == "summary" ]]; then
+  echo "specialist-audit: ${STATUS} (issue=${ISSUE_NUM:-?}, missing=${#MISSING[@]}, actual=${#ACTUAL_SPECIALISTS[@]}/${#EXPECTED_SPECIALISTS[@]})"
+else
+  echo "$RESULT_JSON"
+fi
+
+# --- FAIL 時 stderr 出力 ---
+if [[ "$STATUS" == "FAIL" ]]; then
+  missing_str="${MISSING[*]+"${MISSING[*]}"}"
+  echo "REJECT: specialist-audit FAIL — missing: ${missing_str}" >&2
+fi
+
+exit $EXIT_CODE

--- a/plugins/twl/scripts/specialist-audit.sh
+++ b/plugins/twl/scripts/specialist-audit.sh
@@ -85,18 +85,28 @@ if [[ -z "$ISSUE_NUM" && -z "$JSONL_PATH" ]]; then
   exit 1
 fi
 
+# --- ISSUE_NUM 数値検証（CRITICAL: コマンドインジェクション防止）---
+if [[ -n "$ISSUE_NUM" && ! "$ISSUE_NUM" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --issue は数値のみ指定可能です: ${ISSUE_NUM}" >&2
+  exit 1
+fi
+
 # --- JSONL パス解決（--issue の場合）---
 resolve_jsonl() {
   local issue="$1"
 
   # 99文字切り捨て対応: グロブで前方一致検索（worktrees/fix と worktrees/feat の両方）
+  # ISSUE_NUM は呼び出し前に数値検証済みのため安全にグロブ展開可能
   local proj_dir=""
+  local -a glob_matches=()
   for pattern in \
     "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*-${issue}-*" \
     "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*${issue}*"; do
-    local found
-    found=$(ls -td $pattern 2>/dev/null | head -1 || echo "")
-    if [[ -n "$found" ]]; then
+    glob_matches=("$pattern")  # nullglob 未設定時はリテラルが残る
+    # ls で実在確認（グロブが展開されたかチェック）
+    local found=""
+    found=$(ls -td "$pattern" 2>/dev/null | head -1 || echo "")
+    if [[ -n "$found" && -d "$found" ]]; then
       proj_dir="$found"
       break
     fi
@@ -137,12 +147,21 @@ resolve_jsonl() {
 # --- JSONL 解決 ---
 if [[ -n "$ISSUE_NUM" ]]; then
   resolved_jsonl=""
-  if ! resolved_jsonl=$(resolve_jsonl "$ISSUE_NUM" 2>&1); then
-    warn_msg=$(echo "$resolved_jsonl" | grep -v '^WARN:' || echo "unknown error")
-    out_json="{\"status\":\"WARN\",\"reason\":\"jsonl_resolution_failed\",\"issue\":${ISSUE_NUM},\"detail\":\"${warn_msg}\"}"
+  _resolve_err=""
+  # stderr と stdout を分離（2>&1 で混入させない）
+  resolved_jsonl=$(resolve_jsonl "$ISSUE_NUM" 2>/tmp/_specialist_audit_err_$$) || {
+    _resolve_err=$(cat /tmp/_specialist_audit_err_$$ 2>/dev/null || echo "unknown error")
+    rm -f /tmp/_specialist_audit_err_$$
+    if command -v jq &>/dev/null; then
+      out_json=$(jq -n --argjson issue "$ISSUE_NUM" --arg detail "$_resolve_err" \
+        '{"status":"WARN","reason":"jsonl_resolution_failed","issue":$issue,"detail":$detail}')
+    else
+      out_json="{\"status\":\"WARN\",\"reason\":\"jsonl_resolution_failed\",\"issue\":${ISSUE_NUM}}"
+    fi
     echo "$out_json"
     exit 0
-  fi
+  }
+  rm -f /tmp/_specialist_audit_err_$$
   JSONL_PATH="$resolved_jsonl"
 fi
 
@@ -252,6 +271,10 @@ fi
 # --- audit ログ保存 ---
 TIMESTAMP_NS=$(date +%s%N 2>/dev/null || date +%s 2>/dev/null || echo "0")
 RUN_ID="${AUDIT_RUN_ID:-$(date +%Y%m%d-%H%M%S 2>/dev/null || echo "unknown")}"
+# CRITICAL: AUDIT_RUN_ID のパストラバーサル防止（英数字・ハイフン・アンダースコアのみ許可）
+if [[ ! "$RUN_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+  RUN_ID="$(date +%Y%m%d-%H%M%S 2>/dev/null || echo "fallback")"
+fi
 AUDIT_DIR=".audit/${RUN_ID}"
 mkdir -p "$AUDIT_DIR"
 AUDIT_FILE="${AUDIT_DIR}/specialist-audit-${ISSUE_NUM:-unknown}-${TIMESTAMP_NS}-$$.json"

--- a/plugins/twl/scripts/specialist-audit.sh
+++ b/plugins/twl/scripts/specialist-audit.sh
@@ -97,15 +97,14 @@ resolve_jsonl() {
 
   # 99文字切り捨て対応: グロブで前方一致検索（worktrees/fix と worktrees/feat の両方）
   # ISSUE_NUM は呼び出し前に数値検証済みのため安全にグロブ展開可能
+  # ls -td の引数はクォートなしでシェルのグロブ展開を有効化する（クォートするとリテラル扱い）
   local proj_dir=""
-  local -a glob_matches=()
   for pattern in \
     "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*-${issue}-*" \
     "$HOME/.claude/projects/-home-shuu5-projects-local-projects-twill-worktrees-*${issue}*"; do
-    glob_matches=("$pattern")  # nullglob 未設定時はリテラルが残る
-    # ls で実在確認（グロブが展開されたかチェック）
     local found=""
-    found=$(ls -td "$pattern" 2>/dev/null | head -1 || echo "")
+    # shellcheck disable=SC2086  # クォートなし展開でグロブを有効化（ISSUE_NUM は数値検証済み）
+    found=$(ls -td $pattern 2>/dev/null | head -1 || echo "")
     if [[ -n "$found" && -d "$found" ]]; then
       proj_dir="$found"
       break
@@ -146,12 +145,16 @@ resolve_jsonl() {
 
 # --- JSONL 解決 ---
 if [[ -n "$ISSUE_NUM" ]]; then
+  _err_file="/tmp/_specialist_audit_err_$$"
+  # EXIT 時に一時ファイルを確実にクリーンアップ
+  trap 'rm -f "$_err_file"' EXIT
   resolved_jsonl=""
   _resolve_err=""
   # stderr と stdout を分離（2>&1 で混入させない）
-  resolved_jsonl=$(resolve_jsonl "$ISSUE_NUM" 2>/tmp/_specialist_audit_err_$$) || {
-    _resolve_err=$(cat /tmp/_specialist_audit_err_$$ 2>/dev/null || echo "unknown error")
-    rm -f /tmp/_specialist_audit_err_$$
+  resolved_jsonl=$(resolve_jsonl "$ISSUE_NUM" 2>"$_err_file") || {
+    _resolve_err=$(cat "$_err_file" 2>/dev/null || echo "unknown error")
+    rm -f "$_err_file"
+    trap - EXIT
     if command -v jq &>/dev/null; then
       out_json=$(jq -n --argjson issue "$ISSUE_NUM" --arg detail "$_resolve_err" \
         '{"status":"WARN","reason":"jsonl_resolution_failed","issue":$issue,"detail":$detail}')
@@ -161,7 +164,8 @@ if [[ -n "$ISSUE_NUM" ]]; then
     echo "$out_json"
     exit 0
   }
-  rm -f /tmp/_specialist_audit_err_$$
+  rm -f "$_err_file"
+  trap - EXIT
   JSONL_PATH="$resolved_jsonl"
 fi
 

--- a/plugins/twl/scripts/specialist-audit.sh
+++ b/plugins/twl/scripts/specialist-audit.sh
@@ -30,6 +30,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+if ! command -v jq &>/dev/null; then
+  echo "ERROR: jq が必要です (apt install jq)" >&2
+  exit 1
+fi
+
 # --- デフォルト値 ---
 ISSUE_NUM=""
 JSONL_PATH=""
@@ -245,32 +250,26 @@ else
   fi
 fi
 
-# --- JSON 生成（jq が利用可能な場合は使用、なければ手動構築）---
+# --- JSON 生成 ---
 issue_field="${ISSUE_NUM:-null}"
 
-if command -v jq &>/dev/null; then
-  expected_json=$(printf '%s\n' "${EXPECTED_SPECIALISTS[@]+"${EXPECTED_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
-  actual_json=$(printf '%s\n' "${ACTUAL_SPECIALISTS[@]+"${ACTUAL_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
-  missing_json=$(printf '%s\n' "${MISSING[@]+"${MISSING[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
-  extra_json=$(printf '%s\n' "${EXTRA[@]+"${EXTRA[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+expected_json=$(printf '%s\n' "${EXPECTED_SPECIALISTS[@]+"${EXPECTED_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+actual_json=$(printf '%s\n' "${ACTUAL_SPECIALISTS[@]+"${ACTUAL_SPECIALISTS[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+missing_json=$(printf '%s\n' "${MISSING[@]+"${MISSING[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
+extra_json=$(printf '%s\n' "${EXTRA[@]+"${EXTRA[@]}"}" | jq -R . | jq -s . 2>/dev/null || echo '[]')
 
-  RESULT_JSON=$(jq -n \
-    --arg status "$STATUS" \
-    --argjson issue "$issue_field" \
-    --arg jsonl "$JSONL_PATH" \
-    --arg mode "$MODE" \
-    --argjson expected "$expected_json" \
-    --argjson actual "$actual_json" \
-    --argjson missing "$missing_json" \
-    --argjson extra "$extra_json" \
-    --arg timestamp "$TIMESTAMP" \
-    --arg audit_mode "$AUDIT_MODE" \
-    '{status:$status,issue:$issue,jsonl:$jsonl,mode:$mode,expected:$expected,actual:$actual,missing:$missing,extra:$extra,timestamp:$timestamp,audit_mode:$audit_mode}' \
-    2>/dev/null || echo "{\"status\":\"${STATUS}\",\"error\":\"jq_failed\"}")
-else
-  # jq 非利用時のフォールバック（簡易 JSON）
-  RESULT_JSON="{\"status\":\"${STATUS}\",\"issue\":${issue_field},\"mode\":\"${MODE}\",\"timestamp\":\"${TIMESTAMP}\",\"audit_mode\":\"${AUDIT_MODE}\"}"
-fi
+RESULT_JSON=$(jq -n \
+  --arg status "$STATUS" \
+  --argjson issue "$issue_field" \
+  --arg jsonl "$JSONL_PATH" \
+  --arg mode "$MODE" \
+  --argjson expected "$expected_json" \
+  --argjson actual "$actual_json" \
+  --argjson missing "$missing_json" \
+  --argjson extra "$extra_json" \
+  --arg timestamp "$TIMESTAMP" \
+  --arg audit_mode "$AUDIT_MODE" \
+  '{status:$status,issue:$issue,jsonl:$jsonl,mode:$mode,expected:$expected,actual:$actual,missing:$missing,extra:$extra,timestamp:$timestamp,audit_mode:$audit_mode}')
 
 # --- audit ログ保存 ---
 TIMESTAMP_NS=$(date +%s%N 2>/dev/null || date +%s 2>/dev/null || echo "0")

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -370,6 +370,7 @@ Issue 群の一括実装（Wave）を要求された場合:
    - **specialist completeness 監査（SHOULD）**: audit snapshot 直後に Wave 内の全 Issue を一括監査する。bootstrapping 期間中（`SPECIALIST_AUDIT_MODE=warn`）は常に exit 0 のため merge を阻害しない。結果を `.audit/wave-${WAVE_NUM}/specialist-audit.log` に追記し、FAIL 行があれば次 Wave の手動調査対象としてログに記録する。
      ```bash
      # Wave 内の全 Issue について specialist completeness を監査
+     # JSON 出力でログに記録し、"status":"FAIL" を検出可能にする（--summary を使わない）
      _audit_log=".audit/wave-${WAVE_NUM}/specialist-audit.log"
      mkdir -p ".audit/wave-${WAVE_NUM}"
      for issue_json in "${AUTOPILOT_DIR:-.autopilot}"/issues/issue-*.json; do
@@ -377,12 +378,13 @@ Issue 群の一括実装（Wave）を要求された場合:
        _issue_num=$(basename "$issue_json" | sed 's/issue-\([0-9]*\)\.json/\1/')
        # quick ラベル判定
        _is_quick=$(python3 -m twl.autopilot.state read --type issue --issue "$_issue_num" --field is_quick 2>/dev/null || echo "false")
-       _qflag=""; [[ "$_is_quick" == "true" ]] && _qflag="--quick"
+       _qflag=(); [[ "$_is_quick" == "true" ]] && _qflag=(--quick)
+       # --warn-only で merge を阻害しない。JSON 出力でログに記録（--summary を使わず FAIL 検出可能にする）
        bash "${CLAUDE_PLUGIN_ROOT:-plugins/twl}/scripts/specialist-audit.sh" \
-         --issue "$_issue_num" --summary --warn-only ${_qflag} \
+         --issue "$_issue_num" --warn-only "${_qflag[@]+"${_qflag[@]}"}" \
          >> "$_audit_log" 2>&1 || true
      done
-     # FAIL 行の検出（warn-only のため exit 0 だが内容確認）
+     # FAIL 行の検出（--warn-only で exit 0 だが JSON の "status":"FAIL" で識別）
      if grep -q '"status":"FAIL"' "$_audit_log" 2>/dev/null; then
        echo "WARN: specialist-audit に FAIL あり — ${_audit_log} を確認してください" >&2
      fi

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -367,6 +367,26 @@ Issue 群の一括実装（Wave）を要求された場合:
    - `commands/wave-collect.md` を Read → 実行（`WAVE_NUM=<N>`）
    - `commands/externalize-state.md` を Read → 実行（`--trigger wave_complete`）
    - **audit snapshot（SHOULD）**: `twl audit snapshot --source-dir "${AUTOPILOT_DIR:-.autopilot}" --label "wave/${WAVE_NUM}"` を実行する（audit 非アクティブ時は自動 no-op）
+   - **specialist completeness 監査（SHOULD）**: audit snapshot 直後に Wave 内の全 Issue を一括監査する。bootstrapping 期間中（`SPECIALIST_AUDIT_MODE=warn`）は常に exit 0 のため merge を阻害しない。結果を `.audit/wave-${WAVE_NUM}/specialist-audit.log` に追記し、FAIL 行があれば次 Wave の手動調査対象としてログに記録する。
+     ```bash
+     # Wave 内の全 Issue について specialist completeness を監査
+     _audit_log=".audit/wave-${WAVE_NUM}/specialist-audit.log"
+     mkdir -p ".audit/wave-${WAVE_NUM}"
+     for issue_json in "${AUTOPILOT_DIR:-.autopilot}"/issues/issue-*.json; do
+       [[ -f "$issue_json" ]] || continue
+       _issue_num=$(basename "$issue_json" | sed 's/issue-\([0-9]*\)\.json/\1/')
+       # quick ラベル判定
+       _is_quick=$(python3 -m twl.autopilot.state read --type issue --issue "$_issue_num" --field is_quick 2>/dev/null || echo "false")
+       _qflag=""; [[ "$_is_quick" == "true" ]] && _qflag="--quick"
+       bash "${CLAUDE_PLUGIN_ROOT:-plugins/twl}/scripts/specialist-audit.sh" \
+         --issue "$_issue_num" --summary --warn-only ${_qflag} \
+         >> "$_audit_log" 2>&1 || true
+     done
+     # FAIL 行の検出（warn-only のため exit 0 だが内容確認）
+     if grep -q '"status":"FAIL"' "$_audit_log" 2>/dev/null; then
+       echo "WARN: specialist-audit に FAIL あり — ${_audit_log} を確認してください" >&2
+     fi
+     ```
    - **イベントファイル一括クリーンアップ（MUST）**: externalize-state 実行後に `.supervisor/events/` 配下の全ファイルを削除する:
      ```bash
      rm -f .supervisor/events/* 2>/dev/null || true


### PR DESCRIPTION
## 概要

Worker JSONL を直読みして specialist completeness を独立検証する自動監査システムを実装。#722 事故（specialist review 0 件で auto merge）の再発防止。

## 変更内容

- `plugins/twl/scripts/specialist-audit.sh` 新規作成: JSONL 直読み監査ツール
- `plugins/twl/scripts/merge-gate-check-spawn.sh` 拡張: JSONL 独立検証をマージゲートに統合
- `plugins/twl/skills/su-observer/SKILL.md` 更新: Wave 完了時の一括監査を追加

## bootstrapping 戦略

初回 PR では `SPECIALIST_AUDIT_MODE=warn`（デフォルト）で全 FAIL を WARN に降格。3 Wave 以上 FAIL なしが続いたら `SPECIALIST_AUDIT_MODE=strict` に切替（follow-up Issue）。

Closes #740