### PR TITLE
fix(#731): supervisor hook に TWL_SUPERVISOR_EVENTS_DIR override 追加、テスト sandbox 移行

### DIFF
--- a/plugins/twl/deltaspec/changes/issue-731/design.md
+++ b/plugins/twl/deltaspec/changes/issue-731/design.md
@@ -1,0 +1,46 @@
+## Goals
+
+supervisor hook のテストが production の `main/.supervisor/events/` に直接書き込む副作用を解消する。
+
+- su-observer 稼働中の dev 環境での誤イベント処理リスクを排除
+- CI 並行実行時の race condition と orphan ファイル残留リスクを排除
+- テスト異常終了（SIGINT / disk full）時の production 汚染リスクを排除
+
+## 採用方式
+
+**(b) env override 採用**: フック側に `TWL_SUPERVISOR_EVENTS_DIR` 環境変数による override 機構を追加。
+
+```bash
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
+```
+
+- `:-` bash パラメータ展開で空文字列と unset を同等扱い（誤設定時の fallback 保証）
+- bare repo 構造ガード（`#728`）の後段に配置し、override が bare チェックを bypass しない設計
+- hook ヘッダーコメントで `TEST-ONLY` を明記し production への env leak を抑止
+
+## 変更点サマリ
+
+### hook 側（5 本）
+
+| ファイル | 変更内容 |
+|---|---|
+| `supervisor-heartbeat.sh` | `EVENTS_DIR` を `:-` 形式で override 可能に変更 + TEST-ONLY コメント追加 |
+| `supervisor-input-wait.sh` | 同上 |
+| `supervisor-input-clear.sh` | 同上 |
+| `supervisor-skill-step.sh` | 同上 |
+| `supervisor-session-end.sh` | 同上 |
+
+### テスト側
+
+| 変更内容 | 詳細 |
+|---|---|
+| sandbox 移行 | `setup_sandbox()` で `export TWL_SUPERVISOR_EVENTS_DIR="${SANDBOX}/.supervisor/events"` |
+| AC-3 副作用検証 | `run_test()` 内で `find $GIT_EVENTS_DIR -newer test_start_marker` により production 汚染を自動検証 |
+| AC-6 異常終了耐性 | `trap teardown_sandbox INT TERM EXIT` で強制中断時も sandbox cleanup を保証 |
+| semantic bug 修正 | `run_hook_with_autopilot()` の誤った AUTOPILOT_DIR→EVENTS_DIR override 説明を削除 |
+| `cleanup_git_event_file()` 廃止 | teardown_sandbox の `rm -rf` で網羅されるため削除 |
+
+### DeltaSpec
+
+- `plugins/twl/deltaspec/changes/issue-731/design.md`（本ファイル）を新規作成

--- a/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
+++ b/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
@@ -15,8 +15,8 @@ if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 
-# イベントディレクトリ（main/.supervisor/events/）
-EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
 mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
 
 # session_id 取得: stdin JSON → CLAUDE_SESSION_ID 環境変数 → PID フォールバック

--- a/plugins/twl/scripts/hooks/supervisor-input-clear.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-clear.sh
@@ -15,8 +15,8 @@ if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 
-# イベントディレクトリ（main/.supervisor/events/）
-EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
 
 # session_id 取得
 SESSION_ID=""

--- a/plugins/twl/scripts/hooks/supervisor-input-wait.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-wait.sh
@@ -15,8 +15,8 @@ if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 
-# イベントディレクトリ（main/.supervisor/events/）
-EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
 mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
 
 # session_id 取得

--- a/plugins/twl/scripts/hooks/supervisor-session-end.sh
+++ b/plugins/twl/scripts/hooks/supervisor-session-end.sh
@@ -15,8 +15,8 @@ if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 
-# イベントディレクトリ（main/.supervisor/events/）
-EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
 mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
 
 # session_id 取得

--- a/plugins/twl/scripts/hooks/supervisor-skill-step.sh
+++ b/plugins/twl/scripts/hooks/supervisor-skill-step.sh
@@ -16,8 +16,8 @@ if [[ ! -d "${GIT_COMMON_DIR}/../main" ]]; then
   exit 0
 fi
 
-# イベントディレクトリ（main/.supervisor/events/）
-EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
+# TEST-ONLY: TWL_SUPERVISOR_EVENTS_DIR は test sandbox 専用。production で set しないこと
+EVENTS_DIR="${TWL_SUPERVISOR_EVENTS_DIR:-${GIT_COMMON_DIR}/../main/.supervisor/events}"
 mkdir -p "$EVENTS_DIR" 2>/dev/null || exit 0
 
 # session_id 取得

--- a/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
+++ b/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
@@ -2,7 +2,7 @@
 # =============================================================================
 # Functional Tests: supervisor-event-emission-hooks
 # Tests the behavior of scripts/hooks/supervisor-*.sh
-# Coverage: AUTOPILOT_DIR 設定あり/なし、git repo 内/外、JSON フォーマット検証、exit 0 保証
+# Coverage: sandbox 書き込み分離、git repo 内/外、JSON フォーマット検証、exit 0 保証
 # =============================================================================
 set -uo pipefail
 
@@ -18,9 +18,12 @@ AUTOPILOT_DIR_TEST=""
 EVENTS_DIR_TEST=""
 SUPERVISOR_DIR_TEST=""
 
-# git-common-dir ベースのイベントディレクトリ（fix後の新しい書き込み先）
+# git-common-dir ベースの変数（skip 判定と AC-3 用）
 GIT_COMMON_DIR=""
 GIT_EVENTS_DIR=""
+
+# AC-6: 異常終了でも teardown_sandbox が走るよう trap を設定
+trap teardown_sandbox INT TERM EXIT
 
 setup_sandbox() {
   SANDBOX=$(mktemp -d)
@@ -29,13 +32,17 @@ setup_sandbox() {
   EVENTS_DIR_TEST="${SUPERVISOR_DIR_TEST}/events"
   mkdir -p "$AUTOPILOT_DIR_TEST"
   mkdir -p "$EVENTS_DIR_TEST"
-  # git-common-dir からイベントディレクトリを解決
+  # hook の書き込み先を sandbox に向ける（AC-2: production 汚染防止）
+  export TWL_SUPERVISOR_EVENTS_DIR="${SANDBOX}/.supervisor/events"
+  # git-common-dir からイベントディレクトリを解決（skip 判定と AC-3 用）
   GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
   if [[ -n "$GIT_COMMON_DIR" ]]; then
     GIT_EVENTS_DIR="${GIT_COMMON_DIR}/../main/.supervisor/events"
   else
     GIT_EVENTS_DIR=""
   fi
+  # AC-3: 副作用検証用マーカー
+  touch "${SANDBOX}/test_start_marker"
 }
 
 teardown_sandbox() {
@@ -48,15 +55,7 @@ teardown_sandbox() {
   SUPERVISOR_DIR_TEST=""
   GIT_COMMON_DIR=""
   GIT_EVENTS_DIR=""
-}
-
-# テスト生成ファイルを git-events-dir からクリーンアップ
-cleanup_git_event_file() {
-  local filename="$1"
-  if [[ -n "$GIT_EVENTS_DIR" ]]; then
-    rm -f "${GIT_EVENTS_DIR}/${filename}" 2>/dev/null || true
-    rm -f "${GIT_EVENTS_DIR}/${filename}.tmp."* 2>/dev/null || true
-  fi
+  unset TWL_SUPERVISOR_EVENTS_DIR 2>/dev/null || true
 }
 
 run_test() {
@@ -66,6 +65,15 @@ run_test() {
   setup_sandbox
   result=0
   $func || result=$?
+  # AC-3: teardown_sandbox 直前に production events への書き込みなしを検証
+  if [[ -n "$GIT_EVENTS_DIR" && -d "$GIT_EVENTS_DIR" && -f "${SANDBOX}/test_start_marker" ]]; then
+    local leaked
+    leaked=$(find "$GIT_EVENTS_DIR" -newer "${SANDBOX}/test_start_marker" 2>/dev/null | wc -l)
+    if [[ "$leaked" -gt 0 ]]; then
+      echo "  FAIL (AC-3): production events dir contaminated (${leaked} new files)" >&2
+      result=1
+    fi
+  fi
   teardown_sandbox
   if [[ $result -eq 0 ]]; then
     echo "  PASS: ${name}"
@@ -79,20 +87,17 @@ run_test() {
 
 # --- ヘルパー ---
 
-# AUTOPILOT_DIR を sandbox に向けて hook を実行（EVENTS_DIR を上書き）
-# hook のパス解決: AUTOPILOT_DIR/../.supervisor/events を使うため
-# sandbox 構造: ${SANDBOX}/.autopilot + ${SANDBOX}/.supervisor/events
+# sandbox の TWL_SUPERVISOR_EVENTS_DIR を引き継いで hook を実行
+# TWL_SUPERVISOR_EVENTS_DIR は setup_sandbox で export 済みのため自動伝搬
 run_hook_with_autopilot() {
   local hook_script="$1"
   local input_json="${2-}"
   [[ -z "$input_json" ]] && input_json="{}"
-  local override_autopilot_dir="${3:-$AUTOPILOT_DIR_TEST}"
-  printf '%s' "$input_json" | AUTOPILOT_DIR="$override_autopilot_dir" \
-    bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
+  printf '%s' "$input_json" | bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
 }
 
-# AUTOPILOT_DIR なしで hook を実行（非 git 環境エミュレート用 or レガシーテスト）
-# AUTOPILOT_DIR を明示的に unset して実行（親セッションの環境変数を引き継がない）
+# AUTOPILOT_DIR なしで hook を実行（非 git 環境エミュレート用）
+# AUTOPILOT_DIR を明示的に unset して実行（TWL_SUPERVISOR_EVENTS_DIR は setup_sandbox で export 済み）
 run_hook_without_autopilot() {
   local hook_script="$1"
   local input_json="${2-}"
@@ -101,8 +106,7 @@ run_hook_without_autopilot() {
 }
 
 # AUTOPILOT_DIR 未設定で、実際の git repo 内（現在の worktree）から hook を実行
-# fix 後の新動作: git rev-parse --git-common-dir を使って EVENTS_DIR を解決
-# 書き込み先: main/.supervisor/events/（GIT_EVENTS_DIR）
+# TWL_SUPERVISOR_EVENTS_DIR は setup_sandbox で export 済みのため sandbox に書き込む
 # AUTOPILOT_DIR を明示的に unset して実行（親セッションの環境変数を引き継がない）
 run_hook_in_git_repo_no_autopilot() {
   local hook_script="$1"
@@ -130,27 +134,24 @@ run_hook_in_non_bare() {
 # supervisor-heartbeat.sh テスト
 # =============================================================================
 
-# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → イベントファイルが GIT_EVENTS_DIR に生成される（fix後の新動作）
+# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → イベントファイルが sandbox に生成される
 test_heartbeat_no_autopilot_in_git_repo() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"test-no-ap-heartbeat"}'
   run_hook_in_git_repo_no_autopilot "supervisor-heartbeat.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/heartbeat-test-no-ap-heartbeat"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/heartbeat-test-no-ap-heartbeat"
   local result=0
-  # イベントファイルが生成されていることを確認
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
     jq -e '.session_id == "test-no-ap-heartbeat"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "heartbeat-test-no-ap-heartbeat"
   return $result
 }
 
 # git 外セッション（非 git 環境）での静的終了: AUTOPILOT_DIR 未設定 + git repo 外 → exit 0
 test_heartbeat_no_autopilot_dir() {
   local exit_code
-  # git rev-parse が失敗する環境を再現するため /tmp 配下で実行
   ( cd /tmp && printf '{}' | bash "${HOOKS_DIR}/supervisor-heartbeat.sh" 2>/dev/null )
   exit_code=$?
   [[ "$exit_code" -eq 0 ]] || return 1
@@ -160,7 +161,7 @@ test_heartbeat_creates_event_file() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"test-sess-01","cwd":"/tmp/test"}'
   run_hook_with_autopilot "supervisor-heartbeat.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/heartbeat-test-sess-01"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/heartbeat-test-sess-01"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -169,7 +170,6 @@ test_heartbeat_creates_event_file() {
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e 'has("cwd")' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "heartbeat-test-sess-01"
   return $result
 }
 
@@ -193,12 +193,12 @@ test_heartbeat_no_stdout() {
 # supervisor-input-wait.sh テスト
 # =============================================================================
 
-# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → input-wait イベントファイルが生成される（fix後の新動作）
+# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → input-wait イベントファイルが sandbox に生成される
 test_input_wait_no_autopilot_in_git_repo() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"test-no-ap-input-wait"}'
   run_hook_in_git_repo_no_autopilot "supervisor-input-wait.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/input-wait-test-no-ap-input-wait"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-test-no-ap-input-wait"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -206,7 +206,6 @@ test_input_wait_no_autopilot_in_git_repo() {
     jq -e '.event == "input-wait"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "input-wait-test-no-ap-input-wait"
   return $result
 }
 
@@ -222,7 +221,7 @@ test_input_wait_creates_event_file() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"wait-sess-01"}'
   run_hook_with_autopilot "supervisor-input-wait.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/input-wait-wait-sess-01"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-wait-sess-01"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -230,7 +229,6 @@ test_input_wait_creates_event_file() {
     jq -e '.event == "input-wait"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "input-wait-wait-sess-01"
   return $result
 }
 
@@ -247,16 +245,14 @@ test_input_wait_no_stdout() {
 test_input_clear_removes_file() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_id="clear-sess-01"
-  # hook は GIT_EVENTS_DIR に書くので、ファイルも GIT_EVENTS_DIR に作成する
-  mkdir -p "$GIT_EVENTS_DIR"
-  local event_file="${GIT_EVENTS_DIR}/input-wait-${session_id}"
+  # hook は TWL_SUPERVISOR_EVENTS_DIR に書くので、ファイルも sandbox に作成する
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${session_id}"
   echo '{"event":"input-wait"}' > "$event_file"
   [[ -f "$event_file" ]] || return 1
   local session_json="{\"session_id\":\"${session_id}\"}"
   run_hook_with_autopilot "supervisor-input-clear.sh" "$session_json"
   local result=0
   [[ ! -f "$event_file" ]] || result=1
-  cleanup_git_event_file "input-wait-${session_id}"
   return $result
 }
 
@@ -266,21 +262,18 @@ test_input_clear_no_file_ok() {
   [[ $? -eq 0 ]] || return 1
 }
 
-# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → input-wait ファイルを削除する（fix後の新動作）
+# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → sandbox の input-wait ファイルを削除する
 test_input_clear_no_autopilot_in_git_repo() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_id="test-no-ap-input-clear"
-  # 先に input-wait ファイルを作成
-  mkdir -p "$GIT_EVENTS_DIR"
-  printf '{"event":"input-wait","session_id":"%s"}\n' "$session_id" > "${GIT_EVENTS_DIR}/input-wait-${session_id}"
-  [[ -f "${GIT_EVENTS_DIR}/input-wait-${session_id}" ]] || return 1
+  # 先に input-wait ファイルを sandbox に作成
+  printf '{"event":"input-wait","session_id":"%s"}\n' "$session_id" > "${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${session_id}"
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${session_id}" ]] || return 1
   local session_json="{\"session_id\":\"${session_id}\"}"
   run_hook_in_git_repo_no_autopilot "supervisor-input-clear.sh" "$session_json"
   local result=0
   # ファイルが削除されていることを確認
-  [[ ! -f "${GIT_EVENTS_DIR}/input-wait-${session_id}" ]] || result=1
-  # 念のためクリーンアップ
-  cleanup_git_event_file "input-wait-${session_id}"
+  [[ ! -f "${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${session_id}" ]] || result=1
   return $result
 }
 
@@ -296,12 +289,12 @@ test_input_clear_no_autopilot_dir() {
 # supervisor-skill-step.sh テスト
 # =============================================================================
 
-# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → skill-step イベントファイルが生成される（fix後の新動作）
+# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → skill-step イベントファイルが sandbox に生成される
 test_skill_step_no_autopilot_in_git_repo() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"test-no-ap-skill-step","tool_input":{"skill":"workflow-setup","args":"#725"}}'
   run_hook_in_git_repo_no_autopilot "supervisor-skill-step.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/skill-step-test-no-ap-skill-step"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/skill-step-test-no-ap-skill-step"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -309,7 +302,6 @@ test_skill_step_no_autopilot_in_git_repo() {
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e 'has("skill")' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "skill-step-test-no-ap-skill-step"
   return $result
 }
 
@@ -325,7 +317,7 @@ test_skill_step_creates_event_file() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"skill-sess-01","tool_input":{"skill":"workflow-setup","args":"#123"}}'
   run_hook_with_autopilot "supervisor-skill-step.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/skill-step-skill-sess-01"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/skill-step-skill-sess-01"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -334,7 +326,6 @@ test_skill_step_creates_event_file() {
     jq -e 'has("skill")' "$event_file" > /dev/null 2>&1 || result=1
     jq -e 'has("tool_input")' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "skill-step-skill-sess-01"
   return $result
 }
 
@@ -348,12 +339,12 @@ test_skill_step_no_stdout() {
 # supervisor-session-end.sh テスト
 # =============================================================================
 
-# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → session-end イベントファイルが生成される（fix後の新動作）
+# AUTOPILOT_DIR 未設定かつ git リポジトリ内 → session-end イベントファイルが sandbox に生成される
 test_session_end_no_autopilot_in_git_repo() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"test-no-ap-session-end"}'
   run_hook_in_git_repo_no_autopilot "supervisor-session-end.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/session-end-test-no-ap-session-end"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/session-end-test-no-ap-session-end"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -361,7 +352,6 @@ test_session_end_no_autopilot_in_git_repo() {
     jq -e '.event == "session-end"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "session-end-test-no-ap-session-end"
   return $result
 }
 
@@ -377,7 +367,7 @@ test_session_end_creates_event_file() {
   [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
   local session_json='{"session_id":"end-sess-01"}'
   run_hook_with_autopilot "supervisor-session-end.sh" "$session_json"
-  local event_file="${GIT_EVENTS_DIR}/session-end-end-sess-01"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/session-end-end-sess-01"
   local result=0
   [[ -f "$event_file" ]] || result=1
   if [[ $result -eq 0 ]]; then
@@ -385,7 +375,6 @@ test_session_end_creates_event_file() {
     jq -e '.event == "session-end"' "$event_file" > /dev/null 2>&1 || result=1
     jq -e '.timestamp | type == "number"' "$event_file" > /dev/null 2>&1 || result=1
   fi
-  cleanup_git_event_file "session-end-end-sess-01"
   return $result
 }
 
@@ -436,10 +425,30 @@ test_heartbeat_non_bare_no_events_written() {
   )
   # .supervisor/ ディレクトリが作成されていないことを確認
   [[ ! -d "${non_bare_dir}/.supervisor" ]] || result=1
-  # main/.supervisor/events/ も作成されていないことを確認
-  [[ ! -d "${non_bare_dir}/main/.supervisor/events" ]] || result=1
+  # bare ガードにより main/ 自体が作成されないことを確認（main/以下への書き込みなし）
+  [[ ! -d "${non_bare_dir}/main" ]] || result=1
   rm -rf "$non_bare_dir" 2>/dev/null
   return $result
+}
+
+# =============================================================================
+# AC-6: 異常終了耐性テスト（SIGTERM 後に production events 汚染なし）
+# =============================================================================
+
+test_sigint_no_residual_files() {
+  [[ -n "$GIT_EVENTS_DIR" && -d "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: no production events dir" >&2; return 0; }
+  # 再帰実行を防ぐガード（_SIGINT_TEST_RUNNING が set されている場合は skip）
+  [[ -z "${_SIGINT_TEST_RUNNING:-}" ]] || { echo "  SKIP: nested run" >&2; return 0; }
+  local marker
+  marker=$(mktemp)
+  sleep 0.05  # marker timestamp を settle させる
+  # このスクリプト自体を短い timeout で実行（SIGTERM により中断される）
+  # _SIGINT_TEST_RUNNING=1 で再帰実行ガードを有効化
+  _SIGINT_TEST_RUNNING=1 timeout 0.5 bash "${BASH_SOURCE[0]}" >/dev/null 2>&1 || true
+  local leaked
+  leaked=$(find "$GIT_EVENTS_DIR" -newer "$marker" 2>/dev/null | wc -l)
+  rm -f "$marker"
+  [[ "$leaked" -eq 0 ]] || return 1
 }
 
 # =============================================================================
@@ -449,34 +458,34 @@ test_heartbeat_non_bare_no_events_written() {
 echo "=== supervisor-event-emission-hooks tests ==="
 
 # heartbeat
-run_test "heartbeat: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（fix後）" test_heartbeat_no_autopilot_in_git_repo
+run_test "heartbeat: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（sandbox）" test_heartbeat_no_autopilot_in_git_repo
 run_test "heartbeat: git 外セッションで exit 0（静的終了）" test_heartbeat_no_autopilot_dir
-run_test "heartbeat: イベントファイル生成と JSON フォーマット（AUTOPILOT_DIR あり）" test_heartbeat_creates_event_file
+run_test "heartbeat: イベントファイル生成と JSON フォーマット（sandbox）" test_heartbeat_creates_event_file
 run_test "heartbeat: 書き込み失敗でも exit 0" test_heartbeat_exit_zero_on_failure
 run_test "heartbeat: stdout に何も出力しない" test_heartbeat_no_stdout
 
 # input-wait
-run_test "input-wait: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（fix後）" test_input_wait_no_autopilot_in_git_repo
+run_test "input-wait: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（sandbox）" test_input_wait_no_autopilot_in_git_repo
 run_test "input-wait: git 外セッションで exit 0（静的終了）" test_input_wait_no_autopilot_dir
-run_test "input-wait: イベントファイル生成と JSON フォーマット（AUTOPILOT_DIR あり）" test_input_wait_creates_event_file
+run_test "input-wait: イベントファイル生成と JSON フォーマット（sandbox）" test_input_wait_creates_event_file
 run_test "input-wait: stdout に何も出力しない" test_input_wait_no_stdout
 
 # input-clear
-run_test "input-clear: input-wait ファイルを削除（AUTOPILOT_DIR あり）" test_input_clear_removes_file
+run_test "input-clear: input-wait ファイルを削除（sandbox）" test_input_clear_removes_file
 run_test "input-clear: ファイル不在でも exit 0" test_input_clear_no_file_ok
-run_test "input-clear: AUTOPILOT_DIR 未設定 + git 内で input-wait ファイルを削除（fix後）" test_input_clear_no_autopilot_in_git_repo
+run_test "input-clear: AUTOPILOT_DIR 未設定 + git 内で sandbox の input-wait ファイルを削除" test_input_clear_no_autopilot_in_git_repo
 run_test "input-clear: git 外セッションで exit 0（静的終了）" test_input_clear_no_autopilot_dir
 
 # skill-step
-run_test "skill-step: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（fix後）" test_skill_step_no_autopilot_in_git_repo
+run_test "skill-step: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（sandbox）" test_skill_step_no_autopilot_in_git_repo
 run_test "skill-step: git 外セッションで exit 0（静的終了）" test_skill_step_no_autopilot_dir
-run_test "skill-step: イベントファイル生成と JSON フォーマット（AUTOPILOT_DIR あり）" test_skill_step_creates_event_file
+run_test "skill-step: イベントファイル生成と JSON フォーマット（sandbox）" test_skill_step_creates_event_file
 run_test "skill-step: stdout に何も出力しない" test_skill_step_no_stdout
 
 # session-end
-run_test "session-end: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（fix後）" test_session_end_no_autopilot_in_git_repo
+run_test "session-end: AUTOPILOT_DIR 未設定 + git 内でイベントファイル生成（sandbox）" test_session_end_no_autopilot_in_git_repo
 run_test "session-end: git 外セッションで exit 0（静的終了）" test_session_end_no_autopilot_dir
-run_test "session-end: イベントファイル生成と JSON フォーマット（AUTOPILOT_DIR あり）" test_session_end_creates_event_file
+run_test "session-end: イベントファイル生成と JSON フォーマット（sandbox）" test_session_end_creates_event_file
 run_test "session-end: stdout に何も出力しない" test_session_end_no_stdout
 
 # non-bare 検出（AC-1/AC-2a: bare repo 構造ガード）
@@ -486,6 +495,9 @@ run_test "input-clear: non-bare リポジトリで exit 0（no-op）" test_input
 run_test "skill-step: non-bare リポジトリで exit 0（no-op）" test_skill_step_non_bare_exit_zero
 run_test "session-end: non-bare リポジトリで exit 0（no-op）" test_session_end_non_bare_exit_zero
 run_test "heartbeat: non-bare で .supervisor/events/ への書き込みなし（AC-2b）" test_heartbeat_non_bare_no_events_written
+
+# AC-6: 異常終了耐性
+run_test "AC-6: SIGTERM 後に production events ディレクトリ汚染なし" test_sigint_no_residual_files
 
 echo ""
 echo "Results: ${PASS} passed, ${FAIL} failed"


### PR DESCRIPTION
fix(#731): supervisor hook に TWL_SUPERVISOR_EVENTS_DIR override 追加、テスト sandbox 移行

- 5本の supervisor hook に `TWL_SUPERVISOR_EVENTS_DIR:-` フォールバック形式で env override 機構を追加
- テスト書き込み先を sandbox に切替（TWL_SUPERVISOR_EVENTS_DIR export）
- AC-3: run_test 内で production events への書き込みなしを自動検証
- AC-6: trap teardown_sandbox INT TERM EXIT で異常終了時も sandbox クリーンアップ
- run_hook_with_autopilot の semantic bug（AUTOPILOT_DIR→EVENTS_DIR 説明乖離）を修正
- cleanup_git_event_file() を廃止（teardown_sandbox の rm -rf で網羅）
- deltaspec/changes/issue-731/design.md を新規作成（AC-7）

Closes #731