### PR TITLE
feat(supervisor-hooks): SESSION_ID allow-list sanitize + path-traversal tests (SU-9, #729)

### DIFF
--- a/deltaspec/changes/issue-729/design.md
+++ b/deltaspec/changes/issue-729/design.md
@@ -1,0 +1,46 @@
+# Design: supervisor hook SESSION_ID path-traversal sanitization
+
+## Goals
+
+- supervisor hook 5 本（heartbeat, input-wait, input-clear, skill-step, session-end）で SESSION_ID をファイル名に埋め込む直前に allow-list サニタイズ（`[A-Za-z0-9_-]`）を適用し、path-traversal を根本防止する
+- サニタイズで値が変化した場合は stderr に警告行を出力し、観測可能性を担保する（raw 値は出力しない）
+- architecture spec（supervision.md）に SU-9 として明文化し、defense-in-depth の設計意図を記録する
+- path-traversal テストケースおよび UUID 正常系テストを追加し、回帰防止を機械化する
+
+## Non-Goals
+
+- bare repo 構造ガード（別 Issue #728 の責務）
+- `run_hook_with_autopilot()` 関数名乖離の修正（別 Issue #730）
+- テスト副作用解消（別 Issue #731）
+- Claude Code SDK 側の session_id 形式固定化（外部依存で制御不能）
+- 他 hook スクリプト（`pre-bash-phase3-gate.sh` 等）の SESSION_ID 使用箇所（cksum 経由で数値化されるため path-traversal リスクなし）
+- ADR 新規作成（既存 SU-* 表への追加のみで完結）
+- stderr への raw SESSION_ID 値の出力（制御文字・過大サイズ注入リスクを避けるため明示的拒否）
+
+## 変更点一覧
+
+| ファイル | 変更内容 |
+|----------|---------|
+| `plugins/twl/scripts/hooks/supervisor-heartbeat.sh` | SESSION_ID 確定後・TMP_FILE 構築前にサニタイズブロック挿入 |
+| `plugins/twl/scripts/hooks/supervisor-input-wait.sh` | SESSION_ID 確定後・TMP_FILE 構築前にサニタイズブロック挿入 |
+| `plugins/twl/scripts/hooks/supervisor-input-clear.sh` | SESSION_ID 確定後・TARGET_FILE 構築前にサニタイズブロック挿入 |
+| `plugins/twl/scripts/hooks/supervisor-skill-step.sh` | SESSION_ID 確定後・TMP_FILE 構築前にサニタイズブロック挿入 |
+| `plugins/twl/scripts/hooks/supervisor-session-end.sh` | SESSION_ID 確定後・TMP_FILE 構築前にサニタイズブロック挿入 |
+| `plugins/twl/architecture/domain/contexts/supervision.md` | SU-* 表末尾に SU-9 を新規追加 |
+| `plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh` | `run_hook_capture_stderr()` helper 追加、path-traversal テスト・UUID 正常系テスト追加 |
+
+## サニタイズブロック実装パターン
+
+```bash
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+```
+
+挿入位置は SESSION_ID フォールバック `fi` 行の直後、TMP_FILE/TARGET_FILE 構築の直前（input-clear は TMP_FILE を持たないため TARGET_FILE 直前のみ）。

--- a/plugins/twl/architecture/domain/contexts/supervision.md
+++ b/plugins/twl/architecture/domain/contexts/supervision.md
@@ -193,6 +193,7 @@ flowchart TD
 | SU-6b | context 逼迫時またはユーザー指示時に /compact をユーザーへ提案しなければならない（SHOULD） | built-in CLI のためユーザー手動実行 |
 | SU-7 | observed session への inject/send-keys は介入プロトコルに従う場合に許可（MAY） | OB-3 廃止に対応 |
 | SU-8 | supervisor hook は bare repo 構造（main/ がディレクトリとして存在すること）を前提とし、non-bare 検出時は no-op で exit 0 する（SHALL） | #728 |
+| SU-9 | supervisor hook は filename に埋め込む前に SESSION_ID を allow-list サニタイズ（[A-Za-z0-9_-]）しなければならず、サニタイズ前後で差分があれば stderr に警告を出力しなければならない（SHALL） | #729 |
 
 ### OB-* Constraints との関係
 

--- a/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
+++ b/plugins/twl/scripts/hooks/supervisor-heartbeat.sh
@@ -28,6 +28,16 @@ if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
 fi
 
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+
 TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
 CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || echo "${PWD:-}")
 if [[ -z "$CWD" ]]; then

--- a/plugins/twl/scripts/hooks/supervisor-input-clear.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-clear.sh
@@ -27,6 +27,16 @@ if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
 fi
 
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+
 # input-wait ファイルを削除（存在しなければ何もしない）
 TARGET_FILE="${EVENTS_DIR}/input-wait-${SESSION_ID}"
 rm -f "$TARGET_FILE" 2>/dev/null || true

--- a/plugins/twl/scripts/hooks/supervisor-input-wait.sh
+++ b/plugins/twl/scripts/hooks/supervisor-input-wait.sh
@@ -28,6 +28,16 @@ if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
 fi
 
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+
 TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
 
 # アトミック書き込み

--- a/plugins/twl/scripts/hooks/supervisor-session-end.sh
+++ b/plugins/twl/scripts/hooks/supervisor-session-end.sh
@@ -28,6 +28,16 @@ if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
 fi
 
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+
 TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
 
 # アトミック書き込み

--- a/plugins/twl/scripts/hooks/supervisor-skill-step.sh
+++ b/plugins/twl/scripts/hooks/supervisor-skill-step.sh
@@ -29,6 +29,16 @@ if [[ -z "$SESSION_ID" ]]; then
   SESSION_ID="${CLAUDE_SESSION_ID:-$$}"
 fi
 
+_SESSION_ID_RAW="$SESSION_ID"
+SESSION_ID=$(printf '%s' "$SESSION_ID" | tr -cd 'A-Za-z0-9_-')
+if [[ -z "$SESSION_ID" ]]; then
+  SESSION_ID="$$"
+fi
+if [[ "$SESSION_ID" != "$_SESSION_ID_RAW" ]]; then
+  printf '[supervisor-hook][warn] SESSION_ID sanitized (hook=%s pid=%s)\n' \
+    "$(basename "$0")" "$$" >&2
+fi
+
 TIMESTAMP=$(date +%s 2>/dev/null || echo "0")
 
 # skill 名と tool_input 取得（tool_input は最大 500 文字）

--- a/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
+++ b/plugins/twl/tests/scenarios/supervisor-event-emission-hooks.test.sh
@@ -17,6 +17,7 @@ SANDBOX=""
 AUTOPILOT_DIR_TEST=""
 EVENTS_DIR_TEST=""
 SUPERVISOR_DIR_TEST=""
+HOOK_STDERR=""
 
 # git-common-dir ベースの変数（skip 判定と AC-3 用）
 GIT_COMMON_DIR=""
@@ -112,6 +113,20 @@ run_hook_in_git_repo_no_autopilot() {
   local hook_script="$1"
   local input_json="${2:-{}}"
   printf '%s' "$input_json" | env -u AUTOPILOT_DIR bash "${HOOKS_DIR}/${hook_script}" 2>/dev/null
+}
+
+# stderr を変数 HOOK_STDERR にキャプチャして hook を実行（AC-5/6/7 用）
+# TWL_SUPERVISOR_EVENTS_DIR は setup_sandbox で export 済みのため自動伝搬
+run_hook_capture_stderr() {
+  local hook_script="$1"
+  local input_json="${2:-{}}"
+  local _tmpfile
+  _tmpfile=$(mktemp)
+  printf '%s' "$input_json" | bash "${HOOKS_DIR}/${hook_script}" >/dev/null 2>"$_tmpfile"
+  local _rc=${PIPESTATUS[1]}
+  HOOK_STDERR=$(cat "$_tmpfile")
+  rm -f "$_tmpfile"
+  return $_rc
 }
 
 # non-bare git リポジトリ（.git/ のみ、main/ 不在）から hook を実行
@@ -385,6 +400,140 @@ test_session_end_no_stdout() {
 }
 
 # =============================================================================
