### PR TITLE
fix(merge-gate): add individual error checks to merge-gate-build-manifest.sh

### DIFF
--- a/plugins/twl/scripts/merge-gate-build-manifest.sh
+++ b/plugins/twl/scripts/merge-gate-build-manifest.sh
@@ -4,8 +4,7 @@
 # specialist マニフェストを構築し MANIFEST_FILE, CONTEXT_ID, SPAWNED_FILE を設定する。
 # このスクリプトは source で読み込むこと（変数を親シェルへ export するため）。
 #
-# 【注意】set -euo pipefail は意図的に省略。source スクリプトに set -e を付けると
-# 親シェルのエラーハンドリング設定を上書きするため（tech-debt #689）。
+# set -euo pipefail は省略（sourced script のため parent shell を汚染しない）。
 #
 # 【注意】trap EXIT は source コンテキストでは親シェルの EXIT に設定される（設計上意図的）。
 # 親シェル（merge-gate）終了時に一時ファイルをクリーンアップするため（tech-debt #690）。
@@ -15,12 +14,15 @@
 # origin/main が解決できない場合のフォールバック付き (Issue #198)
 if ! SPECIALISTS=$(git diff --name-only origin/main 2>/dev/null | bash "${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-manifest.sh" --mode merge-gate); then
   echo "WARN: origin/main not found, falling back to FETCH_HEAD" >&2
-  git fetch origin main
+  if ! git fetch origin main; then
+    echo "ERROR: git fetch failed" >&2
+    return 1
+  fi
   SPECIALISTS=$(git diff --name-only FETCH_HEAD | bash "${CLAUDE_PLUGIN_ROOT}/scripts/pr-review-manifest.sh" --mode merge-gate)
 fi
-MANIFEST_FILE=$(mktemp /tmp/.specialist-manifest-merge-gate-XXXXXXXX.txt)
+MANIFEST_FILE=$(mktemp /tmp/.specialist-manifest-merge-gate-XXXXXXXX.txt) || { echo "ERROR: mktemp failed" >&2; return 1; }
 chmod 600 "$MANIFEST_FILE"
-SPAWNED_FILE=$(mktemp /tmp/.specialist-spawned-XXXXXXXX.txt)
+SPAWNED_FILE=$(mktemp /tmp/.specialist-spawned-XXXXXXXX.txt) || { echo "ERROR: mktemp failed" >&2; return 1; }
 chmod 600 "$SPAWNED_FILE"
-echo "$SPECIALISTS" > "$MANIFEST_FILE"
+echo "$SPECIALISTS" > "$MANIFEST_FILE" || return 1
 trap 'rm -f "$MANIFEST_FILE" "$SPAWNED_FILE"' EXIT

--- a/plugins/twl/tests/bats/scripts/merge-gate-build-manifest.bats
+++ b/plugins/twl/tests/bats/scripts/merge-gate-build-manifest.bats
@@ -148,3 +148,41 @@ teardown() {
   grep -qP '(trap.*rm|trap.*MANIFEST_FILE|trap.*SPAWNED_FILE)' \
     "$SANDBOX/scripts/merge-gate-build-manifest.sh"
 }
+
+# ---------------------------------------------------------------------------
+# Error-check: mktemp failure / source pattern (tech-debt #689)
+# ---------------------------------------------------------------------------
+
+@test "[error-check] mktemp 失敗時に source が非 0 を返す" {
+  stub_command "git" '
+    case "$*" in
+      *"diff"*)
+        echo "src/main.ts" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  # mktemp をシェル関数でオーバーライド（BATS set -e を || で回避して終了コードを検証）
+  local rc=0
+  (
+    mktemp() { return 1; }
+    source "$SANDBOX/scripts/merge-gate-build-manifest.sh" 2>/dev/null
+  ) || rc=$?
+  [[ $rc -ne 0 ]]
+}
+
+@test "[error-check] 正常系で MANIFEST_FILE と SPAWNED_FILE が設定される" {
+  stub_command "git" '
+    case "$*" in
+      *"diff"*)
+        echo "src/main.ts" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  source "$SANDBOX/scripts/merge-gate-build-manifest.sh" 2>/dev/null
+  [[ -n "${MANIFEST_FILE:-}" ]]
+  [[ -n "${SPAWNED_FILE:-}" ]]
+}


### PR DESCRIPTION
fix(merge-gate): add individual error checks to merge-gate-build-manifest.sh

- mktemp 2箇所に失敗時 echo+return 1 を追加
- git fetch 失敗時に echo+return 1 を追加
- echo MANIFEST_FILE 書き込み失敗時に return 1 を追加
- ヘッダの tech-debt #689 注記を削除し set -e 非使用理由を簡潔化
- BATS: mktemp 失敗時の source エラー検証テスト追加（関数オーバーライド方式）
- BATS: 正常系で MANIFEST_FILE/SPAWNED_FILE 設定確認テスト追加

Closes #689