### PR TITLE
fix(merge-gate): post-fix-verify checkpoint precedence over stale phase-review (#748)

### DIFF
--- a/plugins/twl/architecture/domain/contexts/pr-cycle.md
+++ b/plugins/twl/architecture/domain/contexts/pr-cycle.md
@@ -153,6 +153,7 @@ flowchart TD
 - **merge-gate リトライ制限**: merge-gate リジェクト後のリトライは最大1回（不変条件 E）。2回目リジェクト = 確定失敗。Pilot に報告し、手動介入を要求
 - **rebase 禁止**: merge 失敗時に rebase は試みない（停止のみ、不変条件 F）
 - **Tech-stack 検出**: 変更ファイルの拡張子・パスから specialist を選択。script 型コンポーネントで実装
+- **checkpoint 優先順位**: post-fix-verify > phase-review。post-fix-verify.json 存在時は phase-review findings を shadow する（merge-gate-checkpoint-merge.sh）
 
 ## Rules
 

--- a/plugins/twl/commands/post-fix-verify.md
+++ b/plugins/twl/commands/post-fix-verify.md
@@ -70,6 +70,14 @@ IF 新規 WARNING finding あり → WARN（続行可）
 IF 新規 CRITICAL finding あり → FAIL（再 fix 必要）
 ```
 
+結果判定後に即座に checkpoint を書き出す（merge-gate が post-fix-verify 結果を参照するために必須）:
+
+```bash
+STATUS=$(echo "$PARSED" | jq -r '.status')
+FINDINGS=$(echo "$PARSED" | jq -c '.findings')
+python3 -m twl.autopilot.checkpoint write --step post-fix-verify --status "$STATUS" --findings "$FINDINGS"
+```
+
 ## チェックポイント（MUST）
 
 `/twl:warning-fix` を Skill tool で自動実行。

--- a/plugins/twl/scripts/merge-gate-checkpoint-merge.sh
+++ b/plugins/twl/scripts/merge-gate-checkpoint-merge.sh
@@ -10,5 +10,10 @@ set -euo pipefail
 
 FINDINGS="${1:-[]}"
 AC_VERIFY_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --field findings 2>/dev/null || echo "[]")
-PHASE_REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field findings 2>/dev/null || echo "[]")
-jq -s 'add' <(echo "$FINDINGS") <(echo "$AC_VERIFY_FINDINGS") <(echo "$PHASE_REVIEW_FINDINGS")
+POST_FIX_VERIFY_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step post-fix-verify --field findings 2>/dev/null || echo "")
+if [[ -n "$POST_FIX_VERIFY_FINDINGS" ]]; then
+  jq -s 'add' <(echo "$FINDINGS") <(echo "$AC_VERIFY_FINDINGS") <(echo "$POST_FIX_VERIFY_FINDINGS")
+else
+  PHASE_REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field findings 2>/dev/null || echo "[]")
+  jq -s 'add' <(echo "$FINDINGS") <(echo "$AC_VERIFY_FINDINGS") <(echo "$PHASE_REVIEW_FINDINGS")
+fi

--- a/plugins/twl/tests/bats/scripts/merge-gate-checkpoint-merge.bats
+++ b/plugins/twl/tests/bats/scripts/merge-gate-checkpoint-merge.bats
@@ -177,6 +177,92 @@ teardown() {
     "$SANDBOX/scripts/merge-gate-checkpoint-merge.sh"
 }
 
+# ---------------------------------------------------------------------------
+# #748: post-fix-verify precedence over phase-review
+# ---------------------------------------------------------------------------
+
+@test "[#748] phase-review CRITICAL あり + post-fix-verify 不在 → phase-review findings が COMBINED に含まれる（回帰保護）" {
+  stub_command "python3" '
+    case "$*" in
+      *"checkpoint"*"read"*"ac-verify"*)
+        echo "[]" ;;
+      *"checkpoint"*"read"*"post-fix-verify"*)
+        exit 1 ;;
+      *"checkpoint"*"read"*"phase-review"*)
+        echo '"'"'[{"severity":"CRITICAL","message":"stale-phase-review-critical","confidence":90}]'"'"' ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/merge-gate-checkpoint-merge.sh" "[]"
+
+  assert_success
+  assert_output --partial "stale-phase-review-critical"
+}
+
+@test "[#748] phase-review CRITICAL あり + post-fix-verify PASS → phase-review CRITICAL が COMBINED から除外される" {
+  stub_command "python3" '
+    case "$*" in
+      *"checkpoint"*"read"*"ac-verify"*)
+        echo "[]" ;;
+      *"checkpoint"*"read"*"post-fix-verify"*)
+        echo "[]" ;;
+      *"checkpoint"*"read"*"phase-review"*)
+        echo '"'"'[{"severity":"CRITICAL","message":"stale-phase-review-critical","confidence":90}]'"'"' ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/merge-gate-checkpoint-merge.sh" "[]"
+
+  assert_success
+  refute_output --partial "stale-phase-review-critical"
+}
+
+@test "[#748] phase-review CRITICAL あり + post-fix-verify WARN → phase-review CRITICAL が除外され post-fix-verify WARNING が含まれる（最頻ケース）" {
+  stub_command "python3" '
+    case "$*" in
+      *"checkpoint"*"read"*"ac-verify"*)
+        echo "[]" ;;
+      *"checkpoint"*"read"*"post-fix-verify"*)
+        echo '"'"'[{"severity":"WARNING","message":"post-fix-verify-warning","confidence":75}]'"'"' ;;
+      *"checkpoint"*"read"*"phase-review"*)
+        echo '"'"'[{"severity":"CRITICAL","message":"stale-phase-review-critical","confidence":90}]'"'"' ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/merge-gate-checkpoint-merge.sh" "[]"
+
+  assert_success
+  assert_output --partial "post-fix-verify-warning"
+  refute_output --partial "stale-phase-review-critical"
+}
+
+@test "[#748] phase-review CRITICAL あり + post-fix-verify FAIL → post-fix-verify findings が採用され CRITICAL が残る" {
+  stub_command "python3" '
+    case "$*" in
+      *"checkpoint"*"read"*"ac-verify"*)
+        echo "[]" ;;
+      *"checkpoint"*"read"*"post-fix-verify"*)
+        echo '"'"'[{"severity":"CRITICAL","message":"post-fix-verify-critical","confidence":85}]'"'"' ;;
+      *"checkpoint"*"read"*"phase-review"*)
+        echo '"'"'[{"severity":"CRITICAL","message":"stale-phase-review-critical","confidence":90}]'"'"' ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/merge-gate-checkpoint-merge.sh" "[]"
+
+  assert_success
+  assert_output --partial "post-fix-verify-critical"
+  refute_output --partial "stale-phase-review-critical"
+}
+
 @test "[edge] スクリプトが stdout に結果を出力する（stderr ではない）" {
   stub_command "python3" '
     case "$*" in


### PR DESCRIPTION
fix(merge-gate): post-fix-verify checkpoint precedence over stale phase-review (#748)

- post-fix-verify.md: checkpoint write を Step 5 直後に追加
- merge-gate-checkpoint-merge.sh: post-fix-verify.json 存在時は phase-review findings を除外し post-fix-verify findings を採用する precedence ロジックを追加
- merge-gate-checkpoint-merge.bats: 4 回帰テスト追加（phase-review CRITICAL + post-fix-verify 不在/PASS/WARN/FAIL）
- pr-cycle.md: checkpoint 優先順位（post-fix-verify > phase-review）を Constraints に追記

Closes #748