### PR TITLE
fix(co-issue): Phase4終了時にspec-review session fileをcleanup (#832)

### DIFF
--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -311,13 +311,25 @@ Step 4a で `fallback_inject_exhausted` に分類された issue が存在する
 
 ## 終了時クリーンアップ（Phase 4 完了後）
 
-co-issue 終了時に Phase 3 gate state ファイルをクリーンアップする:
+co-issue 終了時（正常終了・エラー終了のいずれでも）に以下の一時ファイルをクリーンアップする:
 
 ```bash
+# Phase 3 gate state file（hash 基準: CLAUDE_SESSION_ID）
 SESSION_ID_CKSUM=$(printf '%s' "${CLAUDE_SESSION_ID:-${SESSION_ID:-unknown}}" | cksum | awk '{print $1}')
 GATE_FILE="/tmp/.co-issue-phase3-gate-${SESSION_ID_CKSUM}.json"
 rm -f "$GATE_FILE"
+
+# spec-review session state file（hash 基準: CLAUDE_PROJECT_ROOT — spec-review-session-init.sh と同一）
+SPEC_REVIEW_HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+SPEC_REVIEW_STATE_FILE="/tmp/.spec-review-session-${SPEC_REVIEW_HASH}.json"
+rm -f "$SPEC_REVIEW_STATE_FILE"
 ```
+
+**hash 算出基準の注記**: 2 つのファイルは異なる hash 基準を使用する。
+- Phase 3 gate: `CLAUDE_SESSION_ID` ベース（co-issue セッション固有）
+- spec-review session: `CLAUDE_PROJECT_ROOT` ベース（spec-review-session-init.sh L26 と同一）
+
+この非対称は既存設計上の都合による。統一方針は #834 (deps.yaml 関係定義) で整理予定。
 
 ## 禁止事項（MUST NOT）
 

--- a/plugins/twl/tests/bats/scripts/spec-review-session-init.bats
+++ b/plugins/twl/tests/bats/scripts/spec-review-session-init.bats
@@ -138,3 +138,39 @@ teardown() {
   total=$(jq -r '.total' "$EXPECTED_STATE_FILE")
   [ "$total" = "4" ]
 }
+
+# ---------------------------------------------------------------------------
+# Cleanup: co-issue 終了時クリーンアップ（AC #832 §1）
+# WHEN spec-review session state ファイルが存在する状態でクリーンアップ snippet を実行する
+# THEN state ファイルが削除される
+# ---------------------------------------------------------------------------
+@test "cleanup: spec-review session state ファイルが削除される" {
+  # 初期化してファイルを作成
+  run bash "$SCRIPT_SRC" 1
+  [ "$status" -eq 0 ]
+  [ -f "$EXPECTED_STATE_FILE" ]
+
+  # co-issue SKILL.md の cleanup snippet と同等の処理
+  SPEC_REVIEW_HASH=$(printf '%s' "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk '{print $1}')
+  SPEC_REVIEW_STATE_FILE="/tmp/.spec-review-session-${SPEC_REVIEW_HASH}.json"
+  rm -f "$SPEC_REVIEW_STATE_FILE"
+
+  [ ! -f "$EXPECTED_STATE_FILE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Cleanup: ファイルが存在しない場合も cleanup が冪等である
+# WHEN spec-review session state ファイルが存在しない状態でクリーンアップ snippet を実行する
+# THEN エラーなく終了する
+# ---------------------------------------------------------------------------
+@test "cleanup: state ファイルが存在しなくても冪等に終了する" {
+  [ ! -f "$EXPECTED_STATE_FILE" ]
+
+  # rm -f は対象ファイルが存在しなくても exit 0
+  run bash -c '
+    SPEC_REVIEW_HASH=$(printf "%s" "${CLAUDE_PROJECT_ROOT:-$PWD}" | cksum | awk "{print \$1}")
+    SPEC_REVIEW_STATE_FILE="/tmp/.spec-review-session-${SPEC_REVIEW_HASH}.json"
+    rm -f "$SPEC_REVIEW_STATE_FILE"
+  '
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
fix(co-issue): Phase4終了時にspec-review session fileをcleanup (#832)

- 終了時クリーンアップにspec-review-session-init.shと同じhash基準で
  /tmp/.spec-review-session-<hash>.jsonのrm -fを追加
- hash算出基準の非対称（CLAUDE_SESSION_ID vs CLAUDE_PROJECT_ROOT）を
  注記として明記。統一方針は#834で整理予定
- batsテストでcleanup動作（正常・冪等）を確認

Fixes #832