### PR TITLE
docs(architecture): ADR-020 chain.py SSoT refinement (Issue #790)

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md
+++ b/plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md
@@ -1,0 +1,144 @@
+# ADR-020: chain SSoT refinement — chain.py を真の SSoT 化する具体手順
+
+**Status**: Proposed
+**Date**: 2026-04-21
+**Issue**: #790
+**Supersedes**: —
+**Related**: ADR-0007 (chain SSOT 2 レイヤー責務分離)、ADR-018 (state schema SSoT)、ADR-014 (pilot-driven workflow loop)
+
+---
+
+## Context
+
+ADR-0007 で「chain.py が chain 定義の SSoT、deps.yaml.chains は概念レイヤー、chain-steps.sh は chain.py の bash 向けミラー」と決定された。しかし以下の残存問題がある:
+
+1. **名称不一致**: chain.py L31 `board-status-update` vs deps.yaml/chain-steps.sh `project-board-status-update`。`commands/project-board-status-update.md` が実在し、deps.yaml の正規名。chain-runner.sh (L1497-1498) は両名をエイリアスで救済しており、実行は破綻していないが SSoT として未整合。
+2. **CHAIN_STEPS 非保有ステップ**: `dispatch_mode: llm|trigger` のステップ（`worktree-create`, `e2e-screening`, `merge-gate`, `auto-merge`, `fix-phase`, `post-fix-verify`, `warning-fix`, `arch-phase-review`, `arch-fix-phase`, `pr-cycle-analysis`）が deps.yaml.chains にのみ存在。ADR-0007 の方針では CHAIN_STEPS に含めないことが正だが、chain.py は dispatch や workflow 所属を認識しないため export 時にメタデータを再生成できない。
+3. **CHAIN_STEP_DISPATCH のミラーリング方向**: chain-steps.sh L55-75 の dispatch 定義が SSoT として扱われているが、ADR-0007 に従えば chain.py 側に帰属させるべき。
+4. **feature flag 未実装**: `TWL_CHAIN_SSOT_MODE` は Issue 本文で AC 化されているが、env 検査層が未定義。
+
+## Decision
+
+### D-1: 名称の正規化 — chain.py を deps.yaml 正規名に寄せる
+
+chain.py の以下 3 箇所を `project-board-status-update` に改名する:
+
+- `CHAIN_STEPS` L31
+- `STEP_TO_WORKFLOW` L72
+- （`TERMINAL_STEP_TO_NEXT_SKILL` は `board-status-update` を含まないため変更不要）
+
+合わせて:
+
+- chain-runner.sh L1497-1498 の alias 分岐を廃止 (`project-board-status-update) step_board_status_update "$@" ;;` 単一行に)
+- 関数名 `step_board_status_update` は関数内部名として保持可（dispatch 名と関数名は別責務）
+- chain.py の `step_board_status_update` メソッドも関数内部名として保持可
+- 呼び出し側 (`record_step`, `_ok`, `_skip`) に渡すラベル文字列を `project-board-status-update` に統一
+- ログ・トレース文字列検索で `board-status-update` 残存が発生しないことを `rg` で確認
+
+**根拠**: ADR-0007 の「chain.py が SSoT」原則を maintain しつつ、deps.yaml コンポーネント正規名（`commands/project-board-status-update.md` が実ファイル）に合わせる。alias 廃止により drift 再発源が消える。
+
+### D-2: CHAIN_META データ構造導入
+
+chain.py に新しい dict `CHAIN_META` を追加:
+
+```python
+CHAIN_META: dict[str, dict[str, str]] = {
+    # runner dispatch (既存 CHAIN_STEPS と重複。dispatch_mode 補足用)
+    "init": {"chain": "setup", "dispatch_mode": "runner"},
+    "project-board-status-update": {"chain": "setup", "dispatch_mode": "trigger"},
+    ...
+    # llm dispatch (CHAIN_STEPS 非保有、deps.yaml.chains のみ)
+    "e2e-screening":    {"chain": "pr-merge",  "dispatch_mode": "llm"},
+    "merge-gate":       {"chain": "pr-merge",  "dispatch_mode": "llm"},
+    "pr-cycle-analysis":{"chain": "pr-merge",  "dispatch_mode": "llm"},
+    "fix-phase":        {"chain": "pr-fix",    "dispatch_mode": "llm"},
+    "post-fix-verify":  {"chain": "pr-fix",    "dispatch_mode": "llm"},
+    "warning-fix":      {"chain": "pr-fix",    "dispatch_mode": "llm"},
+    "arch-phase-review":{"chain": "arch-review","dispatch_mode": "llm"},
+    "arch-fix-phase":   {"chain": "arch-review","dispatch_mode": "llm"},
+    # trigger dispatch (chain 外の条件付き実行)
+    "worktree-create":  {"chain": "setup",     "dispatch_mode": "trigger"},
+    "auto-merge":       {"chain": "pr-merge",  "dispatch_mode": "trigger"},
+}
+```
+
+**責務**:
+
+- `CHAIN_STEPS` は `next-step` で返す「runner dispatch の機械的順序」のみ（既存設計保持）
+- `CHAIN_META` は dispatch/chain 所属の正典（export 時に deps.yaml.chains の dispatch_mode と chain: を再生成）
+- chain-steps.sh の `CHAIN_STEP_DISPATCH` / `CHAIN_STEP_WORKFLOW` は `export_chain_steps_sh()` が `CHAIN_META` から再生成
+
+### D-3: export API
+
+chain.py に以下を追加:
+
+```python
+def export_deps_chains() -> dict[str, Any]:
+    """Return the `chains:` section for deps.yaml."""
+    # chain_id ごとに steps 順を CHAIN_STEPS (runner) + CHAIN_META (llm/trigger) から合成
+    # 出力フォーマットは既存 deps.yaml の chains: を忠実に再現
+
+def export_chain_steps_sh() -> str:
+    """Return chain-steps.sh bash source as string."""
+    # CHAIN_STEPS, QUICK_SKIP_STEPS, DIRECT_SKIP_STEPS,
+    # CHAIN_STEP_DISPATCH, CHAIN_STEP_WORKFLOW, CHAIN_WORKFLOW_NEXT_SKILL
+    # を CHAIN_META と STEP_TO_WORKFLOW から再生成
+```
+
+CLI 統合（feasibility HIGH 85 指摘の必須修正）:
+
+- `cli/twl/src/twl/cli.py` L74-88 の `chain` subcommand dispatch に `export` 分岐を追加
+- `twl chain export --yaml` → `plugins/twl/deps.yaml` の `chains:` / `meta_chains:` セクションを再生成（他セクション保持、YAML ラウンドトリップで整合）
+- `twl chain export --shell` → `plugins/twl/scripts/chain-steps.sh` を再生成
+
+### D-4: feature flag の読取層
+
+chain-runner.sh 冒頭 (L17 `source chain-steps.sh`) を env-conditional に変更:
+
+```bash
+if [[ "${TWL_CHAIN_SSOT_MODE:-deps.yaml}" == "chain.py" ]]; then
+  eval "$(twl chain export --shell)"
+else
+  # shellcheck source=./chain-steps.sh
+  source "${SCRIPT_DIR}/chain-steps.sh"
+fi
+```
+
+**責務分離**:
+- chain.py は env を読まない（値の提供者としてピュア）
+- chain-runner.sh が runtime の dispatch 選択を行う
+- Wave 完了後 (= `chain.py` モードが安定) に `TWL_CHAIN_SSOT_MODE` 自体を撤去し chain.py 経由を default 化
+
+### D-5: 整合性検証の強化
+
+`twl chain validate` を以下で拡張:
+
+- chain.py `CHAIN_STEPS` + `CHAIN_META` の set == deps.yaml.chains 全 steps の set（差分ゼロ）
+- chain.py `CHAIN_META[step].dispatch_mode` == deps.yaml components の `dispatch_mode`（export-roundtrip 整合）
+- chain-steps.sh が `twl chain export --shell` 出力と byte-identical
+
+## Consequences
+
+### 利点
+
+- chain drift が「export で常に再生成」により機械的に解消
+- alias 層消失で名称ドリフトの再発源除去
+- CHAIN_META 追加により LLM/trigger ステップの chain 所属・dispatch が SSoT 化
+- feature flag で段階的ロールアウトが可能
+
+### 懸念 / 代償
+
+- 既存コード中の `board-status-update` 文字列参照を洗い出す必要 (`rg 'board-status-update'` で事前確認)
+- `twl chain export` CLI 追加は `cli.py` / `cli_dispatch.py` の変更を伴う（Critical Files に追加が必要）
+- Wave 完了後 `TWL_CHAIN_SSOT_MODE` を撤去するフォロー Issue が必要（本 Issue のスコープ外）
+
+### ロールバック手順
+
+- `TWL_CHAIN_SSOT_MODE=deps.yaml`（default）で従来動作に戻る
+- chain.py 改名を revert 不要な setup に保ち、alias 追加で戻せる（ただし Wave 中は alias 再追加を避ける）
+
+## Non-goal
+
+- pre-commit / CI ゲート統合は `#791 (deps-integrity)` の責務（本 ADR から除外）
+- `twl check` の deps 整合性検証追加は別 Issue（ADR-0007 の TODO 継承）
+- chain-steps.sh の完全廃止は Wave 完了後の別 Issue（この ADR は chain-steps.sh を `computed artifact` 化するまでを扱う）

--- a/plugins/twl/deltaspec/changes/issue-790/.deltaspec.yaml
+++ b/plugins/twl/deltaspec/changes/issue-790/.deltaspec.yaml
@@ -1,0 +1,4 @@
+schema: spec-driven
+created: 2026-04-21
+name: issue-790
+status: pending

--- a/plugins/twl/deltaspec/changes/issue-790/design.md
+++ b/plugins/twl/deltaspec/changes/issue-790/design.md
@@ -1,0 +1,211 @@
+# Design: chain.py SSoT refinement (Issue #790)
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        chain.py (SSoT)                           │
+│                                                                  │
+│   CHAIN_STEPS:   [runner dispatch の機械的順序]                  │
+│   CHAIN_META:    {step: {chain, dispatch_mode, ...}}             │
+│   STEP_TO_WORKFLOW (derived from CHAIN_META)                     │
+│   TERMINAL_STEP_TO_NEXT_SKILL (存続)                             │
+│                                                                  │
+│   export_deps_chains()  -> dict                                  │
+│   export_chain_steps_sh() -> str                                 │
+└──────────────────────────────────────────────────────────────────┘
+                │                          │
+                ▼                          ▼
+    ┌───────────────────┐      ┌────────────────────────┐
+    │ deps.yaml         │      │ chain-steps.sh         │
+    │ (computed)        │      │ (computed)             │
+    │                   │      │                        │
+    │  chains:          │      │  CHAIN_STEPS=(...)     │
+    │  meta_chains:     │      │  QUICK_SKIP_STEPS=(...) │
+    │                   │      │  CHAIN_STEP_DISPATCH   │
+    │  他セクション保持 │      │  CHAIN_STEP_WORKFLOW   │
+    └───────────────────┘      └────────────────────────┘
+                                          │
+                                          ▼
+                             ┌────────────────────────┐
+                             │ chain-runner.sh        │
+                             │                        │
+                             │  if TWL_CHAIN_SSOT_MODE│
+                             │     == "chain.py":     │
+                             │    eval "$(twl chain   │
+                             │      export --shell)"  │
+                             │  else:                 │
+                             │    source chain-steps  │
+                             └────────────────────────┘
+```
+
+## データ構造
+
+### CHAIN_META（新設）
+
+```python
+CHAIN_META: dict[str, dict[str, str]] = {
+    # setup chain
+    "init":                       {"chain": "setup",      "dispatch_mode": "runner"},
+    "worktree-create":            {"chain": "setup",      "dispatch_mode": "trigger"},
+    "project-board-status-update":{"chain": "setup",      "dispatch_mode": "trigger"},
+    "crg-auto-build":             {"chain": "setup",      "dispatch_mode": "llm"},
+    "change-propose":             {"chain": "setup",      "dispatch_mode": "llm"},
+    "ac-extract":                 {"chain": "setup",      "dispatch_mode": "runner"},
+
+    # test-ready chain
+    "arch-ref":                   {"chain": "test-ready", "dispatch_mode": "runner"},
+    "change-id-resolve":          {"chain": "test-ready", "dispatch_mode": "runner"},
+    "test-scaffold":              {"chain": "test-ready", "dispatch_mode": "llm"},
+    "check":                      {"chain": "test-ready", "dispatch_mode": "runner"},
+    "change-apply":               {"chain": "test-ready", "dispatch_mode": "llm"},
+    "post-change-apply":          {"chain": "test-ready", "dispatch_mode": "runner"},
+
+    # pr-verify chain
+    "prompt-compliance":          {"chain": "pr-verify",  "dispatch_mode": "runner"},
+    "ts-preflight":               {"chain": "pr-verify",  "dispatch_mode": "runner"},
+    "phase-review":               {"chain": "pr-verify",  "dispatch_mode": "llm"},
+    "scope-judge":                {"chain": "pr-verify",  "dispatch_mode": "llm"},
+    "pr-test":                    {"chain": "pr-verify",  "dispatch_mode": "runner"},
+    "ac-verify":                  {"chain": "pr-verify",  "dispatch_mode": "llm"},
+
+    # pr-fix chain
+    "fix-phase":                  {"chain": "pr-fix",     "dispatch_mode": "llm"},
+    "post-fix-verify":            {"chain": "pr-fix",     "dispatch_mode": "llm"},
+    "warning-fix":                {"chain": "pr-fix",     "dispatch_mode": "llm"},
+
+    # pr-merge chain
+    "e2e-screening":              {"chain": "pr-merge",   "dispatch_mode": "llm"},
+    "pr-cycle-report":            {"chain": "pr-merge",   "dispatch_mode": "runner"},
+    "pr-cycle-analysis":          {"chain": "pr-merge",   "dispatch_mode": "llm"},
+    "all-pass-check":             {"chain": "pr-merge",   "dispatch_mode": "runner"},
+    "merge-gate":                 {"chain": "pr-merge",   "dispatch_mode": "llm"},
+    "auto-merge":                 {"chain": "pr-merge",   "dispatch_mode": "trigger"},
+
+    # arch-review chain
+    "arch-phase-review":          {"chain": "arch-review", "dispatch_mode": "llm"},
+    "arch-fix-phase":             {"chain": "arch-review", "dispatch_mode": "llm"},
+}
+```
+
+**注記**:
+- `CHAIN_STEPS` は本質的に `CHAIN_META` の subset (dispatch_mode=runner のみ、ただし既存 `ac-verify`/`phase-review` 等の LLM マーカー含む) だが、`next_step()` の挙動を保つため別リストを維持
+- migration フェーズで `CHAIN_STEPS` を `CHAIN_META` から derive する setup は Wave 完了後の refactor で対応
+
+### STEP_TO_WORKFLOW の CHAIN_META からの生成
+
+```python
+# 現状: chain.py L70-90 に static dict
+# 移行後: 下記に置換
+STEP_TO_WORKFLOW: dict[str, str] = {
+    step: {
+        "setup": "setup",
+        "test-ready": "test-ready",
+        "pr-verify": "pr-verify",
+        "pr-fix": "pr-fix",
+        "pr-merge": "pr-merge",
+        "arch-review": "arch-review",
+    }[meta["chain"]]
+    for step, meta in CHAIN_META.items()
+}
+```
+
+## 変更点サマリ
+
+### chain.py
+
+| 変更 | 詳細 |
+|---|---|
+| CHAIN_STEPS L31 改名 | `board-status-update` → `project-board-status-update` |
+| STEP_TO_WORKFLOW L72 改名 | 同上 |
+| CHAIN_META 追加 | 全 step の {chain, dispatch_mode} を管理 |
+| STEP_TO_WORKFLOW 生成化 | static dict を CHAIN_META からの dict comprehension に置換 |
+| `export_deps_chains()` 追加 | deps.yaml.chains / meta_chains セクション生成 |
+| `export_chain_steps_sh()` 追加 | chain-steps.sh bash ソース生成 |
+| `step_board_status_update` メソッド名 | 関数内部名は保持（呼出ラベルのみ改名） |
+
+### chain-runner.sh
+
+| 変更 | 詳細 |
+|---|---|
+| L17 env-conditional | `if TWL_CHAIN_SSOT_MODE == chain.py` 分岐追加 |
+| L1497-1498 alias 削除 | `board-status-update)` 行を削除、`project-board-status-update` 単行化 |
+| L430 record_current_step | `"board-status-update"` → `"project-board-status-update"` |
+| L1458, L1532 usage 表示 | 名称統一 |
+
+### chain-steps.sh
+
+`export_chain_steps_sh()` の出力で置換（L10-122 全体）。
+
+### deps.yaml
+
+`export_deps_chains()` の出力で `chains:` (L26-84) / `meta_chains:` (L87-152) を置換。他セクション（components 等）は YAML ラウンドトリップで保持。
+
+### cli.py
+
+```python
+# L74-88 付近の chain subcommand dispatch に追加
+elif len(sys.argv) >= 3 and sys.argv[2] == 'export':
+    from twl.chain.export import handle_chain_export
+    sys.exit(handle_chain_export(sys.argv[3:]))
+```
+
+新規: `cli/twl/src/twl/chain/export.py` (argparse + writer)
+
+## テスト計画
+
+### 新規テスト
+
+1. `cli/twl/tests/test_autopilot_chain_export.py`
+   - `export_deps_chains()` が既存 deps.yaml.chains と dict-level で等価
+   - `export_chain_steps_sh()` が既存 chain-steps.sh と byte-identical
+   - CHAIN_META と STEP_TO_WORKFLOW の整合性（dict comprehension invariant）
+2. `plugins/twl/tests/bats/scripts/chain-runner-ssot-mode.bats`
+   - `TWL_CHAIN_SSOT_MODE=chain.py` で `next-step 0 init` が `project-board-status-update` を返す
+   - `TWL_CHAIN_SSOT_MODE=deps.yaml`（または unset）で同等動作
+   - alias 削除後 `board-status-update` 引数で未知ステップエラーを返す
+3. `cli/twl/tests/test_chain_validate.py` 拡張
+   - chain.py `CHAIN_STEPS + CHAIN_META` set == deps.yaml.chains 全 steps set
+   - `dispatch_mode` の roundtrip 整合
+
+### 既存テスト更新
+
+1. `plugins/twl/tests/bats/scripts/chain-runner-next-step.bats` — `board-status-update` 期待値更新
+2. `plugins/twl/tests/scenarios/chain-definition.test.sh` — 名称統一前提で再実行
+3. `cli/twl/tests/test_autopilot_chain.py` — CHAIN_STEPS 改名反映
+
+## Migration Path
+
+1. **Pre-flight** (Wave 3 着手前、別 quick Issue または本 Issue の第一タスク)
+   - `rg 'board-status-update'` で全参照洗い出し
+   - W1 #785 (workflow_done 除去) 完了確認
+
+2. **Phase 1**: chain.py 改名 + CHAIN_META 追加（機能等価、コードレベル）
+   - chain.py 変更 → chain-runner.sh alias 削除
+   - bats / pytest 全 PASS
+
+3. **Phase 2**: export API + CLI 統合（機能追加、後方互換）
+   - `export_deps_chains()` / `export_chain_steps_sh()` 実装
+   - `twl chain export --yaml --dry-run` が現行 deps.yaml と byte-identical（diff ゼロ）
+   - `twl chain export --shell --dry-run` が現行 chain-steps.sh と byte-identical
+
+4. **Phase 3**: feature flag 統合
+   - chain-runner.sh 冒頭 env check 追加
+   - `TWL_CHAIN_SSOT_MODE=chain.py` 経路を bats で検証
+   - default は `deps.yaml`
+
+5. **Phase 4** (Wave 終盤、別 Issue)
+   - `TWL_CHAIN_SSOT_MODE=chain.py` を default に切替
+   - 本 Issue の AC 完了後、chain-steps.sh を pre-commit で自動再生成するゲート設置（→ #791）
+
+## Rollback
+
+- chain.py 改名 revert: `git revert <commit>` + alias 再追加
+- feature flag default=`deps.yaml` なので、emergency 時は env を明示しないだけで従来動作
+- deps.yaml export 結果が不整合の場合、`git checkout HEAD~1 plugins/twl/deps.yaml` で戻し
+
+## 未決事項（本 change では扱わない）
+
+- pre-commit hook での `twl chain export --yaml --check` 自動実行 → #791 の責務
+- chain-steps.sh の完全廃止 → Wave 完了後 + `TWL_CHAIN_SSOT_MODE` default 切替後
+- `twl check` の deps 整合性拡張 → 別 Issue (ADR-0007 の継承 TODO)

--- a/plugins/twl/deltaspec/changes/issue-790/proposal.md
+++ b/plugins/twl/deltaspec/changes/issue-790/proposal.md
@@ -1,0 +1,109 @@
+# Proposal: chain.py SSoT refinement (Issue #790)
+
+## Summary
+
+ADR-0007 の「chain.py が chain 定義の SSoT」方針を具体的な export API / CHAIN_META / 名称統一に落とし込み、`deps.yaml.chains` と `chain-steps.sh` を chain.py から生成される `computed artifact` 化する。
+
+参照: ADR-020（本 change と同時提案）
+
+## Goals
+
+1. **名称ドリフトの根治**: chain.py の `board-status-update` を `project-board-status-update` に改名し、chain-runner.sh の alias 層を廃止する
+2. **CHAIN_META の導入**: LLM/trigger dispatch のステップ（CHAIN_STEPS 非保有）も chain.py で SSoT 管理
+3. **export API**: `twl chain export --yaml` / `--shell` で deps.yaml / chain-steps.sh を再生成
+4. **feature flag**: `TWL_CHAIN_SSOT_MODE` を chain-runner.sh 冒頭で判定し段階ロールアウト
+
+## Non-goals
+
+- pre-commit / CI 整合性ゲート（→ #791）
+- `twl check` の deps 整合性チェック拡張（別 Issue）
+- chain-steps.sh の完全廃止（Wave 完了後）
+- workflow_done 完全除去（W1 #785 が先行）
+
+## Alternatives considered
+
+| 選択肢 | 採否 | 理由 |
+|---|---|---|
+| Q-A A-1': chain.py を改名 | **採用** | ADR-0007 (chain.py SSoT) 維持 + deps.yaml 正規名整合 |
+| Q-A A-2: deps.yaml を board-status-update に改名 | 不採用 | ADR-0007 と matrix 整合、ファイル名変更コスト高 |
+| Q-A A-3: export に mapping 追加 | 不採用 | 本末転倒（mapping table が新 SSoT に昇格） |
+| Q-B B-3': CHAIN_META 新設 | **採用** | ADR-0007 の 2 レイヤー分離維持 + LLM/trigger の正典化 |
+| Q-B B-1: 全 CHAIN_STEPS に追加 | 不採用 | ADR-0007 責務分離を破壊、quick-skip ロジック崩壊 |
+| Q-B B-2: 別 Issue 化 | 不採用 | 本 Issue の SSoT 完全化が不完全になる |
+| Q-C C-2: chain-runner.sh 冒頭で env check | **採用** | Python/bash 両方に影響せず fallback 経路保証 |
+| Q-C C-1: chain.py 内部で env check | 不採用 | chain.py SSoT 採用後の env 意識が不自然 |
+| Q-D D-1: CHAIN_META に dispatch 統合 | **採用** | SSoT 完全化、ADR-0007 準拠 |
+| Q-D D-2: chain-steps.sh で手書き維持 | 不採用 | ADR-0007 の「chain-steps.sh は chain.py ミラー」と矛盾 |
+
+## Impact
+
+### 追加 Critical Files (Issue body 修正必要)
+
+- `cli/twl/src/twl/cli.py` — `chain` subcommand dispatch に `export` 分岐を追加
+- `cli/twl/src/twl/cli_dispatch.py` — 必要に応じて handler 統合
+
+### 既存 Critical Files (Issue 宣言済み)
+
+- `cli/twl/src/twl/autopilot/chain.py` — CHAIN_STEPS 名称変更 + CHAIN_META 追加 + export API
+- `plugins/twl/deps.yaml` — chains / meta_chains の export 結果で置換（他セクション保持）
+- `plugins/twl/scripts/chain-runner.sh` — 冒頭 env check 追加、alias 削除
+- `plugins/twl/scripts/chain-steps.sh` — export 結果で置換
+
+### 影響を受ける関連コード
+
+- `plugins/twl/scripts/compaction-resume.sh` — chain-steps.sh を参照
+- `cli/twl/src/twl/autopilot/mergegate_guards.py` — `board-status-update` 文字列参照箇所を調査
+- `plugins/twl/tests/bats/scripts/chain-runner-next-step.bats` — alias 廃止で期待値更新
+- `plugins/twl/tests/scenarios/chain-definition.test.sh` — 名称統一確認
+
+### 新規テスト
+
+- `cli/twl/tests/test_autopilot_chain_export.py` — `export_deps_chains()` / `export_chain_steps_sh()` の単体テスト
+- `plugins/twl/tests/bats/scripts/chain-runner-ssot-mode.bats` — TWL_CHAIN_SSOT_MODE=chain.py / deps.yaml の両モード動作確認
+
+## Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| `board-status-update` 文字列参照の残存 | High | `rg 'board-status-update'` で全件洗い出し、Tasks の第一歩として実行 |
+| `twl chain export --yaml` による deps.yaml 他セクション破壊 | High | YAML ラウンドトリップ ( `yaml.safe_load` → modify chains → dump ) で他セクション保持を保証、bats で diff 検証 |
+| TWL_CHAIN_SSOT_MODE の意図しない早期採用 | Medium | 環境変数 default = `deps.yaml`、明示的に `chain.py` 指定したときのみ新経路 |
+| CHAIN_META と既存 STEP_TO_WORKFLOW の重複 | Low | STEP_TO_WORKFLOW を CHAIN_META から自動生成する migration 経路を AC に明記 |
+
+## Acceptance Criteria (Issue body 修正案)
+
+本 propose 採択後、Issue #790 body の AC を以下へ更新（observer が実装時適用）:
+
+1. **chain.py refinement**
+   - `CHAIN_STEPS` 内の `board-status-update` を `project-board-status-update` に改名
+   - `STEP_TO_WORKFLOW` 対応エントリを同時に改名
+   - `CHAIN_META: dict[str, dict[str, str]]` を追加（dispatch_mode, chain フィールド）
+   - 既存 STEP_TO_WORKFLOW は CHAIN_META から生成（重複回避）
+2. **export API 追加**
+   - `export_deps_chains() -> dict` — `deps.yaml.chains` / `meta_chains:` を構築（他セクション保持は CLI 層で処理）
+   - `export_chain_steps_sh() -> str` — chain-steps.sh bash ソースを構築
+3. **CLI 統合**
+   - `cli/twl/src/twl/cli.py` L74-88 の chain subcommand に `export` を追加
+   - `twl chain export --yaml` / `twl chain export --shell` の実装
+4. **chain-runner.sh 統合**
+   - 冒頭 `source chain-steps.sh` を `TWL_CHAIN_SSOT_MODE` 分岐に変更
+   - alias `board-status-update) step_board_status_update ;;` を削除（`project-board-status-update` 単一行に）
+5. **feature flag**
+   - `TWL_CHAIN_SSOT_MODE=chain.py|deps.yaml` で切替（default: `deps.yaml`、Wave 完了時まで fallback）
+6. **非回帰確認（既存 6 検証項目）**
+   1. `twl check` PASS
+   2. `pytest cli/twl/tests/` PASS
+   3. `bats plugins/twl/tests/bats/` PASS
+   4. `bash plugins/twl/tests/scenarios/chain-definition.test.sh` PASS
+   5. `TWL_CHAIN_SSOT_MODE=chain.py bash plugins/twl/scripts/chain-runner.sh next-step 0 init` が `project-board-status-update` を返す
+   6. `twl chain export --yaml --dry-run` が既存 deps.yaml と diff ゼロ（byte-identical）
+7. **整合性検証**
+   - `twl chain validate` を拡張（ADR-020 D-5）
+8. **Critical Files に `cli/twl/src/twl/cli.py` を追加**
+
+## 依存関係
+
+- **blocked-by**:
+  - W1 #785 (workflow_done 除去) — SSoT 候補を混乱させないため先行推奨
+  - 名称統一 quick Issue (新規作成推奨、または本 Issue の第 1 タスクに包含)
+- **blocks**: #8, #9, Epic #783

--- a/plugins/twl/deltaspec/changes/issue-790/tasks.md
+++ b/plugins/twl/deltaspec/changes/issue-790/tasks.md
@@ -1,0 +1,85 @@
+# Tasks: chain.py SSoT refinement (Issue #790)
+
+## Phase 0: Pre-flight（必須、実装前）
+
+- [ ] **T0.1** W1 #785 (workflow_done 除去) のマージ完了を確認
+- [ ] **T0.2** `rg 'board-status-update' -t py -t sh -t yaml -t md` で全参照を洗い出し、該当行リストを PR 説明に記載
+- [ ] **T0.3** `rg 'CHAIN_STEP_DISPATCH|CHAIN_STEP_WORKFLOW|CHAIN_WORKFLOW_NEXT_SKILL' plugins/twl/scripts/` で bash 側 SSoT 参照箇所を確認
+
+## Phase 1: chain.py 改名 + CHAIN_META 追加
+
+- [ ] **T1.1** `cli/twl/src/twl/autopilot/chain.py`
+  - L31 `"board-status-update"` → `"project-board-status-update"`
+  - L72 同上
+  - `CHAIN_META: dict[str, dict[str, str]]` を CHAIN_STEPS の直後に追加（design.md の全 30 step を列挙）
+  - `STEP_TO_WORKFLOW` を CHAIN_META 由来の dict comprehension に変換
+  - `step_board_status_update()` メソッド内の `self.record_step(issue_num, "board-status-update")` を `"project-board-status-update"` に改名
+- [ ] **T1.2** `plugins/twl/scripts/chain-runner.sh`
+  - L1497-1498 の `board-status-update) step_board_status_update "$@" ;;` 行を削除
+  - L1498 の `project-board-status-update)` を単行化
+  - L430 `record_current_step "board-status-update"` を `"project-board-status-update"` に改名
+  - L1458, L1532 の usage 表示から `board-status-update` を削除
+- [ ] **T1.3** `cli/twl/src/twl/autopilot/mergegate_guards.py` 等 `board-status-update` 文字列参照箇所を修正（T0.2 で洗い出した箇所）
+- [ ] **T1.4** `pytest cli/twl/tests/test_autopilot_chain.py` 単体テスト更新 + PASS
+- [ ] **T1.5** `bats plugins/twl/tests/bats/scripts/chain-runner-next-step.bats` 期待値更新 + PASS
+
+## Phase 2: export API 実装
+
+- [ ] **T2.1** `cli/twl/src/twl/autopilot/chain.py`
+  - `export_deps_chains() -> dict` 実装
+  - `export_chain_steps_sh() -> str` 実装
+  - YAML ラウンドトリップで既存 deps.yaml の他セクション（components 等）保持
+- [ ] **T2.2** `cli/twl/src/twl/chain/export.py` 新規作成
+  - argparse で `--yaml` / `--shell` / `--dry-run` / `--check` (= byte-diff 検証) フラグ
+  - `--yaml`: deps.yaml を YAML ロード → chains/meta_chains 差し替え → dump
+  - `--shell`: `export_chain_steps_sh()` の文字列を chain-steps.sh に書込
+- [ ] **T2.3** `cli/twl/src/twl/cli.py` L74-88 付近の `chain` subcommand dispatch に `export` 分岐を追加
+- [ ] **T2.4** `cli/twl/tests/test_autopilot_chain_export.py` 新規作成
+  - `export_deps_chains()` が現行 deps.yaml.chains と dict-level 等価
+  - `export_chain_steps_sh()` が現行 chain-steps.sh と byte-identical
+- [ ] **T2.5** `twl chain export --yaml --dry-run` と `twl chain export --shell --dry-run` が byte-identical (= diff ゼロ) を CI で検証
+
+## Phase 3: feature flag 統合
+
+- [ ] **T3.1** `plugins/twl/scripts/chain-runner.sh` L17 を env-conditional に変更:
+  ```bash
+  if [[ "${TWL_CHAIN_SSOT_MODE:-deps.yaml}" == "chain.py" ]]; then
+    eval "$(twl chain export --shell)"
+  else
+    source "${SCRIPT_DIR}/chain-steps.sh"
+  fi
+  ```
+- [ ] **T3.2** `plugins/twl/tests/bats/scripts/chain-runner-ssot-mode.bats` 新規作成
+  - `TWL_CHAIN_SSOT_MODE=chain.py bash chain-runner.sh next-step 0 init` → `project-board-status-update`
+  - `TWL_CHAIN_SSOT_MODE=deps.yaml bash chain-runner.sh next-step 0 init` → 同値
+  - `bash chain-runner.sh next-step 0 init`（env 未設定）→ 同値（default fallback 動作）
+  - `bash chain-runner.sh board-status-update <args>` → 未知ステップエラー（alias 削除検証）
+
+## Phase 4: 整合性検証拡張
+
+- [ ] **T4.1** `cli/twl/src/twl/chain/validate.py`
+  - chain.py `CHAIN_STEPS ∪ CHAIN_META.keys()` == deps.yaml.chains 全 steps set（差分ゼロ）
+  - CHAIN_META[step].dispatch_mode == deps.yaml components[step].dispatch_mode（各 step）
+  - chain-steps.sh が `twl chain export --shell` 出力と byte-identical
+- [ ] **T4.2** `cli/twl/tests/test_chain_validate.py` 拡張
+
+## Phase 5: 非回帰検証（AC 6項目）
+
+- [ ] **T5.1** `twl --check` PASS
+- [ ] **T5.2** `pytest cli/twl/tests/` 全 PASS
+- [ ] **T5.3** `bash plugins/twl/tests/bats/run.sh` 全 PASS
+- [ ] **T5.4** `bash plugins/twl/tests/scenarios/chain-definition.test.sh` PASS
+- [ ] **T5.5** `TWL_CHAIN_SSOT_MODE=chain.py bash plugins/twl/scripts/chain-runner.sh next-step 0 init` が `project-board-status-update` を返す
+- [ ] **T5.6** `twl chain export --yaml --dry-run` / `twl chain export --shell --dry-run` が diff ゼロ
+
+## Phase 6: ADR マージ + Issue body 更新
+
+- [ ] **T6.1** `plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md` Status: Proposed → Accepted に更新（本 PR マージ後）
+- [ ] **T6.2** Issue #790 body の Critical Files / AC を proposal.md の「Acceptance Criteria (Issue body 修正案)」セクションに合わせて更新（observer が実装時適用）
+- [ ] **T6.3** refined ラベル再付与（specialist review PASS 後）
+
+## Out of scope (follow-up Issues)
+
+- **#791 deps-integrity**: pre-commit hook で `twl chain export --yaml --check` 自動実行
+- **chain-steps.sh 完全廃止**: Wave 完了後 + `TWL_CHAIN_SSOT_MODE` default 切替
+- **`twl check` の deps 整合性拡張**: ADR-0007 継承 TODO


### PR DESCRIPTION
## Summary

co-architect (Issue #790 W3-7 chain.py SSoT 化) からの architecture docs 更新。Q-A〜Q-D の設計判断を確定し DeltaSpec propose として実装パス化。

## Decisions (all recommended adopted)

| Q | 採択 | 根拠 |
|---|---|---|
| Q-A | A-1' (chain.py を project-board-status-update に改名) | ADR-0007 (chain.py SSoT) + deps.yaml 正規名との整合 |
| Q-B | B-3' (CHAIN_META 新設) | ADR-0007 の 2 レイヤー責務分離維持 + LLM/trigger 正典化 |
| Q-C | C-2 (chain-runner.sh 冒頭で env check) | Python/bash 両方に影響せず fallback 経路保証 |
| Q-D | D-1 (CHAIN_META に dispatch 統合) | SSoT 完全化、ADR-0007 準拠 |

## Files

- `plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md` (新規 ADR, Status: Proposed)
- `plugins/twl/deltaspec/changes/issue-790/`
  - `proposal.md`: Goals / Non-goals / Alternatives / Impact / Risks / AC
  - `design.md`: データ構造 (CHAIN_META) / 変更点 / テスト計画 / Migration Path / Rollback
  - `tasks.md`: Phase 0-6 の実装タスク
  - `.deltaspec.yaml`

## Follow-up (observer 責務)

- Issue #790 body の Critical Files に `cli/twl/src/twl/cli.py` 追加
- AC を proposal.md 'Acceptance Criteria (Issue body 修正案)' に合わせて更新
- refined ラベル再付与（本 PR マージ + specialist review PASS 後）

## Related

- Refs: #790, ADR-0007, ADR-018
- Blocks: #8, #9, Epic #783
- Blocked-by: W1 #785 (workflow_done 除去) 推奨先行

🤖 Generated by co-architect (twl:co-architect)