### PR TITLE
fix(chain-runner): Worker change_id 誤継承バグを修正 (#753, #742)

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -86,6 +86,27 @@ resolve_autopilot_dir() {
   echo "${main_wt:-.}/.autopilot"
 }
 
+# Issue 番号に対応する change_id を厳密に解決する
+# Usage: resolve_change_id_for_issue <issue_num> <changes_dir>
+# - issue_num 非空: changes_dir/issue-<issue_num>/ が存在すれば "issue-<issue_num>" を echo (exit 0)
+#                   存在しなければ空文字を echo (exit 0)
+# - issue_num 空:   ls -td | head -1 による mtime-latest fallback
+resolve_change_id_for_issue() {
+  local issue_num="${1:-}"
+  local changes_dir="${2:-}"
+  if [[ -n "$issue_num" ]]; then
+    local candidate="$changes_dir/issue-${issue_num}"
+    if [[ -d "$candidate" ]]; then
+      echo "issue-${issue_num}"
+    else
+      echo ""
+    fi
+    return 0
+  fi
+  # legacy fallback (issue_num 未設定時のみ)
+  ls -td "$changes_dir"/*/ 2>/dev/null | head -1 | xargs -r basename
+}
+
 # =====================================================================
 # Trace Event (Phase 3 / Layer 1 経験的監査)
 # =====================================================================
@@ -345,9 +366,18 @@ step_init() {
     return 0
   fi
 
-  # 最新 change の proposal 状態
+  # Issue 番号に対応する change を厳密に解決（mtime-latest anti-pattern を排除）
   local latest_change
-  latest_change="$(ls -td "$changes_dir"/*/ 2>/dev/null | head -1 | xargs -r basename)"
+  latest_change="$(resolve_change_id_for_issue "$issue_num" "$changes_dir")"
+
+  # ISSUE_NUM があり issue-<N>/ 不在の場合 → propose (新規作成経路)
+  if [[ -n "$issue_num" && "$issue_num" =~ ^[0-9]+$ && -z "$latest_change" ]]; then
+    jq -n --arg branch "$branch" --argjson is_quick "$is_quick" '{"recommended_action":"propose","branch":$branch,"deltaspec":false,"is_quick":$is_quick}'
+    ok "init" "recommended_action=propose (issue-${issue_num}/ not found, is_quick=$is_quick)"
+    python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "mode=propose" 2>/dev/null || true
+    return 0
+  fi
+
   local proposal="$changes_dir/$latest_change/proposal.md"
 
   if [[ -f "$proposal" ]]; then
@@ -844,12 +874,21 @@ step_change_id_resolve() {
     return 1
   fi
 
+  local issue_num="${ISSUE_NUM:-}"
   local latest
-  latest=$(ls -td "$changes_dir"/*/ 2>/dev/null | head -1 | xargs -r basename)
+  latest="$(resolve_change_id_for_issue "$issue_num" "$changes_dir")"
 
   if [[ -z "$latest" ]]; then
-    err "change-id-resolve" "changes/ が空"
-    return 1
+    if [[ -n "$issue_num" && "${CHANGE_ID_FALLBACK_LATEST:-0}" != "1" ]]; then
+      err "change-id-resolve" "issue-${issue_num}/ が存在しない"
+      return 1
+    fi
+    # legacy fallback: CHANGE_ID_FALLBACK_LATEST=1 opt-in、または ISSUE_NUM 未設定
+    latest=$(ls -td "$changes_dir"/*/ 2>/dev/null | head -1 | xargs -r basename)
+    if [[ -z "$latest" ]]; then
+      err "change-id-resolve" "changes/ が空"
+      return 1
+    fi
   fi
 
   echo "$latest"

--- a/plugins/twl/tests/bats/scripts/chain-runner-change-id-resolve.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-change-id-resolve.bats
@@ -1,0 +1,92 @@
+#!/usr/bin/env bats
+# chain-runner-change-id-resolve.bats
+# Unit tests for Issue #753: step_change_id_resolve() の mtime-latest fallback 修正
+#
+# Spec: Issue #753 — Worker change_id 誤継承バグ
+#
+# Coverage:
+#   (a) issue-748/ 存在 + ISSUE_NUM=748 → change-id-resolve が issue-748 を echo (exit 0)
+#   (b) issue-748/ 不在 + ISSUE_NUM=748 (strict default) → exit 1 + stderr に「issue-748/ が存在しない」
+#   (c) issue-748/ 不在 + ISSUE_NUM=748 + CHANGE_ID_FALLBACK_LATEST=1
+#       → legacy mtime-latest fallback で issue-707 を echo
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*)
+        echo "feat/748-fix" ;;
+      *"rev-parse --show-toplevel"*)
+        echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*)
+        echo "$SANDBOX/.git" ;;
+      *"worktree list"*)
+        echo "worktree $SANDBOX"
+        echo "HEAD abc123"
+        echo "branch refs/heads/main" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  stub_command "gh" 'exit 0'
+
+  # minimal deltaspec root
+  mkdir -p "$SANDBOX/deltaspec/changes"
+  echo "version: 1" > "$SANDBOX/deltaspec/config.yaml"
+
+  # issue-707: mtime 最新（fallback テスト用）
+  mkdir -p "$SANDBOX/deltaspec/changes/issue-707"
+  echo "name: issue-707" > "$SANDBOX/deltaspec/changes/issue-707/.deltaspec.yaml"
+  touch "$SANDBOX/deltaspec/changes/issue-707"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# (a) ISSUE_NUM=748, issue-748/ 存在 → issue-748 を echo (exit 0)
+# WHEN: ISSUE_NUM=748 で issue-748/ が deltaspec/changes/ に存在する
+# THEN: change-id-resolve は "issue-748" を stdout に出力し exit 0
+# ---------------------------------------------------------------------------
+@test "change-id-resolve: ISSUE_NUM=748, issue-748/ 存在 → issue-748 を echo" {
+  mkdir -p "$SANDBOX/deltaspec/changes/issue-748"
+  echo "name: issue-748" > "$SANDBOX/deltaspec/changes/issue-748/.deltaspec.yaml"
+
+  export ISSUE_NUM=748
+  run bash "$SANDBOX/scripts/chain-runner.sh" change-id-resolve
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qi "issue-748"
+  ! echo "$output" | grep -qi "issue-707"
+}
+
+# ---------------------------------------------------------------------------
+# (b) ISSUE_NUM=748, issue-748/ 不在, strict mode → exit 1 + エラーメッセージ
+# WHEN: ISSUE_NUM=748 で issue-748/ が存在せず CHANGE_ID_FALLBACK_LATEST 未設定
+# THEN: change-id-resolve は exit 1 し stderr に「issue-748/ が存在しない」を含む
+# ---------------------------------------------------------------------------
+@test "change-id-resolve: ISSUE_NUM=748, issue-748/ 不在 (strict) → exit 1 + error" {
+  export ISSUE_NUM=748
+  unset CHANGE_ID_FALLBACK_LATEST
+  run bash "$SANDBOX/scripts/chain-runner.sh" change-id-resolve
+  [ "$status" -ne 0 ]
+  echo "$output" | grep -q "issue-748"
+}
+
+# ---------------------------------------------------------------------------
+# (c) ISSUE_NUM=748, issue-748/ 不在 + CHANGE_ID_FALLBACK_LATEST=1
+#     → legacy mtime-latest fallback で issue-707 を echo
+# WHEN: CHANGE_ID_FALLBACK_LATEST=1 の opt-in で issue-748/ 不在
+# THEN: change-id-resolve は ls -td fallback で mtime 最新の issue-707 を echo
+# ---------------------------------------------------------------------------
+@test "change-id-resolve: CHANGE_ID_FALLBACK_LATEST=1 + issue-748/ 不在 → legacy fallback で issue-707" {
+  export ISSUE_NUM=748
+  export CHANGE_ID_FALLBACK_LATEST=1
+  run bash "$SANDBOX/scripts/chain-runner.sh" change-id-resolve
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "issue-707"
+}

