### PR TITLE
feat(#788): 不変条件 A-M を ref-invariants.md に一本化

### DIFF
--- a/deltaspec/changes/issue-788/.deltaspec.yaml
+++ b/deltaspec/changes/issue-788/.deltaspec.yaml
@@ -1,0 +1,5 @@
+schema: spec-driven
+created: 2026-04-21
+issue: 788
+name: issue-788
+status: pending

--- a/deltaspec/changes/issue-788/design.md
+++ b/deltaspec/changes/issue-788/design.md
@@ -1,0 +1,50 @@
+## Context
+
+twill モノリポの不変条件 A-M（13 件）は現在 `autopilot.md`（主箇所）、`CLAUDE.md`、`su-observer/SKILL.md` 等に散在する。`autopilot-invariants.bats` は A-K の 11 件を実装済みで、J/K は `autopilot.md` を直接 grep している。`deps.yaml` 体系における `type: reference` ドキュメントを新設することで、#789 の自動生成ツールが parse できる単一 source を確立する。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `plugins/twl/refs/ref-invariants.md` を正典として不変条件 A-M を一本化
+- 既存ドキュメントの定義重複を削除しリンク参照に統一
+- `autopilot-invariants.bats` の J/K grep パターンを新構造に合わせて更新（テスト FAIL 回避）
+- `ref-invariants-structure.bats` で構造 lint を自動化
+- `deps.yaml` に `type: reference` エントリ追加
+
+**Non-Goals:**
+
+- 不変条件 L/M の bats テスト生成（#789 スコープ）
+- SU-1〜SU-7 の定義移動（`su-observer/SKILL.md` に維持）
+- 不変条件 A-M の内容変更・追加・削除
+
+## Decisions
+
+**D1: セクション形式**
+`## 不変条件 X: <title>`（半角コロン、半角大文字 A-M）を採用。#789 の `## 不変条件 [A-M]` regex が確実に抽出できる。全角文字混入を `ref-invariants-structure.bats` で lint する。
+
+**D2: 根拠フィールドの分類**
+- H/A/C/L: ADR 欄が `autopilot.md` テーブルで空 → "ADR なし — 慣習的制約" と明記
+- D/E/G/I/J/K: ADR ではなく `autopilot-lifecycle.md` / `merge-gate.md` 等の DeltaSpec spec ファイルへのリンク
+
+**D3: 検証方法フィールド**
+- A-K: 既存 `autopilot-invariants.bats` のテスト関数名を記載
+- L/M: "#789 で bats テスト生成予定" と注記し bats 関数名は空欄
+
+**D4: `autopilot-invariants.bats` 更新タイミング**
+AC #2（`autopilot.md` 定義削除）と AC #6（bats 参照先切替）を同一 PR でアトミックに実装。先に定義を削除して bats を放置するとテスト FAIL が発生するため、必ず同時変更とする。
+
+**D5: `deps.yaml` 型ルール**
+`plugins/twl/refs/` 配下は `type: reference` を使用（`/twl:ref-types` 規約準拠）。
+
+**D6: README 更新**
+Refs セクションの合計カウントを 18 → 19 に更新し、`ref-invariants` エントリを追加。
+
+## Risks / Trade-offs
+
+| リスク | 対策 |
+|--------|------|
+| `autopilot.md` 定義削除後に J/K bats が FAIL | D4 でアトミック更新を保証 |
+| 半角/全角混入による #789 parse エラー | `ref-invariants-structure.bats` で lint |
+| L/M の検証方法が未定 | "#789 で生成予定" 注記で明示的に scope 外と宣言 |
+| 不変条件の内容が `autopilot.md` と乖離する可能性 | 移行時に定義を逐語コピーし、変更しない |

--- a/deltaspec/changes/issue-788/proposal.md
+++ b/deltaspec/changes/issue-788/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+twill モノリポの不変条件 A-M（13 件）が `autopilot.md`、`CLAUDE.md`、`skills/su-observer/SKILL.md` 等に散在しており、更新時に複数ドキュメントを同期する必要があって変更コストが高く、正典（single source of truth）が存在しない。
+
+## What Changes
+
+- `plugins/twl/refs/ref-invariants.md` を新規作成し、不変条件 A-M の定義・根拠・検証方法・影響範囲を一本化
+- `plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件定義本文を `ref-invariants.md` へのリンクに置換
+- `plugins/twl/CLAUDE.md` の不変条件 B 言及をリンク参照に更新
+- `plugins/twl/skills/su-observer/SKILL.md` に SU-* と不変条件 A-M の境界を明示し `ref-invariants.md` リンクを追加
+- `plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J/K grep 対象を `autopilot.md` → `refs/ref-invariants.md` に切替
+- `plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を新規作成して 13 件の section 存在と書式を検証
+- `plugins/twl/deps.yaml` に `ref-invariants` エントリを `type: reference` として追加
+- `plugins/twl/README.md` の Refs 一覧を更新（18 → 19）
+
+## Capabilities
+
+### New Capabilities
+
+- `plugins/twl/refs/ref-invariants.md`: 不変条件 A-M の正典ドキュメント。各条件の定義・根拠（ADR/DeltaSpec spec リンク）・検証方法（bats テスト名）・影響範囲を `## 不変条件 X: <title>` 形式で統一
+- `ref-invariants-structure.bats`: `ref-invariants.md` の構造 lint（section 存在・書式・半角コロン強制）を自動検証
+- `issue-788` が `plugins/twl/refs/` の参照ドキュメント体系（#789 自動生成ツールの source）を確立
+
+### Modified Capabilities
+
+- `autopilot-invariants.bats` の invariant-J/K: grep 対象を `ref-invariants.md` の新構造（`## 不変条件 J:` / `## 不変条件 K:`）に合わせて更新
+- `autopilot.md` / `CLAUDE.md`: 不変条件の定義本文を削除し `ref-invariants.md` へのリンクに統一
+
+## Impact
+
+- **新規ファイル**: `plugins/twl/refs/ref-invariants.md`、`plugins/twl/tests/bats/invariants/ref-invariants-structure.bats`
+- **変更ファイル**: `autopilot.md`、`CLAUDE.md`、`su-observer/SKILL.md`、`autopilot-invariants.bats`、`deps.yaml`、`README.md`
+- **破壊的変更**: `autopilot.md` から不変条件定義を削除するため、`autopilot-invariants.bats` の J/K grep パターンを同一 PR で必ず更新（FAIL 回避）
+- **依存**: `#789`（ref-invariants.md 構造を source として使用）が本 Issue 完了に依存

--- a/deltaspec/changes/issue-788/specs/bats-update.md
+++ b/deltaspec/changes/issue-788/specs/bats-update.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: ref-invariants-structure.bats 新規作成
+
+`plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を新規作成し、`ref-invariants.md` の構造を 13 件の section 存在・書式・半角文字強制で自動検証しなければならない（SHALL）。
+
+#### Scenario: 13 件の section 存在を検証する
+- **WHEN** `ref-invariants-structure.bats` を実行する
+- **THEN** 不変条件 A から M まで各 1 件ずつ、`## 不変条件 X:` ヘッダーの存在が検証される
+
+#### Scenario: 全角コロン混入を検出する
+- **WHEN** `ref-invariants.md` に `## 不変条件 A：` のような全角コロンが含まれる
+- **THEN** bats テストが FAIL してエラーを報告する
+
+#### Scenario: 全角アルファベット混入を検出する
+- **WHEN** `ref-invariants.md` に `## 不変条件 Ａ:` のような全角大文字が含まれる
+- **THEN** bats テストが FAIL してエラーを報告する
+
+## MODIFIED Requirements
+
+### Requirement: autopilot-invariants.bats の invariant-J/K grep 対象を切替
+
+`plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の `invariant-J` および `invariant-K` テストの grep 対象を `autopilot.md` から `refs/ref-invariants.md` に変更し、grep パターンを新構造（`## 不変条件 J:` / `## 不変条件 K:`）に合わせて更新しなければならない（SHALL）。
+
+この変更は `autopilot.md` の定義削除（existing-docs-update.md の要件）と同一 PR でアトミックに実装すること（SHALL）。
+
+#### Scenario: invariant-J テストが ref-invariants.md を参照する
+- **WHEN** `autopilot-invariants.bats` の invariant-J テストを確認する
+- **THEN** grep 対象が `refs/ref-invariants.md` であり、パターンが `## 不変条件 J:` にマッチする
+
+#### Scenario: invariant-K テストが ref-invariants.md を参照する
+- **WHEN** `autopilot-invariants.bats` の invariant-K テストを確認する
+- **THEN** grep 対象が `refs/ref-invariants.md` であり、パターンが `## 不変条件 K:` にマッチする
+
+#### Scenario: autopilot.md 定義削除後も bats が PASS する
+- **WHEN** `autopilot.md` から不変条件 J/K の定義が削除された後に `autopilot-invariants.bats` を実行する
+- **THEN** invariant-J および invariant-K の "defines invariant" テストが PASS する

--- a/deltaspec/changes/issue-788/specs/existing-docs-update.md
+++ b/deltaspec/changes/issue-788/specs/existing-docs-update.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: autopilot.md の不変条件定義をリンク参照に統一
+
+`plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件 A-M の定義本文を削除し、`ref-invariants.md` へのリンクに置換しなければならない（SHALL）。定義の逐語コピー（内容変更なし）を確認してから削除すること。
+
+#### Scenario: autopilot.md から不変条件テーブルが削除される
+- **WHEN** `plugins/twl/architecture/domain/contexts/autopilot.md` を確認する
+- **THEN** 不変条件 A-M の定義テーブル行は削除され、`ref-invariants.md` へのリンクが残っている
+
+#### Scenario: autopilot.md の不変条件への言及がリンクに変換される
+- **WHEN** `autopilot.md` で `不変条件` というキーワードを検索する
+- **THEN** 定義テーブルではなくリンク参照として不変条件が言及されている
+
+### Requirement: CLAUDE.md の不変条件 B 言及をリンク参照に更新
+
+`plugins/twl/CLAUDE.md` の不変条件 B に関する言及を `ref-invariants.md` へのリンクに更新しなければならない（SHALL）。
+
+#### Scenario: CLAUDE.md の不変条件 B がリンク参照になる
+- **WHEN** `plugins/twl/CLAUDE.md` を確認する
+- **THEN** 不変条件 B の記述が `ref-invariants.md` へのリンクを含む
+
+### Requirement: su-observer/SKILL.md への境界明示とリンク追加
+
+`plugins/twl/skills/su-observer/SKILL.md` に SU-1〜SU-7 と不変条件 A-M の境界を明示し、`ref-invariants.md` へのリンク言及を追加しなければならない（SHALL）。SU-1〜SU-7 の定義は移動せず `SKILL.md` に維持すること。
+
+#### Scenario: su-observer/SKILL.md に境界説明とリンクが追加される
+- **WHEN** `plugins/twl/skills/su-observer/SKILL.md` を確認する
+- **THEN** "SU-* は supervisor 固有の application-level 制約" という説明と `ref-invariants.md` へのリンクが存在する
+
+#### Scenario: SU-1〜SU-7 の定義が SKILL.md に維持される
+- **WHEN** `plugins/twl/skills/su-observer/SKILL.md` を確認する
+- **THEN** SU-1〜SU-7 の定義が削除されずに残っている

--- a/deltaspec/changes/issue-788/specs/ref-invariants-doc.md
+++ b/deltaspec/changes/issue-788/specs/ref-invariants-doc.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: ref-invariants.md 新規作成
+
+`plugins/twl/refs/ref-invariants.md` を新規作成し、不変条件 A-M（13 件）の定義を単一ドキュメントに一本化しなければならない（SHALL）。
+
+各不変条件は以下の形式で記述しなければならない（SHALL）:
+
+```
+## 不変条件 X: <title>
+
+- **定義**: <1 文の要件>
+- **根拠**: <ADR リンク or DeltaSpec spec リンク or "ADR なし — 慣習的制約">
+- **検証方法**: `<bats テスト関数名>` または `grep -r '<pattern>' <path>`
+- **影響範囲**: <code path 箇条書き>
+```
+
+#### Scenario: 全 13 件の section が存在する
+- **WHEN** `plugins/twl/refs/ref-invariants.md` を読み込む
+- **THEN** `## 不変条件 [A-M]` 形式の section が A から M まで 13 件すべて存在する
+
+#### Scenario: 半角コロンと半角大文字を使用する
+- **WHEN** `ref-invariants.md` の section ヘッダーを検査する
+- **THEN** `## 不変条件 A:` 〜 `## 不変条件 M:` に全角文字・全角コロンが含まれない
+
+#### Scenario: ADR なし条件（H/A/C/L）の根拠フィールド
+- **WHEN** 不変条件 H、A、C、L の根拠フィールドを確認する
+- **THEN** "ADR なし — 慣習的制約" と記載されている
+
+#### Scenario: DeltaSpec spec リンク条件（D/E/F/G/I/J/K）の根拠フィールド
+- **WHEN** 不変条件 D、E、F、G、I、J、K の根拠フィールドを確認する
+- **THEN** `autopilot-lifecycle.md` または `merge-gate.md` の該当 anchor へのリンクが記載されている
+
+#### Scenario: L/M の検証方法フィールド
+- **WHEN** 不変条件 L、M の検証方法フィールドを確認する
+- **THEN** "#789 で bats テスト生成予定" と注記されている
+
+### Requirement: deps.yaml への ref-invariants エントリ追加
+
+`plugins/twl/deps.yaml` に `ref-invariants` エントリを `type: reference` として追加しなければならない（SHALL）。
+
+#### Scenario: deps.yaml に ref-invariants エントリが存在する
+- **WHEN** `plugins/twl/deps.yaml` を確認する
+- **THEN** `ref-invariants` という名前のエントリが `type: reference` で存在する
+
+### Requirement: README.md の Refs 一覧更新
+
+`plugins/twl/README.md` の Refs セクションを更新し、`ref-invariants` を追加して合計カウントを 19 にしなければならない（SHALL）。
+
+#### Scenario: README Refs に ref-invariants が追加される
+- **WHEN** `plugins/twl/README.md` の Refs セクションを確認する
+- **THEN** `ref-invariants` エントリが存在し、Refs の合計カウントが 19 である

--- a/deltaspec/changes/issue-788/tasks.md
+++ b/deltaspec/changes/issue-788/tasks.md
@@ -1,0 +1,37 @@
+## 1. 不変条件ソース確認
+
+- [ ] 1.1 `plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件 A-M テーブルを読み込み、全 13 件の定義・根拠・DeltaSpec 参照を記録する
+- [ ] 1.2 `plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J（L357-361）と invariant-K（L419-423）の現在の grep パターンを確認する
+
+## 2. ref-invariants.md 新規作成
+
+- [ ] 2.1 `plugins/twl/refs/ref-invariants.md` を新規作成し、ファイルヘッダー（title, description, 更新日）を記載する
+- [ ] 2.2 不変条件 A〜G を `## 不変条件 X: <title>` 形式で記載する（定義・根拠・検証方法・影響範囲）
+- [ ] 2.3 不変条件 H〜M を同形式で記載する（H: "ADR なし — 慣習的制約"、L/M: "#789 生成予定"注記）
+- [ ] 2.4 ファイル末尾に SU-* 境界説明（`skills/su-observer/SKILL.md` へのリンク）を追加する
+
+## 3. bats ファイル更新（定義削除と同時実施）
+
+- [ ] 3.1 `autopilot-invariants.bats` の invariant-J テスト（L357-361）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 J:` に更新
+- [ ] 3.2 `autopilot-invariants.bats` の invariant-K テスト（L419-423）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 K:` に更新
+
+## 4. 既存ドキュメント更新
+
+- [ ] 4.1 `autopilot.md` の不変条件 A-M 定義テーブル（224行目付近）を削除し、`ref-invariants.md` へのリンクに置換する
+- [ ] 4.2 `plugins/twl/CLAUDE.md` の不変条件 B 言及を `ref-invariants.md` へのリンクに更新する
+- [ ] 4.3 `plugins/twl/skills/su-observer/SKILL.md` に SU-* と不変条件 A-M の境界説明と `ref-invariants.md` リンクを追加する
+
+## 5. 構造検証 bats 作成
+
+- [ ] 5.1 `plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を新規作成し、section 存在（13 件）・半角コロン・半角大文字のlintテストを実装する
+
+## 6. deps.yaml / README 更新
+
+- [ ] 6.1 `plugins/twl/deps.yaml` に `ref-invariants` エントリを `type: reference` で追加する
+- [ ] 6.2 `plugins/twl/README.md` の Refs 一覧に `ref-invariants` を追加し合計カウントを 18 → 19 に更新する
+
+## 7. 検証
+
+- [ ] 7.1 `bats plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を実行し PASS を確認する
+- [ ] 7.2 `bats plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J/K テストが PASS することを確認する
+- [ ] 7.3 `twl --validate` を実行して deps.yaml 整合性を確認する

--- a/deltaspec/changes/issue-788/tasks.md
+++ b/deltaspec/changes/issue-788/tasks.md
@@ -1,37 +1,37 @@
 ## 1. 不変条件ソース確認
 
-- [ ] 1.1 `plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件 A-M テーブルを読み込み、全 13 件の定義・根拠・DeltaSpec 参照を記録する
-- [ ] 1.2 `plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J（L357-361）と invariant-K（L419-423）の現在の grep パターンを確認する
+- [x] 1.1 `plugins/twl/architecture/domain/contexts/autopilot.md` の不変条件 A-M テーブルを読み込み、全 13 件の定義・根拠・DeltaSpec 参照を記録する
+- [x] 1.2 `plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J（L357-361）と invariant-K（L419-423）の現在の grep パターンを確認する
 
 ## 2. ref-invariants.md 新規作成
 
-- [ ] 2.1 `plugins/twl/refs/ref-invariants.md` を新規作成し、ファイルヘッダー（title, description, 更新日）を記載する
-- [ ] 2.2 不変条件 A〜G を `## 不変条件 X: <title>` 形式で記載する（定義・根拠・検証方法・影響範囲）
-- [ ] 2.3 不変条件 H〜M を同形式で記載する（H: "ADR なし — 慣習的制約"、L/M: "#789 生成予定"注記）
-- [ ] 2.4 ファイル末尾に SU-* 境界説明（`skills/su-observer/SKILL.md` へのリンク）を追加する
+- [x] 2.1 `plugins/twl/refs/ref-invariants.md` を新規作成し、ファイルヘッダー（title, description, 更新日）を記載する
+- [x] 2.2 不変条件 A〜G を `## 不変条件 X: <title>` 形式で記載する（定義・根拠・検証方法・影響範囲）
+- [x] 2.3 不変条件 H〜M を同形式で記載する（H: "ADR なし — 慣習的制約"、L/M: "#789 生成予定"注記）
+- [x] 2.4 ファイル末尾に SU-* 境界説明（`skills/su-observer/SKILL.md` へのリンク）を追加する
 
 ## 3. bats ファイル更新（定義削除と同時実施）
 
-- [ ] 3.1 `autopilot-invariants.bats` の invariant-J テスト（L357-361）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 J:` に更新
-- [ ] 3.2 `autopilot-invariants.bats` の invariant-K テスト（L419-423）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 K:` に更新
+- [x] 3.1 `autopilot-invariants.bats` の invariant-J テスト（L357-361）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 J:` に更新
+- [x] 3.2 `autopilot-invariants.bats` の invariant-K テスト（L419-423）: grep 対象を `refs/ref-invariants.md` に変更、パターンを `## 不変条件 K:` に更新
 
 ## 4. 既存ドキュメント更新
 
-- [ ] 4.1 `autopilot.md` の不変条件 A-M 定義テーブル（224行目付近）を削除し、`ref-invariants.md` へのリンクに置換する
-- [ ] 4.2 `plugins/twl/CLAUDE.md` の不変条件 B 言及を `ref-invariants.md` へのリンクに更新する
-- [ ] 4.3 `plugins/twl/skills/su-observer/SKILL.md` に SU-* と不変条件 A-M の境界説明と `ref-invariants.md` リンクを追加する
+- [x] 4.1 `autopilot.md` の不変条件 A-M 定義テーブル（224行目付近）を削除し、`ref-invariants.md` へのリンクに置換する
+- [x] 4.2 `plugins/twl/CLAUDE.md` の不変条件 B 言及を `ref-invariants.md` へのリンクに更新する
+- [x] 4.3 `plugins/twl/skills/su-observer/SKILL.md` に SU-* と不変条件 A-M の境界説明と `ref-invariants.md` リンクを追加する
 
 ## 5. 構造検証 bats 作成
 
-- [ ] 5.1 `plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を新規作成し、section 存在（13 件）・半角コロン・半角大文字のlintテストを実装する
+- [x] 5.1 `plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を新規作成し、section 存在（13 件）・半角コロン・半角大文字のlintテストを実装する
 
 ## 6. deps.yaml / README 更新
 
-- [ ] 6.1 `plugins/twl/deps.yaml` に `ref-invariants` エントリを `type: reference` で追加する
-- [ ] 6.2 `plugins/twl/README.md` の Refs 一覧に `ref-invariants` を追加し合計カウントを 18 → 19 に更新する
+- [x] 6.1 `plugins/twl/deps.yaml` に `ref-invariants` エントリを `type: reference` で追加する
+- [x] 6.2 `plugins/twl/README.md` の Refs 一覧に `ref-invariants` を追加し合計カウントを 18 → 19 に更新する
 
 ## 7. 検証
 
-- [ ] 7.1 `bats plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を実行し PASS を確認する
-- [ ] 7.2 `bats plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J/K テストが PASS することを確認する
-- [ ] 7.3 `twl --validate` を実行して deps.yaml 整合性を確認する
+- [x] 7.1 `bats plugins/twl/tests/bats/invariants/ref-invariants-structure.bats` を実行し PASS を確認する
+- [x] 7.2 `bats plugins/twl/tests/bats/invariants/autopilot-invariants.bats` の invariant-J/K テストが PASS することを確認する
+- [x] 7.3 `twl --validate` を実行して deps.yaml 整合性を確認する

--- a/deltaspec/changes/issue-788/test-mapping.yaml
+++ b/deltaspec/changes/issue-788/test-mapping.yaml
@@ -1,0 +1,246 @@
+change_id: issue-788
+generated_at: "2026-04-21T00:00:00Z"
+test_framework: bats
+scenarios:
+  # -------------------------------------------------------------------------
+  # specs/ref-invariants-doc.md — Requirement: ref-invariants.md 新規作成
+  # -------------------------------------------------------------------------
+  - id: "ref-invariants-doc-all-13-sections"
+    name: "全 13 件の section が存在する"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 18
+    requirement: "ref-invariants.md 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "ref-invariants: exactly 13 sections exist (A through M)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-halfwidth-colon"
+    name: "半角コロンと半角大文字を使用する"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 22
+    requirement: "ref-invariants.md 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "ref-invariants: no full-width colon in section headers (全角コロン混入検出)"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-adr-none-fields"
+    name: "ADR なし条件（H/A/C/L）の根拠フィールド"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 26
+    requirement: "ref-invariants.md 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "ref-invariants: invariant-H 根拠フィールドに 'ADR なし — 慣習的制約' が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-spec-link-fields"
+    name: "DeltaSpec spec リンク条件（D/E/F/G/I/J/K）の根拠フィールド"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 30
+    requirement: "ref-invariants.md 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "ref-invariants: invariant-J 根拠フィールドに spec リンクが含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-lm-verification-note"
+    name: "L/M の検証方法フィールド"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 34
+    requirement: "ref-invariants.md 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "ref-invariants: invariant-L 検証方法フィールドに '#789 で bats テスト生成予定' が含まれる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-deps-yaml-entry"
+    name: "deps.yaml に ref-invariants エントリが存在する"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 42
+    requirement: "deps.yaml への ref-invariants エントリ追加"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "deps-yaml: ref-invariants エントリが type: reference である"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "ref-invariants-doc-readme-refs-19"
+    name: "README Refs に ref-invariants が追加される"
+    spec_file: "specs/ref-invariants-doc.md"
+    spec_line: 50
+    requirement: "README.md の Refs 一覧更新"
+    test_file: "plugins/twl/tests/bats/invariants/ref-invariants-structure.bats"
+    test_name: "README: Refs の合計カウントが 19 である"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # specs/existing-docs-update.md — Requirement: autopilot.md 更新
+  # -------------------------------------------------------------------------
+  - id: "existing-docs-autopilot-table-removed"
+    name: "autopilot.md から不変条件テーブルが削除される"
+    spec_file: "specs/existing-docs-update.md"
+    spec_line: 7
+    requirement: "autopilot.md の不変条件定義をリンク参照に統一"
+    test_file: "plugins/twl/tests/bats/structure/existing-docs-update.bats"
+    test_name: "autopilot.md: 不変条件 A-M の定義テーブル行が削除されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "existing-docs-autopilot-mention-as-link"
+    name: "autopilot.md の不変条件への言及がリンクに変換される"
+    spec_file: "specs/existing-docs-update.md"
+    spec_line: 11
+    requirement: "autopilot.md の不変条件定義をリンク参照に統一"
+    test_file: "plugins/twl/tests/bats/structure/existing-docs-update.bats"
+    test_name: "autopilot.md: 不変条件キーワードの言及がリンク形式である"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "existing-docs-claude-md-inv-b-link"
+    name: "CLAUDE.md の不変条件 B がリンク参照になる"
+    spec_file: "specs/existing-docs-update.md"
+    spec_line: 19
+    requirement: "CLAUDE.md の不変条件 B 言及をリンク参照に更新"
+    test_file: "plugins/twl/tests/bats/structure/existing-docs-update.bats"
+    test_name: "CLAUDE.md: 不変条件 B の言及行の周辺に ref-invariants リンクが存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "existing-docs-skill-md-boundary-link"
+    name: "su-observer/SKILL.md に境界説明とリンクが追加される"
+    spec_file: "specs/existing-docs-update.md"
+    spec_line: 27
+    requirement: "su-observer/SKILL.md への境界明示とリンク追加"
+    test_file: "plugins/twl/tests/bats/structure/existing-docs-update.bats"
+    test_name: "su-observer/SKILL.md: SU-* は supervisor 固有の application-level 制約 という説明が存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "existing-docs-skill-md-su17-maintained"
+    name: "SU-1〜SU-7 の定義が SKILL.md に維持される"
+    spec_file: "specs/existing-docs-update.md"
+    spec_line: 31
+    requirement: "su-observer/SKILL.md への境界明示とリンク追加"
+    test_file: "plugins/twl/tests/bats/structure/existing-docs-update.bats"
+    test_name: "su-observer/SKILL.md: SU-1〜SU-7 が全て 7 件存在する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  # -------------------------------------------------------------------------
+  # specs/bats-update.md — Requirement: ref-invariants-structure.bats 新規作成
+  # -------------------------------------------------------------------------
+  - id: "bats-update-structure-13-sections"
+    name: "13 件の section 存在を検証する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 7
+    requirement: "ref-invariants-structure.bats 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "ref-invariants-structure.bats: A〜M の全 13 section を検証するテストが定義されている"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-update-detect-fullwidth-colon"
+    name: "全角コロン混入を検出する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 11
+    requirement: "ref-invariants-structure.bats 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "全角コロンを含む仮想 ref-invariants.md を作成すると全角コロン検出できる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-update-detect-fullwidth-alpha"
+    name: "全角アルファベット混入を検出する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 15
+    requirement: "ref-invariants-structure.bats 新規作成"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "全角アルファベットを含む仮想 ref-invariants.md を作成すると全角文字検出できる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-update-invariant-j-ref-target"
+    name: "invariant-J テストが ref-invariants.md を参照する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 27
+    requirement: "autopilot-invariants.bats の invariant-J/K grep 対象を切替"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "autopilot-invariants.bats: invariant-J テストが refs/ref-invariants.md を参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-update-invariant-k-ref-target"
+    name: "invariant-K テストが ref-invariants.md を参照する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 31
+    requirement: "autopilot-invariants.bats の invariant-J/K grep 対象を切替"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "autopilot-invariants.bats: invariant-K テストが refs/ref-invariants.md を参照する"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null
+
+  - id: "bats-update-autopilot-deletion-still-pass"
+    name: "autopilot.md 定義削除後も bats が PASS する"
+    spec_file: "specs/bats-update.md"
+    spec_line: 35
+    requirement: "autopilot-invariants.bats の invariant-J/K grep 対象を切替"
+    test_file: "plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats"
+    test_name: "autopilot-invariants.bats: ref-invariants.md に不変条件 J が定義されており invariant-J テストが通過できる"
+    type: unit
+    criteria: []
+    status: pending
+    last_run: null
+    failure_reason: null

--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -52,7 +52,7 @@ deps.yaml v3.0 がプラグイン構成の唯一の情報源。
 **Worker（実装側）:**
 - Pilot が事前作成した worktree ディレクトリで起動される（autopilot: ADR-008 準拠、co-issue v2: workflow-issue-lifecycle）
 - Worker は worktree 内で作業し、完了後に merge-ready を宣言する
-- Worker が自ら worktree を作成・削除してはならない（不変条件 B）
+- Worker が自ら worktree を作成・削除してはならない（[不変条件 B](refs/ref-invariants.md#不変条件-b-worktree-ライフサイクル-pilot-専任)）
 
 ## 編集フロー（必須）
 

--- a/plugins/twl/README.md
+++ b/plugins/twl/README.md
@@ -37,9 +37,9 @@ Claude Code twl plugin（chain-driven + autopilot-first）。claude-plugin-dev �
 | Skills | 12 | controller 5 + workflow 7 |
 | Commands | 92 | atomic 83 + composite 9 |
 | Agents | 29 | specialist 29 |
-| Refs | 18 | reference 18 |
+| Refs | 19 | reference 19（ref-invariants 含む） |
 | Scripts | 28 | script 28 |
-| **合計** | **179** | |
+| **合計** | **180** | |
 
 ## 使い方
 

--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -223,21 +223,7 @@ status=$(jq -r '.status // "null"' issue-N.json)
 
 ### 不変条件（13件）
 
-| ID | 不変条件 | 概要 | DeltaSpec 参照 |
-|----|----------|------|----------------|
-| **A** | 状態の一意性 | issue-{N}.json の `status` は常に定義された遷移パスのみ許可 | |
-| **B** | Worktree ライフサイクル Pilot 専任（作成・削除ともに Pilot） | Worktree の作成・削除は Pilot が行う。Worker は使用のみ（ADR-008） | autopilot-lifecycle.md#scenario-worktreeライフサイクル安全性 |
-| **C** | Worker マージ禁止 | Worker は `merge-ready` を宣言するのみ。マージは Pilot が実行 | autopilot-lifecycle.md#scenario-worktreeライフサイクル安全性 |
-| **D** | 依存先 fail 時の skip 伝播 | Phase N で fail した Issue に依存する Issue は自動 skip | autopilot-lifecycle.md#scenario-phase内-issue失敗時のskip伝播 |
-| **E** | merge-gate リトライ制限 | リトライは最大1回。2回目リジェクト = 確定失敗 | autopilot-lifecycle.md#scenario-retry制限, merge-gate.md#scenario-merge-gate-reject2回目確定失敗-リトライ最大1回制限 |
-| **F** | squash merge API 失敗時 rebase 禁止 | `gh pr merge --squash` API 呼び出し失敗後は rebase 禁止。停止のみ。merge 前のコンフリクト事前検知とは別概念 | merge-gate.md#scenario-merge失敗時の対応 |
-| **G** | クラッシュ検知保証 | Worker の crash/timeout は必ず検知される | autopilot-lifecycle.md#scenario-worker-crash検知 |
-| **H** | deps.yaml コンフリクト時自動 rebase | deps.yaml 変更 Issue は並列実行を許可。merge-gate がコンフリクト検出時に自動 rebase を試行し、失敗時は conflict 状態に遷移。リトライ上限は 1 回（不変条件 E と整合）。不変条件 F（squash merge API 失敗後 rebase 禁止）とは別概念 | |
-| **I** | 循環依存拒否 | plan.yaml 生成時に循環依存を検出した場合、拒否 | autopilot-lifecycle.md#scenario-循環依存拒否 |
-| **J** | merge 前 base drift 検知 | merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止する | merge-gate.md#scenario-merge前-base-drift検知 |
-| **K** | Pilot 実装禁止 | Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可 | autopilot-lifecycle.md#scenario-不変条件-k-pilot実装禁止228 |
-| **L** | autopilot マージ実行責務 | autopilot 時のマージ実行は Orchestrator の `mergegate.py` 経由のみ。Worker chain の auto-merge ステップは `merge-ready` 宣言のみを行い、マージは実行しない | |
-| **M** | chain 遷移は orchestrator/手動 inject のみ | chain 遷移（`current_step` の terminal 検知後の次 workflow 起動）は orchestrator の `inject_next_workflow` または手動 skill inject（`/twl:workflow-<name>`）のみ許可。Pilot の直接 nudge による chain bypass は禁止。chain 停止時は orchestrator 再起動または手動 inject で chain を再開する（co-autopilot SKILL.md「chain 停止時の復旧手順」参照） | issue-438, ADR-018 |
+不変条件 A-M の正典定義は [`refs/ref-invariants.md`](../../refs/ref-invariants.md) を参照。
 
 ### 並行性の制約
 

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -690,6 +690,11 @@ refs:
     path: refs/ref-glossary-criteria.md
     description: "glossary 用語登録判断基準（3軸基準 + 判定ロジック + 具体例）"
 
+  ref-invariants:
+    type: reference
+    path: refs/ref-invariants.md
+    description: "不変条件 A-M の正典定義（定義・根拠・検証方法・影響範囲）"
+
   ref-compaction-recovery:
     type: reference
     path: refs/ref-compaction-recovery.md

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -336,6 +336,7 @@ skills:
       - script: specialist-audit
       - script: spawn-controller      # Phase A: controller spawn 専用 wrapper (L285 MUST)
       - reference: pitfalls-catalog   # Phase A: 起動時 Step 0 Read MUST
+      - reference: ref-invariants     # 不変条件 A-M 正典参照（境界説明）
     dependencies:
       - plugin: session  # cld --observer: session.json の claude_session_id 読み取りに session plugin の session-state.sh を使用
     description: "メタ認知レイヤー: 全 controller の監視・介入。hook プライマリ / polling フォールバックの Hybrid 検知（#570）。テストシナリオ実行は co-self-improve に委譲"

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -21,7 +21,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 
 - **定義**: Worktree の作成・削除は Pilot が行わなければならない（SHALL）。Worker は使用のみ。
 - **根拠**: [ADR-008: Worktree Lifecycle Pilot Ownership](../architecture/decisions/ADR-008-worktree-lifecycle-pilot-ownership.md) / [DeltaSpec: Worktree ライフサイクル安全性](../deltaspec/specs/autopilot-lifecycle.md#scenario-worktreeライフサイクル安全性)
-- **検証方法**: [`invariant-B: worktree-delete rejects worker role`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-B: Worker chain does not include worktree-create`](../tests/bats/invariants/autopilot-invariants.bats)
+- **検証方法**: [`invariant-B: worktree-delete rejects worker role`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-B: Worker chain (chain-steps.sh) does not include worktree-create`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/worktree-delete.sh`
   - `plugins/twl/scripts/chain-runner.sh`
@@ -110,7 +110,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 
 - **定義**: merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止しなければならない（SHALL）。
 - **根拠**: [DeltaSpec: merge 前 base drift 検知](../deltaspec/specs/merge-gate.md#scenario-merge前-base-drift検知)
-- **検証方法**: [`invariant-J: silent file deletion is detected as base drift`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-J: intentional deletion is not flagged`](../tests/bats/invariants/autopilot-invariants.bats)
+- **検証方法**: [`invariant-J: silent file deletion (no commit) is detected as base drift`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-J: intentional deletion (has commit) is not flagged`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
 
@@ -120,7 +120,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 
 - **定義**: Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない（SHALL）。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可。
 - **根拠**: [DeltaSpec: 不変条件 K — Pilot 実装禁止](../deltaspec/specs/autopilot-lifecycle.md#scenario-不変条件-k-pilot実装禁止228)
-- **検証方法**: [`invariant-K: autopilot.md defines invariant K`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-K: pilot cannot write implementation-only field`](../tests/bats/invariants/autopilot-invariants.bats)
+- **検証方法**: [`invariant-K: ref-invariants.md defines invariant K (Pilot 実装禁止)`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-K: pilot cannot write implementation-only field`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/skills/co-autopilot/SKILL.md`
   - `cli/twl/src/twl/autopilot/mergegate.py`

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -1,0 +1,156 @@
+# 不変条件 A-M 参照ドキュメント
+
+twill autopilot システムの不変条件 A-M（13 件）の正典定義。各条件の定義・根拠・検証方法・影響範囲を一本化する。
+
+更新日: 2026-04-21
+
+---
+
+## 不変条件 A: 状態の一意性
+
+- **定義**: `issue-{N}.json` の `status` は常に定義された遷移パスのみ許可されなければならない（SHALL）。不正な状態遷移は拒否される。
+- **根拠**: ADR なし — 慣習的制約
+- **検証方法**: [`invariant-A: parallel writes to same issue produce valid JSON`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `cli/twl/src/twl/autopilot/state.py`
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+
+---
+
+## 不変条件 B: Worktree ライフサイクル Pilot 専任
+
+- **定義**: Worktree の作成・削除は Pilot が行わなければならない（SHALL）。Worker は使用のみ。
+- **根拠**: [ADR-008: Worktree Lifecycle Pilot Ownership](../architecture/decisions/ADR-008-worktree-lifecycle-pilot-ownership.md) / [DeltaSpec: Worktree ライフサイクル安全性](../deltaspec/specs/autopilot-lifecycle.md#scenario-worktreeライフサイクル安全性)
+- **検証方法**: [`invariant-B: worktree-delete rejects worker role`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-B: Worker chain does not include worktree-create`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/worktree-delete.sh`
+  - `plugins/twl/scripts/chain-runner.sh`
+  - `plugins/twl/scripts/autopilot-orchestrator.sh`
+
+---
+
+## 不変条件 C: Worker マージ禁止
+
+- **定義**: Worker は `merge-ready` を宣言するのみでなければならない（SHALL）。マージは Pilot が実行する。Worker が直接 `gh pr merge` を実行してはならない。
+- **根拠**: ADR なし — 慣習的制約
+- **検証方法**: [`invariant-C: merge-gate-execute rejects invalid ISSUE`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/auto-merge.sh`
+  - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
+  - `cli/twl/src/twl/autopilot/mergegate.py`
+
+---
+
+## 不変条件 D: 依存先 fail 時の skip 伝播
+
+- **定義**: Phase N で fail した Issue に依存する Issue は自動 skip されなければならない（SHALL）。
+- **根拠**: [DeltaSpec: Phase 内 Issue 失敗時の skip 伝播](../deltaspec/specs/autopilot-lifecycle.md#scenario-phase内-issue失敗時のskip伝播)
+- **検証方法**: [`invariant-D: single dependency fail causes skip`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-D: multiple deps with one failed causes skip`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/autopilot-plan.sh`
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+
+---
+
+## 不変条件 E: merge-gate リトライ制限
+
+- **定義**: merge-gate のリトライは最大 1 回でなければならない（SHALL）。2 回目リジェクト = 確定失敗。
+- **根拠**: [DeltaSpec: retry 制限](../deltaspec/specs/autopilot-lifecycle.md#scenario-retry制限) / [DeltaSpec: merge-gate REJECT 2 回目確定失敗](../deltaspec/specs/merge-gate.md#scenario-merge-gate-reject2回目確定失敗-リトライ最大1回制限)
+- **検証方法**: [`invariant-E: first retry allowed`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-E: second retry rejected`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+
+---
+
+## 不変条件 F: squash merge API 失敗時 rebase 禁止
+
+- **定義**: `gh pr merge --squash` API 呼び出し失敗後は rebase を禁止しなければならない（SHALL）。停止のみ。merge 前のコンフリクト事前検知とは別概念。
+- **根拠**: [DeltaSpec: merge 失敗時の対応](../deltaspec/specs/merge-gate.md#scenario-merge失敗時の対応)
+- **検証方法**: [`invariant-F: merge-gate-execute uses --squash flag`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
+  - `cli/twl/src/twl/autopilot/mergegate.py`
+
+---
+
+## 不変条件 G: クラッシュ検知保証
+
+- **定義**: Worker の crash/timeout は必ず検知されなければならない（SHALL）。
+- **根拠**: [DeltaSpec: Worker crash 検知](../deltaspec/specs/autopilot-lifecycle.md#scenario-worker-crash検知)
+- **検証方法**: [`invariant-G: crash-detect transitions to failed when pane absent`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/crash-detect.sh`
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+
+---
+
+## 不変条件 H: deps.yaml コンフリクト時自動 rebase
+
+- **定義**: deps.yaml 変更 Issue は並列実行を許可しなければならない（SHALL）。merge-gate がコンフリクト検出時に自動 rebase を試行し、失敗時は conflict 状態に遷移する。リトライ上限は 1 回（不変条件 E と整合）。不変条件 F（squash merge API 失敗後 rebase 禁止）とは別概念。
+- **根拠**: ADR なし — 慣習的制約
+- **検証方法**: [`invariant-H: deps.yaml components have valid types`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
+  - `plugins/twl/deps.yaml`
+
+---
+
+## 不変条件 I: 循環依存拒否
+
+- **定義**: plan.yaml 生成時に循環依存を検出した場合、拒否しなければならない（SHALL）。
+- **根拠**: [DeltaSpec: 循環依存拒否](../deltaspec/specs/autopilot-lifecycle.md#scenario-循環依存拒否)
+- **検証方法**: [`invariant-I: direct circular dependency rejected`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-I: indirect circular dependency rejected`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/autopilot-plan.sh`
+
+---
+
+## 不変条件 J: merge 前 base drift 検知
+
+- **定義**: merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止しなければならない（SHALL）。
+- **根拠**: [DeltaSpec: merge 前 base drift 検知](../deltaspec/specs/merge-gate.md#scenario-merge前-base-drift検知)
+- **検証方法**: [`invariant-J: silent file deletion is detected as base drift`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-J: intentional deletion is not flagged`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
+
+---
+
+## 不変条件 K: Pilot 実装禁止
+
+- **定義**: Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない（SHALL）。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可。
+- **根拠**: [DeltaSpec: 不変条件 K — Pilot 実装禁止](../deltaspec/specs/autopilot-lifecycle.md#scenario-不変条件-k-pilot実装禁止228)
+- **検証方法**: [`invariant-K: autopilot.md defines invariant K`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-K: pilot cannot write implementation-only field`](../tests/bats/invariants/autopilot-invariants.bats)
+- **影響範囲**:
+  - `plugins/twl/skills/co-autopilot/SKILL.md`
+  - `cli/twl/src/twl/autopilot/mergegate.py`
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+
+---
+
+## 不変条件 L: autopilot マージ実行責務
+
+- **定義**: autopilot 時のマージ実行は Orchestrator の `mergegate.py` 経由のみでなければならない（SHALL）。Worker chain の auto-merge ステップは `merge-ready` 宣言のみを行い、マージは実行しない。
+- **根拠**: ADR なし — 慣習的制約
+- **検証方法**: #789 で bats テスト生成予定
+- **影響範囲**:
+  - `cli/twl/src/twl/autopilot/mergegate.py`
+  - `plugins/twl/scripts/auto-merge.sh`
+
+---
+
+## 不変条件 M: chain 遷移は orchestrator/手動 inject のみ
+
+- **定義**: chain 遷移（`current_step` の terminal 検知後の次 workflow 起動）は orchestrator の `inject_next_workflow` または手動 skill inject（`/twl:workflow-<name>`）のみ許可しなければならない（SHALL）。Pilot の直接 nudge による chain bypass は禁止。
+- **根拠**: [ADR-018: autopilot state schema SSOT](../architecture/decisions/ADR-018-state-schema-ssot.md) / issue-438
+- **検証方法**: #789 で bats テスト生成予定
+- **影響範囲**:
+  - `cli/twl/src/twl/autopilot/orchestrator.py`
+  - `plugins/twl/scripts/chain-runner.sh`
+  - `plugins/twl/skills/co-autopilot/SKILL.md`
+
+---
+
+## SU-* との境界
+
+SU-1〜SU-7 は Supervisor（su-observer）固有の application-level 制約であり、本ドキュメントの不変条件 A-M とは独立した体系である。SU-* の定義は [`skills/su-observer/SKILL.md`](../skills/su-observer/SKILL.md) を参照。

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -618,6 +618,8 @@ Issue 群の一括実装（Wave）を要求された場合:
 
 ## SU-* 制約（MUST）
 
+> **境界**: SU-1〜SU-7 は Supervisor（su-observer）固有の application-level 制約であり、autopilot システムの不変条件 A-M とは独立した体系。不変条件 A-M の定義は [`refs/ref-invariants.md`](../../refs/ref-invariants.md) を参照。
+
 | 制約 ID | 内容 |
 |---------|------|
 | SU-1 | 介入は 3 層プロトコル（Auto/Confirm/Escalate）に従わなければならない（SHALL） |

--- a/plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats
+++ b/plugins/twl/tests/bats/invariants/autopilot-invariants-refupdate.bats
@@ -1,0 +1,301 @@
+#!/usr/bin/env bats
+# autopilot-invariants-refupdate.bats - Validation of autopilot-invariants.bats update to ref-invariants.md
+#
+# Tests for Issue #788: autopilot-invariants.bats の invariant-J/K grep 対象を
+# autopilot.md → refs/ref-invariants.md に切替した後の正常動作を検証する
+#
+# Scenarios covered (specs/bats-update.md):
+#  1. 13 件の section 存在を検証する (ref-invariants-structure.bats 実行確認)
+#  2. 全角コロン混入を検出する
+#  3. 全角アルファベット混入を検出する
+#  4. invariant-J テストが ref-invariants.md を参照する
+#  5. invariant-K テストが ref-invariants.md を参照する
+#  6. autopilot.md 定義削除後も bats が PASS する
+
+setup() {
+  # Resolve REPO_ROOT to plugins/twl/
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_test_dir
+  bats_test_dir="$(cd "$helpers_dir/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "$bats_test_dir/.." && pwd)"
+  REPO_ROOT="$(cd "$tests_dir/.." && pwd)"
+  export REPO_ROOT
+
+  BATS_INV_FILE="$REPO_ROOT/tests/bats/invariants/autopilot-invariants.bats"
+  BATS_STRUCT_FILE="$REPO_ROOT/tests/bats/invariants/ref-invariants-structure.bats"
+  REF_FILE="$REPO_ROOT/refs/ref-invariants.md"
+  AUTOPILOT_MD="$REPO_ROOT/architecture/domain/contexts/autopilot.md"
+}
+
+# ===========================================================================
+# Requirement: ref-invariants-structure.bats 新規作成
+# Scenario: 13 件の section 存在を検証する
+# WHEN: ref-invariants-structure.bats を実行する
+# THEN: 不変条件 A から M まで各 1 件ずつ、## 不変条件 X: ヘッダーの存在が検証される
+# ===========================================================================
+
+@test "ref-invariants-structure.bats: ファイルが存在する" {
+  [ -f "$BATS_STRUCT_FILE" ]
+}
+
+@test "ref-invariants-structure.bats: A〜M の全 13 section を検証するテストが定義されている" {
+  # 各不変条件ヘッダー grep を含むテスト定義がある
+  for letter in A B C D E F G H I J K L M; do
+    if ! grep -q "不変条件 ${letter}:" "$BATS_STRUCT_FILE"; then
+      fail "section ${letter} validation not found in ref-invariants-structure.bats"
+    fi
+  done
+}
+
+@test "ref-invariants-structure.bats: 13 件の section カウント検証テストが定義されている" {
+  grep -q '13' "$BATS_STRUCT_FILE"
+}
+
+# ===========================================================================
+# Scenario: 全角コロン混入を検出する
+# WHEN: ref-invariants.md に ## 不変条件 A： のような全角コロンが含まれる
+# THEN: bats テストが FAIL してエラーを報告する
+# ===========================================================================
+
+@test "ref-invariants-structure.bats: 全角コロン混入検出テストが定義されている" {
+  grep -q "全角コロン" "$BATS_STRUCT_FILE"
+}
+
+@test "ref-invariants-structure.bats: full-width colon (U+FF1A) を検出するロジックが含まれる" {
+  # 全角コロン '：' のリテラルまたは Unicode エスケープ検索ロジックが含まれていること
+  python3 -c "
+import sys
+with open('$BATS_STRUCT_FILE') as f:
+    content = f.read()
+# Check for full-width colon literal or its description
+if '：' in content or 'FF1A' in content or 'full.width' in content or 'full-width' in content:
+    sys.exit(0)
+print('full-width colon detection logic not found')
+sys.exit(1)
+"
+}
+
+@test "全角コロンを含む仮想 ref-invariants.md を作成すると全角コロン検出できる" {
+  # 全角コロン検出ロジックを直接テスト
+  local tmpfile
+  tmpfile=$(mktemp /tmp/test-ref-invariants-XXXXXX.md)
+  echo "## 不変条件 A：タイトル" > "$tmpfile"
+
+  # 全角コロン検出
+  if python3 -c "
+import sys
+with open('$tmpfile') as f:
+    for i, line in enumerate(f, 1):
+        if line.startswith('## 不変条件') and '：' in line:
+            sys.exit(1)
+sys.exit(0)
+"; then
+    rm -f "$tmpfile"
+    fail "full-width colon not detected (should have been detected)"
+  fi
+  rm -f "$tmpfile"
+}
+
+# ===========================================================================
+# Scenario: 全角アルファベット混入を検出する
+# WHEN: ref-invariants.md に ## 不変条件 Ａ: のような全角大文字が含まれる
+# THEN: bats テストが FAIL してエラーを報告する
+# ===========================================================================
+
+@test "ref-invariants-structure.bats: 全角アルファベット混入検出テストが定義されている" {
+  grep -q "全角" "$BATS_STRUCT_FILE"
+}
+
+@test "全角アルファベットを含む仮想 ref-invariants.md を作成すると全角文字検出できる" {
+  local tmpfile
+  tmpfile=$(mktemp /tmp/test-ref-invariants-XXXXXX.md)
+  # 全角 A (U+FF21) を含むヘッダー
+  printf "## 不変条件 \xef\xbc\xa1: タイトル\n" > "$tmpfile"
+
+  if python3 -c "
+import sys
+fullwidth = set(chr(i) for i in range(0xFF21, 0xFF2E))
+with open('$tmpfile') as f:
+    for i, line in enumerate(f, 1):
+        if line.startswith('## 不変条件'):
+            for ch in fullwidth:
+                if ch in line:
+                    sys.exit(1)
+sys.exit(0)
+"; then
+    rm -f "$tmpfile"
+    fail "full-width alphabet not detected (should have been detected)"
+  fi
+  rm -f "$tmpfile"
+}
+
+# ===========================================================================
+# Requirement: autopilot-invariants.bats の invariant-J/K grep 対象を切替
+# Scenario: invariant-J テストが ref-invariants.md を参照する
+# WHEN: autopilot-invariants.bats の invariant-J テストを確認する
+# THEN: grep 対象が refs/ref-invariants.md であり、パターンが ## 不変条件 J: にマッチする
+# ===========================================================================
+
+@test "autopilot-invariants.bats: ファイルが存在する" {
+  [ -f "$BATS_INV_FILE" ]
+}
+
+@test "autopilot-invariants.bats: invariant-J テストが refs/ref-invariants.md を参照する" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+# Find invariant-J test block
+m = re.search(r'@test[^{]*invariant-J[^{]*defines invariant[^{]*\{(.*?)\n\}', content, re.DOTALL)
+if not m:
+    print('invariant-J defines invariant test block not found')
+    sys.exit(1)
+block = m.group(1)
+if 'refs/ref-invariants.md' not in block and 'ref-invariants.md' not in block:
+    print('refs/ref-invariants.md not referenced in invariant-J test')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "autopilot-invariants.bats: invariant-J テストのパターンが '## 不変条件 J:' 形式にマッチする" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+# Find invariant-J test block
+m = re.search(r'@test[^{]*invariant-J[^{]*defines invariant[^{]*\{(.*?)\n\}', content, re.DOTALL)
+if not m:
+    print('invariant-J defines invariant test block not found')
+    sys.exit(1)
+block = m.group(1)
+# Check for new pattern (## 不変条件 J:) rather than old pattern (| **J** |)
+if '不変条件 J' not in block and '## 不変条件 J:' not in block:
+    print('new pattern ## 不変条件 J: not found in invariant-J test')
+    sys.exit(1)
+# Ensure old autopilot.md table pattern is NOT the only reference
+if '\\\\*\\\\*J\\\\*\\\\*' in block and 'ref-invariants' not in block:
+    print('old autopilot.md table grep pattern still used for invariant-J')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "autopilot-invariants.bats: invariant-J 'defines invariant' テストの grep 対象が autopilot.md ではない" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+m = re.search(r'(@test[^\n]*invariant-J[^\n]*defines invariant[^\n]*\n.*?\n\})', content, re.DOTALL)
+if not m:
+    print('invariant-J defines invariant test not found')
+    sys.exit(1)
+block = m.group(1)
+# Should NOT grep from autopilot.md exclusively
+if 'autopilot.md' in block and 'ref-invariants.md' not in block:
+    print('invariant-J still greps from autopilot.md (should use ref-invariants.md)')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Scenario: invariant-K テストが ref-invariants.md を参照する
+# WHEN: autopilot-invariants.bats の invariant-K テストを確認する
+# THEN: grep 対象が refs/ref-invariants.md であり、パターンが ## 不変条件 K: にマッチする
+# ===========================================================================
+
+@test "autopilot-invariants.bats: invariant-K テストが refs/ref-invariants.md を参照する" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+m = re.search(r'@test[^{]*invariant-K[^{]*autopilot.md defines invariant[^{]*\{(.*?)\n\}', content, re.DOTALL)
+if not m:
+    # Try alternate naming
+    m = re.search(r'(@test[^\n]*invariant-K[^\n]*defines invariant K[^\n]*\n.*?\n\})', content, re.DOTALL)
+if not m:
+    print('invariant-K defines invariant test block not found')
+    sys.exit(1)
+block = m.group(1)
+if 'refs/ref-invariants.md' not in block and 'ref-invariants.md' not in block:
+    print('refs/ref-invariants.md not referenced in invariant-K test')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "autopilot-invariants.bats: invariant-K テストのパターンが '## 不変条件 K:' 形式にマッチする" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+# Find any invariant-K test that references ref-invariants
+inv_k_tests = re.findall(r'@test[^\n]*invariant-K[^\n]*\n.*?\n\}', content, re.DOTALL)
+if not inv_k_tests:
+    print('No invariant-K tests found')
+    sys.exit(1)
+found_ref = False
+for block in inv_k_tests:
+    if 'ref-invariants' in block and '不変条件 K' in block:
+        found_ref = True
+        break
+if not found_ref:
+    print('No invariant-K test found that uses ## 不変条件 K: pattern with ref-invariants.md')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "autopilot-invariants.bats: invariant-K 'defines invariant' テストの grep 対象が autopilot.md ではない" {
+  python3 -c "
+import sys, re
+with open('$BATS_INV_FILE') as f:
+    content = f.read()
+# Find the first invariant-K test
+m = re.search(r'(@test[^\n]*invariant-K: autopilot.md defines invariant K[^\n]*\n.*?\n\})', content, re.DOTALL)
+if not m:
+    print('invariant-K: autopilot.md defines invariant K test not found — may already be updated')
+    sys.exit(0)
+block = m.group(1)
+if 'autopilot.md' in block and 'ref-invariants.md' not in block:
+    print('invariant-K still greps from autopilot.md (should use ref-invariants.md)')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Scenario: autopilot.md 定義削除後も bats が PASS する
+# WHEN: autopilot.md から不変条件 J/K の定義が削除された後に autopilot-invariants.bats を実行する
+# THEN: invariant-J および invariant-K の "defines invariant" テストが PASS する
+# ===========================================================================
+
+@test "autopilot-invariants.bats: ref-invariants.md に不変条件 J が定義されており invariant-J テストが通過できる" {
+  [ -f "$REF_FILE" ] || skip "ref-invariants.md not yet created"
+  grep -q "^## 不変条件 J:" "$REF_FILE"
+}
+
+@test "autopilot-invariants.bats: ref-invariants.md に不変条件 K が定義されており invariant-K テストが通過できる" {
+  [ -f "$REF_FILE" ] || skip "ref-invariants.md not yet created"
+  grep -q "^## 不変条件 K:" "$REF_FILE"
+}
+
+@test "autopilot-invariants.bats + ref-invariants.md: J/K テストが ref-invariants.md から PASS する (integration)" {
+  [ -f "$REF_FILE" ] || skip "ref-invariants.md not yet created"
+
+  # invariant-J テストが参照するパスと同じファイルに J が定義されていること
+  local j_grep_target
+  j_grep_target=$(grep -A5 'invariant-J.*defines invariant' "$BATS_INV_FILE" \
+    | grep 'ref-invariants' | head -1 | grep -oP 'refs/ref-invariants\.md|ref-invariants\.md' || true)
+
+  if [ -z "$j_grep_target" ]; then
+    skip "invariant-J grep target could not be determined from bats file"
+  fi
+
+  # 実際のファイルで J が存在することを確認
+  grep -q "不変条件 J" "$REPO_ROOT/$j_grep_target" || \
+    grep -q "不変条件 J" "$REF_FILE"
+}

--- a/plugins/twl/tests/bats/invariants/autopilot-invariants.bats
+++ b/plugins/twl/tests/bats/invariants/autopilot-invariants.bats
@@ -354,8 +354,8 @@ for t in sorted(types):
 
 # (J のテストは merge-gate 内部で実装済み — ここでは不変条件テーブルとの整合性のみ確認)
 
-@test "invariant-J: autopilot.md defines invariant J" {
-  run grep -c "|\s*\*\*J\*\*" "$REPO_ROOT/architecture/domain/contexts/autopilot.md"
+@test "invariant-J: ref-invariants.md defines invariant J" {
+  run grep -c "^## 不変条件 J:" "$REPO_ROOT/refs/ref-invariants.md"
   assert_success
   [ "$output" -ge 1 ]
 }
@@ -416,8 +416,8 @@ except MergeGateError:
 # Invariant K: Pilot implementation prohibition
 # ===========================================================================
 
-@test "invariant-K: autopilot.md defines invariant K (Pilot 実装禁止)" {
-  run grep -c "|\s*\*\*K\*\*" "$REPO_ROOT/architecture/domain/contexts/autopilot.md"
+@test "invariant-K: ref-invariants.md defines invariant K (Pilot 実装禁止)" {
+  run grep -c "^## 不変条件 K:" "$REPO_ROOT/refs/ref-invariants.md"
   assert_success
   [ "$output" -ge 1 ]
 }

--- a/plugins/twl/tests/bats/invariants/ref-invariants-structure.bats
+++ b/plugins/twl/tests/bats/invariants/ref-invariants-structure.bats
@@ -1,0 +1,408 @@
+#!/usr/bin/env bats
+# ref-invariants-structure.bats - Structural validation of ref-invariants.md
+#
+# Tests for Issue #788: plugins/twl/refs/ref-invariants.md 新規作成
+#
+# Scenarios covered (specs/ref-invariants-doc.md):
+#  1. 全 13 件の section が存在する
+#  2. 半角コロンと半角大文字を使用する
+#  3. ADR なし条件（H/A/C/L）の根拠フィールド
+#  4. DeltaSpec spec リンク条件（D/E/F/G/I/J/K）の根拠フィールド
+#  5. L/M の検証方法フィールド
+#  6. deps.yaml に ref-invariants エントリが存在する
+#  7. README Refs に ref-invariants が追加される
+
+setup() {
+  # Resolve REPO_ROOT to plugins/twl/
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_test_dir
+  bats_test_dir="$(cd "$helpers_dir/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "$bats_test_dir/.." && pwd)"
+  REPO_ROOT="$(cd "$tests_dir/.." && pwd)"
+  export REPO_ROOT
+
+  REF_FILE="$REPO_ROOT/refs/ref-invariants.md"
+  DEPS_FILE="$REPO_ROOT/deps.yaml"
+  README_FILE="$REPO_ROOT/README.md"
+}
+
+# ===========================================================================
+# Requirement: ref-invariants.md 新規作成
+# Scenario: 全 13 件の section が存在する
+# ===========================================================================
+
+@test "ref-invariants: file exists" {
+  [ -f "$REF_FILE" ]
+}
+
+@test "ref-invariants: section A exists" {
+  grep -q "^## 不変条件 A:" "$REF_FILE"
+}
+
+@test "ref-invariants: section B exists" {
+  grep -q "^## 不変条件 B:" "$REF_FILE"
+}
+
+@test "ref-invariants: section C exists" {
+  grep -q "^## 不変条件 C:" "$REF_FILE"
+}
+
+@test "ref-invariants: section D exists" {
+  grep -q "^## 不変条件 D:" "$REF_FILE"
+}
+
+@test "ref-invariants: section E exists" {
+  grep -q "^## 不変条件 E:" "$REF_FILE"
+}
+
+@test "ref-invariants: section F exists" {
+  grep -q "^## 不変条件 F:" "$REF_FILE"
+}
+
+@test "ref-invariants: section G exists" {
+  grep -q "^## 不変条件 G:" "$REF_FILE"
+}
+
+@test "ref-invariants: section H exists" {
+  grep -q "^## 不変条件 H:" "$REF_FILE"
+}
+
+@test "ref-invariants: section I exists" {
+  grep -q "^## 不変条件 I:" "$REF_FILE"
+}
+
+@test "ref-invariants: section J exists" {
+  grep -q "^## 不変条件 J:" "$REF_FILE"
+}
+
+@test "ref-invariants: section K exists" {
+  grep -q "^## 不変条件 K:" "$REF_FILE"
+}
+
+@test "ref-invariants: section L exists" {
+  grep -q "^## 不変条件 L:" "$REF_FILE"
+}
+
+@test "ref-invariants: section M exists" {
+  grep -q "^## 不変条件 M:" "$REF_FILE"
+}
+
+@test "ref-invariants: exactly 13 sections exist (A through M)" {
+  local count
+  count=$(grep -c "^## 不変条件 [A-M]:" "$REF_FILE")
+  [ "$count" -eq 13 ]
+}
+
+# ===========================================================================
+# Scenario: 半角コロンと半角大文字を使用する
+# WHEN: ref-invariants.md の section ヘッダーを検査する
+# THEN: ## 不変条件 A: 〜 ## 不変条件 M: に全角文字・全角コロンが含まれない
+# ===========================================================================
+
+@test "ref-invariants: no full-width colon in section headers (全角コロン混入検出)" {
+  # 全角コロン U+FF1A を検出したら FAIL
+  if grep -P "^## \xe4\xb8\x8d\xe5\xa4\x89\xe6\x9d\xa1\xe4\xbb\xb6\s+[A-M]：" "$REF_FILE" 2>/dev/null; then
+    fail "full-width colon found in section header"
+  fi
+  # Python による全角コロン検出（より確実）
+  if python3 -c "
+import sys
+with open('$REF_FILE') as f:
+    for i, line in enumerate(f, 1):
+        if line.startswith('## 不変条件') and '：' in line:
+            print(f'line {i}: {line.rstrip()}')
+            sys.exit(1)
+sys.exit(0)
+"; then
+    true
+  else
+    fail "full-width colon detected in section header"
+  fi
+}
+
+@test "ref-invariants: no full-width alphabet in section headers (全角大文字混入検出)" {
+  # 全角英大文字 A-M (U+FF21〜U+FF2D) を検出したら FAIL
+  if python3 -c "
+import sys
+fullwidth = set(chr(i) for i in range(0xFF21, 0xFF2E))  # A-M fullwidth
+with open('$REF_FILE') as f:
+    for i, line in enumerate(f, 1):
+        if line.startswith('## 不変条件'):
+            for ch in fullwidth:
+                if ch in line:
+                    print(f'line {i}: full-width char {repr(ch)} in: {line.rstrip()}')
+                    sys.exit(1)
+sys.exit(0)
+"; then
+    true
+  else
+    fail "full-width alphabet detected in section header"
+  fi
+}
+
+# ===========================================================================
+# Scenario: ADR なし条件（H/A/C/L）の根拠フィールド
+# WHEN: 不変条件 H、A、C、L の根拠フィールドを確認する
+# THEN: "ADR なし — 慣習的制約" と記載されている
+# ===========================================================================
+
+@test "ref-invariants: invariant-A 根拠フィールドに 'ADR なし — 慣習的制約' が含まれる" {
+  # Extract section A and check for the rationale text
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+# Find section A
+m = re.search(r'## 不変条件 A:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section A not found')
+    sys.exit(1)
+section = m.group(0)
+if 'ADR なし' not in section or '慣習的制約' not in section:
+    print('ADR なし — 慣習的制約 not found in section A')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-C 根拠フィールドに 'ADR なし — 慣習的制約' が含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 C:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section C not found')
+    sys.exit(1)
+section = m.group(0)
+if 'ADR なし' not in section or '慣習的制約' not in section:
+    print('ADR なし — 慣習的制約 not found in section C')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-H 根拠フィールドに 'ADR なし — 慣習的制約' が含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 H:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section H not found')
+    sys.exit(1)
+section = m.group(0)
+if 'ADR なし' not in section or '慣習的制約' not in section:
+    print('ADR なし — 慣習的制約 not found in section H')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-L 根拠フィールドに 'ADR なし — 慣習的制約' が含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 L:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section L not found')
+    sys.exit(1)
+section = m.group(0)
+if 'ADR なし' not in section or '慣習的制約' not in section:
+    print('ADR なし — 慣習的制約 not found in section L')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Scenario: DeltaSpec spec リンク条件（D/E/F/G/I/J/K）の根拠フィールド
+# WHEN: 不変条件 D、E、F、G、I、J、K の根拠フィールドを確認する
+# THEN: autopilot-lifecycle.md または merge-gate.md の anchor リンクが記載されている
+# ===========================================================================
+
+@test "ref-invariants: invariant-D 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 D:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section D not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section D'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-E 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 E:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section E not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section E'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-F 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 F:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section F not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section F'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-G 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 G:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section G not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section G'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-I 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 I:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section I not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section I'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-J 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 J:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section J not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section J'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-K 根拠フィールドに spec リンクが含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 K:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section K not found'); sys.exit(1)
+section = m.group(0)
+if 'autopilot-lifecycle.md' not in section and 'merge-gate.md' not in section:
+    print('spec link not found in section K'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Scenario: L/M の検証方法フィールド
+# WHEN: 不変条件 L、M の検証方法フィールドを確認する
+# THEN: "#789 で bats テスト生成予定" と注記されている
+# ===========================================================================
+
+@test "ref-invariants: invariant-L 検証方法フィールドに '#789 で bats テスト生成予定' が含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 L:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section L not found'); sys.exit(1)
+section = m.group(0)
+if '#789' not in section or 'bats' not in section:
+    print('#789 で bats テスト生成予定 not found in section L'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ref-invariants: invariant-M 検証方法フィールドに '#789 で bats テスト生成予定' が含まれる" {
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 M:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('Section M not found'); sys.exit(1)
+section = m.group(0)
+if '#789' not in section or 'bats' not in section:
+    print('#789 で bats テスト生成予定 not found in section M'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Requirement: deps.yaml への ref-invariants エントリ追加
+# Scenario: deps.yaml に ref-invariants エントリが存在する
+# WHEN: plugins/twl/deps.yaml を確認する
+# THEN: ref-invariants という名前のエントリが type: reference で存在する
+# ===========================================================================
+
+@test "deps-yaml: ref-invariants エントリが存在する" {
+  grep -q 'ref-invariants' "$DEPS_FILE"
+}
+
+@test "deps-yaml: ref-invariants エントリが type: reference である" {
+  python3 -c "
+import sys, yaml
+with open('$DEPS_FILE') as f:
+    data = yaml.safe_load(f)
+refs = data.get('refs', {})
+if 'ref-invariants' not in refs:
+    print('ref-invariants not found in refs section'); sys.exit(1)
+entry = refs['ref-invariants']
+if entry.get('type') != 'reference':
+    print(f'type is {entry.get(\"type\")!r}, expected reference'); sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Requirement: README.md の Refs 一覧更新
+# Scenario: README Refs に ref-invariants が追加される
+# WHEN: plugins/twl/README.md の Refs セクションを確認する
+# THEN: ref-invariants エントリが存在し、Refs の合計カウントが 19 である
+# ===========================================================================
+
+@test "README: ref-invariants エントリが Refs セクションに存在する" {
+  grep -q 'ref-invariants' "$README_FILE"
+}
+
+@test "README: Refs の合計カウントが 19 である" {
+  # 合計カウント表記（例: "Refs: 19" または "19 refs" など）を検出
+  grep -qE 'Refs.*19|19.*[Rr]ef' "$README_FILE"
+}

--- a/plugins/twl/tests/bats/structure/existing-docs-update.bats
+++ b/plugins/twl/tests/bats/structure/existing-docs-update.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# existing-docs-update.bats - Validation that existing docs are updated to reference ref-invariants.md
+#
+# Tests for Issue #788: autopilot.md / CLAUDE.md / su-observer/SKILL.md を
+# ref-invariants.md へのリンク参照に更新することの検証
+#
+# Scenarios covered (specs/existing-docs-update.md):
+#  1. autopilot.md から不変条件テーブルが削除される
+#  2. autopilot.md の不変条件への言及がリンクに変換される
+#  3. CLAUDE.md の不変条件 B がリンク参照になる
+#  4. su-observer/SKILL.md に境界説明とリンクが追加される
+#  5. SU-1〜SU-7 の定義が SKILL.md に維持される
+
+setup() {
+  # Resolve REPO_ROOT to plugins/twl/
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_test_dir
+  bats_test_dir="$(cd "$helpers_dir/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "$bats_test_dir/.." && pwd)"
+  REPO_ROOT="$(cd "$tests_dir/.." && pwd)"
+  export REPO_ROOT
+
+  AUTOPILOT_MD="$REPO_ROOT/architecture/domain/contexts/autopilot.md"
+  CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
+  SKILL_MD="$REPO_ROOT/skills/su-observer/SKILL.md"
+  REF_INVARIANTS="$REPO_ROOT/refs/ref-invariants.md"
+}
+
+# ===========================================================================
+# Requirement: autopilot.md の不変条件定義をリンク参照に統一
+# Scenario: autopilot.md から不変条件テーブルが削除される
+# WHEN: plugins/twl/architecture/domain/contexts/autopilot.md を確認する
+# THEN: 不変条件 A-M の定義テーブル行は削除され、ref-invariants.md へのリンクが残っている
+# ===========================================================================
+
+@test "autopilot.md: file exists" {
+  [ -f "$AUTOPILOT_MD" ]
+}
+
+@test "autopilot.md: ref-invariants.md へのリンクが存在する" {
+  grep -q 'ref-invariants' "$AUTOPILOT_MD"
+}
+
+@test "autopilot.md: 不変条件 A-M の定義テーブル行が削除されている" {
+  # テーブル形式の定義（|  **A** | ... のような行）が残っていないこと
+  # リンク参照行は許可される
+  if grep -qP "^\|[[:space:]]*\*\*[A-M]\*\*[[:space:]]*\|" "$AUTOPILOT_MD"; then
+    fail "Invariant definition table rows still present in autopilot.md (should be replaced with link)"
+  fi
+}
+
+# ===========================================================================
+# Scenario: autopilot.md の不変条件への言及がリンクに変換される
+# WHEN: autopilot.md で 不変条件 というキーワードを検索する
+# THEN: 定義テーブルではなくリンク参照として不変条件が言及されている
+# ===========================================================================
+
+@test "autopilot.md: 不変条件キーワードの言及がリンク形式である" {
+  # 不変条件への言及があればそれはリンク形式であること
+  # リンク形式の例: [ref-invariants.md](refs/ref-invariants.md) または
+  #                 [不変条件](refs/ref-invariants.md) など
+  local mention_count
+  mention_count=$(grep -c "不変条件" "$AUTOPILOT_MD" 2>/dev/null || echo 0)
+
+  if [ "$mention_count" -eq 0 ]; then
+    skip "autopilot.md contains no 不変条件 mentions"
+  fi
+
+  # 言及があるなら、リンクが含まれていること
+  grep -q 'ref-invariants' "$AUTOPILOT_MD"
+}
+
+# ===========================================================================
+# Requirement: CLAUDE.md の不変条件 B 言及をリンク参照に更新
+# Scenario: CLAUDE.md の不変条件 B がリンク参照になる
+# WHEN: plugins/twl/CLAUDE.md を確認する
+# THEN: 不変条件 B の記述が ref-invariants.md へのリンクを含む
+# ===========================================================================
+
+@test "CLAUDE.md: file exists" {
+  [ -f "$CLAUDE_MD" ]
+}
+
+@test "CLAUDE.md: 不変条件 B に ref-invariants.md へのリンクが含まれる" {
+  # CLAUDE.md 内で不変条件 B が言及されている場合、リンクを含むこと
+  local has_inv_b
+  has_inv_b=$(grep -c "不変条件 B" "$CLAUDE_MD" 2>/dev/null || echo 0)
+
+  if [ "$has_inv_b" -eq 0 ]; then
+    skip "CLAUDE.md does not mention 不変条件 B"
+  fi
+
+  # 不変条件 B の言及が ref-invariants リンクと同じコンテキストにあること
+  grep -q 'ref-invariants' "$CLAUDE_MD"
+}
+
+@test "CLAUDE.md: 不変条件 B の言及行の周辺に ref-invariants リンクが存在する" {
+  # 不変条件 B の言及から 5 行以内に ref-invariants が登場すること
+  python3 -c "
+import sys
+with open('$CLAUDE_MD') as f:
+    lines = f.readlines()
+
+inv_b_lines = [i for i, l in enumerate(lines) if '不変条件 B' in l]
+if not inv_b_lines:
+    print('no 不変条件 B mention found — skipping')
+    sys.exit(0)
+
+for idx in inv_b_lines:
+    start = max(0, idx - 5)
+    end = min(len(lines), idx + 6)
+    context = ''.join(lines[start:end])
+    if 'ref-invariants' in context:
+        sys.exit(0)
+
+print('ref-invariants link not found near 不変条件 B mention')
+sys.exit(1)
+"
+}
+
+# ===========================================================================
+# Requirement: su-observer/SKILL.md への境界明示とリンク追加
+# Scenario: su-observer/SKILL.md に境界説明とリンクが追加される
+# WHEN: plugins/twl/skills/su-observer/SKILL.md を確認する
+# THEN: "SU-* は supervisor 固有の application-level 制約" という説明と
+#       ref-invariants.md へのリンクが存在する
+# ===========================================================================
+
+@test "su-observer/SKILL.md: file exists" {
+  [ -f "$SKILL_MD" ]
+}
+
+@test "su-observer/SKILL.md: ref-invariants.md へのリンクが存在する" {
+  grep -q 'ref-invariants' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-* は supervisor 固有の application-level 制約 という説明が存在する" {
+  # 完全一致でなくても "SU" と "supervisor" と "application-level" のキーワードが
+  # 近接して存在していることを確認する
+  python3 -c "
+import sys
+with open('$SKILL_MD') as f:
+    content = f.read()
+
+keywords = ['SU', 'supervisor', 'application-level']
+for kw in keywords:
+    if kw not in content:
+        print(f'keyword {repr(kw)} not found in SKILL.md')
+        sys.exit(1)
+sys.exit(0)
+"
+}
+
+# ===========================================================================
+# Scenario: SU-1〜SU-7 の定義が SKILL.md に維持される
+# WHEN: plugins/twl/skills/su-observer/SKILL.md を確認する
+# THEN: SU-1〜SU-7 の定義が削除されずに残っている
+# ===========================================================================
+
+@test "su-observer/SKILL.md: SU-1 の定義が残っている" {
+  grep -q 'SU-1' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-2 の定義が残っている" {
+  grep -q 'SU-2' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-3 の定義が残っている" {
+  grep -q 'SU-3' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-4 の定義が残っている" {
+  grep -q 'SU-4' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-5 の定義が残っている" {
+  grep -q 'SU-5' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-6 の定義が残っている" {
+  grep -q 'SU-6' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-7 の定義が残っている" {
+  grep -q 'SU-7' "$SKILL_MD"
+}
+
+@test "su-observer/SKILL.md: SU-1〜SU-7 が全て 7 件存在する" {
+  local count
+  count=$(grep -cE 'SU-[1-7]' "$SKILL_MD" 2>/dev/null || echo 0)
+  [ "$count" -ge 7 ]
+}


### PR DESCRIPTION
feat(#788): 不変条件 A-M を ref-invariants.md に一本化

- plugins/twl/refs/ref-invariants.md 新規作成（不変条件 A-M 正典定義）
- autopilot.md の不変条件テーブルを削除し ref-invariants.md へリンク統一
- CLAUDE.md 不変条件 B 言及をリンク参照に更新
- su-observer/SKILL.md に SU-* と不変条件 A-M の境界説明追加
- autopilot-invariants.bats の invariant-J/K grep 対象を ref-invariants.md に切替
- deps.yaml に ref-invariants エントリ（type: reference）追加
- README.md Refs カウント 18 → 19 更新
- tasks.md 全 17 タスク完了

Closes #788