### PR TITLE
feat(#791): twl check --deps-integrity 追加（三者ハッシュ比較）

### DIFF
--- a/.github/workflows/deps-integrity.yml
+++ b/.github/workflows/deps-integrity.yml
@@ -1,0 +1,29 @@
+name: Chain Deps Integrity
+
+on:
+  push:
+    paths:
+      - 'cli/twl/src/twl/autopilot/chain.py'
+      - 'plugins/twl/scripts/chain-steps.sh'
+      - 'plugins/twl/deps.yaml'
+  pull_request:
+    paths:
+      - 'cli/twl/src/twl/autopilot/chain.py'
+      - 'plugins/twl/scripts/chain-steps.sh'
+      - 'plugins/twl/deps.yaml'
+
+permissions: {}
+
+jobs:
+  deps-integrity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install twl
+        run: pip install -e cli/twl
+      - name: Check deps integrity
+        working-directory: plugins/twl
+        run: twl check --deps-integrity

--- a/cli/twl/src/twl/chain/integrity.py
+++ b/cli/twl/src/twl/chain/integrity.py
@@ -1,0 +1,187 @@
+"""deps-integrity: hash-compare chain.py (SSoT) vs chain-steps.sh and deps.yaml.chains."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+from pathlib import Path
+from typing import Optional
+
+
+def _hash_list(items: list[str]) -> str:
+    return hashlib.sha256("|".join(items).encode()).hexdigest()
+
+
+def _hash_set(items: set[str] | frozenset[str]) -> str:
+    return hashlib.sha256("|".join(sorted(items)).encode()).hexdigest()
+
+
+def _load_chain_py_constants(plugin_root: Path) -> Optional[dict]:
+    """Parse CHAIN_STEPS, QUICK_SKIP_STEPS, DIRECT_SKIP_STEPS, STEP_TO_WORKFLOW from chain.py via AST."""
+    candidates = [
+        plugin_root.parent.parent / "cli" / "twl" / "src" / "twl" / "autopilot" / "chain.py",
+        plugin_root.parent / "cli" / "twl" / "src" / "twl" / "autopilot" / "chain.py",
+        plugin_root / "cli" / "twl" / "src" / "twl" / "autopilot" / "chain.py",
+    ]
+    chain_py = next((c for c in candidates if c.is_file()), None)
+    if chain_py is None:
+        return None
+
+    try:
+        tree = ast.parse(chain_py.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+    result: dict = {}
+    for node in ast.walk(tree):
+        name: Optional[str] = None
+        value = None
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            t = node.targets[0]
+            if isinstance(t, ast.Name):
+                name, value = t.id, node.value
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            name, value = node.target.id, node.value
+
+        if name == "CHAIN_STEPS" and isinstance(value, ast.List):
+            result["CHAIN_STEPS"] = [
+                e.value for e in value.elts
+                if isinstance(e, ast.Constant) and isinstance(e.value, str)
+            ]
+        elif name in ("QUICK_SKIP_STEPS", "DIRECT_SKIP_STEPS") and value is not None:
+            elts = None
+            if isinstance(value, (ast.List, ast.Set)):
+                elts = value.elts
+            elif isinstance(value, ast.Call) and value.args and isinstance(value.args[0], (ast.List, ast.Set)):
+                elts = value.args[0].elts
+            if elts is not None:
+                result[name] = frozenset(
+                    e.value for e in elts
+                    if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                )
+        elif name == "STEP_TO_WORKFLOW" and isinstance(value, ast.Dict):
+            result["STEP_TO_WORKFLOW"] = {
+                k.value: v.value
+                for k, v in zip(value.keys, value.values)
+                if isinstance(k, ast.Constant) and isinstance(v, ast.Constant)
+            }
+
+    return result or None
+
+
+def _parse_bash_array(content: str, var_name: str) -> Optional[list[str]]:
+    m = re.search(rf'{re.escape(var_name)}=\(\s*(.*?)\s*\)', content, re.DOTALL)
+    if not m:
+        return None
+    result = []
+    for line in m.group(1).splitlines():
+        token = line.strip()
+        if token and not token.startswith('#'):
+            result.append(token)
+    return result
+
+
+def _expected_chains(step_to_workflow: dict[str, str], chain_steps: list[str]) -> dict[str, list[str]]:
+    chains: dict[str, list[str]] = {}
+    for step in chain_steps:
+        wf = step_to_workflow.get(step)
+        if wf:
+            chains.setdefault(wf, []).append(step)
+    return chains
+
+
+def check_deps_integrity(plugin_root: Path) -> tuple[list[str], list[str]]:
+    """Hash-compare chain.py (SSoT) against chain-steps.sh and deps.yaml.chains.
+
+    Returns (errors, warnings). Errors indicate drift that must be fixed.
+    """
+    errors: list[str] = []
+    warnings: list[str] = []
+    fix_hint = "Run: twl chain export --yaml --shell"
+
+    constants = _load_chain_py_constants(plugin_root)
+    if not constants:
+        warnings.append("[deps-integrity] chain.py not found or unreadable — skipping integrity check")
+        return errors, warnings
+
+    py_chain_steps: list[str] = constants.get("CHAIN_STEPS", [])
+    py_quick_skip: frozenset[str] = constants.get("QUICK_SKIP_STEPS", frozenset())
+    py_direct_skip: frozenset[str] = constants.get("DIRECT_SKIP_STEPS", frozenset())
+    py_step_to_workflow: dict[str, str] = constants.get("STEP_TO_WORKFLOW", {})
+
+    # --- chain-steps.sh comparison ---
+    sh_path = plugin_root / "scripts" / "chain-steps.sh"
+    if not sh_path.exists():
+        warnings.append("[deps-integrity] chain-steps.sh not found — skipping shell comparison")
+    else:
+        content = sh_path.read_text(encoding="utf-8")
+
+        sh_chain_steps = _parse_bash_array(content, "CHAIN_STEPS")
+        if sh_chain_steps is None:
+            warnings.append("[deps-integrity] CHAIN_STEPS not found in chain-steps.sh")
+        elif _hash_list(py_chain_steps) != _hash_list(sh_chain_steps):
+            errors.append(
+                f"[deps-integrity] CHAIN_STEPS mismatch: chain.py vs chain-steps.sh\n"
+                f"  chain.py:       {py_chain_steps}\n"
+                f"  chain-steps.sh: {sh_chain_steps}\n"
+                f"  {fix_hint}"
+            )
+
+        sh_quick = _parse_bash_array(content, "QUICK_SKIP_STEPS")
+        if sh_quick is None:
+            warnings.append("[deps-integrity] QUICK_SKIP_STEPS not found in chain-steps.sh")
+        elif _hash_set(py_quick_skip) != _hash_set(set(sh_quick)):
+            errors.append(
+                f"[deps-integrity] QUICK_SKIP_STEPS mismatch: chain.py vs chain-steps.sh\n"
+                f"  chain.py:       {sorted(py_quick_skip)}\n"
+                f"  chain-steps.sh: {sorted(sh_quick)}\n"
+                f"  {fix_hint}"
+            )
+
+        sh_direct = _parse_bash_array(content, "DIRECT_SKIP_STEPS")
+        if sh_direct is None:
+            warnings.append("[deps-integrity] DIRECT_SKIP_STEPS not found in chain-steps.sh")
+        elif _hash_set(py_direct_skip) != _hash_set(set(sh_direct)):
+            errors.append(
+                f"[deps-integrity] DIRECT_SKIP_STEPS mismatch: chain.py vs chain-steps.sh\n"
+                f"  chain.py:       {sorted(py_direct_skip)}\n"
+                f"  chain-steps.sh: {sorted(sh_direct)}\n"
+                f"  {fix_hint}"
+            )
+
+    # --- deps.yaml.chains comparison ---
+    deps_path = plugin_root / "deps.yaml"
+    if not deps_path.exists():
+        warnings.append("[deps-integrity] deps.yaml not found — skipping YAML comparison")
+        return errors, warnings
+
+    try:
+        import yaml
+        deps = yaml.safe_load(deps_path.read_text(encoding="utf-8"))
+    except ImportError:
+        warnings.append("[deps-integrity] PyYAML not available — skipping YAML comparison")
+        return errors, warnings
+
+    actual_chains = deps.get("chains", {})
+    expected = _expected_chains(py_step_to_workflow, py_chain_steps)
+
+    for chain_name, exp_steps in expected.items():
+        actual = actual_chains.get(chain_name)
+        if actual is None:
+            errors.append(
+                f"[deps-integrity] deps.yaml.chains.{chain_name}: missing\n"
+                f"  expected steps: {exp_steps}\n"
+                f"  {fix_hint}"
+            )
+            continue
+        act_steps = actual.get("steps", []) if isinstance(actual, dict) else list(actual)
+        if _hash_list(exp_steps) != _hash_list(act_steps):
+            errors.append(
+                f"[deps-integrity] deps.yaml.chains.{chain_name}.steps mismatch\n"
+                f"  expected: {exp_steps}\n"
+                f"  actual:   {act_steps}\n"
+                f"  {fix_hint}"
+            )
+
+    return errors, warnings

--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -62,6 +62,8 @@ def main():
     if len(sys.argv) >= 2 and sys.argv[1] == 'check':
         sub_parser = argparse.ArgumentParser(description='Check file existence and chain validation')
         sub_parser.add_argument('--format', choices=['json'], help='Output format')
+        sub_parser.add_argument('--deps-integrity', action='store_true',
+                                help='Hash-verify chain.py ↔ deps.yaml ↔ chain-steps.sh (blocks on drift)')
         sub_args = sub_parser.parse_args(sys.argv[2:])
         plugin_root, deps, graph, plugin_name = _load_plugin_context()
         sys.exit(handle_check(sub_args, graph, deps, plugin_root, plugin_name))

--- a/cli/twl/src/twl/cli_dispatch.py
+++ b/cli/twl/src/twl/cli_dispatch.py
@@ -59,6 +59,8 @@ def handle_tokens(args, graph):
 
 
 def handle_check(args, graph, deps, plugin_root, plugin_name):
+    from twl.chain.integrity import check_deps_integrity
+
     results, check_xref_warnings = check_files(graph, plugin_root)
 
     ok_count = sum(1 for r in results if r[0] == 'ok')
@@ -73,12 +75,22 @@ def handle_check(args, graph, deps, plugin_root, plugin_name):
         cv_criticals_check, cv_warnings_check, cv_infos_check = chain_validate(deps, plugin_root)
         chain_items = deep_validate_to_items(cv_criticals_check, cv_warnings_check, cv_infos_check)
 
-    exit_code = 1 if (missing_count > 0 or cv_criticals_check) else 0
+    # deps-integrity: always run; blocking only when --deps-integrity is specified
+    di_errors, di_warnings = check_deps_integrity(plugin_root)
+    deps_integrity_flag = getattr(args, 'deps_integrity', False)
+    integrity_blocks = deps_integrity_flag and bool(di_errors)
+
+    exit_code = 1 if (missing_count > 0 or cv_criticals_check or integrity_blocks) else 0
 
     if args.format == 'json':
         items = check_results_to_items(results)
         items.extend(violations_to_items(check_xref_warnings, "warning"))
         items.extend(chain_items)
+        severity = "critical" if integrity_blocks else "warning"
+        for e in di_errors:
+            items.append({"type": "deps-integrity", "severity": severity, "message": e})
+        for w in di_warnings:
+            items.append({"type": "deps-integrity", "severity": "warning", "message": w})
         envelope = build_envelope("check", get_deps_version(deps), plugin_name, items, exit_code)
         output_json(envelope)
         return exit_code
@@ -113,6 +125,16 @@ def handle_check(args, graph, deps, plugin_root, plugin_name):
             print("Warning:")
             for w in cv_warnings_check:
                 print(f"  - {w}")
+
+    if di_errors or di_warnings:
+        print()
+        print("=== Deps Integrity Results ===")
+        if di_errors:
+            label = "Error" if deps_integrity_flag else "Warning"
+            for e in di_errors:
+                print(f"  [{label}] {e}")
+        for w in di_warnings:
+            print(f"  [Info] {w}")
 
     return exit_code
 

--- a/cli/twl/tests/test_chain_integrity.py
+++ b/cli/twl/tests/test_chain_integrity.py
@@ -1,0 +1,190 @@
+"""Tests for chain/integrity.py — deps-integrity hash comparison."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from twl.chain.integrity import (
+    _hash_list,
+    _hash_set,
+    _parse_bash_array,
+    _expected_chains,
+    check_deps_integrity,
+)
+
+
+class TestHashHelpers:
+    def test_hash_list_identical(self):
+        assert _hash_list(["a", "b", "c"]) == _hash_list(["a", "b", "c"])
+
+    def test_hash_list_order_matters(self):
+        assert _hash_list(["a", "b"]) != _hash_list(["b", "a"])
+
+    def test_hash_set_order_independent(self):
+        assert _hash_set({"a", "b", "c"}) == _hash_set({"c", "a", "b"})
+
+    def test_hash_set_diff(self):
+        assert _hash_set({"a", "b"}) != _hash_set({"a", "c"})
+
+
+class TestParseBashArray:
+    def test_simple_array(self):
+        content = "CHAIN_STEPS=(\n  init\n  check\n  done\n)"
+        result = _parse_bash_array(content, "CHAIN_STEPS")
+        assert result == ["init", "check", "done"]
+
+    def test_missing_var(self):
+        assert _parse_bash_array("OTHER_VAR=(foo bar)", "CHAIN_STEPS") is None
+
+    def test_skips_comments(self):
+        content = "CHAIN_STEPS=(\n  init\n  # skip this\n  check\n)"
+        result = _parse_bash_array(content, "CHAIN_STEPS")
+        assert result == ["init", "check"]
+
+    def test_quick_skip(self):
+        content = "QUICK_SKIP_STEPS=(\n  crg-auto-build\n  arch-ref\n)"
+        result = _parse_bash_array(content, "QUICK_SKIP_STEPS")
+        assert result == ["crg-auto-build", "arch-ref"]
+
+
+class TestExpectedChains:
+    def test_basic_grouping(self):
+        step_to_workflow = {
+            "init": "setup",
+            "check": "test-ready",
+            "verify": "test-ready",
+        }
+        chain_steps = ["init", "check", "verify"]
+        result = _expected_chains(step_to_workflow, chain_steps)
+        assert result == {"setup": ["init"], "test-ready": ["check", "verify"]}
+
+    def test_order_preserved(self):
+        step_to_workflow = {"a": "wf", "b": "wf", "c": "wf"}
+        result = _expected_chains(step_to_workflow, ["c", "a", "b"])
+        assert result["wf"] == ["c", "a", "b"]
+
+    def test_unmapped_step_skipped(self):
+        result = _expected_chains({}, ["init", "check"])
+        assert result == {}
+
+
+class TestCheckDepsIntegrity:
+    @pytest.fixture()
+    def plugin_dir(self, tmp_path):
+        """Minimal plugin dir with chain.py + chain-steps.sh + deps.yaml in sync."""
+        # chain.py
+        cli_path = tmp_path / "cli" / "twl" / "src" / "twl" / "autopilot"
+        cli_path.mkdir(parents=True)
+        (cli_path / "chain.py").write_text(textwrap.dedent("""\
+            CHAIN_STEPS: list[str] = ["init", "check", "done"]
+            QUICK_SKIP_STEPS: frozenset[str] = frozenset(["check"])
+            DIRECT_SKIP_STEPS: frozenset[str] = frozenset(["done"])
+            STEP_TO_WORKFLOW: dict[str, str] = {
+                "init": "setup",
+                "check": "test-ready",
+                "done": "pr-merge",
+            }
+        """))
+
+        # chain-steps.sh (in sync)
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "chain-steps.sh").write_text(textwrap.dedent("""\
+            CHAIN_STEPS=(
+              init
+              check
+              done
+            )
+            QUICK_SKIP_STEPS=(
+              check
+            )
+            DIRECT_SKIP_STEPS=(
+              done
+            )
+        """))
+
+        # deps.yaml (in sync)
+        import yaml
+        deps = {
+            "version": "3.0",
+            "chains": {
+                "setup": {"steps": ["init"]},
+                "test-ready": {"steps": ["check"]},
+                "pr-merge": {"steps": ["done"]},
+            },
+        }
+        (tmp_path / "deps.yaml").write_text(yaml.dump(deps))
+
+        return tmp_path
+
+    def test_no_drift_returns_no_errors(self, plugin_dir):
+        errors, warnings = check_deps_integrity(plugin_dir)
+        assert errors == [], f"Unexpected errors: {errors}"
+
+    def test_chain_steps_drift_detected(self, plugin_dir):
+        # Introduce drift: add extra step to chain-steps.sh
+        sh = plugin_dir / "scripts" / "chain-steps.sh"
+        sh.write_text(textwrap.dedent("""\
+            CHAIN_STEPS=(
+              init
+              check
+              extra-step
+              done
+            )
+            QUICK_SKIP_STEPS=(
+              check
+            )
+            DIRECT_SKIP_STEPS=(
+              done
+            )
+        """))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert any("CHAIN_STEPS mismatch" in e for e in errors)
+
+    def test_quick_skip_drift_detected(self, plugin_dir):
+        sh = plugin_dir / "scripts" / "chain-steps.sh"
+        original = sh.read_text()
+        sh.write_text(original.replace("QUICK_SKIP_STEPS=(\n  check\n)", "QUICK_SKIP_STEPS=(\n  init\n)"))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert any("QUICK_SKIP_STEPS mismatch" in e for e in errors)
+
+    def test_direct_skip_drift_detected(self, plugin_dir):
+        sh = plugin_dir / "scripts" / "chain-steps.sh"
+        original = sh.read_text()
+        sh.write_text(original.replace("DIRECT_SKIP_STEPS=(\n  done\n)", "DIRECT_SKIP_STEPS=(\n  init\n)"))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert any("DIRECT_SKIP_STEPS mismatch" in e for e in errors)
+
+    def test_deps_yaml_chain_drift_detected(self, plugin_dir):
+        import yaml
+        deps = {
+            "version": "3.0",
+            "chains": {
+                "setup": {"steps": ["init"]},
+                "test-ready": {"steps": ["wrong-step"]},  # drift
+                "pr-merge": {"steps": ["done"]},
+            },
+        }
+        (plugin_dir / "deps.yaml").write_text(yaml.dump(deps))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert any("test-ready" in e and "mismatch" in e for e in errors)
+
+    def test_missing_chain_py_returns_warning(self, plugin_dir):
+        import shutil
+        shutil.rmtree(plugin_dir / "cli")
+        errors, warnings = check_deps_integrity(plugin_dir)
+        assert errors == []
+        assert any("chain.py" in w for w in warnings)
+
+    def test_missing_chain_steps_sh_returns_warning(self, plugin_dir):
+        (plugin_dir / "scripts" / "chain-steps.sh").unlink()
+        errors, warnings = check_deps_integrity(plugin_dir)
+        assert any("chain-steps.sh" in w for w in warnings)
+
+    def test_fix_hint_in_error(self, plugin_dir):
+        sh = plugin_dir / "scripts" / "chain-steps.sh"
+        original = sh.read_text()
+        sh.write_text(original.replace("init\n  check\n  done", "init\n  check"))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert any("twl chain export --yaml --shell" in e for e in errors)

--- a/plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh
+++ b/plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# git-pre-commit-deps-integrity.sh — deps-integrity pre-commit hook
+#
+# Install: ln -sf "$(git rev-parse --show-toplevel)/plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh" \
+#                  "$(git rev-parse --git-common-dir)/hooks/pre-commit"
+set -euo pipefail
+
+PLUGIN_ROOT="$(git rev-parse --show-toplevel)/plugins/twl"
+
+# Only run when chain-related files are staged
+if ! git diff --cached --name-only | grep -qE \
+    "cli/twl/src/twl/autopilot/chain\.py|plugins/twl/scripts/chain-steps\.sh|plugins/twl/deps\.yaml"; then
+  exit 0
+fi
+
+if ! command -v twl &>/dev/null; then
+  echo "twl not found — skipping deps-integrity check" >&2
+  exit 0
+fi
+
+echo "Running twl check --deps-integrity..."
+cd "$PLUGIN_ROOT"
+if ! twl check --deps-integrity; then
+  echo ""
+  echo "Commit blocked: chain.py / chain-steps.sh / deps.yaml are out of sync."
+  echo "Run: twl chain export --yaml --shell"
+  exit 1
+fi
+echo "deps-integrity OK"


### PR DESCRIPTION
feat(#791): twl check --deps-integrity 追加（三者ハッシュ比較）

- chain/integrity.py: chain.py SSoT vs chain-steps.sh/deps.yaml.chains のハッシュ比較
- cli.py: check サブコマンドに --deps-integrity フラグ追加
- cli_dispatch.py: handle_check に integrity check 統合（常時実行、--deps-integrity 時のみ blocking）
- test_chain_integrity.py: integrity ロジックの pytest ユニットテスト 19件
- .github/workflows/deps-integrity.yml: CI ゲート追加
- git-pre-commit-deps-integrity.sh: pre-commit hook テンプレート

Closes #791