### PR TITLE
fix: supervisor hook に non-bare graceful degradation を追加（#728）

### DIFF
--- a/deltaspec/changes/issue-728/design.md
+++ b/deltaspec/changes/issue-728/design.md
@@ -1,0 +1,43 @@
+# Design: supervisor hook non-bare graceful degradation
+
+## Goals
+
+- supervisor hook 5 本（heartbeat, input-wait, input-clear, skill-step, session-end）に bare repo 構造判定ガードを追加し、non-bare 検出時は exit 0 で no-op 終了させる
+- architecture spec（vision.md + supervision.md）に bare repo 前提制約を明文化し、architectural constraint として文書化する
+
+## Non-Goals
+
+- 通常 git リポジトリ（`.git/` のみ）への完全対応実装（architecture constraint により Non-Goal）
+- Issue #725 の AC 文言の retroactive 書き換え
+- SESSION_ID サニタイズ（別 Issue #729）
+- `run_hook_with_autopilot()` 関数名乖離の修正（別 Issue #730）
+- テスト副作用の解消（別 Issue #731）
+- ADR 新規作成
+
+## 変更点一覧
+
+| ファイル | 変更内容 |
+|----------|---------|
+| `plugins/twl/scripts/hooks/supervisor-heartbeat.sh` | bare repo 構造ガード追加 + コメント統一 |
+| `plugins/twl/scripts/hooks/supervisor-input-wait.sh` | bare repo 構造ガード追加 + コメント統一 |
+| `plugins/twl/scripts/hooks/supervisor-input-clear.sh` | bare repo 構造ガード追加 + コメント統一 |
+| `plugins/twl/scripts/hooks/supervisor-skill-step.sh` | bare repo 構造ガード追加 + コメント統一 |
+| `plugins/twl/scripts/hooks/supervisor-session-end.sh` | bare repo 構造ガード追加 + コメント統一 |
+| `plugins/twl/architecture/vision.md` | Constraints 節末尾に supervisor hook の bare repo 前提を 1 行追記 |
+| `plugins/twl/architecture/domain/contexts/supervision.md` | SU-* 表末尾に SU-8 を新規追加 |
+| `plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh` | non-bare 検出テストケース 5 件追加 |
+
+## ガード実装パターン
+
+```bash
+# bare repo 構造（main/ 存在）でなければ no-op
+GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
+  exit 0
+fi
+```
+
+判定に `[[ -d ... ]]` を採用した理由：bare + worktree 構造・non-bare のどちらでも副作用なく正確に分岐できる。`git rev-parse --is-bare-repository` は worktree から実行すると `false` を返すため不採用。

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -192,6 +192,7 @@ flowchart TD
 | SU-6a | Wave 完了時に結果収集と externalize-state を実行しなければならない（SHALL） | SU-6 分割（#498） |
 | SU-6b | context 逼迫時またはユーザー指示時に /compact をユーザーへ提案しなければならない（SHOULD） | built-in CLI のためユーザー手動実行 |
 | SU-7 | observed session への inject/send-keys は介入プロトコルに従う場合に許可（MAY） | OB-3 廃止に対応 |
+| SU-8 | supervisor hook は bare repo 構造（main/ がディレクトリとして存在すること）を前提とし、non-bare 検出時は no-op で exit 0 する（SHALL） | #728 |
 
 ### OB-* Constraints との関係
 

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -25,6 +25,7 @@
 | Spec Implementation | Architecture spec（`architecture/` 配下のドキュメント）の変更・PR 作成を担う controller カテゴリ。co-architect のみ該当。Implementation（コード変更）とは区別される（ADR-019） | 全体 |
 | DCI | Dynamic Context Injection。実行時にファイルを Read してコンテキストに注入するパターン | 全体 |
 | CRG | Code Review Graph。MCP 経由でコード依存関係を可視化・分析するツール | TWiLL Integration |
+| graceful degradation | 対応外環境（non-bare git リポ等）で機能を完全に停止せず、no-op（exit 0）で安全に終了する設計パターン。supervisor hook がその実装例（SU-8） | Supervision |
 | Supervisor | プロジェクト常駐のメタ認知レイヤー。全 controller を監視・調整・知識外部化する上位層（ADR-014） | Supervision |
 | su-observer | Supervisor 型の唯一のコンポーネント（ADR-014 で observer 型から再定義）。main session そのものとして機能し、controller を spawn → observe する。Observer（read-only）とは異なり介入権限を持つ | Supervision |
 | SupervisorSession | su-observer のプロジェクト常駐セッション状態。Wave 管理・介入記録・記憶予算を追跡 | Supervision |

