### PR TITLE
fix: branch regex から . を除外してパストラバーサルリスクを排除 (#685)

### DIFF
--- a/plugins/twl/scripts/autopilot-cleanup.sh
+++ b/plugins/twl/scripts/autopilot-cleanup.sh
@@ -182,8 +182,8 @@ while IFS= read -r line; do
         else
           if bash "$SCRIPTS_ROOT/worktree-delete.sh" "$wt_branch" 2>/dev/null; then
             echo "[cleanup] 孤立 worktree 削除: $wt_path (branch=$wt_branch)" >&2
-            # リモートブランチも削除（パストラバーサル防止ガード: cleanup_worker() L427 相当）
-            if [[ -n "$wt_branch" && "$wt_branch" =~ ^[a-zA-Z0-9._/\-]+$ ]]; then
+            # リモートブランチも削除（パストラバーサル防止: L288 と同一の `.` 除外 regex を使用）
+            if [[ -n "$wt_branch" && "$wt_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
               git push origin --delete "$wt_branch" 2>/dev/null || \
                 echo "[cleanup] ⚠️ リモートブランチ削除失敗: $wt_branch（続行）" >&2
             else

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -291,6 +291,8 @@ launch_worker() {
       worktree_dir="$candidate_dir"
       echo "[orchestrator] Issue #${ISSUE}: 既存 worktree を使用: $worktree_dir" >&2
     fi
+  elif [[ -n "$existing_branch" ]]; then
+    echo "[orchestrator] Issue #${ISSUE}: ⚠️ 不正なブランチ名を拒否: $existing_branch" >&2
   fi
 
   # 既存 worktree が見つからない場合は Python モジュールで作成

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -284,8 +284,8 @@ launch_worker() {
   [[ "$ISSUE_REPO_ID" != "_default" ]] && _repo_args=(--repo "$ISSUE_REPO_ID")
   local existing_branch
   existing_branch=$(python3 -m twl.autopilot.state read --type issue "${_repo_args[@]}" --issue "$ISSUE" --field branch 2>/dev/null || echo "")
-  # ブランチ名バリデーション（パストラバーサル防止、cleanup_worker と同一パターン）
-  if [[ -n "$existing_branch" && "$existing_branch" =~ ^[a-zA-Z0-9._/\-]+$ ]]; then
+  # ブランチ名バリデーション: `.` 除外の統一 regex（L288/L418/L1270 + autopilot-cleanup.sh L186 + orchestrator-cleanup-sequence.bats test double）
+  if [[ -n "$existing_branch" && "$existing_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
     local candidate_dir="$effective_project_dir/worktrees/$existing_branch"
     if [[ -d "$candidate_dir" ]]; then
       worktree_dir="$candidate_dir"
@@ -414,8 +414,8 @@ cleanup_worker() {
 
   local branch
   branch=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field branch 2>/dev/null || echo "")
-  # ブランチ名バリデーション（コマンドインジェクション防止）
-  if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9._/\-]+$ ]]; then
+  # ブランチ名バリデーション（コマンドインジェクション防止、パストラバーサル防止: L288 と同一 `.` 除外 regex）
+  if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
     # Step 2: worktree削除（ローカルブランチ込み）— bare repo（worktreeモード）のみ実行
     if [[ "$repo_mode" == "worktree" ]]; then
       bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>/dev/null || \
@@ -1266,8 +1266,8 @@ startup_cleanup() {
   while IFS= read -r _raw_branch; do
     local _branch="${_raw_branch#"  "}"  # 先頭空白除去
     [[ "$_branch" =~ $prefixes_pattern ]] || continue
-    # ブランチ名バリデーション（コマンドインジェクション防止）
-    [[ "$_branch" =~ ^[a-zA-Z0-9._/\-]+$ ]] || continue
+    # ブランチ名バリデーション（コマンドインジェクション防止、パストラバーサル防止: L288 と同一 `.` 除外 regex）
+    [[ "$_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]] || continue
     merged_branches+=("$_branch")
   done < <(git branch --merged origin/main 2>/dev/null | grep -v '^\* ' | grep -v '^  main$' || true)
 

--- a/plugins/twl/tests/bats/scripts/orchestrator-branch-regex.bats
+++ b/plugins/twl/tests/bats/scripts/orchestrator-branch-regex.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# orchestrator-branch-regex.bats
+# AC-3: branch 名バリデーション regex の統一 unit tests
+# 対象箇所: autopilot-orchestrator.sh L288/L418/L1270 + autopilot-cleanup.sh L186
+#
+# Regex: ^[a-zA-Z0-9_/\-]+$  (`.` を完全除外)
+
+load '../helpers/common'
+
+# ---------------------------------------------------------------------------
+# Helper: regex と同一の bash 条件式で accept/reject を判定
+# 各ロケーション（L288/L418/L1270/cleanup L186）を独立してカバー
+# ---------------------------------------------------------------------------
+
+# _branch_regex_match <branch> — returns 0 if accepted, 1 if rejected
+_branch_regex_match() {
+  local branch="$1"
+  [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]
+}
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# accept cases — autopilot _ALLOWED_PREFIXES に対応する正常系
+# ---------------------------------------------------------------------------
+
+@test "accept: feat/ prefix (L288 orchestrator existing_branch)" {
+  run bash -c '[[ -n "feat/685-fix-regex" && "feat/685-fix-regex" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+@test "accept: fix/ prefix (L418 orchestrator cleanup_worker)" {
+  run bash -c '[[ -n "fix/issue-685-orchestrator" && "fix/issue-685-orchestrator" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+@test "accept: chore/ prefix (L1270 orchestrator startup_cleanup)" {
+  run bash -c '[[ -n "chore/cleanup-scripts" && "chore/cleanup-scripts" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+@test "accept: refactor/ prefix (cleanup.sh L186)" {
+  run bash -c '[[ -n "refactor/autopilot" && "refactor/autopilot" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+@test "accept: test/ prefix" {
+  run bash -c '[[ -n "test/validate" && "test/validate" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+@test "accept: docs/ prefix" {
+  run bash -c '[[ -n "docs/update" && "docs/update" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok'
+  assert_output "ok"
+}
+
+# ---------------------------------------------------------------------------
+# reject cases — `.` 含み / パストラバーサル / 空文字列
+# ---------------------------------------------------------------------------
+
+@test "reject: .. (path traversal — L288)" {
+  run bash -c '[[ -n ".." && ".." =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: ../ (path traversal — L418)" {
+  run bash -c '[[ -n "../" && "../" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: foo/.. (path traversal — L1270)" {
+  run bash -c '[[ -n "foo/.." && "foo/.." =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: foo/../bar (path traversal — cleanup L186)" {
+  run bash -c '[[ -n "foo/../bar" && "foo/../bar" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: ../../etc/passwd (deep traversal)" {
+  run bash -c '[[ -n "../../etc/passwd" && "../../etc/passwd" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: foo..bar (dot in branch name)" {
+  run bash -c '[[ -n "foo..bar" && "foo..bar" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: release/v1.2.3 (dot in version tag)" {
+  run bash -c '[[ -n "release/v1.2.3" && "release/v1.2.3" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}
+
+@test "reject: empty string (-n guard)" {
+  run bash -c '[[ -n "" && "" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
+  assert_output "rejected"
+}

--- a/plugins/twl/tests/bats/scripts/orchestrator-branch-regex.bats
+++ b/plugins/twl/tests/bats/scripts/orchestrator-branch-regex.bats
@@ -103,3 +103,74 @@ teardown() {
   run bash -c '[[ -n "" && "" =~ ^[a-zA-Z0-9_/\-]+$ ]] && echo ok || echo rejected'
   assert_output "rejected"
 }
+
+# ---------------------------------------------------------------------------
+# AC-4: integration — state file injection で candidate_dir が作られずエラーログ出力
+# orchestrator-cleanup-sequence.bats の pattern 準拠（test double + JSON mock）
+# ---------------------------------------------------------------------------
+
+_create_existing_branch_double() {
+  local project_dir="$1"
+  cat > "$SANDBOX/scripts/existing-branch-double.sh" <<DOUBLE_EOF
+#!/usr/bin/env bash
+# existing-branch-double.sh
+# autopilot-orchestrator.sh の L288 ブランチバリデーション ロジックを抽出したテストダブル
+set -uo pipefail
+
+ISSUE="\${1:-999}"
+effective_project_dir="${project_dir}"
+
+existing_branch=\$(python3 -m twl.autopilot.state read --autopilot-dir "$SANDBOX/.autopilot" --type issue --issue "\$ISSUE" --field branch 2>/dev/null || echo "")
+
+# ブランチ名バリデーション: `.` 除外の統一 regex (L288 と同一ロジック)
+if [[ -n "\$existing_branch" && "\$existing_branch" =~ ^[a-zA-Z0-9_/\\-]+\$ ]]; then
+  local candidate_dir="\$effective_project_dir/worktrees/\$existing_branch"
+  if [[ -d "\$candidate_dir" ]]; then
+    echo "[orchestrator] Issue #\${ISSUE}: 既存 worktree を使用: \$candidate_dir" >&2
+    echo "USED:\$candidate_dir"
+  fi
+elif [[ -n "\$existing_branch" ]]; then
+  echo "[orchestrator] Issue #\${ISSUE}: ⚠️ 不正なブランチ名を拒否: \$existing_branch" >&2
+  echo "REJECTED:\$existing_branch"
+fi
+DOUBLE_EOF
+  chmod +x "$SANDBOX/scripts/existing-branch-double.sh"
+}
+
+@test "AC-4: state file injection ../../../etc/passwd — candidate_dir 未作成 + エラーログ出力" {
+  # Setup: JSON mock state file with malicious branch name
+  local issue_json="$SANDBOX/.autopilot/issues/issue-999.json"
+  cat > "$issue_json" <<'EOF'
+{"branch": "../../../etc/passwd", "status": "in_progress", "role": "worker"}
+EOF
+
+  # Worktree dir must not exist for the injection target
+  local target="$SANDBOX/worktrees/../../../etc/passwd"
+  [[ -d "$target" ]] && fail "target dir must not exist pre-test"
+
+  _create_existing_branch_double "$SANDBOX"
+
+  run bash "$SANDBOX/scripts/existing-branch-double.sh" "999"
+
+  # candidate_dir must not be used
+  refute_output --partial "USED:"
+  # Error log must be output
+  assert_output --partial "REJECTED:../../../etc/passwd"
+}
+
+@test "AC-4: valid branch — candidate_dir 構築試行（エラーログなし）" {
+  # Setup: JSON mock with valid branch name (dir not present → no USED output)
+  local issue_json="$SANDBOX/.autopilot/issues/issue-998.json"
+  cat > "$issue_json" <<'EOF'
+{"branch": "feat/998-valid", "status": "in_progress", "role": "worker"}
+EOF
+
+  _create_existing_branch_double "$SANDBOX"
+
+  run bash "$SANDBOX/scripts/existing-branch-double.sh" "998"
+
+  # No rejection error
+  refute_output --partial "REJECTED:"
+  # No worktree dir → no USED output either
+  refute_output --partial "USED:"
+}

--- a/plugins/twl/tests/bats/scripts/orchestrator-cleanup-sequence.bats
+++ b/plugins/twl/tests/bats/scripts/orchestrator-cleanup-sequence.bats
@@ -47,7 +47,7 @@ tmux kill-window -t "$window_name" 2>/dev/null || true
 
 # Step 2: worktree-delete.sh（失敗時は警告して継続）
 branch=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field branch 2>/dev/null || echo "")
-if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9._/\-]+$ ]]; then
+if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
   echo "STEP:worktree_delete:${branch}" >> "$CALL_LOG"
   if ! bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>/dev/null; then
     echo "[cleanup-double] WARN: worktree-delete.sh 失敗（継続）: ${branch}" >&2
@@ -56,7 +56,7 @@ fi
 
 # Step 3: git push origin --delete（クロスリポ対応）
 branch=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field branch 2>/dev/null || echo "")
-if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9._/\-]+$ ]]; then
+if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
   # クロスリポ解決: REPOS_JSON から entry のパスを取得
   ISSUE_REPO_PATH=""
   ISSUE_REPO_ID="${entry%%:*}"


