### PR TITLE
feat(#831): add session-end-pitfall-append.sh + bats tests + §9 template

### DIFF
--- a/plugins/twl/scripts/hooks/session-end-pitfall-append.sh
+++ b/plugins/twl/scripts/hooks/session-end-pitfall-append.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# session-end-pitfall-append.sh
+# Appends new observer-pitfall entries to pitfalls-catalog.md at session end.
+#
+# Usage:
+#   echo "pitfall text" | session-end-pitfall-append.sh [OPTIONS]
+#   session-end-pitfall-append.sh [OPTIONS] -- "entry1" "entry2"
+#
+# Options:
+#   --dry-run           Write diff to pending file; do not modify catalog
+#   --catalog <path>    Override catalog path (default: auto-detect from repo)
+#   --supervisor-dir <path>  Override .supervisor dir (default: auto-detect)
+#   --hash <hash>       doobidoo hash to annotate the entry
+#   --session <id>      Session ID for annotation
+#
+# Stdin: one pitfall entry per line (used when no '--' args are given)
+# '--' separates options from entry strings passed as positional args
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DRY_RUN=false
+CATALOG_PATH=""
+SUPERVISOR_DIR=""
+ENTRY_HASH=""
+SESSION_ID=""
+POSITIONAL_ENTRIES=()
+PARSE_OPTS=true
+MAX_LINES=200
+
+while [[ $# -gt 0 ]]; do
+  if [[ "$PARSE_OPTS" == true ]]; then
+    case "$1" in
+      --dry-run) DRY_RUN=true; shift ;;
+      --catalog) CATALOG_PATH="$2"; shift 2 ;;
+      --supervisor-dir) SUPERVISOR_DIR="$2"; shift 2 ;;
+      --hash) ENTRY_HASH="$2"; shift 2 ;;
+      --session) SESSION_ID="$2"; shift 2 ;;
+      --) PARSE_OPTS=false; shift ;;
+      --*) echo "[pitfall-append][warn] Unknown option: $1" >&2; shift ;;
+      *) POSITIONAL_ENTRIES+=("$1"); shift ;;
+    esac
+  else
+    POSITIONAL_ENTRIES+=("$1"); shift
+  fi
+done
+
+# Auto-detect repo root from bare repo structure
+_detect_repo_main() {
+  local common_dir
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+  if [[ -n "$common_dir" && -d "${common_dir}/../main" ]]; then
+    echo "${common_dir}/../main"
+  else
+    echo ""
+  fi
+}
+
+REPO_MAIN="${TWL_REPO_MAIN:-$(_detect_repo_main)}"
+
+# Resolve catalog path
+if [[ -z "$CATALOG_PATH" ]]; then
+  if [[ -n "$REPO_MAIN" ]]; then
+    CATALOG_PATH="${REPO_MAIN}/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"
+  else
+    echo "[pitfall-append][error] Cannot detect repo root; use --catalog" >&2
+    exit 1
+  fi
+fi
+
+# Resolve supervisor dir
+if [[ -z "$SUPERVISOR_DIR" ]]; then
+  if [[ -n "$REPO_MAIN" ]]; then
+    SUPERVISOR_DIR="${REPO_MAIN}/.supervisor"
+  else
+    SUPERVISOR_DIR="$(pwd)/.supervisor"
+  fi
+fi
+
+PENDING_DIFF="${SUPERVISOR_DIR}/pending-pitfall-append.diff"
+ARCHIVE_PATH="$(dirname "$CATALOG_PATH")/pitfalls-archive.md"
+
+# Collect entries
+ENTRIES=()
+if [[ ${#POSITIONAL_ENTRIES[@]} -gt 0 ]]; then
+  ENTRIES=("${POSITIONAL_ENTRIES[@]}")
+elif [[ ! -t 0 ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && ENTRIES+=("$line")
+  done
+fi
+
+if [[ ${#ENTRIES[@]} -eq 0 ]]; then
+  echo "[pitfall-append] No entries to append." >&2
+  exit 0
+fi
+
+if [[ ! -f "$CATALOG_PATH" ]]; then
+  echo "[pitfall-append][error] Catalog not found: $CATALOG_PATH" >&2
+  exit 1
+fi
+
+# Format entries
+TODAY=$(date +%Y-%m-%d 2>/dev/null || echo "unknown")
+HASH_ANNOTATION=""
+[[ -n "$ENTRY_HASH" ]] && HASH_ANNOTATION=" hash=${ENTRY_HASH}"
+SESSION_ANNOTATION=""
+[[ -n "$SESSION_ID" ]] && SESSION_ANNOTATION=" session=${SESSION_ID}"
+
+_format_entries() {
+  local annotation="<!-- auto-append: date=${TODAY}${HASH_ANNOTATION}${SESSION_ANNOTATION} -->"
+  echo "$annotation"
+  for entry in "${ENTRIES[@]}"; do
+    printf -- '- [auto] %s\n' "$entry"
+  done
+}
+
+FORMATTED="$(_format_entries)"
+
+if [[ "$DRY_RUN" == true ]]; then
+  mkdir -p "$SUPERVISOR_DIR"
+  {
+    printf '--- a/pitfalls-catalog.md\n'
+    printf '+++ b/pitfalls-catalog.md (pending)\n'
+    printf '@@ pending auto-append @@\n'
+    while IFS= read -r line; do
+      printf '+%s\n' "$line"
+    done <<< "$FORMATTED"
+  } > "$PENDING_DIFF"
+  printf '[pitfall-append] dry-run: diff written to %s\n' "$PENDING_DIFF"
+  exit 0
+fi
+
+# Check line count; archive if needed before appending
+CURRENT_LINES=$(wc -l < "$CATALOG_PATH")
+NEW_LINES_COUNT=$(printf '%s\n' "$FORMATTED" | wc -l)
+PROJECTED=$((CURRENT_LINES + NEW_LINES_COUNT))
+
+if [[ $PROJECTED -gt $MAX_LINES ]]; then
+  # Move content from line 10 to line $((MAX_LINES / 2)) into archive to free space
+  ARCHIVE_END=$((MAX_LINES / 2))
+  ARCHIVE_CONTENT=$(sed -n "10,${ARCHIVE_END}p" "$CATALOG_PATH")
+  TMP_CAT=$(mktemp)
+  {
+    head -n 9 "$CATALOG_PATH"
+    tail -n "+$((ARCHIVE_END + 1))" "$CATALOG_PATH"
+  } > "$TMP_CAT"
+  mv "$TMP_CAT" "$CATALOG_PATH"
+  {
+    [[ -f "$ARCHIVE_PATH" ]] && cat "$ARCHIVE_PATH"
+    echo ""
+    printf '## Archived %s\n' "$TODAY"
+    printf '%s\n' "$ARCHIVE_CONTENT"
+  } > "${ARCHIVE_PATH}.tmp"
+  mv "${ARCHIVE_PATH}.tmp" "$ARCHIVE_PATH"
+  echo "[pitfall-append] Archived old entries to $(basename "$ARCHIVE_PATH")"
+fi
+
+# Append entries at end of catalog
+printf '\n%s\n' "$FORMATTED" >> "$CATALOG_PATH"
+printf '[pitfall-append] Appended %d entries to catalog.\n' "${#ENTRIES[@]}"

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -204,6 +204,31 @@ rm -f .supervisor/events/* 2>/dev/null || true
 - 古いエントリで陳腐化したものは削除せず「解決済（<commit hash>）」と注記して残す（履歴保持）
 - 追加は最大 200 行。超過したら古いエントリを別 `refs/pitfalls-archive.md` へ移動
 
+### 自動追記形式（session-end-pitfall-append.sh）
+
+`scripts/hooks/session-end-pitfall-append.sh` が session 終了時に、observer が doobidoo `observer-pitfall` タグで保存した新規エントリをカタログ末尾に自動追記する。
+
+**呼び出し例（observer が doobidoo search 結果を pipe）:**
+
+```bash
+# observer が doobidoo 検索し content を 1 行ずつ pipe する
+echo "pitfall description" | \
+  scripts/hooks/session-end-pitfall-append.sh --hash <doobidoo_hash> --session <session_id>
+
+# dry-run: diff のみ生成（カタログ未更新）
+echo "pitfall description" | \
+  scripts/hooks/session-end-pitfall-append.sh --dry-run
+```
+
+**自動追記エントリ形式:**
+
+```markdown
+<!-- auto-append: date=<YYYY-MM-DD> hash=<doobidoo_hash> session=<session_id> -->
+- [auto] <pitfall content>
+```
+
+commit は行わず `.supervisor/pending-pitfall-append.diff` として保存。observer が diff を確認して手動 commit/discard を判断する（SU-3 遵守）。
+
 ---
 
 ## 10. spawn prompt 最小化原則（MUST NOT / MUST）

--- a/plugins/twl/tests/bats/scripts/session-end-pitfall-append.bats
+++ b/plugins/twl/tests/bats/scripts/session-end-pitfall-append.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+# session-end-pitfall-append.bats
+
+load '../helpers/common'
+
+SCRIPT=""
+
+setup() {
+  common_setup
+  SCRIPT="$REPO_ROOT/scripts/hooks/session-end-pitfall-append.sh"
+
+  # Minimal catalog fixture with §9 section
+  CATALOG="$SANDBOX/pitfalls-catalog.md"
+  cat > "$CATALOG" <<'EOF'
+# Observer Pitfalls Catalog
+
+## 1. Example section
+
+| # | Pitfall | 対策 |
+|---|---------|------|
+| 1.1 | example pitfall | example fix |
+
+---
+
+## 9. 追記ルール
+
+- 追加は最大 200 行。超過したら ancient entries を archive へ移動
+
+---
+
+## 10. Other section
+
+content here
+EOF
+
+  SUPERVISOR_DIR="$SANDBOX/.supervisor"
+  mkdir -p "$SUPERVISOR_DIR"
+
+  # Stub git to prevent real repo detection
+  stub_command "git" 'echo ""'
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# dry-run: diff generation
+# ---------------------------------------------------------------------------
+
+@test "dry-run generates pending-pitfall-append.diff" {
+  run bash "$SCRIPT" \
+    --dry-run \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "New pitfall found in session"
+
+  assert_success
+  assert_output --partial "dry-run"
+  assert_output --partial "pending-pitfall-append.diff"
+
+  [ -f "$SUPERVISOR_DIR/pending-pitfall-append.diff" ]
+}
+
+@test "dry-run diff contains the entry content" {
+  run bash "$SCRIPT" \
+    --dry-run \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "Observer missed the inject timing"
+
+  assert_success
+  [ -f "$SUPERVISOR_DIR/pending-pitfall-append.diff" ]
+
+  DIFF_CONTENT=$(cat "$SUPERVISOR_DIR/pending-pitfall-append.diff")
+  echo "$DIFF_CONTENT" | grep -q "Observer missed the inject timing"
+}
+
+@test "dry-run does not modify catalog" {
+  BEFORE=$(cat "$CATALOG")
+
+  run bash "$SCRIPT" \
+    --dry-run \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "Some new pitfall"
+
+  assert_success
+  AFTER=$(cat "$CATALOG")
+  [ "$BEFORE" = "$AFTER" ]
+}
+
+@test "dry-run diff includes auto-append marker" {
+  run bash "$SCRIPT" \
+    --dry-run \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "session-end timing pitfall"
+
+  assert_success
+  [ -f "$SUPERVISOR_DIR/pending-pitfall-append.diff" ]
+  grep -q "auto-append" "$SUPERVISOR_DIR/pending-pitfall-append.diff"
+}
+
+# ---------------------------------------------------------------------------
+# normal mode: catalog append
+# ---------------------------------------------------------------------------
+
+@test "normal mode appends entry to catalog" {
+  run bash "$SCRIPT" \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "New pitfall from session"
+
+  assert_success
+  assert_output --partial "Appended 1 entries"
+  grep -q "\[auto\] New pitfall from session" "$CATALOG"
+}
+
+@test "normal mode appends multiple entries" {
+  run bash "$SCRIPT" \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "First pitfall" "Second pitfall"
+
+  assert_success
+  grep -q "\[auto\] First pitfall" "$CATALOG"
+  grep -q "\[auto\] Second pitfall" "$CATALOG"
+}
+
+@test "normal mode with --hash annotates the entry" {
+  run bash "$SCRIPT" \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    --hash "abc1234f" \
+    -- "Hash annotated pitfall"
+
+  assert_success
+  grep -q "hash=abc1234f" "$CATALOG"
+}
+
+@test "normal mode with --session annotates the entry" {
+  run bash "$SCRIPT" \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    --session "sess-xyz" \
+    -- "Session annotated pitfall"
+
+  assert_success
+  grep -q "session=sess-xyz" "$CATALOG"
+}
+
+# ---------------------------------------------------------------------------
+# stdin input
+# ---------------------------------------------------------------------------
+
+@test "reads entries from stdin when no positional args" {
+  run bash -c "echo 'Stdin pitfall entry' | bash '$SCRIPT' --catalog '$CATALOG' --supervisor-dir '$SUPERVISOR_DIR'"
+
+  assert_success
+  grep -q "\[auto\] Stdin pitfall entry" "$CATALOG"
+}
+
+@test "dry-run reads entries from stdin" {
+  run bash -c "echo 'Stdin dry-run entry' | bash '$SCRIPT' --dry-run --catalog '$CATALOG' --supervisor-dir '$SUPERVISOR_DIR'"
+
+  assert_success
+  [ -f "$SUPERVISOR_DIR/pending-pitfall-append.diff" ]
+  grep -q "Stdin dry-run entry" "$SUPERVISOR_DIR/pending-pitfall-append.diff"
+}
+
+# ---------------------------------------------------------------------------
+# edge cases
+# ---------------------------------------------------------------------------
+
+@test "empty input exits cleanly with no error" {
+  run bash -c "echo -n | bash '$SCRIPT' --catalog '$CATALOG' --supervisor-dir '$SUPERVISOR_DIR'"
+
+  assert_success
+  assert_output --partial "No entries"
+}
+
+@test "missing catalog exits with error" {
+  run bash "$SCRIPT" \
+    --catalog "$SANDBOX/nonexistent.md" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "entry"
+
+  assert_failure
+  assert_output --partial "error"
+}
+
+# ---------------------------------------------------------------------------
+# 200-line limit: archive trigger
+# ---------------------------------------------------------------------------
+
+@test "exceeding 200 lines triggers archive" {
+  # Generate a 210-line catalog
+  {
+    echo "# Catalog"
+    echo ""
+    for i in $(seq 1 205); do
+      echo "- line $i"
+    done
+  } > "$CATALOG"
+
+  ARCHIVE="$(dirname "$CATALOG")/pitfalls-archive.md"
+  [ ! -f "$ARCHIVE" ]
+
+  run bash "$SCRIPT" \
+    --catalog "$CATALOG" \
+    --supervisor-dir "$SUPERVISOR_DIR" \
+    -- "Overflow pitfall entry"
+
+  assert_success
+  [ -f "$ARCHIVE" ] || assert_output --partial "Archived"
+}


### PR DESCRIPTION
feat(#831): add session-end-pitfall-append.sh + bats tests + §9 template

- New script: plugins/twl/scripts/hooks/session-end-pitfall-append.sh
  - Appends observer-pitfall entries to pitfalls-catalog.md at session end
  - --dry-run generates .supervisor/pending-pitfall-append.diff (no catalog write)
  - --hash / --session flags for doobidoo hash annotation
  - 200-line limit: archives old entries to pitfalls-archive.md
  - Accepts entries via stdin or positional args after '--'
- New bats tests: 13 tests, all PASS
- Updated pitfalls-catalog.md §9: added auto-append template and usage example

Closes #831