### PR TITLE
feat: observation-pattern-catalogにclassifier bypass context累積観察ルール追加 (#840)

### DIFF
--- a/plugins/twl/refs/observation-pattern-catalog.md
+++ b/plugins/twl/refs/observation-pattern-catalog.md
@@ -214,6 +214,17 @@ hist-inject-wait-timeout:
   detection_condition: "cld-spawn 直後 (~60s 以内) に inject-file --wait を実行した場合"
   action: "待機時間を 120s 以上に設定するか、cld-spawn 後 90s 待ってから inject を試みる"
   memory_hash: "15ab26c5"
+
+hist-classifier-bypass-context:
+  regex: 'bypass.*intent|classifier.*bypass|deny.*bypass|Layer D.*deny'
+  severity: warning
+  category: classifier-bypass-context
+  description: "[BYPASS-CONTEXT] Classifier の bypass 意図検出はセッション内 action history で累積判定される。類似操作の deny 後にアプローチを変えた再試行も deny される（実測: 6 連続拒否、2026-04-21）。W5-1 (Security gate MUST NOT), W5-2 (2-deny STOP rule) と三位一体。observer は deny を「意図の二次検証」として受容し即 STOP すること"
+  observation_signal: "同一セッション内で類似操作が複数回 deny され、trick を変えても deny が継続する（gh issue edit → deny、spec-review-session-init + gh issue edit → deny、計 6 連続拒否）"
+  detection_condition: "bypass 意図を持つ操作（label 追加・settings.json 変更提案等）が deny され、直後に手法を変えた類似操作も deny された場合。deny 回数に関係なく累積検出される"
+  action: "deny を受容し即 STOP。W5-2 (2-deny STOP rule) に従い 2 回目 deny の時点で作業停止しユーザーに報告。bypass 試行を重ねるほど検出感度が上がるため早期停止が最善策"
+  related_issue: "840"
+  memory_hash: "886e374d"
 ```
 
 ## 拡張ガイド

--- a/plugins/twl/tests/bats/refs/observation-references.bats
+++ b/plugins/twl/tests/bats/refs/observation-references.bats
@@ -296,3 +296,28 @@ setup() {
   grep -q 'expected_conflicts: 0' "$file"
   grep -q 'expected_duration_max: 60' "$file"
 }
+
+# ---------------------------------------------------------------------------
+# Case 7: issue-840 classifier bypass context 累積パターン追加検証
+# ---------------------------------------------------------------------------
+
+@test "observation-pattern-catalog: hist-classifier-bypass-context pattern exists with related_issue 840" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'hist-classifier-bypass-context:' "$file"
+  grep -q 'category: classifier-bypass-context' "$file"
+  grep -q 'related_issue: "840"' "$file"
+}
+
+@test "observation-pattern-catalog: hist-classifier-bypass-context cross-references W5-1 and W5-2" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q 'W5-1' "$file"
+  grep -q 'W5-2' "$file"
+}
+
+@test "observation-pattern-catalog: hist-classifier-bypass-context mentions 6-consecutive-deny example" {
+  local file="$REPO_ROOT/refs/observation-pattern-catalog.md"
+
+  grep -q '6 連続拒否' "$file"
+}


### PR DESCRIPTION
feat: observation-pattern-catalogにclassifier bypass context累積観察ルール追加 (#840)

- hist-classifier-bypass-contextパターンを追加
  - 同一セッション内の累積判定による bypass 意図検出
  - 実測データ: 6連続拒否（2026-04-21）
  - W5-1 (Security gate MUST NOT), W5-2 (2-deny STOP rule) と相互参照
- bats テスト3件追加 (Case 7: issue-840)
  - related_issue: 840 の存在確認
  - W5-1/W5-2 クロスリファレンス検証
  - 6連続拒否事例の記述確認
- 全30テスト PASS

Closes #840