### PR TITLE
feat(#790): chain.py を SSoT 化 — export API + twl chain export CLI 追加

### DIFF
--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -109,6 +109,164 @@ TERMINAL_STEP_TO_NEXT_SKILL: dict[str, str] = {
     "warning-fix": "workflow-pr-merge",
 }
 
+# ---------------------------------------------------------------------------
+# Computed-artifact metadata (SSOT for twl chain export)
+# ---------------------------------------------------------------------------
+
+# Dispatch mode per step: runner=bash direct, llm=LLM skill, trigger=external
+CHAIN_STEP_DISPATCH: dict[str, str] = {
+    "init": "runner",
+    "board-status-update": "trigger",
+    "crg-auto-build": "llm",
+    "arch-ref": "runner",
+    "change-propose": "llm",
+    "ac-extract": "runner",
+    "change-id-resolve": "runner",
+    "test-scaffold": "llm",
+    "check": "runner",
+    "change-apply": "llm",
+    "post-change-apply": "runner",
+    "prompt-compliance": "runner",
+    "ts-preflight": "runner",
+    "phase-review": "llm",
+    "scope-judge": "llm",
+    "pr-test": "runner",
+    "ac-verify": "llm",
+    "all-pass-check": "runner",
+    "pr-cycle-report": "runner",
+}
+
+# Command path for LLM steps (empty string = Skill で実行)
+CHAIN_STEP_COMMAND: dict[str, str] = {
+    "crg-auto-build": "commands/crg-auto-build.md",
+    "change-propose": "commands/change-propose.md",
+    "test-scaffold": "",
+    "change-apply": "",
+    "phase-review": "commands/phase-review.md",
+    "scope-judge": "commands/scope-judge.md",
+    "ac-verify": "commands/ac-verify.md",
+}
+
+# Chain metadata per workflow (type + description)
+CHAIN_METADATA: dict[str, dict[str, str]] = {
+    "setup": {
+        "type": "A",
+        "description": "開発準備ワークフロー（worktree作成 → DeltaSpec → テスト準備）",
+    },
+    "test-ready": {
+        "type": "B",
+        "description": "テスト生成と準備確認（DeltaSpec → テスト → 実装）",
+    },
+    "pr-verify": {
+        "type": "B",
+        "description": "PR検証（preflight → review → scope → test → ac-verify）",
+    },
+    "pr-merge": {
+        "type": "B",
+        "description": "PRマージ（e2e → report → analysis → check → merge）",
+    },
+}
+
+
+def export_deps_chains() -> dict:
+    """Build deps.yaml.chains section from chain.py SSOT data.
+
+    Groups CHAIN_STEPS by their workflow (STEP_TO_WORKFLOW) and attaches
+    type/description metadata from CHAIN_METADATA.
+
+    Returns:
+        dict mapping workflow-name → {type, description, steps}
+    """
+    workflow_steps: dict[str, list[str]] = {}
+    for step in CHAIN_STEPS:
+        workflow = STEP_TO_WORKFLOW.get(step, "")
+        if workflow:
+            workflow_steps.setdefault(workflow, []).append(step)
+
+    chains: dict[str, dict] = {}
+    for workflow, steps in workflow_steps.items():
+        meta = CHAIN_METADATA.get(workflow, {})
+        chains[workflow] = {
+            "type": meta.get("type", "B"),
+            "description": meta.get("description", ""),
+            "steps": steps,
+        }
+    return chains
+
+
+def export_chain_steps_sh() -> str:
+    """Build chain-steps.sh bash content from chain.py SSOT data.
+
+    Returns a complete shell script string ready to be written to
+    plugins/twl/scripts/chain-steps.sh.
+    """
+    lines: list[str] = [
+        "#!/usr/bin/env bash",
+        "# chain-steps.sh — chain ステップ順序の共有定義（chain.py から生成）",
+        "# このファイルは `twl chain export --shell` で再生成される。直接編集しないこと。",
+        "#",
+        "# このファイルを source して CHAIN_STEPS 配列を取得する:",
+        '#   source "$(dirname "${BASH_SOURCE[0]}")/chain-steps.sh"',
+        "#",
+        "# workflow-setup → workflow-test-ready → workflow-pr-cycle の全ステップ順。",
+        "",
+        "CHAIN_STEPS=(",
+    ]
+    for step in CHAIN_STEPS:
+        lines.append(f"  {step}")
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# quick Issue でスキップするステップの一覧（SSOT）")
+    lines.append("QUICK_SKIP_STEPS=(")
+    for step in CHAIN_STEPS:
+        if step in QUICK_SKIP_STEPS:
+            lines.append(f"  {step}")
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# direct モード（DeltaSpec なし）でスキップするステップの一覧（SSOT）")
+    lines.append("DIRECT_SKIP_STEPS=(")
+    for step in CHAIN_STEPS:
+        if step in DIRECT_SKIP_STEPS:
+            lines.append(f"  {step}")
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# dispatch_mode SSOT: 各ステップの実行モード")
+    lines.append("# runner = chain-runner.sh が bash で直接実行")
+    lines.append("# llm   = LLM Skill が実行し、chain-runner は llm-delegate/llm-complete で記録")
+    lines.append("declare -A CHAIN_STEP_DISPATCH=(")
+    for step in CHAIN_STEPS:
+        dispatch = CHAIN_STEP_DISPATCH.get(step, "runner")
+        lines.append(f"  [{step}]={dispatch}")
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# ワークフロー境界メタデータ（SSOT は chain.py の STEP_TO_WORKFLOW）")
+    lines.append("declare -A CHAIN_STEP_WORKFLOW=(")
+    for step in CHAIN_STEPS:
+        workflow = STEP_TO_WORKFLOW.get(step, "")
+        lines.append(f"  [{step}]={workflow}")
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# ワークフロー完了後の次 skill（SSOT は chain.py の WORKFLOW_NEXT_SKILL）")
+    lines.append("declare -A CHAIN_WORKFLOW_NEXT_SKILL=(")
+    for workflow, skill in WORKFLOW_NEXT_SKILL.items():
+        lines.append(f'  [{workflow}]="{skill}"')
+    lines.append(")")
+    lines.append("")
+
+    lines.append("# LLM ステップのコマンドパス（空 = Skill で実行）")
+    lines.append("declare -A CHAIN_STEP_COMMAND=(")
+    for step, cmd in CHAIN_STEP_COMMAND.items():
+        lines.append(f'  [{step}]="{cmd}"')
+    lines.append(")")
+    lines.append("")
+
+    return "\n".join(lines)
+
 
 class ChainError(Exception):
     """Raised for chain step errors."""

--- a/cli/twl/src/twl/chain/export.py
+++ b/cli/twl/src/twl/chain/export.py
@@ -1,0 +1,135 @@
+"""twl chain export — regenerate computed artifacts from chain.py SSOT.
+
+Usage:
+    twl chain export --yaml [--write] [--plugin-root PATH]
+    twl chain export --shell [--write] [--plugin-root PATH]
+
+Feature flag:
+    TWL_CHAIN_SSOT_MODE=chain.py   (default) — export from chain.py
+    TWL_CHAIN_SSOT_MODE=deps.yaml             — fallback, print warning only
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from twl.autopilot.chain import export_chain_steps_sh, export_deps_chains
+from twl.core.plugin import get_plugin_root, load_deps
+
+
+def _get_ssot_mode() -> str:
+    return os.environ.get("TWL_CHAIN_SSOT_MODE", "chain.py")
+
+
+def _update_deps_yaml_chains(plugin_root: Path, deps: dict[str, Any]) -> str:
+    """Return updated deps.yaml text with chains: section replaced from chain.py."""
+    chains = export_deps_chains()
+    deps_path = plugin_root / "deps.yaml"
+    original = deps_path.read_text(encoding="utf-8")
+
+    # Locate the chains: block start
+    lines = original.splitlines(keepends=True)
+    chain_start = None
+    for i, line in enumerate(lines):
+        if line.rstrip() == "chains:":
+            chain_start = i
+            break
+
+    if chain_start is None:
+        return original  # no chains section to replace
+
+    # Find the end of the chains: block (next top-level key or EOF)
+    chain_end = len(lines)
+    for i in range(chain_start + 1, len(lines)):
+        stripped = lines[i].rstrip()
+        if stripped and not stripped.startswith(" ") and not stripped.startswith("\t") and not stripped.startswith("#"):
+            chain_end = i
+            break
+
+    # Build replacement lines
+    new_chains_lines: list[str] = []
+    new_chains_lines.append("# チェーン（chain.py から生成 — twl chain export --yaml で再生成）\n")
+    new_chains_lines.append("chains:\n")
+
+    # Preserve workflow order from deps.yaml, then add any new ones from chain.py
+    existing_order = list(deps.get("chains", {}).keys())
+    chain_order = existing_order + [k for k in chains if k not in existing_order]
+
+    for workflow in chain_order:
+        if workflow not in chains:
+            continue
+        data = chains[workflow]
+        new_chains_lines.append(f"  {workflow}:\n")
+        new_chains_lines.append(f'    type: "{data["type"]}"\n')
+        new_chains_lines.append(f'    description: "{data["description"]}"\n')
+        new_chains_lines.append("    steps:\n")
+        for step in data["steps"]:
+            new_chains_lines.append(f"      - {step}\n")
+        new_chains_lines.append("\n")
+
+    updated = lines[:chain_start] + new_chains_lines + lines[chain_end:]
+    return "".join(updated)
+
+
+def handle_chain_export_subcommand(argv: list[str]) -> int:
+    """Handle `twl chain export` subcommand. Returns exit code."""
+    parser = argparse.ArgumentParser(
+        prog="twl chain export",
+        description="Regenerate computed artifacts from chain.py SSOT",
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--yaml", action="store_true", help="Export deps.yaml chains: section")
+    group.add_argument("--shell", action="store_true", help="Export chain-steps.sh bash variables")
+    parser.add_argument("--write", action="store_true", help="Write output to file (default: stdout)")
+    parser.add_argument(
+        "--plugin-root",
+        default=None,
+        help="Plugin root directory (auto-detected from CWD if omitted)",
+    )
+
+    args = parser.parse_args(argv)
+
+    mode = _get_ssot_mode()
+    if mode != "chain.py":
+        print(
+            f"⚠️  TWL_CHAIN_SSOT_MODE={mode}: chain.py は SSoT として使用されていません。"
+            " `TWL_CHAIN_SSOT_MODE=chain.py` を設定してください。",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.plugin_root is not None:
+        plugin_root = Path(args.plugin_root)
+        if not (plugin_root / "deps.yaml").exists():
+            print(f"Error: deps.yaml not found in --plugin-root: {plugin_root}", file=sys.stderr)
+            return 1
+    else:
+        plugin_root = get_plugin_root()
+
+    deps = load_deps(plugin_root)
+
+    if args.yaml:
+        content = _update_deps_yaml_chains(plugin_root, deps)
+        if args.write:
+            (plugin_root / "deps.yaml").write_text(content, encoding="utf-8")
+            print(f"✓ deps.yaml chains: セクションを再生成しました ({plugin_root / 'deps.yaml'})")
+        else:
+            print(content, end="")
+
+    elif args.shell:
+        content = export_chain_steps_sh()
+        target = plugin_root / "scripts" / "chain-steps.sh"
+        if args.write:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            print(f"✓ chain-steps.sh を再生成しました ({target})")
+        else:
+            print(content, end="")
+
+    return 0

--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -79,12 +79,17 @@ def main():
             from twl.chain.viz import handle_chain_viz_subcommand
             handle_chain_viz_subcommand(sys.argv[3:])
             sys.exit(0)
+        elif len(sys.argv) >= 3 and sys.argv[2] == 'export':
+            from twl.chain.export import handle_chain_export_subcommand
+            sys.exit(handle_chain_export_subcommand(sys.argv[3:]))
         else:
             print(f"Error: unknown chain subcommand '{sys.argv[2] if len(sys.argv) >= 3 else ''}'", file=sys.stderr)
             print("Usage: twl chain generate <chain-name> [--write]", file=sys.stderr)
             print("       twl chain viz <chain-name>", file=sys.stderr)
             print("       twl chain viz --all [--update-readme]", file=sys.stderr)
             print("       twl chain viz --update-arch", file=sys.stderr)
+            print("       twl chain export --yaml [--write]", file=sys.stderr)
+            print("       twl chain export --shell [--write]", file=sys.stderr)
             sys.exit(1)
 
     parser = argparse.ArgumentParser(description='Analyze plugin dependencies')

--- a/cli/twl/tests/test_chain_export.py
+++ b/cli/twl/tests/test_chain_export.py
@@ -1,0 +1,261 @@
+"""Tests for chain.py export API and twl chain export CLI (Issue #790)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from twl.autopilot.chain import (
+    CHAIN_METADATA,
+    CHAIN_STEP_COMMAND,
+    CHAIN_STEP_DISPATCH,
+    CHAIN_STEPS,
+    STEP_TO_WORKFLOW,
+    WORKFLOW_NEXT_SKILL,
+    export_chain_steps_sh,
+    export_deps_chains,
+)
+
+
+# ===========================================================================
+# export_deps_chains()
+# ===========================================================================
+
+
+class TestExportDepsChains:
+    def test_returns_dict(self) -> None:
+        result = export_deps_chains()
+        assert isinstance(result, dict)
+
+    def test_all_workflows_present(self) -> None:
+        result = export_deps_chains()
+        workflows = set(STEP_TO_WORKFLOW.values())
+        for wf in workflows:
+            assert wf in result, f"Workflow '{wf}' missing from export_deps_chains()"
+
+    def test_each_chain_has_required_keys(self) -> None:
+        result = export_deps_chains()
+        for wf, data in result.items():
+            assert "type" in data, f"{wf}: missing 'type'"
+            assert "description" in data, f"{wf}: missing 'description'"
+            assert "steps" in data, f"{wf}: missing 'steps'"
+            assert isinstance(data["steps"], list), f"{wf}: 'steps' must be a list"
+
+    def test_steps_are_subsets_of_chain_steps(self) -> None:
+        result = export_deps_chains()
+        all_steps = set(CHAIN_STEPS)
+        for wf, data in result.items():
+            for step in data["steps"]:
+                assert step in all_steps, f"{wf}: step '{step}' not in CHAIN_STEPS"
+
+    def test_no_step_duplicated_across_chains(self) -> None:
+        result = export_deps_chains()
+        seen: list[str] = []
+        for data in result.values():
+            for step in data["steps"]:
+                assert step not in seen, f"Step '{step}' appears in multiple chains"
+                seen.append(step)
+
+    def test_all_chain_steps_are_exported(self) -> None:
+        result = export_deps_chains()
+        exported_steps: set[str] = set()
+        for data in result.values():
+            exported_steps.update(data["steps"])
+        for step in CHAIN_STEPS:
+            if STEP_TO_WORKFLOW.get(step):
+                assert step in exported_steps, f"Step '{step}' not exported"
+
+    def test_type_values_are_valid(self) -> None:
+        result = export_deps_chains()
+        valid_types = {"A", "B", "meta"}
+        for wf, data in result.items():
+            assert data["type"] in valid_types, f"{wf}: invalid type '{data['type']}'"
+
+    def test_setup_chain_contains_init(self) -> None:
+        result = export_deps_chains()
+        assert "setup" in result
+        assert "init" in result["setup"]["steps"]
+
+
+# ===========================================================================
+# export_chain_steps_sh()
+# ===========================================================================
+
+
+class TestExportChainStepsSh:
+    def test_returns_string(self) -> None:
+        result = export_chain_steps_sh()
+        assert isinstance(result, str)
+
+    def test_starts_with_shebang(self) -> None:
+        result = export_chain_steps_sh()
+        assert result.startswith("#!/usr/bin/env bash")
+
+    def test_contains_chain_steps_array(self) -> None:
+        result = export_chain_steps_sh()
+        assert "CHAIN_STEPS=(" in result
+
+    def test_all_chain_steps_in_output(self) -> None:
+        result = export_chain_steps_sh()
+        for step in CHAIN_STEPS:
+            assert f"  {step}\n" in result or f"  {step}" in result, \
+                f"Step '{step}' not found in chain-steps.sh output"
+
+    def test_contains_quick_skip_steps(self) -> None:
+        result = export_chain_steps_sh()
+        assert "QUICK_SKIP_STEPS=(" in result
+
+    def test_contains_direct_skip_steps(self) -> None:
+        result = export_chain_steps_sh()
+        assert "DIRECT_SKIP_STEPS=(" in result
+
+    def test_contains_dispatch_assoc_array(self) -> None:
+        result = export_chain_steps_sh()
+        assert "CHAIN_STEP_DISPATCH=(" in result
+
+    def test_contains_workflow_assoc_array(self) -> None:
+        result = export_chain_steps_sh()
+        assert "CHAIN_STEP_WORKFLOW=(" in result
+
+    def test_contains_workflow_next_skill(self) -> None:
+        result = export_chain_steps_sh()
+        assert "CHAIN_WORKFLOW_NEXT_SKILL=(" in result
+
+    def test_contains_step_command(self) -> None:
+        result = export_chain_steps_sh()
+        assert "CHAIN_STEP_COMMAND=(" in result
+
+    def test_all_workflow_next_skills_in_output(self) -> None:
+        result = export_chain_steps_sh()
+        for workflow in WORKFLOW_NEXT_SKILL:
+            assert f"[{workflow}]" in result, f"Workflow '{workflow}' missing from output"
+
+    def test_no_auto_generated_notice(self) -> None:
+        result = export_chain_steps_sh()
+        assert "直接編集しないこと" in result
+
+
+# ===========================================================================
+# CHAIN_STEP_DISPATCH integrity
+# ===========================================================================
+
+
+class TestChainStepDispatch:
+    def test_all_chain_steps_have_dispatch(self) -> None:
+        for step in CHAIN_STEPS:
+            assert step in CHAIN_STEP_DISPATCH, f"Step '{step}' missing from CHAIN_STEP_DISPATCH"
+
+    def test_dispatch_values_are_valid(self) -> None:
+        valid = {"runner", "llm", "trigger"}
+        for step, mode in CHAIN_STEP_DISPATCH.items():
+            assert mode in valid, f"Step '{step}' has invalid dispatch mode '{mode}'"
+
+    def test_llm_steps_have_or_empty_command(self) -> None:
+        for step, mode in CHAIN_STEP_DISPATCH.items():
+            if mode == "llm":
+                assert step in CHAIN_STEP_COMMAND, \
+                    f"LLM step '{step}' missing from CHAIN_STEP_COMMAND"
+
+    def test_non_llm_steps_not_in_command(self) -> None:
+        for step, mode in CHAIN_STEP_DISPATCH.items():
+            if mode != "llm":
+                assert step not in CHAIN_STEP_COMMAND, \
+                    f"Non-LLM step '{step}' should not be in CHAIN_STEP_COMMAND"
+
+
+# ===========================================================================
+# CHAIN_METADATA integrity
+# ===========================================================================
+
+
+class TestChainMetadata:
+    def test_all_workflows_have_metadata(self) -> None:
+        workflows = set(STEP_TO_WORKFLOW.values())
+        for wf in workflows:
+            assert wf in CHAIN_METADATA, f"Workflow '{wf}' missing from CHAIN_METADATA"
+
+    def test_metadata_has_type_and_description(self) -> None:
+        for wf, meta in CHAIN_METADATA.items():
+            assert "type" in meta, f"{wf}: missing 'type' in CHAIN_METADATA"
+            assert "description" in meta, f"{wf}: missing 'description' in CHAIN_METADATA"
+
+
+# ===========================================================================
+# CLI: twl chain export (with feature flag)
+# ===========================================================================
+
+
+class TestChainExportCLI:
+    def _run(self, *args: str, env: dict | None = None) -> subprocess.CompletedProcess:
+        base_env = {**os.environ, "TWL_CHAIN_SSOT_MODE": "chain.py"}
+        if env:
+            base_env.update(env)
+        return subprocess.run(
+            [sys.executable, "-m", "twl", "chain", "export", *args],
+            capture_output=True,
+            text=True,
+            env=base_env,
+        )
+
+    def test_yaml_stdout(self, tmp_path: Path) -> None:
+        """--yaml prints deps.yaml with chains: section."""
+        result = self._run("--yaml", "--plugin-root", str(_make_plugin_root(tmp_path)))
+        assert result.returncode == 0
+        assert "chains:" in result.stdout
+
+    def test_shell_stdout(self, tmp_path: Path) -> None:
+        """--shell prints chain-steps.sh content."""
+        result = self._run("--shell", "--plugin-root", str(_make_plugin_root(tmp_path)))
+        assert result.returncode == 0
+        assert "CHAIN_STEPS=(" in result.stdout
+
+    def test_yaml_write(self, tmp_path: Path) -> None:
+        """--yaml --write updates deps.yaml."""
+        pr = _make_plugin_root(tmp_path)
+        result = self._run("--yaml", "--write", "--plugin-root", str(pr))
+        assert result.returncode == 0
+        updated = (pr / "deps.yaml").read_text()
+        assert "chains:" in updated
+
+    def test_shell_write(self, tmp_path: Path) -> None:
+        """--shell --write writes chain-steps.sh."""
+        pr = _make_plugin_root(tmp_path)
+        result = self._run("--shell", "--write", "--plugin-root", str(pr))
+        assert result.returncode == 0
+        assert (pr / "scripts" / "chain-steps.sh").exists()
+
+    def test_fallback_mode_returns_error(self, tmp_path: Path) -> None:
+        """TWL_CHAIN_SSOT_MODE=deps.yaml → exit 1."""
+        pr = _make_plugin_root(tmp_path)
+        result = self._run(
+            "--yaml", "--plugin-root", str(pr),
+            env={"TWL_CHAIN_SSOT_MODE": "deps.yaml"},
+        )
+        assert result.returncode != 0
+
+    def test_no_flag_errors(self) -> None:
+        """Missing --yaml/--shell → exit non-zero."""
+        result = self._run()
+        assert result.returncode != 0
+
+    def test_mutually_exclusive_flags(self, tmp_path: Path) -> None:
+        """--yaml and --shell are mutually exclusive."""
+        pr = _make_plugin_root(tmp_path)
+        result = self._run("--yaml", "--shell", "--plugin-root", str(pr))
+        assert result.returncode != 0
+
+
+def _make_plugin_root(tmp_path: Path) -> Path:
+    """Create a minimal plugin root with deps.yaml for tests."""
+    pr = tmp_path / "plugin"
+    pr.mkdir()
+    (pr / "scripts").mkdir()
+    (pr / "deps.yaml").write_text(
+        "version: \"3.0\"\nplugin: test\nchains:\n  setup:\n    type: \"A\"\n    steps:\n      - init\n",
+        encoding="utf-8",
+    )
+    return pr


### PR DESCRIPTION
feat(#790): chain.py を SSoT 化 — export API + twl chain export CLI 追加

- chain.py に CHAIN_STEP_DISPATCH / CHAIN_STEP_COMMAND / CHAIN_METADATA を追加
- export_deps_chains() → deps.yaml.chains セクションを構築
- export_chain_steps_sh() → chain-steps.sh bash 変数群を構築
- twl chain export --yaml / --shell CLI コマンド追加
- TWL_CHAIN_SSOT_MODE=chain.py|deps.yaml フィーチャーフラグ対応
- テスト 33 件追加（全 PASS）

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #790