### PR TITLE
revert(session): cld を --dangerously-skip-permissions に戻す

### DIFF
--- a/plugins/session/scripts/cld
+++ b/plugins/session/scripts/cld
@@ -115,4 +115,4 @@ done < <(env | grep '^DEV_')
 
 exec systemd-run --user --scope -p MemoryMax=12G \
     "${ENV_ARGS[@]}" \
-    claude --permission-mode auto "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"
+    claude --dangerously-skip-permissions "${PLUGIN_ARGS[@]}" "${PASS_ARGS[@]+"${PASS_ARGS[@]}"}"

--- a/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
+++ b/plugins/twl/tests/scenarios/su-observer-session-resume.test.sh
@@ -691,15 +691,15 @@ else
   run_test_skip "cld スクリプト: 全引数パススルー維持" "cld スクリプトが見つからない"
 fi
 
-# Test: --observer フラグは permission-mode 等の既存フラグと共存できる
+# Test: --observer フラグは権限フラグ等の既存フラグと共存できる
 test_cld_observer_coexists_with_existing_flags() {
   [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]] || return 1
-  # permission-mode auto が残っている（2026-04 移行後）
-  assert_file_contains "$CLD_SCRIPT" "permission-mode auto"
+  # --dangerously-skip-permissions が残っている（2026-04-21 auto mode revert 後）
+  assert_file_contains "$CLD_SCRIPT" "dangerously-skip-permissions"
 }
 
 if [[ -n "$CLD_SCRIPT" && -f "$CLD_SCRIPT" ]]; then
-  run_test "cld スクリプト: --permission-mode auto 等の既存フラグが維持されている" test_cld_observer_coexists_with_existing_flags
+  run_test "cld スクリプト: --dangerously-skip-permissions 等の既存フラグが維持されている" test_cld_observer_coexists_with_existing_flags
 else
   run_test_skip "cld スクリプト: 既存フラグ共存確認" "cld スクリプトが見つからない"
 fi


### PR DESCRIPTION
## 概要
PR #796 (commit 97bad17) の逆操作。cld ラッパーの auto mode を revert。

## 理由（ユーザー feedback）
- auto mode classifier が複雑 bash や git push を頻繁にブロック
- co-autopilot worker で permission prompt stuck が発生（doobidoo 04791076）
- ユーザー判断「クソ使いづらくて微妙」

## 変更
- \`plugins/session/scripts/cld\`: \`--permission-mode auto\` → \`--dangerously-skip-permissions\`
- \`plugins/twl/tests/scenarios/su-observer-session-resume.test.sh\`: アサーション更新

## 連動
ubuntu-note-system 側の cld/cld-ch も同期 revert 済み（commit 5d911b7）。
ipatho1/ipatho2 へのデプロイは ubuntu-note-system の deploy.sh --all で実施。

## ロールバック手順
\`git revert <this-merge-commit>\` で再 auto mode に戻せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)