--- a/plugins/twl/tests/bats/scripts/chain-runner-init.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-init.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+# chain-runner-init.bats
+# Unit tests for Issue #753: step_init() の mtime-latest fallback 修正
+#
+# Spec: Issue #753 — Worker change_id 誤継承バグ
+#
+# Coverage:
+#   (a) issue-707/ (approved) 存在 + issue-748/ 不在 + ISSUE_NUM=748
+#       → recommended_action=propose, change_id 不在
+#   (b) issue-707/ (approved) 存在 + issue-748/ (pending) 存在 + ISSUE_NUM=748
+#       → change_id=issue-748（issue-707 を参照しない）
+#   (c) issue-707/ 存在 + ISSUE_NUM 未設定
+#       → ls -td fallback で issue-707 採用（legacy 互換）
+#   (d) issue-707/ 存在 + ISSUE_NUM=707 + .deltaspec.yaml=approved
+#       → recommended_action=apply, change_id=issue-707
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*)
+        echo "feat/test-branch" ;;
+      *"rev-parse --show-toplevel"*)
+        echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*)
+        echo "$SANDBOX/.git" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"diff"*"--name-only"*)
+        # 実装コードを含む diff → retroactive 経路を回避
+        echo "plugins/twl/scripts/chain-runner.sh" ;;
+      *"worktree list"*)
+        echo "worktree $SANDBOX"
+        echo "HEAD abc123"
+        echo "branch refs/heads/main" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  stub_command "gh" 'exit 0'
+
+  # minimal deltaspec root
+  mkdir -p "$SANDBOX/deltaspec/changes"
+  echo "version: 1" > "$SANDBOX/deltaspec/config.yaml"
+
+  # issue-707: approved (mtime 最新にする)
+  mkdir -p "$SANDBOX/deltaspec/changes/issue-707"
+  cat > "$SANDBOX/deltaspec/changes/issue-707/.deltaspec.yaml" <<'EOF'
+name: issue-707
+status: approved
+EOF
+  echo "# Proposal" > "$SANDBOX/deltaspec/changes/issue-707/proposal.md"
+  # issue-707 を mtime 最新にする
+  touch "$SANDBOX/deltaspec/changes/issue-707"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# (a) ISSUE_NUM=748, issue-748/ 不在 → propose (新規作成経路)
+# WHEN: issue-707/ (approved) が mtime 最新で存在し、issue-748/ は不在
+# THEN: ISSUE_NUM=748 で init を実行すると recommended_action=propose
+# ---------------------------------------------------------------------------
+@test "init: ISSUE_NUM=748, issue-748/ 不在 → recommended_action=propose (issue-707 を誤採用しない)" {
+  # issue-707.json を作成してテスト
+  jq -n '{issue: 748, status: "running", branch: "feat/748", current_step: "init"}' \
+    > "$SANDBOX/.autopilot/issues/issue-748.json"
+
+  export ISSUE_NUM=748
+  run bash "$SANDBOX/scripts/chain-runner.sh" init 748
+  [ "$status" -eq 0 ]
+  # recommended_action が propose であること
+  echo "$output" | grep -q '"recommended_action".*"propose"'
+  # change_id が issue-707 でないこと
+  ! echo "$output" | grep -q '"change_id".*"issue-707"'
+}
+
+# ---------------------------------------------------------------------------
+# (b) ISSUE_NUM=748, issue-748/ (pending) 存在 → change_id=issue-748
+# WHEN: issue-707/ (approved, mtime 最新) と issue-748/ (pending) が共存
+# THEN: ISSUE_NUM=748 で init を実行すると change_id=issue-748 を返す
+# ---------------------------------------------------------------------------
+@test "init: ISSUE_NUM=748, issue-748/ (pending) 存在 → change_id=issue-748 (issue-707 を参照しない)" {
+  # issue-748: pending (proposal あり、未承認)
+  mkdir -p "$SANDBOX/deltaspec/changes/issue-748"
+  cat > "$SANDBOX/deltaspec/changes/issue-748/.deltaspec.yaml" <<'EOF'
+name: issue-748
+status: pending
+EOF
+  echo "# Draft proposal" > "$SANDBOX/deltaspec/changes/issue-748/proposal.md"
+
+  jq -n '{issue: 748, status: "running", branch: "feat/748", current_step: "init"}' \
+    > "$SANDBOX/.autopilot/issues/issue-748.json"
+
+  export ISSUE_NUM=748
+  run bash "$SANDBOX/scripts/chain-runner.sh" init 748
+  [ "$status" -eq 0 ]
+  # change_id が issue-748 であること（issue-707 ではない）
+  echo "$output" | grep -q '"change_id".*"issue-748"'
+  ! echo "$output" | grep -q '"change_id".*"issue-707"'
+}
+
+# ---------------------------------------------------------------------------
+# (c) ISSUE_NUM 未設定 → legacy mtime-latest fallback で issue-707 採用
+# WHEN: issue-707/ (approved) が mtime 最新で存在、ISSUE_NUM は未設定
+# THEN: init は既存挙動（ls -td fallback）で issue-707 を採用する
+# ---------------------------------------------------------------------------
+@test "init: ISSUE_NUM 未設定 → legacy fallback で mtime-latest (issue-707) を採用" {
+  unset ISSUE_NUM
+  run bash "$SANDBOX/scripts/chain-runner.sh" init
+  [ "$status" -eq 0 ]
+  # recommended_action=apply かつ change_id=issue-707
+  echo "$output" | grep -q '"change_id".*"issue-707"'
+  echo "$output" | grep -q '"recommended_action".*"apply"'
+}
+
+# ---------------------------------------------------------------------------
+# (d) ISSUE_NUM=707, issue-707/ .deltaspec.yaml=approved → recommended_action=apply
+# WHEN: issue-707/ が存在し .deltaspec.yaml=approved、ISSUE_NUM=707
+# THEN: recommended_action=apply, change_id=issue-707
+# ---------------------------------------------------------------------------
+@test "init: ISSUE_NUM=707, issue-707/ (approved) → recommended_action=apply, change_id=issue-707" {
+  jq -n '{issue: 707, status: "running", branch: "feat/707", current_step: "init"}' \
+    > "$SANDBOX/.autopilot/issues/issue-707.json"
+
+  export ISSUE_NUM=707
+  run bash "$SANDBOX/scripts/chain-runner.sh" init 707
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q '"recommended_action".*"apply"'
+  echo "$output" | grep -q '"change_id".*"issue-707"'
+}


### PR DESCRIPTION
fix(chain-runner): Worker change_id 誤継承バグを修正 (#753, #742)

## 変更概要

`step_init()` と `step_change_id_resolve()` の `ls -td | head -1`
mtime-latest fallback を廃止し、Issue 番号に基づく厳密な
change_id 解決に置き換える。

## 修正内容

- `resolve_change_id_for_issue()` ヘルパー関数を追加
  - `issue_num` 非空: `changes_dir/issue-<N>/` を厳密に検索
  - `issue_num` 空: 後方互換のため mtime-latest fallback
- `step_init()`: `ISSUE_NUM` 環境変数を読み取り、対応する
  change directory が不在なら `recommended_action=propose` を返す
- `step_change_id_resolve()`: 厳密モードを default に。
  `CHANGE_ID_FALLBACK_LATEST=1` で旧挙動に opt-in 可能
- `chain-runner-init.bats` 新規作成（4 ケース）
- `chain-runner-change-id-resolve.bats` 新規作成（3 ケース）

Closes #742

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #753