### PR TITLE
feat(#785): ADR-018 残作業 — chain-runner.sh の workflow_done 書込除去

### DIFF
--- a/cli/twl/src/twl/chain/meta_generate.py
+++ b/cli/twl/src/twl/chain/meta_generate.py
@@ -6,8 +6,6 @@ from pathlib import Path
 from typing import Dict, List, Tuple
 
 
-_VALID_WORKFLOW_DONE_RE = re.compile(r'^[a-zA-Z0-9_-]+$')
-
 
 def _normalize_for_check(text: str) -> str:
     """比較用にテキストを正規化する（trailing whitespace 除去 + LF 統一）。"""
@@ -64,22 +62,10 @@ def meta_chain_generate(deps: dict, meta_chain_name: str, plugin_root: Path) -> 
             goto = entry.get('goto')
             stop = entry.get('stop', False)
             message = entry.get('message', '')
-            workflow_done = entry.get('workflow_done', '')
 
             if stop:
                 if 'autopilot' in condition and '!' not in condition:
-                    if workflow_done and _VALID_WORKFLOW_DONE_RE.match(workflow_done):
-                        # ADR-014: workflow_done state write + 停止
-                        state_cmd = (
-                            f'python3 -m twl.autopilot.state write '
-                            f'--autopilot-dir "${{AUTOPILOT_DIR:-}}" '
-                            f'--type issue --issue "$ISSUE_NUM" '
-                            f'--role worker --set "workflow_done={workflow_done}"'
-                        )
-                        transition_lines.append(
-                            f'- IS_AUTOPILOT=true → `{state_cmd}` を実行して停止'
-                        )
-                    elif message:
+                    if message:
                         transition_lines.append(f"- IS_AUTOPILOT=true → 「{message}」と案内")
                     else:
                         transition_lines.append("- IS_AUTOPILOT=true → ユーザーへ案内して停止")

--- a/cli/twl/tests/autopilot/test_chain_e2e_transition.py
+++ b/cli/twl/tests/autopilot/test_chain_e2e_transition.py
@@ -99,7 +99,7 @@ WORKER_LIFECYCLE_FLOW: list[dict] = [
 def _assert_no_inject_skip(result: str, from_workflow: str) -> None:
     """resolve_next_workflow が空文字を返した場合に inject-skip として失敗させる。"""
     assert result != "", (
-        f"inject-skip 検出: workflow_done={from_workflow!r} の次 workflow が空です。"
+        f"inject-skip 検出: current_workflow={from_workflow!r} の次 workflow が空です。"
         " orchestrator が inject_next_workflow を呼べません。"
     )
 
@@ -112,7 +112,7 @@ def _make_runner(tmp_path: Path) -> ChainRunner:
     return ChainRunner(scripts_root=scripts_root, autopilot_dir=autopilot_dir)
 
 
-def _write_issue_state(autopilot_dir: Path, issue_num: int, workflow_done: str) -> Path:
+def _write_issue_state(autopilot_dir: Path, issue_num: int, current_workflow: str) -> Path:
     """tmp_path 配下に issue state ファイルを作成する。"""
     issues_dir = autopilot_dir / "issues"
     issues_dir.mkdir(exist_ok=True)
@@ -130,7 +130,6 @@ def _write_issue_state(autopilot_dir: Path, issue_num: int, workflow_done: str) 
         "merged_at": None,
         "files_changed": [],
         "failure": None,
-        "workflow_done": workflow_done,
         "implementation_pr": None,
         "deltaspec_mode": None,
         "is_quick": False,
@@ -161,10 +160,10 @@ def patched_runner(runner: ChainRunner):
 # ---------------------------------------------------------------------------
 
 class TestSetupToTestReadyTransition:
-    """Issue #450 AC-1: setup chain 完了 → workflow_done=setup → next=workflow-test-ready."""
+    """Issue #450 AC-1: setup chain 完了 → next=workflow-test-ready."""
 
     def test_setup_returns_test_ready(self, patched_runner: ChainRunner) -> None:
-        """workflow_done=setup で resolve_next_workflow が workflow-test-ready を返す。"""
+        """current_workflow=setup で resolve_next_workflow が workflow-test-ready を返す。"""
         result = patched_runner.resolve_next_workflow(
             "setup", is_autopilot=True, is_quick=False
         )
@@ -179,10 +178,10 @@ class TestSetupToTestReadyTransition:
 # ---------------------------------------------------------------------------
 
 class TestTestReadyToPrVerifyTransition:
-    """Issue #450 AC-1: test-ready chain 完了 → workflow_done=test-ready → next=workflow-pr-verify."""
+    """Issue #450 AC-1: test-ready chain 完了 → next=workflow-pr-verify."""
 
     def test_test_ready_returns_pr_verify(self, patched_runner: ChainRunner) -> None:
-        """workflow_done=test-ready で resolve_next_workflow が workflow-pr-verify を返す。"""
+        """current_workflow=test-ready で resolve_next_workflow が workflow-pr-verify を返す。"""
         result = patched_runner.resolve_next_workflow(
             "test-ready", is_autopilot=True, is_quick=False
         )
@@ -200,7 +199,7 @@ class TestPrVerifyTransition:
     """Issue #450 AC-1: pr-verify に到達した後の遷移確認。"""
 
     def test_pr_verify_returns_pr_fix(self, patched_runner: ChainRunner) -> None:
-        """workflow_done=pr-verify (autopilot=True) で workflow-pr-fix を返す。"""
+        """current_workflow=pr-verify (autopilot=True) で workflow-pr-fix を返す。"""
         result = patched_runner.resolve_next_workflow(
             "pr-verify", is_autopilot=True, is_quick=False
         )
@@ -210,7 +209,7 @@ class TestPrVerifyTransition:
         )
 
     def test_pr_verify_autopilot_false_stops(self, patched_runner: ChainRunner) -> None:
-        """workflow_done=pr-verify (autopilot=False) で停止（空を返す）。"""
+        """current_workflow=pr-verify (autopilot=False) で停止（空を返す）。"""
         result = patched_runner.resolve_next_workflow(
             "pr-verify", is_autopilot=False, is_quick=False
         )
@@ -223,7 +222,7 @@ class TestPrVerifyTransition:
 # Scenario: 3 Issue 以上の chain 遷移が成立する（inject-skip = 0）
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("issue_num,workflow_done,expected_next", [
+@pytest.mark.parametrize("issue_num,current_workflow,expected_next", [
     (451, "setup", "workflow-test-ready"),
     (452, "test-ready", "workflow-pr-verify"),
     (453, "pr-verify", "workflow-pr-fix"),
@@ -231,21 +230,21 @@ class TestPrVerifyTransition:
 def test_three_issues_no_inject_skip(
     tmp_path: Path,
     issue_num: int,
-    workflow_done: str,
+    current_workflow: str,
     expected_next: str,
 ) -> None:
     """Issue #450 AC-3: 3 Issue 分の chain 遷移が inject-skip 0 で成立することを確認。
 
-    3 件の Issue がそれぞれ異なる workflow_done 状態にあるとき、
+    3 件の Issue がそれぞれ異なる current_workflow 状態にあるとき、
     resolve_next_workflow が inject-skip（空文字）を返さないことを検証する。
     """
     runner = _make_runner(tmp_path)
-    _write_issue_state(runner.autopilot_dir, issue_num=issue_num, workflow_done=workflow_done)
+    _write_issue_state(runner.autopilot_dir, issue_num=issue_num, current_workflow=current_workflow)
     with patch.object(runner, "_load_worker_lifecycle_flow", return_value=WORKER_LIFECYCLE_FLOW):
-        result = runner.resolve_next_workflow(workflow_done, is_autopilot=True, is_quick=False)
-    _assert_no_inject_skip(result, workflow_done)
+        result = runner.resolve_next_workflow(current_workflow, is_autopilot=True, is_quick=False)
+    _assert_no_inject_skip(result, current_workflow)
     assert result == expected_next, (
-        f"issue #{issue_num}: workflow_done={workflow_done!r} → expected {expected_next!r}, got {result!r}"
+        f"issue #{issue_num}: current_workflow={current_workflow!r} → expected {expected_next!r}, got {result!r}"
     )
 
 
@@ -265,8 +264,8 @@ class TestInjectSkipDetection:
         """_assert_no_inject_skip は非空文字に対して AssertionError を発生させない。"""
         _assert_no_inject_skip("workflow-test-ready", "setup")  # should not raise
 
-    def test_unknown_workflow_returns_empty_not_skipped(self, patched_runner: ChainRunner) -> None:
-        """未知の workflow_done は空文字を返す（inject-skip として正しく検出される）。"""
+    def test_unknown_workflow_returns_empty(self, patched_runner: ChainRunner) -> None:
+        """未知の current_workflow は空文字を返す（inject-skip として正しく検出される）。"""
         result = patched_runner.resolve_next_workflow(
             "unknown-workflow", is_autopilot=True, is_quick=False
         )
@@ -288,11 +287,11 @@ class TestFullChainSequence:
             ("setup", "workflow-test-ready"),
             ("test-ready", "workflow-pr-verify"),
         ]
-        for workflow_done, expected_next in chain_sequence:
+        for current_workflow, expected_next in chain_sequence:
             result = patched_runner.resolve_next_workflow(
-                workflow_done, is_autopilot=True, is_quick=False
+                current_workflow, is_autopilot=True, is_quick=False
             )
-            _assert_no_inject_skip(result, workflow_done)
+            _assert_no_inject_skip(result, current_workflow)
             assert result == expected_next, (
-                f"workflow_done={workflow_done!r}: expected {expected_next!r}, got {result!r}"
+                f"current_workflow={current_workflow!r}: expected {expected_next!r}, got {result!r}"
             )

--- a/cli/twl/tests/autopilot/test_nonterminal_chain_recovery.py
+++ b/cli/twl/tests/autopilot/test_nonterminal_chain_recovery.py
@@ -60,7 +60,6 @@ def issue_state_file(autopilot_dir: Path) -> Path:
         "merged_at": None,
         "files_changed": [],
         "failure": None,
-        "workflow_done": None,
         "implementation_pr": None,
         "deltaspec_mode": None,
         "is_quick": False,
@@ -95,30 +94,30 @@ def chain_runner(scripts_root: Path, autopilot_dir: Path) -> ChainRunner:
 
 class TestResolveNextWorkflowModule:
     """
-    Scenario: workflow_done=test-ready の場合に次 skill を返す
-    WHEN: issue-469.json の workflow_done が "test-ready" で is_quick=false の状態で
+    Scenario: current_step=post-change-apply の場合に次 skill を返す
+    WHEN: issue-469.json の current_step が "post-change-apply" で is_quick=false の状態で
           python3 -m twl.autopilot.resolve_next_workflow --issue 469 を実行する
     THEN: stdout に /twl:workflow-pr-verify が出力され exit 0 で終了する
 
-    Scenario: workflow_done=null の場合に失敗する
-    WHEN: issue-469.json の workflow_done が null または空の状態で
+    Scenario: current_step 未設定の場合に失敗する
+    WHEN: issue-469.json の current_step が空の状態で
           python3 -m twl.autopilot.resolve_next_workflow --issue 469 を実行する
     THEN: stdout は空で exit 非ゼロで終了する
 
-    Scenario: workflow_done=setup の場合に次 skill を返す
-    WHEN: issue-469.json の workflow_done が "setup" で is_quick=false の状態で
+    Scenario: current_step=ac-extract の場合に次 skill を返す
+    WHEN: issue-469.json の current_step が "ac-extract" で is_quick=false の状態で
           python3 -m twl.autopilot.resolve_next_workflow --issue 469 を実行する
     THEN: stdout に /twl:workflow-test-ready が出力され exit 0 で終了する
     """
 
-    def test_workflow_done_test_ready_returns_pr_verify(
+    def test_current_step_post_change_apply_returns_pr_verify(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """WHEN workflow_done=test-ready, is_quick=false
+        """WHEN current_step=post-change-apply, is_quick=false
         THEN stdout=/twl:workflow-pr-verify, exit=0."""
-        # Arrange: write workflow_done=test-ready into state file
+        # Arrange: write current_step=post-change-apply into state file (ADR-018)
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = "test-ready"
+        data["current_step"] = "post-change-apply"
         data["is_quick"] = False
         issue_state_file.write_text(json.dumps(data))
 
@@ -138,14 +137,14 @@ class TestResolveNextWorkflowModule:
             f"Expected '/twl:workflow-pr-verify' but got {result.stdout.strip()!r}"
         )
 
-    def test_workflow_done_null_returns_nonzero_exit_empty_stdout(
+    def test_current_step_empty_returns_nonzero_exit_empty_stdout(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """WHEN workflow_done=null
+        """WHEN current_step is empty (not set)
         THEN stdout is empty, exit != 0."""
-        # Arrange: ensure workflow_done is null (already null in fixture)
+        # Arrange: ensure current_step is empty (already "" in fixture)
         data = json.loads(issue_state_file.read_text())
-        assert data["workflow_done"] is None
+        assert data["current_step"] == ""
 
         # Act
         result = subprocess.run(
@@ -157,20 +156,20 @@ class TestResolveNextWorkflowModule:
 
         # Assert: exit non-zero and stdout empty
         assert result.returncode != 0, (
-            "Expected non-zero exit when workflow_done=null, "
+            "Expected non-zero exit when current_step is empty, "
             f"but got returncode={result.returncode}. stdout={result.stdout!r}"
         )
         assert result.stdout.strip() == "", (
             f"Expected empty stdout but got {result.stdout.strip()!r}"
         )
 
-    def test_workflow_done_empty_string_returns_nonzero_exit_empty_stdout(
+    def test_current_step_non_terminal_returns_nonzero_exit_empty_stdout(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """WHEN workflow_done is empty string
+        """WHEN current_step is a non-terminal step
         THEN stdout is empty, exit != 0."""
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = ""
+        data["current_step"] = "board-status-update"
         issue_state_file.write_text(json.dumps(data))
 
         result = subprocess.run(
@@ -183,13 +182,13 @@ class TestResolveNextWorkflowModule:
         assert result.returncode != 0
         assert result.stdout.strip() == ""
 
-    def test_workflow_done_setup_returns_workflow_test_ready(
+    def test_current_step_ac_extract_returns_workflow_test_ready(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """WHEN workflow_done=setup, is_quick=false
+        """WHEN current_step=ac-extract (terminal step of setup chain), is_quick=false
         THEN stdout=/twl:workflow-test-ready, exit=0."""
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = "setup"
+        data["current_step"] = "ac-extract"
         data["is_quick"] = False
         issue_state_file.write_text(json.dumps(data))
 
@@ -237,7 +236,7 @@ class TestResolveNextWorkflowModule:
     ) -> None:
         """stdout contains exactly the skill command with optional trailing newline only."""
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = "test-ready"
+        data["current_step"] = "post-change-apply"
         issue_state_file.write_text(json.dumps(data))
 
         result = subprocess.run(
@@ -254,17 +253,17 @@ class TestResolveNextWorkflowModule:
 
 
 # ---------------------------------------------------------------------------
-# Requirement: ChainRunner.resolve_next_workflow — workflow_done 委譲ロジック
+# Requirement: ChainRunner.resolve_next_workflow — chain 遷移ロジック (ADR-018)
 # (Unit-level: tests how STEP_TO_WORKFLOW feeds into WORKFLOW_NEXT_SKILL)
 # ---------------------------------------------------------------------------
 
 
-class TestWorkflowDoneChainMapping:
+class TestWorkflowChainMapping:
     """Unit tests for the STEP_TO_WORKFLOW + WORKFLOW_NEXT_SKILL mapping constants.
 
     These constants are the SSOT for which skill follows a completed workflow.
     Issue #469 root cause: test-ready workflow completion was not triggering
-    workflow-pr-verify because workflow_done=test-ready was not set/read.
+    workflow-pr-verify (historical: pre-ADR-018 used workflow_done field).
     """
 
     def test_test_ready_maps_to_workflow_pr_verify(self) -> None:
@@ -313,10 +312,10 @@ class TestWorkflowDoneChainMapping:
             f"Expected 'workflow-pr-verify', got {result!r}"
         )
 
-    def test_resolve_next_workflow_returns_empty_for_null_workflow_done(
+    def test_resolve_next_workflow_returns_empty_for_unknown_workflow(
         self, chain_runner: ChainRunner
     ) -> None:
-        """When workflow_done is absent (''), resolve_next_workflow returns ''."""
+        """When current_workflow is empty or unknown, resolve_next_workflow returns ''."""
         with patch.object(
             chain_runner,
             "_load_worker_lifecycle_flow",
@@ -336,27 +335,27 @@ class TestWorkflowDoneChainMapping:
 
 class TestOrchestratorRecoveryE2E:
     """
-    Scenario: workflow_done 未書き込み時の resolve 失敗確認
-    WHEN: issue-469 の state で workflow_done=null のまま
+    Scenario: current_step 未設定時の resolve 失敗確認
+    WHEN: issue-469 の state で current_step="" のまま
           resolve_next_workflow --issue 469 を呼ぶ
     THEN: exit 非ゼロで終了し、stdout が空であることを確認できる
 
-    Scenario: workflow_done 書き込み後の resolve 成功確認
-    WHEN: state write --set workflow_done=test-ready で書き込んだ後に
+    Scenario: current_step 書き込み後の resolve 成功確認
+    WHEN: Worker が current_step=post-change-apply を書き込んだ後に
           resolve_next_workflow --issue 469 を呼ぶ
     THEN: exit 0 で /twl:workflow-pr-verify が stdout に出力される
     """
 
-    def test_resolve_fails_when_workflow_done_not_written(
+    def test_resolve_fails_when_current_step_not_set(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
         """
-        WHEN: workflow_done=null (未書き込み)
+        WHEN: current_step="" (未設定)
         THEN: resolve_next_workflow exits non-zero, stdout empty.
         """
-        # Verify fixture: workflow_done is null
+        # Verify fixture: current_step is empty
         data = json.loads(issue_state_file.read_text())
-        assert data.get("workflow_done") is None, "Fixture must have workflow_done=null"
+        assert data.get("current_step") == "", "Fixture must have current_step=''"
 
         result = subprocess.run(
             [sys.executable, "-m", "twl.autopilot.resolve_next_workflow", "--issue", "469"],
@@ -366,31 +365,31 @@ class TestOrchestratorRecoveryE2E:
         )
 
         assert result.returncode != 0, (
-            "resolve_next_workflow must fail (non-zero exit) when workflow_done=null"
+            "resolve_next_workflow must fail (non-zero exit) when current_step is empty"
         )
         assert result.stdout.strip() == "", (
-            f"stdout must be empty when workflow_done=null, got {result.stdout!r}"
+            f"stdout must be empty when current_step is empty, got {result.stdout!r}"
         )
 
-    def test_resolve_succeeds_after_workflow_done_written(
+    def test_resolve_succeeds_after_current_step_written(
         self, autopilot_dir: Path, issue_state_file: Path, state_manager: StateManager
     ) -> None:
         """
-        WHEN: state write --set workflow_done=test-ready → then resolve_next_workflow
+        WHEN: Worker writes current_step=post-change-apply → then resolve_next_workflow
         THEN: exit 0, stdout=/twl:workflow-pr-verify.
         """
-        # Step 1: Write workflow_done=test-ready via StateManager (simulates orchestrator write)
+        # Step 1: Worker writes current_step=post-change-apply (ADR-018: current_step SSOT)
         state_manager.write(
             type_="issue",
-            role="pilot",
+            role="worker",
             issue="469",
-            sets=["workflow_done=test-ready"],
+            sets=["current_step=post-change-apply"],
         )
 
         # Verify write succeeded
         updated = json.loads(issue_state_file.read_text())
-        assert updated.get("workflow_done") == "test-ready", (
-            "State write must persist workflow_done=test-ready"
+        assert updated.get("current_step") == "post-change-apply", (
+            "State write must persist current_step=post-change-apply"
         )
 
         # Step 2: Invoke resolve_next_workflow CLI
@@ -402,41 +401,40 @@ class TestOrchestratorRecoveryE2E:
         )
 
         assert result.returncode == 0, (
-            f"Expected exit 0 after workflow_done=test-ready write. "
+            f"Expected exit 0 after current_step=post-change-apply write. "
             f"returncode={result.returncode}, stderr={result.stderr!r}"
         )
         assert result.stdout.strip() == "/twl:workflow-pr-verify", (
             f"Expected '/twl:workflow-pr-verify', got {result.stdout.strip()!r}"
         )
 
-    def test_state_write_pilot_workflow_done_is_allowed(
+    def test_pilot_cannot_write_current_step_directly(
         self, issue_state_file: Path, state_manager: StateManager
     ) -> None:
-        """StateManager.write() with role=pilot and workflow_done is in the allow-list."""
-        # Should not raise — workflow_done is an allowed pilot key
-        msg = state_manager.write(
-            type_="issue",
-            role="pilot",
-            issue="469",
-            sets=["workflow_done=test-ready"],
-        )
-        assert "OK" in msg
+        """Pilot は current_step を直接書けないこと（RBAC: Pilot は current_step を変更しない）."""
+        from twl.autopilot.state import StateError
+        with pytest.raises(StateError, match="権限"):
+            state_manager.write(
+                type_="issue",
+                role="pilot",
+                issue="469",
+                sets=["current_step=post-change-apply"],
+            )
 
-    def test_workflow_done_null_after_state_write_null_re_fails_resolve(
+    def test_current_step_reset_to_empty_re_fails_resolve(
         self, autopilot_dir: Path, issue_state_file: Path, state_manager: StateManager
     ) -> None:
-        """After setting workflow_done=test-ready then resetting to null,
-        resolve_next_workflow must fail again."""
-        # Step 1: set
+        """After setting current_step then resetting to empty, resolve_next_workflow must fail."""
+        # Step 1: set to terminal step
         state_manager.write(
-            type_="issue", role="pilot", issue="469", sets=["workflow_done=test-ready"]
+            type_="issue", role="worker", issue="469", sets=["current_step=post-change-apply"]
         )
-        # Step 2: reset to null
-        state_manager.write(
-            type_="issue", role="pilot", issue="469", sets=["workflow_done=null"]
-        )
+        # Step 2: reset to empty
         data = json.loads(issue_state_file.read_text())
-        assert data.get("workflow_done") is None
+        data["current_step"] = ""
+        issue_state_file.write_text(json.dumps(data))
+
+        assert data.get("current_step") == ""
 
         result = subprocess.run(
             [sys.executable, "-m", "twl.autopilot.resolve_next_workflow", "--issue", "469"],
@@ -453,16 +451,16 @@ class TestOrchestratorRecoveryE2E:
     ) -> None:
         """AC-4: core recovery scenario must PASS 10 consecutive times for stability.
 
-        WHEN: workflow_done=null → resolve fails; write test-ready → resolve succeeds.
+        WHEN: current_step="" → resolve fails; write post-change-apply → resolve succeeds.
         THEN: exit codes and stdout are correct across 10 independent runs.
         """
         for run in range(10):
-            # Reset workflow_done to null for each iteration
+            # Reset current_step to "" for each iteration
             data = json.loads(issue_state_file.read_text())
-            data["workflow_done"] = None
+            data["current_step"] = ""
             issue_state_file.write_text(json.dumps(data))
 
-            # Verify: null → fail
+            # Verify: empty → fail
             result_null = subprocess.run(
                 [sys.executable, "-m", "twl.autopilot.resolve_next_workflow", "--issue", "469"],
                 capture_output=True,
@@ -470,21 +468,21 @@ class TestOrchestratorRecoveryE2E:
                 env={**os.environ, "AUTOPILOT_DIR": str(autopilot_dir)},
             )
             assert result_null.returncode != 0, (
-                f"Run {run}: expected non-zero exit when workflow_done=null"
+                f"Run {run}: expected non-zero exit when current_step is empty"
             )
             assert result_null.stdout.strip() == "", (
-                f"Run {run}: expected empty stdout when workflow_done=null"
+                f"Run {run}: expected empty stdout when current_step is empty"
             )
 
-            # Write workflow_done=test-ready via state manager
+            # Write current_step=post-change-apply via Worker
             state_manager.write(
                 type_="issue",
-                role="pilot",
+                role="worker",
                 issue="469",
-                sets=["workflow_done=test-ready"],
+                sets=["current_step=post-change-apply"],
             )
 
-            # Verify: test-ready → /twl:workflow-pr-verify
+            # Verify: post-change-apply → /twl:workflow-pr-verify
             result_ok = subprocess.run(
                 [sys.executable, "-m", "twl.autopilot.resolve_next_workflow", "--issue", "469"],
                 capture_output=True,
@@ -492,7 +490,7 @@ class TestOrchestratorRecoveryE2E:
                 env={**os.environ, "AUTOPILOT_DIR": str(autopilot_dir)},
             )
             assert result_ok.returncode == 0, (
-                f"Run {run}: expected exit 0 after workflow_done=test-ready. "
+                f"Run {run}: expected exit 0 after current_step=post-change-apply. "
                 f"stderr={result_ok.stderr!r}"
             )
             assert result_ok.stdout.strip() == "/twl:workflow-pr-verify", (
@@ -516,40 +514,40 @@ class TestOrchestratorRecoveryE2E:
 
 class TestNudgeCommandForPattern:
     """
-    Scenario: 実装完了パターン検知時に workflow_done を書き inject する
+    Scenario: 実装完了パターン検知時に current_step を書き inject する (ADR-018)
     WHEN: Worker pane 出力が静止し、最終出力に '>>> 実装完了: issue-469' が含まれる
-    THEN: orchestrator が state write --role pilot --set workflow_done=test-ready を実行し、
+    THEN: Worker が state write --role worker --set current_step=post-change-apply を実行し、
           その後 tmux に /twl:workflow-pr-verify #469 を inject する
 
     Scenario: 既存パターンへの影響なし
     WHEN: pane 出力が 'setup chain 完了' を含む（既存パターン）
     THEN: 従来通り /twl:workflow-test-ready #469 が inject され、
-          実装完了パターン処理は行われない
+          完了パターン処理は行われない
     """
 
-    def test_completion_pattern_triggers_state_write_workflow_done_test_ready(
+    def test_completion_pattern_triggers_state_write_current_step(
         self,
         issue_state_file: Path,
         state_manager: StateManager,
     ) -> None:
-        """Simulate orchestrator state write when '>>> 実装完了: issue-469' is detected.
+        """Simulate Worker state write when '>>> 実装完了: issue-469' is detected.
 
-        The bash _nudge_command_for_pattern function (to be implemented) must call:
-            state write --type issue --issue 469 --role pilot --set workflow_done=test-ready
+        The bash _nudge_command_for_pattern function must call:
+            state write --type issue --issue 469 --role worker --set current_step=post-change-apply
         before injecting the skill command.  This test verifies the state layer
         accepts such a write and persists the value correctly.
         """
-        # Simulate what orchestrator fallback must do
+        # Simulate what Worker must do: write current_step (ADR-018 SSOT)
         state_manager.write(
             type_="issue",
-            role="pilot",
+            role="worker",
             issue="469",
-            sets=["workflow_done=test-ready"],
+            sets=["current_step=post-change-apply"],
         )
 
         data = json.loads(issue_state_file.read_text())
-        assert data.get("workflow_done") == "test-ready", (
-            "After completion-pattern detection, workflow_done must be 'test-ready'"
+        assert data.get("current_step") == "post-change-apply", (
+            "After completion-pattern detection, current_step must be 'post-change-apply'"
         )
 
     def test_completion_pattern_expected_inject_command(self) -> None:
@@ -571,20 +569,20 @@ class TestNudgeCommandForPattern:
     def test_setup_chain_kanryo_pattern_is_unaffected(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """'setup chain 完了' pattern must not set workflow_done=test-ready.
+        """'setup chain 完了' pattern must not alter current_step.
 
         The bash fallback for '>>> 実装完了' must only fire on that specific pattern.
         'setup chain 完了' must continue routing to /twl:workflow-test-ready (existing behavior).
         """
         # The state must remain untouched for 'setup chain 完了'
         data_before = json.loads(issue_state_file.read_text())
-        assert data_before.get("workflow_done") is None
+        assert data_before.get("current_step") == ""
 
         # 'setup chain 完了' is handled by the existing _nudge_command_for_pattern branch
-        # which does NOT write workflow_done. Verify state is unchanged (no side-effect).
+        # which does NOT write current_step. Verify state is unchanged (no side-effect).
         data_after = json.loads(issue_state_file.read_text())
-        assert data_after.get("workflow_done") == data_before.get("workflow_done"), (
-            "'setup chain 完了' pattern must not alter workflow_done in state"
+        assert data_after.get("current_step") == data_before.get("current_step"), (
+            "'setup chain 完了' pattern must not alter current_step in state"
         )
 
     def test_completion_pattern_keyword_is_precise(self) -> None:
@@ -720,7 +718,7 @@ class TestResolveNextWorkflowEdgeCases:
         import re
 
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = "test-ready"
+        data["current_step"] = "post-change-apply"
         issue_state_file.write_text(json.dumps(data))
 
         result = subprocess.run(
@@ -737,12 +735,12 @@ class TestResolveNextWorkflowEdgeCases:
             f"Skill '{skill}' must match /twl:workflow-<kebab> allow-list pattern"
         )
 
-    def test_is_quick_false_test_ready_gives_pr_verify_not_quick_path(
+    def test_is_quick_false_post_change_apply_gives_pr_verify_not_quick_path(
         self, autopilot_dir: Path, issue_state_file: Path
     ) -> None:
-        """is_quick=false must not route to quick-path; test-ready must give pr-verify."""
+        """is_quick=false must not route to quick-path; post-change-apply must give pr-verify."""
         data = json.loads(issue_state_file.read_text())
-        data["workflow_done"] = "test-ready"
+        data["current_step"] = "post-change-apply"
         data["is_quick"] = False
         issue_state_file.write_text(json.dumps(data))
 

--- a/cli/twl/tests/autopilot/test_state.py
+++ b/cli/twl/tests/autopilot/test_state.py
@@ -128,7 +128,6 @@ class TestPilotPrWriteAllowed:
                     "merged_at": None,
                     "files_changed": [],
                     "failure": None,
-                    "workflow_done": None,
                     "implementation_pr": None,
                     "deltaspec_mode": None,
                     "is_quick": False,

--- a/cli/twl/tests/scenarios/test_state_schema_ssot.py
+++ b/cli/twl/tests/scenarios/test_state_schema_ssot.py
@@ -6,15 +6,15 @@ Scenarios covered:
   1. Monitor が単一フィールドで進捗判定できる
   2. status=merge-ready 時に STAGNATE 警告が発生しない
   3. 状態遷移グラフの完全性 (IssueState 5値)
-  4. workflow_done の writer が全て削除される (state.py 観点)
-  5. orchestrator が workflow_done を参照しない (resolve_next_workflow 観点)
-  6. state.py の PILOT_ISSUE_ALLOWED_KEYS に workflow_done が含まれない
+  4. 廃止フィールドの writer が全て削除される (ADR-018 状態 state.py 観点)
+  5. orchestrator が status を参照する (resolve_next_workflow 観点)
+  6. state.py の PILOT_ISSUE_ALLOWED_KEYS に廃止フィールドが含まれない
   7. status=merge-ready で次 workflow が inject される (resolve_next_workflow)
 
 Edge-cases focus:
   - conflict → merge-ready リトライ上限
   - done 終端状態からの全遷移拒否
-  - _PILOT_ISSUE_ALLOWED_KEYS に workflow_done が含まれないこと
+  - _PILOT_ISSUE_ALLOWED_KEYS に廃止フィールドが含まれないこと
   - status フィールド単一クエリで全 5 値が表現可能
   - running/merge-ready 両方で status 単一フィールド判定が成立
 """
@@ -120,11 +120,11 @@ class TestStatusFieldSSOT:
             # Monitor は .status の値のみで判定すればよい
             assert data["status"] in self.VALID_STATUSES
 
-    def test_status_unambiguous_without_workflow_done(
+    def test_status_unambiguous_for_merge_ready(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
-        """workflow_done が null でも status=merge-ready で状態が判定できること."""
-        _write_issue(autopilot_dir, "21", "merge-ready", workflow_done=None)
+        """status=merge-ready が status フィールドのみで判定できること (ADR-018 SSOT)."""
+        _write_issue(autopilot_dir, "21", "merge-ready")
         result = mgr.read(type_="issue", issue="21", field="status")
         assert result == "merge-ready"
 
@@ -298,25 +298,14 @@ class TestIssueStateCompleteness:
 class TestWorkflowDoneRemovedFromAllowedKeys:
     """WHEN: Pilot が state file を更新しようとするとき
     THEN: workflow_done は _PILOT_ISSUE_ALLOWED_KEYS に含まれておらず、書き込みが拒否される
-
-    NOTE: これらのテストは Issue #507 の実装完了後に green になる。
-    現状 (pre-implementation) では xfail でマークされる。
     """
 
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: workflow_done が _PILOT_ISSUE_ALLOWED_KEYS からまだ除去されていない",
-        strict=True,
-    )
     def test_workflow_done_not_in_pilot_issue_allowed_keys(self) -> None:
-        """_PILOT_ISSUE_ALLOWED_KEYS に workflow_done が含まれないこと (Issue #507 AC)."""
+        """_PILOT_ISSUE_ALLOWED_KEYS に workflow_done が含まれないこと (ADR-018 AC)."""
         assert "workflow_done" not in _PILOT_ISSUE_ALLOWED_KEYS, (
-            "workflow_done は _PILOT_ISSUE_ALLOWED_KEYS から除去されなければならない (Issue #507)"
+            "workflow_done は _PILOT_ISSUE_ALLOWED_KEYS から除去されなければならない (ADR-018)"
         )
 
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: Pilot が workflow_done を書けてしまう（廃止前）",
-        strict=True,
-    )
     def test_pilot_write_workflow_done_is_rejected(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
@@ -329,21 +318,11 @@ class TestWorkflowDoneRemovedFromAllowedKeys:
                 cwd="/some/main/path",
             )
 
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: workflow_done が _PILOT_ISSUE_ALLOWED_KEYS からまだ除去されていない",
-        strict=True,
-    )
     def test_worker_cannot_be_blocked_by_workflow_done_removal(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
-        """worker は workflow_done フィールドを直接書けるが、SSOT は status であること.
-
-        workflow_done 廃止後は worker も workflow_done を書かない前提だが、
-        RBAC の観点では worker に制限はない（worker は任意フィールドを書ける）。
-        """
+        """SSOT は status であること。廃止フィールドが PILOT_ISSUE_ALLOWED_KEYS に含まれない。"""
         _write_issue(autopilot_dir, "41", "running")
-        # worker は現状 workflow_done を書けるが、これは廃止フィールドのため使わないこと
-        # ここでは PILOT_ISSUE_ALLOWED_KEYS に含まれていないことだけを検証
         assert "workflow_done" not in _PILOT_ISSUE_ALLOWED_KEYS
 
     def test_allowed_keys_still_contain_status(self) -> None:
@@ -374,15 +353,9 @@ class TestWorkflowDoneRemovedFromAllowedKeys:
 
 class TestInitSchemaWithoutWorkflowDone:
     """WHEN: Worker が issue を init するとき
-    THEN: 初期スキーマに workflow_done フィールドが存在しない (廃止)
-
-    NOTE: Issue #507 実装完了後に green になる。
+    THEN: 初期スキーマに workflow_done フィールドが存在しない (ADR-018 廃止済み)
     """
 
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: init スキーマにまだ workflow_done が含まれている",
-        strict=True,
-    )
     def test_init_does_not_create_workflow_done(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
@@ -390,7 +363,7 @@ class TestInitSchemaWithoutWorkflowDone:
         mgr.write(type_="issue", role="worker", issue="50", init=True)
         data = _load_issue(autopilot_dir, "50")
         assert "workflow_done" not in data, (
-            "廃止された workflow_done フィールドは init スキーマから除去されなければならない"
+            "廃止された workflow_done フィールドは init スキーマに含まれてはならない"
         )
 
     def test_init_creates_status_field(self, mgr: StateManager, autopilot_dir: Path) -> None:
@@ -477,113 +450,62 @@ class TestResolveNextWorkflowStatusBased:
     """WHEN: issue の status が running から merge-ready に遷移したとき
     THEN: orchestrator が次の workflow を tmux inject する
 
-    resolve_next_workflow モジュールは workflow_done ではなく
-    status フィールドを参照するべきである。
-    このテストは新実装後の動作仕様を定義する。
+    resolve_next_workflow モジュールは current_step フィールドを参照する (ADR-018)。
     """
 
-    def test_resolve_next_workflow_uses_status_not_workflow_done(
+    def test_resolve_next_workflow_uses_current_step(
         self, autopilot_dir: Path
     ) -> None:
-        """resolve_next_workflow が status フィールドを参照することを検証する.
-
-        SSOT 移行後: workflow_done ではなく status=merge-ready を参照する。
-        現実装では workflow_done を参照しているが、SSOT 移行後は status を参照する。
-        このテストは新実装の AC として機能する。
-        """
+        """resolve_next_workflow が current_step フィールドを参照することを検証する (ADR-018)."""
         import twl.autopilot.resolve_next_workflow as rnw_module
 
-        # merge-ready issue を作成
-        _write_issue(autopilot_dir, "70", "merge-ready", workflow_done=None)
+        _write_issue(autopilot_dir, "70", "merge-ready")
 
         captured_fields: list[str] = []
 
         def mock_read_state(issue_num, field, autopilot_dir):
             captured_fields.append(field)
-            if field == "status":
-                return "merge-ready"
+            if field == "current_step":
+                return "warning-fix"
             return ""
 
         with patch.object(rnw_module, "_read_state", side_effect=mock_read_state):
-            # resolve_next_workflow の main を呼ぶと _read_state が呼ばれる
-            # 新実装では "status" が captured_fields に含まれるはず
             try:
                 rnw_module.main(["--issue", "70"])
             except SystemExit:
-                pass  # exit() は正常
+                pass
             except Exception:
                 pass
 
-        # 現実装は workflow_done を読む；新実装は status を読むべき
-        # このアサーションは SSOT 移行後にパスする（今は WARNING として記録）
-        # NOTE: このテストは実装後に green になることを期待している
-        if "status" in captured_fields:
-            assert "status" in captured_fields, "resolve_next_workflow は status を参照すること"
-        else:
-            pytest.xfail(
-                "resolve_next_workflow がまだ workflow_done を参照している。"
-                "status ベースへの移行後にこのテストは green になる。"
-            )
+        assert "current_step" in captured_fields, (
+            "resolve_next_workflow は current_step を参照すること (ADR-018)"
+        )
 
-    def test_workflow_done_null_with_merge_ready_status_triggers_next_workflow(
+    def test_status_merge_ready_issue_is_inject_target(
         self, autopilot_dir: Path
     ) -> None:
-        """workflow_done=null かつ status=merge-ready で次の workflow が決定できること.
-
-        SSOT 移行後: workflow_done が null でも status=merge-ready から
-        next_skill (pr-merge) が決定できること。
-        """
-        import twl.autopilot.resolve_next_workflow as rnw_module
-
+        """status=merge-ready で次の workflow が決定できること (ADR-018 SSOT)."""
         _write_issue(autopilot_dir, "71", "merge-ready")
 
-        status_reads: list[str] = []
+        mgr = StateManager(autopilot_dir=autopilot_dir)
+        status = mgr.read(type_="issue", issue="71", field="status")
 
-        def mock_read_state(issue_num, field, apdir):
-            if field == "status":
-                status_reads.append(field)
-                return "merge-ready"
-            if field == "workflow_done":
-                return "null"  # workflow_done が null でも動作すること
-            return ""
+        assert status == "merge-ready", (
+            "status=merge-ready の issue は inject 対象"
+        )
 
-        with patch.object(rnw_module, "_read_state", side_effect=mock_read_state):
-            try:
-                rnw_module.main(["--issue", "71"])
-            except SystemExit:
-                pass
-            except Exception:
-                pass
-
-        # status ベースの実装では status=merge-ready から pr-merge を決定できる
-        # 現状の workflow_done ベース実装では失敗するが、SSOT 移行後はパスする
-        # このテストは仕様の定義として機能する
-
-    def test_orchestrator_polls_status_not_workflow_done_for_inject_trigger(
+    def test_orchestrator_polls_status_for_inject_trigger(
         self, autopilot_dir: Path
     ) -> None:
-        """orchestrator が inject trigger として status を参照することを確認する.
-
-        shell script (autopilot-orchestrator.sh) の Python 等価テスト。
-        inject_next_workflow のトリガー条件: workflow_done != null/empty (現状)
-        SSOT 移行後: status == merge-ready (新仕様)
-        """
-        # このテストは SSOT 移行後の仕様を定義する
-        # status=merge-ready のとき、workflow_done の有無に関わらず next inject が実行される
-        _write_issue(autopilot_dir, "72", "merge-ready", workflow_done=None)
+        """orchestrator が inject trigger として status を参照することを確認する (ADR-018)."""
+        _write_issue(autopilot_dir, "72", "merge-ready")
 
         mgr = StateManager(autopilot_dir=autopilot_dir)
         status = mgr.read(type_="issue", issue="72", field="status")
-        workflow_done = mgr.read(type_="issue", issue="72", field="workflow_done")
 
-        # SSOT 後の判定ロジック: status == "merge-ready" のみで inject 可能
         should_inject = (status == "merge-ready")
         assert should_inject, (
-            "status=merge-ready の issue は workflow_done の有無に関わらず inject 対象"
-        )
-        # workflow_done は null/空 でも inject すべき
-        assert workflow_done in ("", "null", None), (
-            "workflow_done が null でも status=merge-ready で inject すること"
+            "status=merge-ready の issue は inject 対象 (ADR-018 SSOT)"
         )
 
 
@@ -617,19 +539,12 @@ class TestDoneTerminalStateEdgeCases:
 
 
 class TestPilotRBACWorkflowDoneExclusion:
-    """Pilot RBAC における workflow_done 除外のエッジケース.
+    """Pilot RBAC における廃止フィールドの除外エッジケース (ADR-018)."""
 
-    NOTE: workflow_done 関連テストは Issue #507 実装完了後に green になる。
-    """
-
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: Pilot が workflow_done を書けてしまう（廃止前）",
-        strict=True,
-    )
     def test_pilot_cannot_write_workflow_done_even_with_valid_value(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
-        """Pilot が有効な workflow_done 値を書こうとしても拒否されること."""
+        """Pilot が workflow_done（廃止フィールド）を書こうとすると拒否されること."""
         _write_issue(autopilot_dir, "90", "running")
         for value in ("test-ready", "pr-verify", "pr-fix", "null"):
             with pytest.raises(StateError, match="権限"):
@@ -653,14 +568,10 @@ class TestPilotRBACWorkflowDoneExclusion:
         assert data["status"] == "done"
         assert data["merged_at"] == "2026-01-01T00:00:00Z"
 
-    @pytest.mark.xfail(
-        reason="Issue #507未実装: Pilot が workflow_done を混在 sets に含めても拒否されない（廃止前）",
-        strict=True,
-    )
     def test_pilot_write_with_workflow_done_in_mixed_sets_fails(
         self, mgr: StateManager, autopilot_dir: Path
     ) -> None:
-        """複数 --set の中に workflow_done が含まれると全体が拒否されること."""
+        """複数 --set の中に workflow_done（廃止フィールド）が含まれると全体が拒否されること."""
         _write_issue(autopilot_dir, "92", "running")
         with pytest.raises(StateError, match="権限"):
             mgr.write(

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -94,10 +94,8 @@ meta_chains:
         next:
           - condition: "quick && autopilot"
             goto: quick-path
-            workflow_done: "setup"
           - condition: "!quick && autopilot"
             goto: test-ready
-            workflow_done: "setup"
           - condition: "!autopilot"
             stop: true
             message: "setup chain 完了。次: /twl:workflow-test-ready"
@@ -119,7 +117,6 @@ meta_chains:
         next:
           - condition: "autopilot"
             goto: pr-verify
-            workflow_done: "test-ready"
           - condition: "!autopilot"
             stop: true
             message: "完了。次: /twl:workflow-pr-verify"
@@ -129,7 +126,6 @@ meta_chains:
         next:
           - condition: "autopilot"
             goto: pr-fix
-            workflow_done: "pr-verify"
           - condition: "!autopilot"
             stop: true
             message: "workflow-pr-verify 完了。次のステップ: /twl:workflow-pr-fix を実行してください"
@@ -139,7 +135,6 @@ meta_chains:
         next:
           - condition: "autopilot"
             goto: pr-merge
-            workflow_done: "pr-fix"
           - condition: "!autopilot"
             stop: true
             message: "workflow-pr-fix 完了。次のステップ: /twl:workflow-pr-merge を実行してください"

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1091,7 +1091,7 @@ step_all_pass_check() {
     local _cr_branch _cr_pr
     _cr_branch=$(git branch --show-current 2>/dev/null || echo "")
     _cr_pr=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
-    if ! python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=merge-ready" --set "workflow_done=pr-merge" --set "pr=$_cr_pr" --set "branch=$_cr_branch" >&2; then
+    if ! python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "status=merge-ready" --set "pr=$_cr_pr" --set "branch=$_cr_branch" >&2; then
       err "all-pass-check" "state write merge-ready 失敗"
       return 1
     fi

--- a/plugins/twl/tests/unit/all-pass-check-workflow-done/all-pass-check-workflow-done.bats
+++ b/plugins/twl/tests/unit/all-pass-check-workflow-done/all-pass-check-workflow-done.bats
@@ -1,15 +1,14 @@
 #!/usr/bin/env bats
 # all-pass-check-workflow-done.bats
-# Requirement: step_all_pass_check() — merge-ready 時に workflow_done=pr-merge を書き込む
-# Spec: deltaspec/changes/issue-494/specs/chain-runner-workflow-done/spec.md
+# Requirement: step_all_pass_check() — merge-ready 時に status=merge-ready を書き込む
 # Coverage: --type=unit --coverage=edge-cases
 #
 # step_all_pass_check() は chain-runner.sh の終端ステップ。
-# overall_result=PASS で merge-ready と同時に workflow_done=pr-merge を書き込む。
+# overall_result=PASS で status=merge-ready を書き込む（ADR-018: workflow_done 廃止済み）。
 #
 # テスト対象: plugins/twl/scripts/chain-runner.sh
-#   - bash "$CR" all-pass-check PASS → status=merge-ready かつ workflow_done=pr-merge
-#   - bash "$CR" all-pass-check FAIL → status=failed のみ (workflow_done なし)
+#   - bash "$CR" all-pass-check PASS → status=merge-ready
+#   - bash "$CR" all-pass-check FAIL → status=failed
 #   - state write 失敗 (read-only dir) → exit 1
 #
 # 環境変数:
@@ -41,12 +40,12 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Scenario: 正常終了時に workflow_done が書かれる
+# Scenario: 正常終了時に status=merge-ready が書かれる
 # WHEN step_all_pass_check() が overall_result=PASS で実行される
-# THEN state に status=merge-ready と workflow_done=pr-merge が両方書き込まれ exit 0
+# THEN state に status=merge-ready が書き込まれ exit 0
 # ---------------------------------------------------------------------------
 
-@test "all-pass-check[PASS]: status=merge-ready と workflow_done=pr-merge が書き込まれる" {
+@test "all-pass-check[PASS]: status=merge-ready が書き込まれる" {
   # issue state を running で初期化
   create_issue_json 494 "running"
 
@@ -60,34 +59,15 @@ teardown() {
     --autopilot-dir "$AUTOPILOT_DIR" \
     --type issue --issue 494 --field status 2>/dev/null)
   [ "$status" = "merge-ready" ]
-
-  # state から workflow_done を読む（本 Issue の主眼）
-  local workflow_done
-  workflow_done=$(python3 -m twl.autopilot.state read \
-    --autopilot-dir "$AUTOPILOT_DIR" \
-    --type issue --issue 494 --field workflow_done 2>/dev/null)
-  [ "$workflow_done" = "pr-merge" ]
-
-  # _cr_pr / _cr_branch: gh/git が利用不可の sandbox では空文字で書き込まれる（設計上の期待値）
-  local pr_val branch_val
-  pr_val=$(python3 -m twl.autopilot.state read \
-    --autopilot-dir "$AUTOPILOT_DIR" \
-    --type issue --issue 494 --field pr 2>/dev/null || echo "")
-  branch_val=$(python3 -m twl.autopilot.state read \
-    --autopilot-dir "$AUTOPILOT_DIR" \
-    --type issue --issue 494 --field branch 2>/dev/null || echo "")
-  # pr / branch は空文字または null が期待値（sandbox 環境では gh/git コマンドが利用不可）
-  [[ -z "$pr_val" || "$pr_val" == "null" ]]
-  [[ -z "$branch_val" || "$branch_val" == "null" ]]
 }
 
 # ---------------------------------------------------------------------------
-# Scenario: FAIL 時は status=failed のみが書かれる
+# Scenario: FAIL 時は status=failed が書かれる
 # WHEN step_all_pass_check() が overall_result=FAIL で実行される
-# THEN state に status=failed が書き込まれ workflow_done は書かれず exit 1
+# THEN state に status=failed が書き込まれ exit 1
 # ---------------------------------------------------------------------------
 
-@test "all-pass-check[FAIL]: status=failed のみ書かれ workflow_done は書かれない" {
+@test "all-pass-check[FAIL]: status=failed が書かれる" {
   create_issue_json 494 "running"
 
   run bash "$CR" all-pass-check FAIL
@@ -100,13 +80,6 @@ teardown() {
     --autopilot-dir "$AUTOPILOT_DIR" \
     --type issue --issue 494 --field status 2>/dev/null)
   [ "$status" = "failed" ]
-
-  # workflow_done は書かれていない（空文字 or null）
-  local workflow_done
-  workflow_done=$(python3 -m twl.autopilot.state read \
-    --autopilot-dir "$AUTOPILOT_DIR" \
-    --type issue --issue 494 --field workflow_done 2>/dev/null || echo "")
-  [ -z "$workflow_done" ] || [ "$workflow_done" = "null" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -130,12 +103,12 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Scenario: smoke — PASS 後に workflow_done=pr-merge を state から読み出せる
+# Scenario: smoke — PASS 後に status=merge-ready を state から読み出せる
 # WHEN all-pass-check PASS を実行する smoke テストが走る
-# THEN テスト完了後に state から workflow_done を読み取ると pr-merge が返る
+# THEN テスト完了後に state から status を読み取ると merge-ready が返る
 # ---------------------------------------------------------------------------
 
-@test "smoke[all-pass-check]: PASS 後に state.workflow_done=pr-merge が確認できる" {
+@test "smoke[all-pass-check]: PASS 後に state.status=merge-ready が確認できる" {
   create_issue_json 494 "running"
 
   # 実行（run 経由でアサーション到達を保証）
@@ -146,7 +119,7 @@ teardown() {
   local state_file="$AUTOPILOT_DIR/issues/issue-494.json"
   [ -f "$state_file" ]
 
-  local wf_done
-  wf_done=$(jq -r '.workflow_done // empty' "$state_file")
-  [ "$wf_done" = "pr-merge" ]
+  local status_val
+  status_val=$(jq -r '.status // empty' "$state_file")
+  [ "$status_val" = "merge-ready" ]
 }


### PR DESCRIPTION
feat(#785): ADR-018 残作業 — chain-runner.sh の workflow_done 書込除去

- chain-runner.sh の all-pass-check から --set workflow_done=pr-merge を削除
- deps.yaml の meta_chains から workflow_done フィールドを削除
- meta_generate.py の workflow_done 処理(_VALID_WORKFLOW_DONE_RE)を削除
- test_nonterminal_chain_recovery.py: workflow_done → current_step に移行
- test_state_schema_ssot.py: xfail マーカーを除去（既実装済み）
- test_chain_e2e_transition.py: workflow_done 変数を current_workflow に改名
- test_state.py: フィクスチャから workflow_done フィールドを削除
- all-pass-check-workflow-done.bats: workflow_done 検証を status 検証に更新

ADR-018: workflow_done 廃止、state machine の current_step で判定

Closes #785