### PR DESCRIPTION
fix: branch regex から `.` を除外してパストラバーサルリスクを排除 (#685)

## 変更内容

6 箇所の branch 名バリデーション regex を統一（`.` を完全除外）:

| ファイル | 行 | 変更前 | 変更後 |
|---|---|---|---|
| autopilot-orchestrator.sh | L288 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |
| autopilot-orchestrator.sh | L418 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |
| autopilot-orchestrator.sh | L1270 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |
| autopilot-cleanup.sh | L186 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |
| orchestrator-cleanup-sequence.bats | L50 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |
| orchestrator-cleanup-sequence.bats | L59 | ^[a-zA-Z0-9._/\-]+$ | ^[a-zA-Z0-9_/\-]+$ |

また、autopilot-orchestrator.sh L288 に invalid branch 拒否時のエラーログを追加。

## reject される test case（AC-1 確認）

- `..` → rejected
- `foo/../bar` → rejected
- `../../etc/passwd` → rejected

## accept される test case（AC-2 確認）

- `feat/685-fix-regex` → accepted
- `fix/issue-685-orchestrator` → accepted
- `chore/cleanup` → accepted

## `.` を含む branch の運用ポリシー

`_ALLOWED_PREFIXES`（feat/, fix/, refactor/, docs/, test/, chore/）に `.` を使う convention はなく、autopilot 運用で `release/v1.2.3` のような `.` 入り branch は発生しない。本修正による legitimate な影響はない。

## grep 網羅検索結果（残存 0 件）

`grep -rnE '\[a-zA-Z0-9[.]_/\\-\]\+' plugins/twl/scripts/ plugins/twl/tests/bats/scripts/` → 0 matches

## Issue #686 との conflict

PR #763（Issue #686）は autopilot-orchestrator.sh を変更していないため conflict なし。本 PR を先に merge 可能。

## テスト

orchestrator-branch-regex.bats を新設（16 PASS）:
- accept 6 件: feat/, fix/, chore/, refactor/, test/, docs/ prefix
- reject 8 件: .., ../, foo/.., foo/../bar, ../../etc/passwd, foo..bar, release/v1.2.3, 空文字列
- AC-4 integration test 2 件: state file injection でのパストラバーサル拒否確認

Closes #685