--- a/plugins/twl/architecture/vision.md
+++ b/plugins/twl/architecture/vision.md
@@ -13,6 +13,7 @@ chain-driven + autopilot-first アーキテクチャに基づく Claude Code 開
 - **Project Board 必須**（ADR-006）: 全プロジェクトで GitHub Projects V2 を使用。autopilot の Issue 選択元、ステータス同期先
 - **クロスリポジトリ対応**（ADR-007）: twill-ecosystem プロジェクトで複数リポを統合管理
 - Emergency Bypass: co-autopilot 障害時のみ手動パス許可（retrospective 記録義務あり）
+- supervisor hook の EVENTS_DIR 解決は bare repo 構造（`.bare/` + `main/`）を前提とし、non-bare では graceful degradation（no-op）
 
 ### Controller 操作カテゴリ
 

--- a/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
+++ b/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
@@ -6,9 +6,12 @@ set -uo pipefail
 # stdin を消費
 INPUT=$(cat 2>/dev/null || echo "")
 
-# git リポジトリ内でなければ何もしない（git 外セッションは静かに終了）
+# bare repo 構造（main/ 存在）でなければ no-op
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 

--- a/plugins/twl/scripts/hooks/supervisor-input-clear.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-clear.sh
@@ -6,9 +6,12 @@ set -uo pipefail
 # stdin を消費
 INPUT=$(cat 2>/dev/null || echo "")
 
-# git リポジトリ内でなければ何もしない（git 外セッションは静かに終了）
+# bare repo 構造（main/ 存在）でなければ no-op
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 

--- a/plugins/twl/scripts/hooks/supervisor-input-wait.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-wait.sh
@@ -6,9 +6,12 @@ set -uo pipefail
 # stdin を消費
 INPUT=$(cat 2>/dev/null || echo "")
 
-# git リポジトリ内でなければ何もしない（git 外セッションは静かに終了）
+# bare repo 構造（main/ 存在）でなければ no-op
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 

--- a/plugins/twl/scripts/hooks/supervisor-session-end.sh
+++ b/plugins/twl/scripts/hooks/supervisor-session-end.sh
@@ -6,9 +6,12 @@ set -uo pipefail
 # stdin を消費
 INPUT=$(cat 2>/dev/null || echo "")
 
-# git リポジトリ内でなければ何もしない（git 外セッションは静かに終了）
+# bare repo 構造（main/ 存在）でなければ no-op
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 

--- a/plugins/twl/scripts/hooks/supervisor-skill-step.sh
+++ b/plugins/twl/scripts/hooks/supervisor-skill-step.sh
@@ -7,9 +7,12 @@ set -uo pipefail
 # stdin を消費
 INPUT=$(cat 2>/dev/null || echo "")
 
-# git リポジトリ内でなければ何もしない（git 外セッションは静かに終了）
+# bare repo 構造（main/ 存在）でなければ no-op
 GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
 if [[ -z "$GIT_COMMON_DIR" ]]; then
+  exit 0
+fi
+if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 

