### PR TITLE
fix(session): cld ラッパーを --permission-mode auto に切り替え

### DIFF
--- a/plugins/session/scripts/cld
+++ b/plugins/session/scripts/cld
@@ -115,4 +115,4 @@ done < <(env | grep '^DEV_')
 
 exec systemd-run --user --scope -p MemoryMax=12G \
     "${ENV_ARGS[@]}" \
-    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"
+    claude --permission-mode auto "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"

--- a/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
+++ b/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
@@ -691,15 +691,15 @@ else
   run_test_skip "cld スクリプト: 全引数パススルー維持" "cld スクリプトが見つからない"
 fi
 
-# Test: --observer フラグは --dangerously-skip-permissions 等の既存フラグと共存できる
+# Test: --observer フラグは permission-mode 等の既存フラグと共存できる
 test_cld_observer_coexists_with_existing_flags() {
   [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
-  # dangerously-skip-permissions が残っている
-  assert_file_contains "$CLD_SCRIPT" "dangerously-skip-permissions"
+  # permission-mode auto が残っている（2026-04 移行後）
+  assert_file_contains "$CLD_SCRIPT" "permission-mode auto"
 }
 
 if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
-  run_test "cld スクリプト: --dangerously-skip-permissions 等の既存フラグが維持されている" test_cld_observer_coexists_with_existing_flags
+  run_test "cld スクリプト: --permission-mode auto 等の既存フラグが維持されている" test_cld_observer_coexists_with_existing_flags
 else
   run_test_skip "cld スクリプト: 既存フラグ共存確認" "cld スクリプトが見つからない"
 fi


### PR DESCRIPTION
## 概要

Claude Code v2.1.111 で auto mode が Max + Opus 4.7 に対応したため、session プラグインの cld ラッパーを `--dangerously-skip-permissions` から `--permission-mode auto` に変更。

## 背景

- 2026-03-14 に ubuntu-note-system 側で同等試行を行ったが (PR #130) mid-session で無効化される問題で revert
- Claude Code v2.1.95 / v2.1.98 で silent downgrade 修正済み
- 既知バグ [#49273](https://github.com/anthropics/claude-code/issues/49273) (`settings.json` の `defaultMode: auto` が起動時に効かない) のため CLI フラグ `--permission-mode auto` 必須

## 変更

| ファイル | 変更 |
|---------|------|
| `plugins/session/scripts/cld` | line 118 フラグ置換 |
| `plugins/twl/tests/scenarios/su-observer-session-resume.test.sh` | 既存フラグ維持テストのアサーションを `permission-mode auto` に更新 |

## 動作確認

- ubuntu-note-system (67bd9ba) 側で同等変更と deploy.sh 済み
- ipatho1 / ipatho2 は ubuntu-note-system の cld ファイルが直接配置されているため反映済み
- **本 PR マージ後、ローカル `~/.local/bin/cld` → twill の symlink 経由で新フラグが有効化**

## 関連

- ubuntu-note-system: commit 67bd9ba
- Research report: doobidoo hash `d6b4d61702f653a0`

## ロールバック

1 行戻して revert すれば元に戻る。