+# AC-5/AC-6/AC-7: SESSION_ID path-traversal サニタイズテスト
+# =============================================================================
+
+# AC-5: heartbeat - SESSION_ID=../evil でファイル名が sanitize され EVENTS_DIR 外への書き込みなし
+test_heartbeat_path_traversal() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local session_json='{"session_id":"../evil"}'
+  run_hook_capture_stderr "supervisor-heartbeat.sh" "$session_json"
+  local result=0
+  # (a) EVENTS_DIR の外にファイルが生成されない（../evil → ${EVENTS_DIR}/../evil）
+  [[ ! -f "${TWL_SUPERVISOR_EVENTS_DIR}/../evil" ]] || result=1
+  # (b) サニタイズ後の名前でファイルが生成される（../が除去されて evil のみ残る）
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/heartbeat-evil" ]] || result=1
+  # (c) stderr 警告が出力される
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' || result=1
+  return $result
+}
+
+# AC-5: input-wait - SESSION_ID=../evil でファイル名が sanitize され EVENTS_DIR 外への書き込みなし
+test_input_wait_path_traversal() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local session_json='{"session_id":"../evil"}'
+  run_hook_capture_stderr "supervisor-input-wait.sh" "$session_json"
+  local result=0
+  [[ ! -f "${TWL_SUPERVISOR_EVENTS_DIR}/../evil" ]] || result=1
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-evil" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' || result=1
+  return $result
+}
+
+# AC-5: skill-step - SESSION_ID=../evil でファイル名が sanitize され EVENTS_DIR 外への書き込みなし
+test_skill_step_path_traversal() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local session_json='{"session_id":"../evil","tool_input":{"skill":"test"}}'
+  run_hook_capture_stderr "supervisor-skill-step.sh" "$session_json"
+  local result=0
+  [[ ! -f "${TWL_SUPERVISOR_EVENTS_DIR}/../evil" ]] || result=1
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/skill-step-evil" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' || result=1
+  return $result
+}
+
+# AC-5: session-end - SESSION_ID=../evil でファイル名が sanitize され EVENTS_DIR 外への書き込みなし
+test_session_end_path_traversal() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local session_json='{"session_id":"../evil"}'
+  run_hook_capture_stderr "supervisor-session-end.sh" "$session_json"
+  local result=0
+  [[ ! -f "${TWL_SUPERVISOR_EVENTS_DIR}/../evil" ]] || result=1
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/session-end-evil" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' || result=1
+  return $result
+}
+
+# AC-6: input-clear - SESSION_ID=../secret で canary ファイルが削除されない
+test_input_clear_path_traversal() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  # canary を EVENTS_DIR の親（traverse 先）に配置
+  local canary="${TWL_SUPERVISOR_EVENTS_DIR}/../secret"
+  touch "$canary" 2>/dev/null || { echo "  SKIP: cannot create canary" >&2; return 0; }
+  local session_json='{"session_id":"../secret"}'
+  run_hook_capture_stderr "supervisor-input-clear.sh" "$session_json"
+  local result=0
+  # canary が残存している（rm が EVENTS_DIR 外に到達しなかった）
+  [[ -f "$canary" ]] || result=1
+  # stderr 警告が出力される
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' || result=1
+  rm -f "$canary" 2>/dev/null
+  return $result
+}
+
+# AC-7: heartbeat - UUID v4 SESSION_ID はサニタイズで変化せず、stderr 警告なし
+test_heartbeat_uuid_no_warn() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local uuid="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+  local session_json="{\"session_id\":\"${uuid}\"}"
+  run_hook_capture_stderr "supervisor-heartbeat.sh" "$session_json"
+  local result=0
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/heartbeat-${uuid}" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' && result=1
+  return $result
+}
+
+# AC-7: input-wait - UUID v4 はサニタイズで変化せず、stderr 警告なし
+test_input_wait_uuid_no_warn() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local uuid="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+  local session_json="{\"session_id\":\"${uuid}\"}"
+  run_hook_capture_stderr "supervisor-input-wait.sh" "$session_json"
+  local result=0
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${uuid}" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' && result=1
+  return $result
+}
+
+# AC-7: skill-step - UUID v4 はサニタイズで変化せず、stderr 警告なし
+test_skill_step_uuid_no_warn() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local uuid="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+  local session_json="{\"session_id\":\"${uuid}\",\"tool_input\":{\"skill\":\"test\"}}"
+  run_hook_capture_stderr "supervisor-skill-step.sh" "$session_json"
+  local result=0
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/skill-step-${uuid}" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' && result=1
+  return $result
+}
+
+# AC-7: session-end - UUID v4 はサニタイズで変化せず、stderr 警告なし
+test_session_end_uuid_no_warn() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local uuid="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+  local session_json="{\"session_id\":\"${uuid}\"}"
+  run_hook_capture_stderr "supervisor-session-end.sh" "$session_json"
+  local result=0
+  [[ -f "${TWL_SUPERVISOR_EVENTS_DIR}/session-end-${uuid}" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' && result=1
+  return $result
+}
+
+# AC-7: input-clear - UUID v4 では rm が正しいファイルを削除し、stderr 警告なし
+test_input_clear_uuid_no_warn() {
+  [[ -n "$GIT_EVENTS_DIR" ]] || { echo "  SKIP: not in git repo" >&2; return 0; }
+  local uuid="3f2504e0-4f89-41d3-9a0c-0305e82c3301"
+  local event_file="${TWL_SUPERVISOR_EVENTS_DIR}/input-wait-${uuid}"
+  echo '{"event":"input-wait"}' > "$event_file"
+  local session_json="{\"session_id\":\"${uuid}\"}"
+  run_hook_capture_stderr "supervisor-input-clear.sh" "$session_json"
+  local result=0
+  [[ ! -f "$event_file" ]] || result=1
+  printf '%s' "$HOOK_STDERR" | grep -q '\[supervisor-hook\]\[warn\] SESSION_ID sanitized' && result=1
+  return $result
+}
+
+# =============================================================================
 # non-bare 検出テスト（AC-1/AC-2a/AC-2b: bare repo 構造ガード）
 # サンドボックス: git init のみ（.git/ 構造）、main/ ディレクトリなし
 # =============================================================================
@@ -487,6 +636,22 @@ run_test "session-end: AUTOPILOT_DIR 未設定 + git 内でイベントファイ
 run_test "session-end: git 外セッションで exit 0（静的終了）" test_session_end_no_autopilot_dir
 run_test "session-end: イベントファイル生成と JSON フォーマット（sandbox）" test_session_end_creates_event_file
 run_test "session-end: stdout に何も出力しない" test_session_end_no_stdout
+
+# AC-5: path-traversal write hooks（../evil）
+run_test "heartbeat: SESSION_ID=../evil でサニタイズ・EVENTS_DIR 外書き込みなし（AC-5）" test_heartbeat_path_traversal
+run_test "input-wait: SESSION_ID=../evil でサニタイズ・EVENTS_DIR 外書き込みなし（AC-5）" test_input_wait_path_traversal
+run_test "skill-step: SESSION_ID=../evil でサニタイズ・EVENTS_DIR 外書き込みなし（AC-5）" test_skill_step_path_traversal
+run_test "session-end: SESSION_ID=../evil でサニタイズ・EVENTS_DIR 外書き込みなし（AC-5）" test_session_end_path_traversal
+
+# AC-6: path-traversal rm hook（../secret canary 保護）
+run_test "input-clear: SESSION_ID=../secret で canary ファイル保護・stderr 警告（AC-6）" test_input_clear_path_traversal
+
+# AC-7: UUID v4 非破壊・stderr 警告なし
+run_test "heartbeat: UUID v4 SESSION_ID でサニタイズなし・警告出力なし（AC-7）" test_heartbeat_uuid_no_warn
+run_test "input-wait: UUID v4 SESSION_ID でサニタイズなし・警告出力なし（AC-7）" test_input_wait_uuid_no_warn
+run_test "skill-step: UUID v4 SESSION_ID でサニタイズなし・警告出力なし（AC-7）" test_skill_step_uuid_no_warn
+run_test "session-end: UUID v4 SESSION_ID でサニタイズなし・警告出力なし（AC-7）" test_session_end_uuid_no_warn
+run_test "input-clear: UUID v4 SESSION_ID でサニタイズなし・警告出力なし（AC-7）" test_input_clear_uuid_no_warn
 
 # non-bare 検出（AC-1/AC-2a: bare repo 構造ガード）
 run_test "heartbeat: non-bare リポジトリで exit 0（no-op）" test_heartbeat_non_bare_exit_zero


### PR DESCRIPTION
feat(supervisor-hooks): SESSION_ID allow-list sanitize + path-traversal tests (SU-9, #729)

- Add SESSION_ID sanitize block to all 5 supervisor hooks (heartbeat,
  input-wait, input-clear, skill-step, session-end). Inserted after
  SESSION_ID fallback fi and before TMP_FILE/TARGET_FILE construction.
- Sanitize via tr -cd 'A-Za-z0-9_-'; re-fallback to $$ if empty.
- Emit stderr warning when value changes; raw value excluded from log.
- Add run_hook_capture_stderr() helper and 11 new test cases (AC-5/6/7)
  covering path-traversal prevention and UUID non-destruction.
- Add SU-9 constraint to supervision.md.
- Add deltaspec/changes/issue-729/design.md.

Closes #729