### PR TITLE
fix(#778): worktree-delete.sh の bare_root 特定バグを修正

### DIFF
--- a/plugins/twl/scripts/autopilot-cleanup.sh
+++ b/plugins/twl/scripts/autopilot-cleanup.sh
@@ -180,7 +180,8 @@ while IFS= read -r line; do
             echo "[dry-run] 孤立 worktree 削除: $wt_path (branch=$wt_branch, 真の孤立: state file なし)" >&2
           fi
         else
-          if bash "$SCRIPTS_ROOT/worktree-delete.sh" "$wt_branch" 2>/dev/null; then
+          _wt_del_out=""
+          if _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$wt_branch" 2>&1); then
             echo "[cleanup] 孤立 worktree 削除: $wt_path (branch=$wt_branch)" >&2
             # リモートブランチも削除（パストラバーサル防止: L288 と同一の `.` 除外 regex を使用）
             if [[ -n "$wt_branch" && "$wt_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
@@ -190,7 +191,7 @@ while IFS= read -r line; do
               echo "[cleanup] ⚠️ ブランチ名に不正な文字: $wt_branch — リモート削除スキップ" >&2
             fi
           else
-            echo "[cleanup] ⚠️ worktree 削除失敗: $wt_branch（続行）" >&2
+            echo "[cleanup] ⚠️ worktree 削除失敗: $wt_branch（続行）: ${_wt_del_out}" >&2
           fi
         fi
         ORPHAN_COUNT=$((ORPHAN_COUNT + 1))

--- a/plugins/twl/scripts/autopilot-cleanup.sh
+++ b/plugins/twl/scripts/autopilot-cleanup.sh
@@ -180,8 +180,14 @@ while IFS= read -r line; do
             echo "[dry-run] 孤立 worktree 削除: $wt_path (branch=$wt_branch, 真の孤立: state file なし)" >&2
           fi
         else
-          _wt_del_out=""
-          if _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$wt_branch" 2>&1); then
+          _wt_del_out="" _wt_ok=false
+          for _wt_r in 1 2; do
+            if _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$wt_branch" 2>&1); then
+              _wt_ok=true; break
+            fi
+            [[ $_wt_r -lt 2 ]] && sleep 2
+          done
+          if $_wt_ok; then
             echo "[cleanup] 孤立 worktree 削除: $wt_path (branch=$wt_branch)" >&2
             # リモートブランチも削除（パストラバーサル防止: L288 と同一の `.` 除外 regex を使用）
             if [[ -n "$wt_branch" && "$wt_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -420,9 +420,14 @@ cleanup_worker() {
   if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
     # Step 2: worktree削除（ローカルブランチ込み）— bare repo（worktreeモード）のみ実行
     if [[ "$repo_mode" == "worktree" ]]; then
-      local _wt_del_out
-      _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>&1) || \
-        echo "[orchestrator] Issue #${issue}: ⚠️ worktree削除失敗（クリーンアップは続行）: ${_wt_del_out}" >&2
+      local _wt_del_out _wt_ok=false
+      for _wt_r in 1 2; do
+        if _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>&1); then
+          _wt_ok=true; break
+        fi
+        [[ $_wt_r -lt 2 ]] && sleep 2
+      done
+      $_wt_ok || echo "[orchestrator] Issue #${issue}: ⚠️ worktree削除失敗（クリーンアップは続行）: ${_wt_del_out}" >&2
     fi
 
     # Step 3: リモートブランチ削除（クロスリポ対応）

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -420,7 +420,7 @@ cleanup_worker() {
   if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
     # Step 2: worktree削除（ローカルブランチ込み）— bare repo（worktreeモード）のみ実行
     if [[ "$repo_mode" == "worktree" ]]; then
-      local _wt_del_out _wt_ok=false
+      local _wt_del_out="" _wt_ok=false _wt_r
       for _wt_r in 1 2; do
         if _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>&1); then
           _wt_ok=true; break

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -420,8 +420,9 @@ cleanup_worker() {
   if [[ -n "$branch" && "$branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
     # Step 2: worktree削除（ローカルブランチ込み）— bare repo（worktreeモード）のみ実行
     if [[ "$repo_mode" == "worktree" ]]; then
-      bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>/dev/null || \
-        echo "[orchestrator] Issue #${issue}: ⚠️ worktree削除失敗（クリーンアップは続行）" >&2
+      local _wt_del_out
+      _wt_del_out=$(bash "$SCRIPTS_ROOT/worktree-delete.sh" "$branch" 2>&1) || \
+        echo "[orchestrator] Issue #${issue}: ⚠️ worktree削除失敗（クリーンアップは続行）: ${_wt_del_out}" >&2
     fi
 
     # Step 3: リモートブランチ削除（クロスリポ対応）

--- a/plugins/twl/scripts/worktree-delete.sh
+++ b/plugins/twl/scripts/worktree-delete.sh
@@ -50,10 +50,10 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# bare repo のルートを特定
+# bare repo のルートを特定（SCRIPT_DIR ではなく CWD の .git を参照）
 bare_root=""
-if [[ -f "$PROJECT_ROOT/.git" ]]; then
-  gitdir=$(sed 's/^gitdir: //' "$PROJECT_ROOT/.git")
+if [[ -f "$cwd/.git" ]]; then
+  gitdir=$(sed 's/^gitdir: //' "$cwd/.git")
   if [[ "$gitdir" != /* ]]; then
     echo "ERROR: gitdir は絶対パスである必要があります" >&2
     exit 1

--- a/plugins/twl/scripts/worktree-delete.sh
+++ b/plugins/twl/scripts/worktree-delete.sh
@@ -50,7 +50,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# bare repo のルートを特定（SCRIPT_DIR ではなく CWD の .git を参照）
+# bare repo のルートを特定（CWD の .git を優先、不在時は git rev-parse fallback）
 bare_root=""
 if [[ -f "$cwd/.git" ]]; then
   gitdir=$(sed 's/^gitdir: //' "$cwd/.git")
@@ -68,6 +68,19 @@ if [[ -f "$cwd/.git" ]]; then
     bare_root="${gitdir%/.bare}/"
   else
     bare_root=$(echo "$gitdir" | sed 's|/\.bare/.*|/|')
+  fi
+else
+  # fallback: git rev-parse --git-common-dir で bare root を検索
+  fb_gitdir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+  if [[ -n "$fb_gitdir" && ! "$fb_gitdir" =~ \.\. ]]; then
+    if [[ "$fb_gitdir" =~ /\.bare$ ]]; then
+      bare_root="${fb_gitdir%/.bare}/"
+    elif [[ "$fb_gitdir" =~ /\.bare/ ]]; then
+      bare_root=$(echo "$fb_gitdir" | sed 's|/\.bare/.*|/|')
+    fi
+  fi
+  if [[ -n "$bare_root" ]]; then
+    echo "WARN: cwd/.git 不在のため git rev-parse fallback で bare_root を解決: $bare_root" >&2
   fi
 fi
 


### PR DESCRIPTION
fix(#778): worktree-delete.sh の bare_root 特定バグを修正

PROJECT_ROOT (plugins/twl/) に .git を探していたため bare_root が
空のまま exit 1 し、worktree の自動削除が常に失敗していた。

CWD (main/) の .git を参照するよう修正。両 caller の 2>/dev/null
を除去して stderr をキャプチャし、失敗時の原因をログに含める。

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #778