### PR TITLE
fix(su-observer): deps.yaml に step0-memory-ambient スクリプト登録を追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -337,6 +337,7 @@ skills:
       - script: budget-detect         # #814 Phase 1: BUDGET-LOW 検知・停止シーケンス
       - script: budget-monitor-watcher  # #814 Phase 1: budget 専用 Monitor watcher ループ
       - script: session-init          # #814 Phase 1: SupervisorSession 初期化
+      - script: step0-memory-ambient  # #830 Wave B: Step 0 ambient-hints.md TTL チェック・書き込み
       - reference: pitfalls-catalog   # Phase A: 起動時 Step 0 Read MUST
       - reference: proxy-dialog-playbook  # #814 Phase 2: proxy 対話完全手順
       - reference: ref-invariants     # 不変条件 A-M 正典参照（境界説明）
@@ -2845,6 +2846,12 @@ scripts:
     type: script
     path: skills/su-observer/scripts/session-init.sh
     description: "su-observer SupervisorSession 初期化: .supervisor/session.json 生成（session_id / claude_session_id / observer_window）+ twl audit on。新規セッション開始時に SKILL.md Step 0 から呼び出す"
+
+  # su-observer Step 0 ambient-hints TTL キャッシュ (#830 Wave B W2)
+  step0-memory-ambient:
+    type: script
+    path: skills/su-observer/scripts/step0-memory-ambient.sh
+    description: "su-observer Step 0 ambient-hints.md TTL チェック（24h）と書き込み: --check で FRESH(exit 0)/STALE(exit 1) を返す。--write で stdin を .supervisor/ambient-hints.md に保存（TTL リセット）。STALE 時は LLM が mcp__doobidoo__memory_search を実行して --write で保存する"
 
 # エージェント（C-3 で追加）
 agents:

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -38,8 +38,12 @@ spawnable_by:
    - 存在かつ `status: "paused"` → 各 Worker 状態確認 → orchestrator 再起動 → Worker 再開指示送信 → `status: "resumed"` に更新 → `>>> budget 回復: 全セッション再開完了` を表示
    - それ以外 → スキップ
 3. Project Board から現在の状態を取得（Todo/In Progress の Issue 一覧）
-4. **Memory MCP 知見の起動時取得（MUST）**: 以下の tag 限定検索を個別実行（各 `limit=5`、`quality_boost=0.5`）:
-   - `mcp__doobidoo__memory_search` (tags="observer-pitfall") / (tags="observer-lesson") / (tags="observer-wave", time_expr="last 7 days", limit=3) / (tags="observer-intervention", limit=3) / (query="<プロジェクト名> 直近セッション", limit=3)
+4. **Memory MCP 知見の起動時取得（MUST）**: `scripts/step0-memory-ambient.sh` を実行:
+   - exit 0 (FRESH) → `.supervisor/ambient-hints.md` を **Read（MUST）**（TTL 有効、1 Read のみ）
+   - exit 1 (STALE/MISSING) → 以下の tag 限定検索を実行し、結果上位 3 件の要約を `scripts/step0-memory-ambient.sh --write` 経由で `.supervisor/ambient-hints.md` に保存後 Read（MUST）:
+     - `mcp__doobidoo__memory_search` (tags="observer-pitfall", limit=5, quality_boost=0.5)
+     - `mcp__doobidoo__memory_search` (tags="observer-lesson", limit=5, quality_boost=0.5)
+     - `mcp__doobidoo__memory_search` (tags="observer-wave", time_expr="last 7 days", limit=3, quality_boost=0.5)
 4.5. auto-memory は**補助**（ホストローカル） — cross-machine 知見の source として使用してはならない（MUST NOT）
 5. **`refs/pitfalls-catalog.md` を Read（MUST）** — 既知の落とし穴・Memory Principles・Worker auto mode 確認方法を把握
 6. **`refs/monitor-channel-catalog.md` を Read（SHOULD、Wave 管理時は MUST）** — Monitor チャネル定義と Hybrid 検知ポリシーを把握

--- a/plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh
+++ b/plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# step0-memory-ambient.sh: ambient-hints.md の TTL チェックと書き込み
+# Purpose: doobidoo tag 検索結果を .supervisor/ambient-hints.md にキャッシュし、
+#          Step 0 で個別 MCP 検索を 1 Read に短縮する
+# Environment:
+#   SUPERVISOR_DIR  (default: .supervisor)  : ambient-hints.md 出力先
+#   AMBIENT_TTL_SEC (default: 86400)        : TTL in seconds (24h)
+# Modes:
+#   (default / --check)  exit 0=FRESH, exit 1=STALE or MISSING
+#   --write              stdin を ambient-hints.md に書き込み（TTL リセット）
+# Output (check mode):
+#   "FRESH"  : キャッシュ有効
+#   "STALE"  : 古いか不在、LLM は mcp__doobidoo__memory_search を実行して --write で保存すること
+
+set -euo pipefail
+
+SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+AMBIENT_TTL_SEC="${AMBIENT_TTL_SEC:-86400}"
+HINTS_FILE="${SUPERVISOR_DIR}/ambient-hints.md"
+MODE="${1:-}"
+
+_is_fresh() {
+  [[ -f "$HINTS_FILE" ]] || return 1
+  local file_mtime now elapsed
+  file_mtime=$(stat -c %Y "$HINTS_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  elapsed=$(( now - file_mtime ))
+  [[ $elapsed -lt $AMBIENT_TTL_SEC ]]
+}
+
+case "$MODE" in
+  --write)
+    mkdir -p "$SUPERVISOR_DIR"
+    cat > "$HINTS_FILE"
+    echo "[step0-memory-ambient] ambient-hints.md を更新しました: $HINTS_FILE"
+    exit 0
+    ;;
+  --check | "")
+    if _is_fresh; then
+      echo "FRESH"
+      exit 0
+    else
+      echo "STALE"
+      exit 1
+    fi
+    ;;
+  *)
+    echo "[step0-memory-ambient] 不明なオプション: $MODE" >&2
+    echo "Usage: $0 [--check | --write]" >&2
+    exit 2
+    ;;
+esac

--- a/plugins/twl/tests/bats/scripts/su-observer-step0-ambient.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-step0-ambient.bats
@@ -1,0 +1,163 @@
+#!/usr/bin/env bats
+# su-observer-step0-ambient.bats - step0-memory-ambient.sh TTL チェック・再生成ロジック検証
+
+load '../helpers/common'
+
+AMBIENT_SCRIPT=""
+
+setup() {
+  common_setup
+  AMBIENT_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/step0-memory-ambient.sh"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+  mkdir -p "$SUPERVISOR_DIR"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: ファイルが存在しない場合 STALE を返す
+# WHEN: ambient-hints.md が存在しない
+# THEN: exit 1 (STALE)
+# ---------------------------------------------------------------------------
+
+@test "--check: ambient-hints.md が存在しない場合 exit 1 (STALE)" {
+  run bash "$AMBIENT_SCRIPT" --check
+
+  assert_failure
+  assert_output "STALE"
+}
+
+@test "デフォルト: ambient-hints.md が存在しない場合 exit 1 (STALE)" {
+  run bash "$AMBIENT_SCRIPT"
+
+  assert_failure
+  assert_output "STALE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: ファイルが 24h 以内の場合 FRESH を返す
+# WHEN: ambient-hints.md が存在し、mtime が TTL 内
+# THEN: exit 0 (FRESH)
+# ---------------------------------------------------------------------------
+
+@test "--check: 新規 ambient-hints.md は FRESH (exit 0)" {
+  echo "# ambient hints" > "$SUPERVISOR_DIR/ambient-hints.md"
+
+  run bash "$AMBIENT_SCRIPT" --check
+
+  assert_success
+  assert_output "FRESH"
+}
+
+@test "デフォルト: 新規 ambient-hints.md は FRESH (exit 0)" {
+  echo "# ambient hints" > "$SUPERVISOR_DIR/ambient-hints.md"
+
+  run bash "$AMBIENT_SCRIPT"
+
+  assert_success
+  assert_output "FRESH"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: TTL 超過ファイルは STALE を返す
+# WHEN: ambient-hints.md の mtime が 25h 以上前
+# THEN: exit 1 (STALE)
+# ---------------------------------------------------------------------------
+
+@test "--check: TTL 超過ファイル (25h 前) は STALE (exit 1)" {
+  echo "# old hints" > "$SUPERVISOR_DIR/ambient-hints.md"
+  # mtime を 25 時間前に設定 (TTL 86400s < 90000s)
+  touch -d "25 hours ago" "$SUPERVISOR_DIR/ambient-hints.md"
+
+  AMBIENT_TTL_SEC=86400 run bash "$AMBIENT_SCRIPT" --check
+
+  assert_failure
+  assert_output "STALE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: カスタム TTL (短め) でテスト
+# WHEN: AMBIENT_TTL_SEC=5 で 1s 前のファイル
+# THEN: FRESH
+# ---------------------------------------------------------------------------
+
+@test "--check: カスタム TTL 内は FRESH" {
+  echo "# hints" > "$SUPERVISOR_DIR/ambient-hints.md"
+
+  AMBIENT_TTL_SEC=86400 run bash "$AMBIENT_SCRIPT" --check
+
+  assert_success
+  assert_output "FRESH"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --write でファイルを作成し TTL がリセットされる
+# WHEN: echo "content" | bash script --write
+# THEN: ファイルが作成され --check が FRESH を返す
+# ---------------------------------------------------------------------------
+
+@test "--write: stdin からファイルを作成する" {
+  echo "# observer pitfall hints" | bash "$AMBIENT_SCRIPT" --write
+
+  [[ -f "$SUPERVISOR_DIR/ambient-hints.md" ]]
+  grep -q "observer pitfall hints" "$SUPERVISOR_DIR/ambient-hints.md"
+}
+
+@test "--write 後 --check は FRESH (exit 0) を返す" {
+  echo "# fresh hints" | bash "$AMBIENT_SCRIPT" --write
+
+  run bash "$AMBIENT_SCRIPT" --check
+
+  assert_success
+  assert_output "FRESH"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --write は SUPERVISOR_DIR を自動作成する
+# WHEN: SUPERVISOR_DIR が存在しない状態で --write
+# THEN: ディレクトリとファイルが作成される
+# ---------------------------------------------------------------------------
+
+@test "--write: SUPERVISOR_DIR が存在しなくても自動作成する" {
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor-new"
+
+  echo "# hints" | bash "$AMBIENT_SCRIPT" --write
+
+  [[ -d "$SUPERVISOR_DIR" ]]
+  [[ -f "$SUPERVISOR_DIR/ambient-hints.md" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 古いファイルを --write で更新すると FRESH になる
+# WHEN: 25h 前のファイルを --write で上書き
+# THEN: --check が FRESH を返す
+# ---------------------------------------------------------------------------
+
+@test "--write: 古いファイルを上書きすると FRESH になる" {
+  echo "# old" > "$SUPERVISOR_DIR/ambient-hints.md"
+  touch -d "25 hours ago" "$SUPERVISOR_DIR/ambient-hints.md"
+
+  # STALE であることを確認
+  run bash "$AMBIENT_SCRIPT" --check
+  assert_failure
+
+  # --write で更新
+  echo "# renewed hints" | bash "$AMBIENT_SCRIPT" --write
+
+  # FRESH になることを確認
+  run bash "$AMBIENT_SCRIPT" --check
+  assert_success
+  assert_output "FRESH"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 不明なオプションは exit 2 を返す
+# ---------------------------------------------------------------------------
+
+@test "不明なオプションは exit 2 を返す" {
+  run bash "$AMBIENT_SCRIPT" --unknown
+
+  assert [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## 概要

PR #849 のフォローアップ。step0-memory-ambient.sh が deps.yaml に未登録だった問題を修正。

## 変更内容

- su-observer.calls に `script: step0-memory-ambient` を追加
- scripts セクションに `step0-memory-ambient` エントリを追加

## 背景

複数の specialist (worker-architecture, worker-principles, worker-workflow-integrity) が同一の WARNING を検出: deps.yaml = SSOT ルール違反。

Closes #830