### PR TITLE
test(su-observer): spawn-controller.sh の bats テスト 4+ ケース追加 (#841)

### DIFF
--- a/plugins/twl/tests/bats/scripts/spawn-controller.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller.bats
@@ -1,0 +1,252 @@
+#!/usr/bin/env bats
+# spawn-controller.bats - spawn-controller.sh の動作確認テスト
+# Issue #841: spawn-controller.sh の bats テスト 4+ ケース追加
+#
+# Coverage:
+#   1. /twl:<skill> 自動 prepend
+#   2. --help / -h / --version invalid flag reject
+#   3. window 名 wt-<skill>-<HHMMSS> 自動生成
+#   4. prompt-file が存在しない場合のエラー処理
+#   5. invalid skill 名 reject
+
+load '../helpers/common'
+
+SPAWN_CONTROLLER=""
+CLD_SPAWN_ARGS_LOG=""
+
+setup() {
+  common_setup
+
+  SPAWN_CONTROLLER="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+  export SPAWN_CONTROLLER
+
+  CLD_SPAWN_ARGS_LOG="$SANDBOX/cld-spawn-args.log"
+  export CLD_SPAWN_ARGS_LOG
+
+  cat > "$STUB_BIN/cld-spawn" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "${CLD_SPAWN_ARGS_LOG:-/dev/null}"
+exit 0
+MOCK
+  chmod +x "$STUB_BIN/cld-spawn"
+
+  MOCK_CLD_SPAWN="$STUB_BIN/cld-spawn"
+  export MOCK_CLD_SPAWN
+
+  cat > "$SANDBOX/run-spawn-controller.sh" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+TMP_SCRIPT="\$(mktemp)"
+cp "$SPAWN_CONTROLLER" "\$TMP_SCRIPT"
+sed -i "s|CLD_SPAWN=\"\\\$TWILL_ROOT/plugins/session/scripts/cld-spawn\"|CLD_SPAWN=\"$MOCK_CLD_SPAWN\"|g" "\$TMP_SCRIPT"
+chmod +x "\$TMP_SCRIPT"
+exec bash "\$TMP_SCRIPT" "\$@"
+WRAPPER
+  chmod +x "$SANDBOX/run-spawn-controller.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+make_prompt_file() {
+  local lines="$1"
+  local path="$2"
+  local i
+  for i in $(seq 1 "$lines"); do
+    echo "line $i of the prompt"
+  done > "$path"
+}
+
+# ===========================================================================
+# Requirement 1: /twl:<skill> 自動 prepend
+# ===========================================================================
+
+@test "prepend: skill 名が /twl:co-explore として prompt 先頭に prepend される" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --window-name "test-window"
+
+  assert_success
+  [[ -f "$CLD_SPAWN_ARGS_LOG" ]] || fail "cld-spawn が呼ばれなかった"
+  [[ "$(cat "$CLD_SPAWN_ARGS_LOG")" == *"/twl:co-explore"* ]] \
+    || fail "cld-spawn への引数に /twl:co-explore が含まれない"
+}
+
+@test "prepend: twl: prefix 付き skill 名でも /twl:<skill> として prepend される" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" twl:co-issue "$SANDBOX/prompt.txt" \
+    --window-name "test-window"
+
+  assert_success
+  [[ "$(cat "$CLD_SPAWN_ARGS_LOG")" == *"/twl:co-issue"* ]] \
+    || fail "cld-spawn への引数に /twl:co-issue が含まれない"
+}
+
+@test "prepend: prompt 本文が /twl:<skill> の後ろに続く" {
+  echo "my-unique-prompt-content" > "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --window-name "test-window"
+
+  assert_success
+  local args
+  args="$(cat "$CLD_SPAWN_ARGS_LOG")"
+  [[ "$args" == *"my-unique-prompt-content"* ]] \
+    || fail "cld-spawn への引数に prompt 本文が含まれない: $args"
+}
+
+# ===========================================================================
+# Requirement 2: --help / -h / --version invalid flag reject
+# ===========================================================================
+
+@test "invalid-flag: --help が渡された場合はエラーで終了する" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --help --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"--help"* ]] \
+    || fail "--help エラーメッセージが出ない: $output"
+}
+
+@test "invalid-flag: -h が渡された場合はエラーで終了する" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    -h --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"-h"* ]] \
+    || fail "-h エラーメッセージが出ない: $output"
+}
+
+@test "invalid-flag: --version が渡された場合はエラーで終了する" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --version --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"--version"* ]] \
+    || fail "--version エラーメッセージが出ない: $output"
+}
+
+@test "invalid-flag: エラーメッセージに有効な cld-spawn option のヒントが含まれる" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --help 2>&1
+
+  assert_failure
+  [[ "$output" == *"--window-name"* ]] \
+    || fail "エラーメッセージに有効な option のヒントが含まれない: $output"
+}
+
+# ===========================================================================
+# Requirement 3: window 名 wt-<skill>-<HHMMSS> 自動生成
+# ===========================================================================
+
+@test "window-name: --window-name 未指定時は wt-<skill>-<HHMMSS> 形式で自動設定される" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt"
+
+  assert_success
+  local args
+  args="$(cat "$CLD_SPAWN_ARGS_LOG")"
+  [[ "$args" =~ wt-co-explore-[0-9]{6} ]] \
+    || fail "wt-co-explore-HHMMSS 形式の window 名が含まれない: $args"
+}
+
+@test "window-name: --window-name 明示時は自動生成されない" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-issue "$SANDBOX/prompt.txt" \
+    --window-name "my-custom-window"
+
+  assert_success
+  local args
+  args="$(cat "$CLD_SPAWN_ARGS_LOG")"
+  [[ "$args" == *"my-custom-window"* ]] \
+    || fail "指定した window 名が cld-spawn に渡らない: $args"
+  [[ "$args" != *"wt-co-issue-"* ]] \
+    || fail "明示 window 名があるのに自動生成 window 名も渡された: $args"
+}
+
+@test "window-name: skill 名が window 名に反映される（co-autopilot の場合）" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-autopilot "$SANDBOX/prompt.txt"
+
+  assert_success
+  local args
+  args="$(cat "$CLD_SPAWN_ARGS_LOG")"
+  [[ "$args" =~ wt-co-autopilot-[0-9]{6} ]] \
+    || fail "wt-co-autopilot-HHMMSS 形式の window 名が含まれない: $args"
+}
+
+# ===========================================================================
+# Requirement 4: prompt-file が存在しない場合のエラー処理
+# ===========================================================================
+
+@test "prompt-not-found: 存在しない prompt ファイルはエラーで終了する" {
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore \
+    "$SANDBOX/nonexistent.txt" --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"prompt file not found"* ]] \
+    || fail "存在しない prompt file で適切なエラーが出ない: $output"
+}
+
+@test "prompt-not-found: エラーメッセージにファイルパスが含まれる" {
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore \
+    "$SANDBOX/no-such-file.txt" --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"no-such-file.txt"* ]] \
+    || fail "エラーメッセージに問題ファイルパスが含まれない: $output"
+}
+
+@test "prompt-not-found: exit code が 2 である" {
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore \
+    "$SANDBOX/nonexistent.txt" --window-name "test-window" 2>&1
+
+  [[ "$status" -eq 2 ]] \
+    || fail "exit code が 2 ではない: $status"
+}
+
+# ===========================================================================
+# Requirement 5: invalid skill 名 reject
+# ===========================================================================
+
+@test "skill-validate: 無効な skill 名はエラーで終了する" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" co-invalid "$SANDBOX/prompt.txt" \
+    --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"invalid skill name"* ]] \
+    || fail "無効な skill 名でエラーが出ない: $output"
+}
+
+@test "skill-validate: エラーメッセージに有効な skill リストが含まれる" {
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+
+  run bash "$SANDBOX/run-spawn-controller.sh" unknown-skill "$SANDBOX/prompt.txt" \
+    --window-name "test-window" 2>&1
+
+  assert_failure
+  [[ "$output" == *"co-explore"* ]] \
+    || fail "エラーメッセージに有効な skill リストが含まれない: $output"
+}


### PR DESCRIPTION
test(su-observer): spawn-controller.sh の bats テスト 4+ ケース追加 (#841)

spawn-controller.sh の主要動作を検証する 15 ケースを追加:
- /twl:<skill> 自動 prepend（prefix 正規化含む）
- --help / -h / --version の invalid flag reject
- window 名 wt-<skill>-<HHMMSS> 自動生成と明示指定の相互排他
- prompt-file 不在時のエラー処理（メッセージ・exit code 2）
- invalid skill 名の reject とエラーヒント

既存の spawn-controller-prompt-size.bats / spawn-controller-docs.bats との
重複を避け、未カバーのケースのみ対象。

Co-Authored-By: Claude <noreply@anthropic.com>

Closes #841