### PR TITLE
docs: document autopilot-launch.sh vs spawn-controller.sh co-autopilot startup path differences

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2127,6 +2127,9 @@ commands:
       - script: session-create
     description: "セッション初期化（autopilot-init.sh + session-create.sh ラッパー）"
 
+  # [起動経路 A] autopilot-launch: Pilot が Issue 単位で Worker を起動する経路。
+  # window 名 ap-<N>、issue-<N>.json 生成、/twl:workflow-setup #N を inject して chain を回転させる。
+  # spawn-controller.sh co-autopilot（起動経路 B）とは役割が異なる（#836）。
   autopilot-launch:
     type: atomic
     refined_by: "ref-prompt-guide@2c7a62f2"
@@ -2845,6 +2848,9 @@ scripts:
     description: "phase-review 必須チェック（merge-gate）: phase-review 不在時は REJECT。scope/direct / quick ラベルはスキップ"
 
   # su-observer controller spawn wrapper (Phase A 2026-04-21)
+  # [起動経路 B] spawn-controller.sh co-autopilot: su-observer が Pilot セッション全体を spawn する経路。
+  # window 名 wt-co-autopilot-<HHMMSS>、issue-<N>.json は Pilot が生成（未生成のままでは chain 不回転）。
+  # Issue 単位 Worker 起動（起動経路 A）と混同禁止（#836、pitfalls-catalog §13 参照）。
   spawn-controller:
     type: script
     path: skills/su-observer/scripts/spawn-controller.sh

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -93,6 +93,20 @@ su-observer が `supervise` モードで起動すると、co-autopilot の tmux 
 
 co-autopilot は su-observer の存在を前提とせず動作する。su-observer との連携は state ファイル（`$AUTOPILOT_DIR/session.json`, `issue-{N}.json`）と tmux window 名を通じて疎結合に行われる。
 
+### 起動経路比較（#836 文書化）
+
+co-autopilot 起動には 2 経路が存在する。混同すると chain が不回転になる（`pitfalls-catalog §13` 参照）。
+
+| 項目 | 経路 A: `autopilot-launch.sh`（Worker 起動） | 経路 B: `spawn-controller.sh co-autopilot`（Pilot spawn） |
+|------|---------------------------------------------|----------------------------------------------------------|
+| **呼び出し元** | co-autopilot Pilot（`autopilot-launch.md`） | su-observer |
+| **window 名** | `ap-<N>`（Issue 番号ベース） | `wt-co-autopilot-<HHMMSS>` |
+| **state file** | `issue-<N>.json` 生成（`--init`） | Pilot が内部で生成（経路 A を経由） |
+| **起動対象** | Worker セッション（Issue 1 件） | Pilot セッション全体（co-autopilot SKILL） |
+| **chain** | 回転（`/twl:workflow-setup #N` を inject） | co-autopilot Step 1-5 が回転 |
+| **使用場面** | Issue 単位 Worker 起動（co-autopilot 内部） | observer から Issue 群を一括実装する場合 |
+| **注意** | 直接呼び出し禁止（co-autopilot 内部専用） | state file は Pilot 経由（経路 A）で生成される |
+
 ### Worker auto mode 確認方針（observer 観察用 — Issue #800）
 
 Pilot が `autopilot-launch.sh` で起動する Worker は `--permission-mode auto` 付きで cld 経由起動される。Worker pane tail に `⏵⏵ auto mode on` が出ない場合でも auto mode は有効である（positional prompt 即送信で status bar が上書きされる仕様。Issue #800 explore で全起動経路を検証済み）。observer / Pilot は以下の手順で間接的に確認する。

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -116,6 +116,12 @@ scripts/spawn-controller.sh <skill> <prompt-file> [cld-spawn opts...]
 - テスト実行 → `spawn-controller.sh co-self-improve <prompt>` → `cld-observe`（単発）
 - その他 → `spawn-controller.sh co-utility <prompt>` → 指示待ち
 
+**co-autopilot 起動時の推奨経路（#836 — MUST）:**
+`spawn-controller.sh co-autopilot` は **Pilot セッション全体**を spawn する（経路 B）。
+Issue 単位の Worker 起動（経路 A: `autopilot-launch.sh`、window `ap-<N>`、`issue-<N>.json` 生成）は
+Pilot が内部で実行する。observer が `autopilot-launch.sh` を直接呼んで Worker を起動してはならない。
+2 経路の詳細は `co-autopilot SKILL.md §Step 3.5 起動経路比較` および `refs/pitfalls-catalog.md §13` を参照。
+
 使用可能な session plugin スクリプト: `cld-observe`, `cld-observe-loop`, `cld-observe-any`, `session-state.sh`（A5 補助のみ、単独使用禁止）, `session-comm.sh`
 
 ### spawn プロンプトの文脈包含

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -366,3 +366,28 @@ gate deny (1 回目) → STOP（即時停止、追加試行禁止）→ AskUserQ
 - memory hash `886e374d`（bypass permission lesson）、`1ca5829f`（Layer D refined-label pitfall）
 - **W5-1（SKILL.md Security gate MUST NOT 節）** と相互参照: gate deny 後の禁止行動を SKILL.md に明記予定
 - Layer 2 Escalate 手順: `plugins/twl/refs/intervention-catalog.md` §3（Escalate パターン）
+
+---
+
+## 13. 起動経路の混同（autopilot-launch.sh vs spawn-controller.sh co-autopilot）（#836 文書化）
+
+2 種類の起動経路が存在するが、混同すると chain 不回転・state file 未生成・window 名誤判定を引き起こす。
+
+| 経路 | window 名 | state file | orchestrator | chain |
+|------|-----------|------------|--------------|-------|
+| **A: `autopilot-launch.sh`** | `ap-<N>` | `issue-<N>.json` 生成 | Pilot が管理 | 回転（`/twl:workflow-setup #N` inject） |
+| **B: `spawn-controller.sh co-autopilot`** | `wt-co-autopilot-<HHMMSS>` | Pilot 経由で生成 | co-autopilot が Pilot として動作 | co-autopilot Step 1-5 が回転 |
+
+| # | Pitfall | 観察パターン（chain 不回転の症状） | 対策 |
+|---|---------|----------------------------------|------|
+| 13.1 | `spawn-controller.sh co-autopilot` で Issue 単位 Worker を直接起動しようとする | window 名が `wt-co-autopilot-*`（`ap-*` でない）、`issue-N.json` が生成されない、Worker が `/twl:workflow-setup` を実行せずに idle | **Issue 単位 Worker 起動は `autopilot-launch.sh` の責務**。observer は `spawn-controller.sh co-autopilot` で Pilot を spawn し、Worker 起動は Pilot に委譲する |
+| 13.2 | Pilot が `autopilot-launch.sh` の代わりに `cld-spawn` を直接呼んで Worker を起動する | Worker の `AUTOPILOT_DIR` / `WORKER_ISSUE_NUM_ENV` が未設定、クラッシュ検知フック非設定、state file missing | `autopilot-launch.sh` 経由必須（環境変数・クラッシュ検知フック・window-manifest を担当） |
+| 13.3 | su-observer が Worker window（`ap-*`）に `spawn-controller.sh` を呼んで Pilot を二重起動する | 同一セッションに `ap-*` と `wt-co-autopilot-*` が混在、Pilot 二重起動 | observer が spawn するのは Pilot（`wt-co-autopilot-*`）のみ。Worker（`ap-*`）への介入は `session-comm.sh inject` 経由 |
+| 13.4 | `spawn-controller.sh co-autopilot` で起動した Pilot が `issue-N.json` を生成しないまま停滞（chain 不回転の典型） | `.autopilot/issues/issue-N.json` が存在しない、tmux window は存在するが `ap-*` window がない | Pilot が Step 3 `autopilot-init` → Step 4 `autopilot-launch.sh` を実行していることを確認する。state file 未生成なら Pilot session の chain ログを確認し、stuck 箇所を特定して inject で再開 |
+
+**正しい経路選択:**
+- observer がユーザー指示で Issue 群を実装させる場合 → `spawn-controller.sh co-autopilot`（経路 B）
+- Pilot が個別 Issue の Worker を起動する場合 → `autopilot-launch.sh`（経路 A、`autopilot-launch.md` 経由）
+- observer が Worker に直接介入する場合 → `session-comm.sh inject`（`spawn-controller.sh` 経由でない）
+
+詳細: `co-autopilot SKILL.md §Step 3.5 起動経路比較`


### PR DESCRIPTION
docs: document autopilot-launch.sh vs spawn-controller.sh co-autopilot startup path differences

- deps.yaml: 両経路にコメント追加（起動経路 A/B の役割差異を明示、#836）
- co-autopilot SKILL.md: Step 3.5 に起動経路比較表を追加
- su-observer SKILL.md: controller spawn セクションに co-autopilot 推奨経路を明記
- pitfalls-catalog.md: §13 に誤経路使用時の観察パターン（chain 不回転の症状）を追記

Closes #836