### PR TITLE
fix(state): write --set でドット区切りフィールドをサポート (#779)

### DIFF
--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -226,7 +226,7 @@ class StateManager:
         for kv in sets:
             key, _, raw_value = kv.partition("=")
             if not _VALID_SET_KEY_RE.match(key):
-                raise StateArgError(f"不正なフィールド名: {key}（英数字とアンダースコアのみ許可）")
+                raise StateArgError(f"不正なフィールド名: {key}（英数字、アンダースコア、ドット区切りパスのみ許可）")
 
             if key == "status" and type_ == "issue":
                 data = self._transition(data, raw_value, force_done=force_done, override_reason=override_reason)
@@ -247,8 +247,10 @@ class StateManager:
                     state_log.parent.mkdir(parents=True, exist_ok=True)
                     for kv in (sets or []):
                         key, _, raw_value = kv.partition("=")
-                        old_val = str(old_data.get(key, ""))
-                        new_val = str(data.get(key, raw_value))
+                        old_raw = _get_nested(old_data, key)
+                        old_val = str(old_raw) if old_raw is not None else ""
+                        new_raw = _get_nested(data, key)
+                        new_val = str(new_raw) if new_raw is not None else raw_value
                         if old_val != new_val:
                             record = json.dumps({
                                 "ts": ts,

--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 _VALID_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+_VALID_SET_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z0-9_]+)*$")
 _VALID_FIELD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 _VALID_REPO_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
@@ -224,7 +225,7 @@ class StateManager:
 
         for kv in sets:
             key, _, raw_value = kv.partition("=")
-            if not _VALID_KEY_RE.match(key):
+            if not _VALID_SET_KEY_RE.match(key):
                 raise StateArgError(f"不正なフィールド名: {key}（英数字とアンダースコアのみ許可）")
 
             if key == "status" and type_ == "issue":
@@ -344,11 +345,24 @@ class StateManager:
 
     def _set_field(self, data: dict[str, Any], key: str, raw: str) -> dict[str, Any]:
         data = dict(data)
-        # Try JSON parse first (arrays, objects, null, numbers, booleans)
+        if "." not in key:
+            try:
+                data[key] = json.loads(raw)
+            except (json.JSONDecodeError, ValueError):
+                data[key] = raw
+            return data
+        # Dot-path: navigate into nested dicts, creating missing intermediate dicts
+        parts = key.split(".")
+        cur = data
+        for part in parts[:-1]:
+            if not isinstance(cur.get(part), dict):
+                cur[part] = {}
+            cur = cur[part]
+        last = parts[-1]
         try:
-            data[key] = json.loads(raw)
+            cur[last] = json.loads(raw)
         except (json.JSONDecodeError, ValueError):
-            data[key] = raw
+            cur[last] = raw
         return data
 
     def _atomic_write(self, file: Path, data: dict[str, Any]) -> None:

--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -10,6 +10,7 @@ CLI usage:
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import re
@@ -19,7 +20,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-_VALID_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 _VALID_SET_KEY_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z0-9_]+)*$")
 _VALID_FIELD_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 _VALID_REPO_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
@@ -221,7 +221,7 @@ class StateManager:
             raise StateArgError("--set が指定されていません")
 
         data = json.loads(file.read_text(encoding="utf-8"))
-        old_data = dict(data)
+        old_data = copy.deepcopy(data)
 
         for kv in sets:
             key, _, raw_value = kv.partition("=")

--- a/cli/twl/tests/test_autopilot_state.py
+++ b/cli/twl/tests/test_autopilot_state.py
@@ -180,6 +180,40 @@ class TestStateWriteFields:
         with pytest.raises(StateArgError, match="--set"):
             state.write(type_="issue", role="worker", issue="1", sets=[])
 
+    def test_set_dot_path_creates_nested(self, state: StateManager, autopilot_dir: Path) -> None:
+        _init_issue(state, "1")
+        state.write(type_="issue", role="worker", issue="1",
+                    sets=["completed_issues.2.pr=11"])
+        data = _load_issue(autopilot_dir, "1")
+        assert data["completed_issues"]["2"]["pr"] == 11
+
+    def test_set_dot_path_updates_existing_nested(
+        self, state: StateManager, autopilot_dir: Path
+    ) -> None:
+        file = autopilot_dir / "issues" / "issue-1.json"
+        file.write_text(json.dumps({
+            "issue": 1, "status": "running",
+            "completed_issues": {"2": {"pr": 10, "status": "done"}},
+        }))
+        state.write(type_="issue", role="worker", issue="1",
+                    sets=["completed_issues.2.pr=99"])
+        data = _load_issue(autopilot_dir, "1")
+        assert data["completed_issues"]["2"]["pr"] == 99
+        assert data["completed_issues"]["2"]["status"] == "done"
+
+    def test_set_dot_path_string_value(self, state: StateManager, autopilot_dir: Path) -> None:
+        _init_issue(state, "1")
+        state.write(type_="issue", role="worker", issue="1",
+                    sets=["completed_issues.2.branch=fix/my-branch"])
+        data = _load_issue(autopilot_dir, "1")
+        assert data["completed_issues"]["2"]["branch"] == "fix/my-branch"
+
+    def test_set_dot_path_invalid_rejected(self, state: StateManager) -> None:
+        _init_issue(state, "1")
+        with pytest.raises(StateArgError, match="不正なフィールド名"):
+            state.write(type_="issue", role="worker", issue="1",
+                        sets=["completed_issues..pr=bad"])
+
 
 # ===========================================================================
 # StateManager — transition validation


### PR DESCRIPTION
fix(state): write --set でドット区切りフィールドをサポート (#779)

completed_issues.X.pr のようなドットパスを --set で指定すると
_VALID_KEY_RE がドットを拒否し、_set_field もトップレベルのみ
対応していたため失敗していた。

- _VALID_SET_KEY_RE を追加（セグメント間ドットを許可）
- _set_field にドットパス走査を追加（中間 dict を自動生成）
- pytest テスト 4 件追加

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #779