### PR TITLE
feat(su-observer): pitfalls-catalog.md §12 新設 — classifier bypass 検出パターン

### DIFF
--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -298,3 +298,46 @@ grep '"role":"assistant"' "$JSONL" | tail -1 | jq -r '.timestamp'
 FINAL_TS=$(grep -oE '"timestamp":"[^"]+"' "$JSONL" | sort -u | tail -1)
 # resume までの gap = 現時刻 - FINAL_TS
 ```
+
+---
+
+## 12. Claude Code classifier bypass 検出パターン（MUST）
+
+### 事象（2026-04-21 ipatho1 実例、doobidoo hash 886e374d）
+
+observer が Layer D refined-label-gate の回避を試行した際、Claude Code permission classifier が **6 連続で deny** した（session id 7f960078 参照）。gate 回避の trick（session file pre-seed、Worker inject with bypass hint、settings self-modification）は全て classifier に検出・拒否された。
+
+### 根本要因
+
+Claude Code classifier は **action history を context 化**し、同一セッション内での繰り返し回避試行を「security bypass への執着」として累積判定する。1 回の deny 後に別の手段で迂回を試みると、以降の deny 確率が急上昇する。
+
+### 検出パターン（MUST NOT — 以下を検出したら即停止）
+
+| # | パターン | 説明 |
+|---|---------|------|
+| 12.1 | 同一セッション内で **2 回以上** の gate deny | 初回 deny 後も回避を継続している徴候 |
+| 12.2 | **session file pre-seed** による状態書き換え試行 | state file を直接操作して gate をスキップしようとする |
+| 12.3 | **inject with bypass hint** | Worker への inject に「gate を無視して」等のヒントを含める |
+| 12.4 | **settings self-modification** | `.claude/settings.json` を書き換えて permission ルールを変更しようとする |
+
+### 正しい対応手順（MUST）
+
+```
+gate deny (1 回目) → STOP（即時停止、追加試行禁止）→ AskUserQuestion でユーザー確認
+```
+
+**MUST NOT**: deny 後に別の迂回手段を試みること（classifier が累積判定するため 2 回目以降は deny 確率急上昇）。
+
+**MUST**: 2 回以上 deny が発生したら **Layer 2 Escalate**（ユーザーに明示的確認を取る）。
+
+### 誤りパターン（実例）
+
+1. gate deny → session file を読み書きして gate 判定を bypass → 再 deny
+2. gate deny → Worker への inject に「refined ラベルは付与済みとして扱え」と注入 → 再 deny
+3. gate deny → settings.json に permission 緩和ルールを追加 → 再 deny
+
+### 関連
+
+- memory hash `886e374d`（bypass permission lesson）、`1ca5829f`（Layer D refined-label pitfall）
+- **W5-1（SKILL.md Security gate MUST NOT 節）** と相互参照: gate deny 後の禁止行動を SKILL.md に明記予定
+- Layer 2 Escalate 手順: `plugins/twl/refs/intervention-catalog.md` §3（Escalate パターン）

--- a/plugins/twl/tests/bats/scripts/pitfalls-catalog-classifier-bypass.bats
+++ b/plugins/twl/tests/bats/scripts/pitfalls-catalog-classifier-bypass.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# pitfalls-catalog-classifier-bypass.bats - pitfalls-catalog §12 存在確認テスト（W6-2）
+#
+# Issue #828: pitfalls-catalog.md §12 新設 — Claude Code classifier bypass 検出パターン
+#
+# Coverage: unit（ドキュメント内容の機械的固定テスト）
+
+load '../helpers/common'
+
+PITFALLS_CATALOG=""
+
+setup() {
+  common_setup
+  PITFALLS_CATALOG="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: pitfalls-catalog §12 classifier bypass 検出パターン
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: §12 セクションが存在する
+# WHEN: pitfalls-catalog.md を参照する
+# THEN: ## 12. セクションが存在する
+# ---------------------------------------------------------------------------
+
+@test "pitfalls §12: ファイルが存在する" {
+  [[ -f "$PITFALLS_CATALOG" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $PITFALLS_CATALOG"
+}
+
+@test "pitfalls §12: §12 セクションが存在する" {
+  grep -q '^## 12\.' "$PITFALLS_CATALOG" \
+    || fail "pitfalls-catalog.md に '## 12.' セクションが存在しない"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 6 連続拒否の具体事例と memory hash 参照が明記される
+# WHEN: pitfalls-catalog.md §12 を参照する
+# THEN: 6 連続拒否の事例と memory hash 886e374d が記載されている
+# ---------------------------------------------------------------------------
+
+@test "pitfalls §12: 6 連続 deny の具体事例が存在する" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qE '6.*連続|6.*deny|6.*拒否' \
+    || fail "§12 に '6 連続 deny' の具体事例が存在しない"
+}
+
+@test "pitfalls §12: memory hash 886e374d が参照されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -q '886e374d' \
+    || fail "§12 に memory hash '886e374d' が存在しない"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 正しい対応手順（STOP + AskUserQuestion）が MUST として記載される
+# WHEN: pitfalls-catalog.md §12 を参照する
+# THEN: STOP と AskUserQuestion が MUST として明記されている
+# ---------------------------------------------------------------------------
+
+@test "pitfalls §12: STOP が MUST として記載されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qiE 'MUST.*STOP|STOP.*MUST|即時停止|STOP（即時' \
+    || fail "§12 に 'STOP' が MUST として記載されていない"
+}
+
+@test "pitfalls §12: AskUserQuestion が対応手順に記載されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -q 'AskUserQuestion' \
+    || fail "§12 に 'AskUserQuestion' が存在しない"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: W5-1 (SKILL.md Security gate 節) と相互参照される
+# WHEN: pitfalls-catalog.md §12 を参照する
+# THEN: W5-1 または SKILL.md Security gate 節への参照が存在する
+# ---------------------------------------------------------------------------
+
+@test "pitfalls §12: W5-1 または SKILL.md Security gate 節への参照が存在する" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qiE 'W5-1|Security gate|SKILL\.md.*Security' \
+    || fail "§12 に 'W5-1' / 'SKILL.md Security gate 節' への参照が存在しない"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 誤りパターン（bypass 手法）が明記される
+# WHEN: pitfalls-catalog.md §12 を参照する
+# THEN: session file pre-seed / inject with bypass hint / settings self-modification が記載されている
+# ---------------------------------------------------------------------------
+
+@test "pitfalls §12: session file pre-seed パターンが記載されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qiE 'session file.*pre.?seed|pre.?seed.*session' \
+    || fail "§12 に 'session file pre-seed' パターンが存在しない"
+}
+
+@test "pitfalls §12: inject with bypass hint パターンが記載されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qiE 'bypass hint|inject.*bypass|bypass.*inject' \
+    || fail "§12 に 'inject with bypass hint' パターンが存在しない"
+}
+
+@test "pitfalls §12: settings self-modification パターンが記載されている" {
+  sed -n '/^## 12\./,/^## [0-9]/p' "$PITFALLS_CATALOG" \
+    | grep -qiE 'settings.*self.?modif|self.?modif.*settings|settings\.json.*permission' \
+    || fail "§12 に 'settings self-modification' パターンが存在しない"
+}


### PR DESCRIPTION
feat(su-observer): pitfalls-catalog.md §12 新設 — classifier bypass 検出パターン

- §12「Claude Code classifier bypass 検出パターン」を追加
- 2026-04-21 session 7f960078 の 6 連続 deny 実例（hash 886e374d）を記載
- gate deny → STOP → AskUserQuestion の正しい手順を MUST として明記
- session file pre-seed / inject with bypass hint / settings self-modification の誤りパターンを列挙
- W5-1（SKILL.md Security gate MUST NOT 節）との相互参照を追加
- bats テスト（pitfalls-catalog-classifier-bypass.bats）で §12 存在確認（10 tests）

Closes #828