### PR TITLE
fix: JSON-escape reason in _generate_fallback_report fallback path

### DIFF
--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -59,6 +59,57 @@ Environment:
 EOF
 }
 
+# report.json フォールバック生成 (#647)
+# specialist が report.json を書かずに完了した場合に、
+# findings.yaml / aggregate.yaml から report.json を構築する
+_generate_fallback_report() {
+  local subdir="$1" reason="$2"
+  local report_file="${subdir}/OUT/report.json"
+
+  # findings.yaml / aggregate.yaml がある場合はそこから構築
+  local aggregate_file="${subdir}/OUT/aggregate.yaml"
+  local findings_file="${subdir}/OUT/findings.yaml"
+
+  if [[ -f "$aggregate_file" ]]; then
+    # aggregate.yaml → report.json 変換（環境変数経由でパスを渡す — CWE-78 対策）
+    _FB_INPUT="$aggregate_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="aggregate" \
+      python3 -c '
+import yaml, json, os, sys
+with open(os.environ["_FB_INPUT"]) as f:
+    data = yaml.safe_load(f) or {}
+report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
+          "findings_count": len(data.get("findings", [])), os.environ["_FB_KEY"]: data}
+with open(os.environ["_FB_OUTPUT"], "w") as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+' 2>/dev/null && return 0
+  fi
+
+  if [[ -f "$findings_file" ]]; then
+    _FB_INPUT="$findings_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="findings" \
+      python3 -c '
+import yaml, json, os, sys
+with open(os.environ["_FB_INPUT"]) as f:
+    data = yaml.safe_load(f) or {}
+report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
+          os.environ["_FB_KEY"]: data}
+with open(os.environ["_FB_OUTPUT"], "w") as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+' 2>/dev/null && return 0
+  fi
+
+  # 中間ファイルもない場合は最小限のフォールバック
+  _FB_OUTPUT="$report_file" _FB_REASON="$reason" python3 -c '
+import json, os
+report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
+          "error": "no_intermediate_files"}
+with open(os.environ["_FB_OUTPUT"], "w") as f:
+    json.dump(report, f, ensure_ascii=False, indent=2)
+'
+}
+
+# source 経由でのテスト用に、直接実行時のみメインロジックを実行する
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then return 0; fi
+
 # --- 引数パーサー ---
 PER_ISSUE_DIR=""
 WORKER_MODEL="sonnet"
@@ -233,48 +284,6 @@ _build_worker_prompt() {
     "- quick_flag: ${quick_flag}" \
     "- target_repo: ${target_repo}" \
     > "$_bwp_prompt_file"
-}
-
-# report.json フォールバック生成 (#647)
-# specialist が report.json を書かずに完了した場合に、
-# findings.yaml / aggregate.yaml から report.json を構築する
-_generate_fallback_report() {
-  local subdir="$1" reason="$2"
-  local report_file="${subdir}/OUT/report.json"
-
-  # findings.yaml / aggregate.yaml がある場合はそこから構築
-  local aggregate_file="${subdir}/OUT/aggregate.yaml"
-  local findings_file="${subdir}/OUT/findings.yaml"
-
-  if [[ -f "$aggregate_file" ]]; then
-    # aggregate.yaml → report.json 変換（環境変数経由でパスを渡す — CWE-78 対策）
-    _FB_INPUT="$aggregate_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="aggregate" \
-      python3 -c '
-import yaml, json, os, sys
-with open(os.environ["_FB_INPUT"]) as f:
-    data = yaml.safe_load(f) or {}
-report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
-          "findings_count": len(data.get("findings", [])), os.environ["_FB_KEY"]: data}
-with open(os.environ["_FB_OUTPUT"], "w") as f:
-    json.dump(report, f, ensure_ascii=False, indent=2)
-' 2>/dev/null && return 0
-  fi
-
-  if [[ -f "$findings_file" ]]; then
-    _FB_INPUT="$findings_file" _FB_OUTPUT="$report_file" _FB_REASON="$reason" _FB_KEY="findings" \
-      python3 -c '
-import yaml, json, os, sys
-with open(os.environ["_FB_INPUT"]) as f:
-    data = yaml.safe_load(f) or {}
-report = {"status": "done", "fallback": True, "reason": os.environ["_FB_REASON"],
-          os.environ["_FB_KEY"]: data}
-with open(os.environ["_FB_OUTPUT"], "w") as f:
-    json.dump(report, f, ensure_ascii=False, indent=2)
-' 2>/dev/null && return 0
-  fi
-
-  # 中間ファイルもない場合は最小限のフォールバック
-  printf '{"status":"done","fallback":true,"reason":"%s","error":"no_intermediate_files"}\n' "$reason" > "$report_file"
 }
 
 # cld-spawn でウィンドウを起動し inject-file でプロンプトを送達する

--- a/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator.bats
+++ b/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator.bats
@@ -332,3 +332,34 @@ teardown() {
   [[ "$shebang" == "#!/usr/bin/env bash" || "$shebang" == "#!/bin/bash" ]] \
     || fail "Expected bash shebang, got: $shebang"
 }
+
+# ===========================================================================
+# _generate_fallback_report: JSON エスケープ検証
+# ===========================================================================
+
+@test "_generate_fallback_report: reason に \" と \\ と改行を含んでも valid JSON を生成する" {
+  local subdir
+  subdir="$(mktemp -d)"
+  mkdir -p "$subdir/OUT"
+
+  # script を source して _generate_fallback_report だけ使う
+  # set -euo pipefail が有効なので SCRIPTS_ROOT だけ設定してから source
+  export SCRIPTS_ROOT="$SANDBOX/scripts"
+  source "$SCRIPT_SRC"
+
+  local bad_reason
+  bad_reason='bad"value\\here
+with newline'
+
+  _generate_fallback_report "$subdir" "$bad_reason"
+
+  # 出力ファイルが存在すること
+  [[ -f "$subdir/OUT/report.json" ]] \
+    || fail "report.json was not created"
+
+  # python3 で parse 可能なこと（JSON として valid であること）
+  python3 -c "import json; json.load(open('$subdir/OUT/report.json'))" \
+    || fail "report.json is not valid JSON"
+
+  rm -rf "$subdir"
+}


### PR DESCRIPTION
fix: JSON-escape reason in _generate_fallback_report fallback path

The minimal fallback path in _generate_fallback_report used printf to
embed $reason directly into JSON, leaving it vulnerable to injection
when the value contains " or \.

Replace with python3 json.dump (same idiom as the sibling aggregate/
findings paths) and pass values via environment variables to avoid
CWE-78 argument injection.

Also move _generate_fallback_report before the BASH_SOURCE guard so
the function is accessible when the script is sourced in tests.

Closes #718