--- a/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
+++ b/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
@@ -118,7 +118,7 @@ run_hook_in_non_bare() {
   local non_bare_dir
   non_bare_dir=$(mktemp -d)
   (
-    cd "$non_bare_dir" && git init -q 2>/dev/null
+    cd "$non_bare_dir" && git init -q 2>/dev/null &&
     printf '%s' "$input_json" | env -u AUTOPILOT_DIR bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
   )
   local rc=$?
@@ -425,6 +425,23 @@ test_session_end_non_bare_exit_zero() {
   [[ $? -eq 0 ]] || return 1
 }
 
+# AC-2b: non-bare 環境で .supervisor/events/ への書き込みが発生しないことを明示検証
+test_heartbeat_non_bare_no_events_written() {
+  local non_bare_dir
+  non_bare_dir=$(mktemp -d)
+  local result=0
+  (
+    cd "$non_bare_dir" && git init -q 2>/dev/null &&
+    printf '{"session_id":"nb-ac2b"}' | env -u AUTOPILOT_DIR bash "${HOOKS_DIR}/supervisor-heartbeat.sh" 2>/dev/null
+  )
+  # .supervisor/ ディレクトリが作成されていないことを確認
+  [[ ! -d "${non_bare_dir}/.supervisor" ]] || result=1
+  # main/.supervisor/events/ も作成されていないことを確認
+  [[ ! -d "${non_bare_dir}/main/.supervisor/events" ]] || result=1
+  rm -rf "$non_bare_dir" 2>/dev/null
+  return $result
+}
+
 # =============================================================================
 # 実行
 # =============================================================================
@@ -468,6 +485,7 @@ run_test "input-wait: non-bare リポジトリで exit 0（no-op）" test_input_
 run_test "input-clear: non-bare リポジトリで exit 0（no-op）" test_input_clear_non_bare_exit_zero
 run_test "skill-step: non-bare リポジトリで exit 0（no-op）" test_skill_step_non_bare_exit_zero
 run_test "session-end: non-bare リポジトリで exit 0（no-op）" test_session_end_non_bare_exit_zero
+run_test "heartbeat: non-bare で .supervisor/events/ への書き込みなし（AC-2b）" test_heartbeat_non_bare_no_events_written
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"

--- a/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
+++ b/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
@@ -110,6 +110,22 @@ run_hook_in_git_repo_no_autopilot() {
   printf '%s' "$input_json" | env -u AUTOPILOT_DIR bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
 }
 
+# non-bare git リポジトリ（.git/ のみ、main/ 不在）から hook を実行
+# AC-1/AC-2a/AC-2b 用: git init サンドボックスで bare repo 構造ガードを検証
+run_hook_in_non_bare() {
+  local hook_script="$1"
+  local input_json="${2:-{}}"
+  local non_bare_dir
+  non_bare_dir=$(mktemp -d)
+  (
+    cd "$non_bare_dir" && git init -q 2>/dev/null
+    printf '%s' "$input_json" | env -u AUTOPILOT_DIR bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
+  )
+  local rc=$?
+  rm -rf "$non_bare_dir" 2>/dev/null
+  return $rc
+}
+
 # =============================================================================
 # supervisor-heartbeat.sh テスト
 # =============================================================================
@@ -380,6 +396,36 @@ test_session_end_no_stdout() {
 }
 
 # =============================================================================
+# non-bare 検出テスト（AC-1/AC-2a/AC-2b: bare repo 構造ガード）
+# サンドボックス: git init のみ（.git/ 構造）、main/ ディレクトリなし
+# =============================================================================
+
+test_heartbeat_non_bare_exit_zero() {
+  run_hook_in_non_bare "supervisor-heartbeat.sh" '{"session_id":"nb-heartbeat"}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+test_input_wait_non_bare_exit_zero() {
+  run_hook_in_non_bare "supervisor-input-wait.sh" '{"session_id":"nb-input-wait"}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+test_input_clear_non_bare_exit_zero() {
+  run_hook_in_non_bare "supervisor-input-clear.sh" '{"session_id":"nb-input-clear"}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+test_skill_step_non_bare_exit_zero() {
+  run_hook_in_non_bare "supervisor-skill-step.sh" '{"session_id":"nb-skill-step","tool_input":{"skill":"test"}}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+test_session_end_non_bare_exit_zero() {
+  run_hook_in_non_bare "supervisor-session-end.sh" '{"session_id":"nb-session-end"}'
+  [[ $? -eq 0 ]] || return 1
+}
+
+# =============================================================================
 # 実行
 # =============================================================================
 
@@ -415,6 +461,13 @@ run_test "session-end: AUTOPILOT_DIR 未設定 + git 内でイベントファイ
 run_test "session-end: git 外セッションで exit 0（静的終了）" test_session_end_no_autopilot_dir
 run_test "session-end: イベントファイル生成と JSON フォーマット（AUTOPILOT_DIR あり）" test_session_end_creates_event_file
 run_test "session-end: stdout に何も出力しない" test_session_end_no_stdout
+
+# non-bare 検出（AC-1/AC-2a: bare repo 構造ガード）
+run_test "heartbeat: non-bare リポジトリで exit 0（no-op）" test_heartbeat_non_bare_exit_zero
+run_test "input-wait: non-bare リポジトリで exit 0（no-op）" test_input_wait_non_bare_exit_zero
+run_test "input-clear: non-bare リポジトリで exit 0（no-op）" test_input_clear_non_bare_exit_zero
+run_test "skill-step: non-bare リポジトリで exit 0（no-op）" test_skill_step_non_bare_exit_zero
+run_test "session-end: non-bare リポジトリで exit 0（no-op）" test_session_end_non_bare_exit_zero
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
fix: supervisor hook に non-bare graceful degradation を追加（#728）

- supervisor hook 5 本に bare repo 構造ガード（-d main/ 判定）を追加
- non-bare 検出時は exit 0 で no-op 終了（AC-1/AC-2a/AC-2b）
- bare repo 構造では従来通り events/ に書き込み（AC-3 後方互換）
- plugins/twl/architecture/vision.md Constraints 末尾に 1 行追記（AC-4）
- supervision.md SU-* 表末尾に SU-8 を新規追加（AC-5）
- supervisor-event-emission-hooks.test.sh に non-bare テスト 5 件追加（AC-6）
- 各 hook コメントを「bare repo 構造でなければ no-op」に統一（AC-7）
- deltaspec/changes/issue-728/design.md 作成（AC-8）

Closes #728