### PR TITLE
fix(autopilot-init): AUTOPILOT_DIR パストラバーサル検証を追加 (#747)

### DIFF
--- a/plugins/twl/scripts/autopilot-init.sh
+++ b/plugins/twl/scripts/autopilot-init.sh
@@ -7,6 +7,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # AUTOPILOT_DIR 環境変数によるオーバーライドをサポート（テスト用）
 AUTOPILOT_DIR="${AUTOPILOT_DIR:-$PROJECT_ROOT/.autopilot}"
+if [[ "$AUTOPILOT_DIR" == *".."* ]]; then
+  echo "ERROR: AUTOPILOT_DIR にパストラバーサル文字 '..' が含まれています: $AUTOPILOT_DIR" >&2
+  exit 1
+fi
 ISSUES_DIR="$AUTOPILOT_DIR/issues"
 ARCHIVE_DIR="$AUTOPILOT_DIR/archive"
 SESSION_FILE="$AUTOPILOT_DIR/session.json"

--- a/plugins/twl/tests/bats/scripts/autopilot-init.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-init.bats
@@ -260,6 +260,20 @@ JSON
 # Requirement: autopilot-init.md の eval 除去 (eval-removal)
 # ---------------------------------------------------------------------------
 
+# ---------------------------------------------------------------------------
+# Requirement: AUTOPILOT_DIR パストラバーサル検証 (#747)
+# ---------------------------------------------------------------------------
+
+@test "autopilot-init rejects AUTOPILOT_DIR containing '..'" {
+  export AUTOPILOT_DIR="/tmp/../etc"
+
+  run bash "$SANDBOX/scripts/autopilot-init.sh"
+
+  assert_failure
+  assert_output --partial "ERROR"
+  assert_output --partial ".."
+}
+
 @test "autopilot-init.md does not use eval for autopilot-init.sh execution" {
   local md_file="$REPO_ROOT/commands/autopilot-init.md"
 


### PR DESCRIPTION
fix(autopilot-init): AUTOPILOT_DIR パストラバーサル検証を追加 (#747)

Closes #747