### PR TITLE
fix(orchestrator): SESSION_STATE_CMD デフォルトパスを session-state-wrapper.sh に修正

### DIFF
--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -420,6 +420,41 @@ tmux send-keys -t "<WORKER_WINDOW>" "/twl:workflow-test-ready" Enter
 |----|----------|------|-------------|
 | **P1** | Pilot 能動評価の atomic 経由限定 | Pilot による PR diff / Issue body 能動評価は autopilot-pilot-* atomic を経由した場合のみ推奨。SKILL.md への直接記述による責務拡大は避ける | ADR-010 参照 + コードレビュー時の人手チェック |
 
+## Operational Notes
+
+### SESSION_STATE_CMD 解決経路の不変条件（#752）
+
+`autopilot-orchestrator.sh`・`crash-detect.sh`・`health-check.sh` の 3 スクリプトは、
+同一の SESSION_STATE_CMD 解決経路を共有する。
+
+- **デフォルト**: `${SCRIPTS_ROOT}/session-state-wrapper.sh`（スクリプトと同ディレクトリの wrapper）
+- **wrapper の実体**: `plugins/session/scripts/session-state.sh`（session プラグイン）
+- **環境変数上書き可**: `export SESSION_STATE_CMD=/custom/path` で任意パスに変更可能
+- **不変条件**: `$HOME/ubuntu-note-system/...` のような外部ハードコードパスをデフォルトに使ってはならない。fresh clone / CI 環境で存在せず `USE_SESSION_STATE=false` へ silent fallback するため（regression guard: `plugins/twl/tests/bats/scripts/autopilot-session-state-cmd.bats` AC-6）
+
+### detect_input_waiting() 2 回検知デバウンスの設計意図（AC-3 / #752）
+
+`autopilot-orchestrator.sh` の `detect_input_waiting()` は `INPUT_WAITING_SEEN_PATTERN` により
+1 回目の検知では state を書き込まず、2 回目で確定する仕様になっている。
+
+- **意図**: 一時的な TUI 表示ゆらぎ（approve/reject ダイアログ等の一過性の input-waiting）を
+  誤検知しないための debounce。
+- **inject トリガーとの関係**: `detect_input_waiting()` は `check_and_nudge()` 内（state 書き込み専用）で
+  呼ばれる。`inject_next_workflow()` は `current_step` terminal 検知ルートから独立した
+  input-waiting 検出ロジックを持つため、debounce は inject トリガーの直接原因ではない。
+  状態の可観測性（state.json）を 1 サイクル遅延させるだけで、inject 自体は影響を受けない。
+
+### Detection Layer Regression ポストモーテム（#707 / #722 / #752）
+
+| Issue | PR | 内容 |
+|-------|-----|------|
+| #707 | #716 | orchestrator resolve ログ分離 + session-state.sh inject 検出（初期実装） |
+| #722 | #733 | inject が input-waiting を見逃す問題修正（`USE_SESSION_STATE=true` ブランチの backoff 改善） |
+| #752 | #760 | SESSION_STATE_CMD デフォルトパス (`$HOME/ubuntu-note-system/...`) が fresh clone 環境で不在 → 全 3 スクリプトで `USE_SESSION_STATE=false` に silent fallback。wrapper 参照に変更して解決 |
+
+**再発防止**: `autopilot-session-state-cmd.bats` の AC-6 tests が `ubuntu-note-system` ハードコードの
+再導入を CI で検知する。
+
 ## Dependencies
 
 - **Downstream -> PR Cycle**: merge-gate を呼び出してマージ判定。Contract: contracts/autopilot-pr-cycle.md

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -25,6 +25,7 @@ if [[ -n "$SESSION_STATE_CMD" && "$SESSION_STATE_CMD" == /* && "$SESSION_STATE_C
 else
   USE_SESSION_STATE=false
 fi
+echo "[orchestrator] USE_SESSION_STATE=${USE_SESSION_STATE}" >&2
 
 # --- 定数 ---
 MAX_PARALLEL="${DEV_AUTOPILOT_MAX_PARALLEL:-4}"

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -19,7 +19,7 @@ source "${SCRIPTS_ROOT}/lib/deltaspec-helpers.sh"
 source "${SCRIPTS_ROOT}/chain-steps.sh" 2>/dev/null || true
 
 # --- session-state.sh 検出 ---
-SESSION_STATE_CMD="${SESSION_STATE_CMD-$HOME/ubuntu-note-system/scripts/session-state.sh}"
+SESSION_STATE_CMD="${SESSION_STATE_CMD-${SCRIPTS_ROOT}/session-state-wrapper.sh}"
 if [[ -n "$SESSION_STATE_CMD" && "$SESSION_STATE_CMD" == /* && "$SESSION_STATE_CMD" != *..* && -x "$SESSION_STATE_CMD" ]]; then
   USE_SESSION_STATE=true
 else

--- a/plugins/twl/scripts/crash-detect.sh
+++ b/plugins/twl/scripts/crash-detect.sh
@@ -11,7 +11,7 @@ AUTOPILOT_DIR="${AUTOPILOT_DIR:-$PROJECT_ROOT/.autopilot}"
 source "${SCRIPT_DIR}/lib/python-env.sh"
 
 # session-state.sh の解決（環境変数で上書き可能）
-SESSION_STATE_CMD="${SESSION_STATE_CMD-$HOME/ubuntu-note-system/scripts/session-state.sh}"
+SESSION_STATE_CMD="${SESSION_STATE_CMD-${SCRIPT_DIR}/session-state-wrapper.sh}"
 # パス安全性検証: 相対パス・空文字列・.. を含むパスを拒否
 if [[ -n "$SESSION_STATE_CMD" && "$SESSION_STATE_CMD" == /* && "$SESSION_STATE_CMD" != *..* && -x "$SESSION_STATE_CMD" ]]; then
   USE_SESSION_STATE=true

--- a/plugins/twl/scripts/health-check.sh
+++ b/plugins/twl/scripts/health-check.sh
@@ -16,7 +16,7 @@ CHAIN_STALL_MIN="${DEV_HEALTH_CHAIN_STALL_MIN:-10}"
 INPUT_WAIT_MIN="${DEV_HEALTH_INPUT_WAIT_MIN:-5}"
 
 # session-state.sh の解決
-SESSION_STATE_CMD="${SESSION_STATE_CMD-$HOME/ubuntu-note-system/scripts/session-state.sh}"
+SESSION_STATE_CMD="${SESSION_STATE_CMD-${SCRIPT_DIR}/session-state-wrapper.sh}"
 if [[ -n "$SESSION_STATE_CMD" && "$SESSION_STATE_CMD" == /* && "$SESSION_STATE_CMD" != *..* && -x "$SESSION_STATE_CMD" ]]; then
   USE_SESSION_STATE=true
 else

--- a/plugins/twl/tests/bats/scripts/autopilot-session-state-cmd.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-session-state-cmd.bats
@@ -1,0 +1,149 @@
+#!/usr/bin/env bats
+# autopilot-session-state-cmd.bats
+# AC-1/AC-2: SESSION_STATE_CMD デフォルトが session-state-wrapper.sh に解決されることを検証
+# AC-6: ubuntu-note-system ハードコード不在の invariant check
+# Issue #752
+
+load '../helpers/common'
+
+FAKE_HOME=""
+
+setup() {
+  common_setup
+  stub_command "tmux" 'exit 0'
+  FAKE_HOME="$(mktemp -d)"
+}
+
+teardown() {
+  common_teardown
+  [[ -n "$FAKE_HOME" ]] && rm -rf "$FAKE_HOME" 2>/dev/null || true
+}
+
+# ===========================================================================
+# AC-6: ubuntu-note-system ハードコード invariant（全 3 スクリプト）
+# ===========================================================================
+
+@test "AC-6: autopilot-orchestrator.sh に ubuntu-note-system の SESSION_STATE_CMD ハードコードが存在しない" {
+  run grep "SESSION_STATE_CMD.*ubuntu-note-system" "$SANDBOX/scripts/autopilot-orchestrator.sh"
+  assert_failure
+}
+
+@test "AC-6: crash-detect.sh に ubuntu-note-system の SESSION_STATE_CMD ハードコードが存在しない" {
+  run grep "SESSION_STATE_CMD.*ubuntu-note-system" "$SANDBOX/scripts/crash-detect.sh"
+  assert_failure
+}
+
+@test "AC-6: health-check.sh に ubuntu-note-system の SESSION_STATE_CMD ハードコードが存在しない" {
+  run grep "SESSION_STATE_CMD.*ubuntu-note-system" "$SANDBOX/scripts/health-check.sh"
+  assert_failure
+}
+
+# ===========================================================================
+# AC-1: autopilot-orchestrator.sh
+# デフォルト SESSION_STATE_CMD が session-state-wrapper.sh を参照し、
+# ubuntu-note-system 不在でも USE_SESSION_STATE=true になることを検証
+# ===========================================================================
+
+@test "AC-1: autopilot-orchestrator.sh のデフォルト SESSION_STATE_CMD は session-state-wrapper.sh を指す" {
+  # デフォルト値が ubuntu-note-system ではなく wrapper を参照していること
+  run grep "SESSION_STATE_CMD.*session-state-wrapper" "$SANDBOX/scripts/autopilot-orchestrator.sh"
+  assert_success
+}
+
+@test "AC-1: session-state-wrapper.sh は sandbox に存在して実行可能" {
+  [[ -x "$SANDBOX/scripts/session-state-wrapper.sh" ]]
+}
+
+@test "AC-1: ubuntu-note-system 不在でも USE_SESSION_STATE=true になる（detection logic 単体検証）" {
+  # autopilot-orchestrator.sh の SESSION_STATE_CMD 検出ロジックを抽出して検証
+  # HOME を fake dir に向け、SESSION_STATE_CMD を未設定にする
+  local resolved_cmd
+  run bash -c "
+    SCRIPTS_ROOT=\"$SANDBOX/scripts\"
+    SESSION_STATE_CMD=\"\${SESSION_STATE_CMD:-\${SCRIPTS_ROOT}/session-state-wrapper.sh}\"
+    if [[ -n \"\$SESSION_STATE_CMD\" && \"\$SESSION_STATE_CMD\" == /* && \"\$SESSION_STATE_CMD\" != *..* && -x \"\$SESSION_STATE_CMD\" ]]; then
+      echo 'USE_SESSION_STATE=true'
+    else
+      echo 'USE_SESSION_STATE=false'
+    fi
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == "USE_SESSION_STATE=true" ]]
+}
+
+# ===========================================================================
+# AC-2: crash-detect.sh
+# ubuntu-note-system 不在で USE_SESSION_STATE=true パスが使われることを
+# 行動的に検証（session-state ベースの exited 検知 vs tmux フォールバック）
+# ===========================================================================
+
+@test "AC-2: crash-detect.sh のデフォルト SESSION_STATE_CMD は session-state-wrapper.sh を指す" {
+  run grep "SESSION_STATE_CMD.*session-state-wrapper" "$SANDBOX/scripts/crash-detect.sh"
+  assert_success
+}
+
+@test "AC-2: crash-detect.sh: ubuntu-note-system 不在 + SESSION_STATE_CMD 未設定でも USE_SESSION_STATE=true パスが実行される" {
+  create_issue_json 1 "running"
+
+  # tmux はペイン存在を返す（USE_SESSION_STATE=false フォールバックなら exit 0 になる）
+  stub_command "tmux" 'exit 0'
+
+  # wrapper を "exited" を返す stub で上書き（USE_SESSION_STATE=true なら exit 2 になる）
+  cat > "$SANDBOX/scripts/session-state-wrapper.sh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  state) echo "exited" ;;
+  *) echo '{"state":"exited"}' ;;
+esac
+STUB
+  chmod +x "$SANDBOX/scripts/session-state-wrapper.sh"
+
+  # HOME を fake dir に向け、SESSION_STATE_CMD は設定しない
+  HOME="$FAKE_HOME" \
+    run bash "$SANDBOX/scripts/crash-detect.sh" \
+    --issue 1 --window "ap-#1"
+
+  # USE_SESSION_STATE=true → session-state で exited を検知 → CRASH メッセージ出力
+  # USE_SESSION_STATE=false → tmux pane exists → クリーン終了（出力なし）
+  # NOTE: exit code 2 は report_crash 内の state write が worktrees/ ガードで
+  # 失敗することで変わる場合があるが、出力内の "exited" 検知は確実
+  assert_failure
+  [[ "$output" == *"exited"* ]]
+}
+
+# ===========================================================================
+# AC-2: health-check.sh
+# ubuntu-note-system 不在で USE_SESSION_STATE=true パスが使われることを
+# 行動的に検証（session-state ベースの input-waiting 検知）
+# ===========================================================================
+
+@test "AC-2: health-check.sh のデフォルト SESSION_STATE_CMD は session-state-wrapper.sh を指す" {
+  run grep "SESSION_STATE_CMD.*session-state-wrapper" "$SANDBOX/scripts/health-check.sh"
+  assert_success
+}
+
+@test "AC-2: health-check.sh: ubuntu-note-system 不在 + SESSION_STATE_CMD 未設定でも USE_SESSION_STATE=true パスが実行される" {
+  create_issue_json 1 "running"
+
+  # wrapper を input-waiting を返す stub で上書き（since=0: epoch → elapsed が閾値超過）
+  # USE_SESSION_STATE=true なら input_waiting を検知（exit 1）
+  # USE_SESSION_STATE=false なら入力待ち検知スキップ（exit 0）
+  cat > "$SANDBOX/scripts/session-state-wrapper.sh" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  state) echo "input-waiting" ;;
+  get)   echo '{"state":"input-waiting","since":0}' ;;
+  *)     exit 1 ;;
+esac
+STUB
+  chmod +x "$SANDBOX/scripts/session-state-wrapper.sh"
+
+  HOME="$FAKE_HOME" \
+    run bash "$SANDBOX/scripts/health-check.sh" \
+    --issue 1 --window "ap-#1"
+
+  # USE_SESSION_STATE=true → input-waiting 検知 → exit 1 + "input_waiting" in output
+  # USE_SESSION_STATE=false → スキップ → exit 0
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"input_waiting"* ]]
+}


### PR DESCRIPTION
fix(orchestrator): SESSION_STATE_CMD デフォルトパスを session-state-wrapper.sh に修正

$HOME/ubuntu-note-system/scripts/session-state.sh は fresh clone 環境で
不在のため USE_SESSION_STATE=false に silent fallback していた。
既存の session-state-wrapper.sh（plugins/session への正しい参照）を
デフォルトに設定することで全環境で input-waiting 検知が機能する。

対象: autopilot-orchestrator.sh, crash-detect.sh, health-check.sh

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #752