### PR TITLE
feat(su-observer): spawn-controller.sh に --with-chain オプション追加 (#835)

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2848,7 +2848,7 @@ scripts:
   spawn-controller:
     type: script
     path: skills/su-observer/scripts/spawn-controller.sh
-    description: "su-observer 用 controller 起動 wrapper: /twl:<skill> invocation 自動 prepend + invalid flag (--help 等) ガード + window 名自動一意化。cld-spawn 直接呼び出しを代替し pitfalls-catalog §1 の失敗を防ぐ"
+    description: "su-observer 用 controller 起動 wrapper: /twl:<skill> invocation 自動 prepend + invalid flag (--help 等) ガード + window 名自動一意化。cld-spawn 直接呼び出しを代替し pitfalls-catalog §1 の失敗を防ぐ。co-autopilot + --with-chain --issue N で autopilot-launch.sh に委譲し chain 連携モードで起動（#835）"
 
   # su-observer budget/session scripts (#814 Phase 1 2026-04-22)
   budget-detect:

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -91,6 +91,27 @@ su-observer が `supervise` モードで起動すると、co-autopilot の tmux 
 1. **co-autopilot 単独起動**（後方互換）: ユーザーが直接 `co-autopilot` を起動し、su-observer は別途起動して監視にアタッチする
 2. **su-observer spawn 起動**: su-observer がユーザー指示に基づき co-autopilot セッションを spawn する（ADR-014 Decision 2 の正規フロー）
 
+### spawn-controller.sh 経由 chain 連携起動（`--with-chain`）
+
+su-observer が `spawn-controller.sh` 経由で co-autopilot を起動する場合、2 種類のモードを使い分ける:
+
+| モード | コマンド例 | window 名 | state file | chain |
+|--------|-----------|-----------|------------|-------|
+| **standalone**（デフォルト） | `spawn-controller.sh co-autopilot /tmp/prompt.txt` | `wt-co-autopilot-<HHMMSS>` | 未生成 | 不回転 |
+| **chain 連携**（`--with-chain`） | `spawn-controller.sh co-autopilot /tmp/ctx.txt --with-chain --issue N` | `ap-#N` | `issue-N.json` 生成 | 回転 |
+
+chain 連携モード（`--with-chain`）では `spawn-controller.sh` が `autopilot-launch.sh` に委譲する。`autopilot-launch.sh` が state file 初期化・worktree 作成・orchestrator 起動・crash-detect hook 設定を担う。
+
+```bash
+# chain 連携起動例（su-observer からの典型的な呼び出し）
+spawn-controller.sh co-autopilot /tmp/issue-835-ctx.txt --with-chain --issue 835
+
+# --project-dir / --autopilot-dir は省略時に bare repo 構造から自動解決される
+# 明示指定も可能:
+spawn-controller.sh co-autopilot /tmp/ctx.txt --with-chain --issue 835 \
+  --project-dir /path/to/project --autopilot-dir /path/to/.autopilot
+```
+
 co-autopilot は su-observer の存在を前提とせず動作する。su-observer との連携は state ファイル（`$AUTOPILOT_DIR/session.json`, `issue-{N}.json`）と tmux window 名を通じて疎結合に行われる。
 
 ### Worker auto mode 確認方針（observer 観察用 — Issue #800）

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -3,6 +3,7 @@
 #
 # Usage:
 #   spawn-controller.sh <skill-name> <prompt-file> [cld-spawn extra args...]
+#   spawn-controller.sh co-autopilot <prompt-file> --with-chain --issue N [--project-dir DIR] [--autopilot-dir DIR]
 #
 #   <skill-name>: co-explore / co-issue / co-architect / co-autopilot /
 #                 co-project / co-utility / co-self-improve
@@ -16,6 +17,12 @@
 #      （cld-spawn は *) break で positional 扱いし prompt に混入する）
 #   4. --window-name 未指定時は wt-<skill>-<HHMMSS> を自動設定
 #   5. cld-spawn を exec
+#
+# chain 連携モード（co-autopilot のみ）:
+#   --with-chain  autopilot-launch.sh に委譲し state 初期化 + chain を起動する
+#   --issue N     chain 連携時必須。Issue 番号
+#   --project-dir DIR  省略時は bare repo 親ディレクトリを自動解決
+#   --autopilot-dir DIR  省略時は project-dir から自動解決
 #
 # 背景: 本 wrapper は pitfalls-catalog.md 1.1-1.4 の失敗を防ぐ:
 #   - --help 注入ミス
@@ -41,6 +48,7 @@ VALID_SKILLS=(co-explore co-issue co-architect co-autopilot co-project co-utilit
 usage() {
   cat >&2 <<EOF
 Usage: $(basename "$0") <skill-name> <prompt-file> [cld-spawn extra args...]
+       $(basename "$0") co-autopilot <prompt-file> --with-chain --issue N [--project-dir DIR] [--autopilot-dir DIR]
 
 Valid skills: ${VALID_SKILLS[*]}
 (Accepts with or without "twl:" prefix)
@@ -48,6 +56,7 @@ Valid skills: ${VALID_SKILLS[*]}
 Example:
   $(basename "$0") co-explore /tmp/my-prompt.txt
   $(basename "$0") co-issue /tmp/issue-prompt.txt --timeout 90
+  $(basename "$0") co-autopilot /tmp/ctx.txt --with-chain --issue 835
 EOF
   exit 2
 }
@@ -81,6 +90,62 @@ fi
 if [[ ! -f "$PROMPT_FILE" ]]; then
   echo "Error: prompt file not found: $PROMPT_FILE" >&2
   exit 2
+fi
+
+# --with-chain: co-autopilot chain 連携モード（autopilot-launch.sh に委譲）
+WITH_CHAIN=false
+CHAIN_ISSUE=""
+CHAIN_PROJECT_DIR=""
+CHAIN_AUTOPILOT_DIR=""
+PASS_THROUGH_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-chain)    WITH_CHAIN=true; shift ;;
+    --issue)         CHAIN_ISSUE="$2"; shift 2 ;;
+    --project-dir)   CHAIN_PROJECT_DIR="$2"; shift 2 ;;
+    --autopilot-dir) CHAIN_AUTOPILOT_DIR="$2"; shift 2 ;;
+    *)               PASS_THROUGH_ARGS+=("$1"); shift ;;
+  esac
+done
+set -- "${PASS_THROUGH_ARGS[@]+"${PASS_THROUGH_ARGS[@]}"}"
+
+if [[ "$WITH_CHAIN" == "true" ]]; then
+  if [[ "$SKILL_NORMALIZED" != "co-autopilot" ]]; then
+    echo "Error: --with-chain は co-autopilot のみで有効です。" >&2
+    exit 2
+  fi
+  if [[ -z "$CHAIN_ISSUE" ]]; then
+    echo "Error: --with-chain には --issue N が必須です。" >&2
+    exit 2
+  fi
+
+  # autopilot-launch.sh パス解決（AUTOPILOT_LAUNCH_SH 環境変数でテスト時に上書き可能）
+  AUTOPILOT_LAUNCH_SH="${AUTOPILOT_LAUNCH_SH:-$TWILL_ROOT/plugins/twl/scripts/autopilot-launch.sh}"
+  if [[ ! -x "$AUTOPILOT_LAUNCH_SH" ]]; then
+    echo "Error: autopilot-launch.sh not executable at $AUTOPILOT_LAUNCH_SH" >&2
+    exit 2
+  fi
+
+  # プロジェクト・autopilot ディレクトリ自動解決
+  [[ -z "$CHAIN_PROJECT_DIR" ]] && CHAIN_PROJECT_DIR="$TWILL_ROOT"
+  if [[ -z "$CHAIN_AUTOPILOT_DIR" ]]; then
+    if [[ -d "$CHAIN_PROJECT_DIR/.bare" ]]; then
+      CHAIN_AUTOPILOT_DIR="$CHAIN_PROJECT_DIR/main/.autopilot"
+    else
+      CHAIN_AUTOPILOT_DIR="$CHAIN_PROJECT_DIR/.autopilot"
+    fi
+  fi
+
+  # prompt-file の内容を --context として注入
+  CHAIN_CONTEXT="$(cat "$PROMPT_FILE" 2>/dev/null || true)"
+  CONTEXT_ARG=()
+  [[ -n "$CHAIN_CONTEXT" ]] && CONTEXT_ARG=(--context "$CHAIN_CONTEXT")
+
+  exec bash "$AUTOPILOT_LAUNCH_SH" \
+    --issue "$CHAIN_ISSUE" \
+    --project-dir "$CHAIN_PROJECT_DIR" \
+    --autopilot-dir "$CHAIN_AUTOPILOT_DIR" \
+    "${CONTEXT_ARG[@]+"${CONTEXT_ARG[@]}"}"
 fi
 
 # 残り引数に invalid flag が含まれていないか検査

--- a/plugins/twl/tests/bats/scripts/spawn-controller-with-chain.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller-with-chain.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# spawn-controller-with-chain.bats - --with-chain オプションのユニットテスト
+# Generated from: Issue #835 (spawn-controller.sh 経由 co-autopilot chain 自動開始)
+#
+# Requirements:
+#   - co-autopilot + --with-chain --issue N で autopilot-launch.sh に委譲する
+#   - --with-chain なしは従来の cld-spawn 経由（wt-* window）
+#   - co-autopilot 以外で --with-chain を指定するとエラー
+#   - --with-chain 時に --issue N がなければエラー
+
+load '../helpers/common'
+
+SPAWN_CONTROLLER=""
+AUTOPILOT_LAUNCH_ARGS_LOG=""
+CLD_SPAWN_ARGS_LOG=""
+
+setup() {
+  common_setup
+
+  SPAWN_CONTROLLER="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+  export SPAWN_CONTROLLER
+
+  AUTOPILOT_LAUNCH_ARGS_LOG="$SANDBOX/autopilot-launch-args.log"
+  export AUTOPILOT_LAUNCH_ARGS_LOG
+
+  CLD_SPAWN_ARGS_LOG="$SANDBOX/cld-spawn-args.log"
+  export CLD_SPAWN_ARGS_LOG
+
+  # autopilot-launch.sh mock: 引数を記録して正常終了
+  cat > "$STUB_BIN/autopilot-launch.sh" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "${AUTOPILOT_LAUNCH_ARGS_LOG:-/dev/null}"
+exit 0
+MOCK
+  chmod +x "$STUB_BIN/autopilot-launch.sh"
+
+  # cld-spawn mock: 引数を記録して正常終了
+  cat > "$STUB_BIN/cld-spawn" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "${CLD_SPAWN_ARGS_LOG:-/dev/null}"
+exit 0
+MOCK
+  chmod +x "$STUB_BIN/cld-spawn"
+
+  # spawn-controller.sh wrapper: CLD_SPAWN を mock に差し替えて実行
+  # AUTOPILOT_LAUNCH_SH は呼び出し元が設定している場合はそれを使い、
+  # 未設定の場合のみ stub にフォールバックする
+  cat > "$SANDBOX/run-spawn-controller.sh" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+_DEFAULT_AUTOPILOT_LAUNCH="$STUB_BIN/autopilot-launch.sh"
+TMP_SCRIPT="\$(mktemp)"
+cp "$SPAWN_CONTROLLER" "\$TMP_SCRIPT"
+sed -i "s|CLD_SPAWN=\"\\\$TWILL_ROOT/plugins/session/scripts/cld-spawn\"|CLD_SPAWN=\"$STUB_BIN/cld-spawn\"|g" "\$TMP_SCRIPT"
+chmod +x "\$TMP_SCRIPT"
+_AUTOPILOT_LAUNCH_SH="\${AUTOPILOT_LAUNCH_SH:-\$_DEFAULT_AUTOPILOT_LAUNCH}"
+exec env AUTOPILOT_LAUNCH_SH="\$_AUTOPILOT_LAUNCH_SH" bash "\$TMP_SCRIPT" "\$@"
+WRAPPER
+  chmod +x "$SANDBOX/run-spawn-controller.sh"
+
+  # テスト用 prompt ファイル
+  echo "context: issue #835 chain test" > "$SANDBOX/prompt.txt"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Requirement: --with-chain で autopilot-launch.sh に委譲する
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: co-autopilot + --with-chain --issue N で autopilot-launch.sh が呼ばれる
+# WHEN: spawn-controller.sh co-autopilot <prompt> --with-chain --issue 835 を実行
+# THEN: autopilot-launch.sh が --issue 835 で呼ばれる
+# ---------------------------------------------------------------------------
+
+@test "--with-chain: autopilot-launch.sh が --issue 付きで呼ばれる" {
+  run bash "$SANDBOX/run-spawn-controller.sh" \
+    co-autopilot "$SANDBOX/prompt.txt" --with-chain --issue 835 2>&1
+
+  assert_success
+  [[ -f "$AUTOPILOT_LAUNCH_ARGS_LOG" ]] \
+    || fail "autopilot-launch.sh が呼ばれなかった（ログファイル未生成）"
+  grep -q -- "--issue 835" "$AUTOPILOT_LAUNCH_ARGS_LOG" \
+    || fail "autopilot-launch.sh が --issue 835 で呼ばれなかった: $(cat "$AUTOPILOT_LAUNCH_ARGS_LOG" 2>/dev/null)"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --with-chain 時は cld-spawn が呼ばれない
+# WHEN: spawn-controller.sh co-autopilot <prompt> --with-chain --issue 835 を実行
+# THEN: cld-spawn が呼ばれない（chain 連携モードで bypass）
+# ---------------------------------------------------------------------------
+
+@test "--with-chain: cld-spawn は呼ばれない" {
+  run bash "$SANDBOX/run-spawn-controller.sh" \
+    co-autopilot "$SANDBOX/prompt.txt" --with-chain --issue 835 2>&1
+
+  assert_success
+  [[ ! -f "$CLD_SPAWN_ARGS_LOG" ]] \
+    || fail "chain モードなのに cld-spawn が呼ばれた: $(cat "$CLD_SPAWN_ARGS_LOG" 2>/dev/null)"
+}
+
+# ===========================================================================
+# Requirement: --with-chain のバリデーション
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: co-autopilot 以外で --with-chain はエラー
+# WHEN: spawn-controller.sh co-explore <prompt> --with-chain --issue 835 を実行
+# THEN: exit 2 + "co-autopilot のみ" エラー
+# ---------------------------------------------------------------------------
+
+@test "--with-chain: co-autopilot 以外ではエラー" {
+  run bash "$SANDBOX/run-spawn-controller.sh" \
+    co-explore "$SANDBOX/prompt.txt" --with-chain --issue 835 2>&1
+
+  assert_failure
+  assert_output --partial "co-autopilot のみ"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --with-chain に --issue がなければエラー
+# WHEN: spawn-controller.sh co-autopilot <prompt> --with-chain を実行（--issue 省略）
+# THEN: exit 2 + "--issue N が必須" エラー
+# ---------------------------------------------------------------------------
+
+@test "--with-chain: --issue 省略でエラー" {
+  run bash "$SANDBOX/run-spawn-controller.sh" \
+    co-autopilot "$SANDBOX/prompt.txt" --with-chain 2>&1
+
+  assert_failure
+  assert_output --partial "--issue N が必須"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --with-chain なしは従来の cld-spawn 経由（standalone モード）
+# WHEN: spawn-controller.sh co-autopilot <prompt> を --with-chain なしで実行
+# THEN: cld-spawn が呼ばれ、autopilot-launch.sh は呼ばれない
+# ---------------------------------------------------------------------------
+
+@test "standalone モード: --with-chain なしは cld-spawn 経由" {
+  run bash "$SANDBOX/run-spawn-controller.sh" \
+    co-autopilot "$SANDBOX/prompt.txt" --window-name "test-window" 2>&1
+
+  assert_success
+  [[ -f "$CLD_SPAWN_ARGS_LOG" ]] \
+    || fail "standalone モードで cld-spawn が呼ばれなかった"
+  [[ ! -f "$AUTOPILOT_LAUNCH_ARGS_LOG" ]] \
+    || fail "standalone モードなのに autopilot-launch.sh が呼ばれた"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: --with-chain 時に autopilot-launch.sh が存在しなければエラー
+# WHEN: AUTOPILOT_LAUNCH_SH を存在しないパスに設定して実行
+# THEN: exit 2 + "not executable" エラー
+# ---------------------------------------------------------------------------
+
+@test "--with-chain: autopilot-launch.sh 不在でエラー" {
+  run env AUTOPILOT_LAUNCH_SH="/nonexistent/autopilot-launch.sh" \
+    bash "$SANDBOX/run-spawn-controller.sh" \
+    co-autopilot "$SANDBOX/prompt.txt" --with-chain --issue 835 2>&1
+
+  assert_failure
+  assert_output --partial "not executable"
+}


### PR DESCRIPTION
feat(su-observer): spawn-controller.sh に --with-chain オプション追加 (#835)

spawn-controller.sh 経由の co-autopilot 起動時に autopilot chain を
自動開始する --with-chain オプションを実装する。

- spawn-controller.sh: `--with-chain --issue N` オプション追加
  - co-autopilot のみ有効
  - autopilot-launch.sh に委譲し state 初期化 + chain を起動
  - `--project-dir` / `--autopilot-dir` は bare repo 構造から自動解決
  - `AUTOPILOT_LAUNCH_SH` 環境変数でテスト時にパスを上書き可能
- co-autopilot SKILL.md: chain 連携起動セクション追加（比較表付き）
- deps.yaml: spawn-controller の description を更新
- 新規 bats テスト: spawn-controller-with-chain.bats (6 ケース)

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #835