### PR TITLE
fix(#867): chain.py CHAIN_STEPS step 名を project-board-status-update に統一

### DIFF
--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -5,7 +5,7 @@ Replaces: chain-runner.sh, chain-steps.sh
 CLI usage:
     python3 -m twl.autopilot.chain <step-name> [args...]
 
-Steps: init, worktree-create, board-status-update, board-archive, ac-extract,
+Steps: init, worktree-create, project-board-status-update, board-archive, ac-extract,
        arch-ref, change-id-resolve, next-step, ts-preflight, pr-test,
        ac-verify, all-pass-check, pr-cycle-report, check, quick-guard,
        autopilot-detect, quick-detect, resolve-next-workflow
@@ -23,12 +23,13 @@ from pathlib import Path
 from typing import Any
 
 # ---------------------------------------------------------------------------
-# Step definitions (SSOT — mirrors chain-steps.sh)
+# Step definitions (SSOT for chain definitions).
+# deps.yaml.chains and chain-steps.sh are generated via 'twl chain export'.
 # ---------------------------------------------------------------------------
 
 CHAIN_STEPS: list[str] = [
     "init",
-    "board-status-update",
+    "project-board-status-update",
     "crg-auto-build",
     "arch-ref",
     "change-propose",
@@ -69,7 +70,7 @@ DIRECT_SKIP_STEPS: frozenset[str] = frozenset([
 # Workflow boundary metadata (SSOT — mirrors chain-steps.sh)
 STEP_TO_WORKFLOW: dict[str, str] = {
     "init": "setup",
-    "board-status-update": "setup",
+    "project-board-status-update": "setup",
     "crg-auto-build": "setup",
     "arch-ref": "setup",
     "change-propose": "setup",
@@ -116,7 +117,7 @@ TERMINAL_STEP_TO_NEXT_SKILL: dict[str, str] = {
 # Dispatch mode per step: runner=bash direct, llm=LLM skill, trigger=external
 CHAIN_STEP_DISPATCH: dict[str, str] = {
     "init": "runner",
-    "board-status-update": "trigger",
+    "project-board-status-update": "trigger",
     "crg-auto-build": "llm",
     "arch-ref": "runner",
     "change-propose": "llm",
@@ -522,26 +523,26 @@ class ChainRunner:
         return result
 
     # ------------------------------------------------------------------
-    # Step: board-status-update
+    # Step: project-board-status-update
     # ------------------------------------------------------------------
 
     def step_board_status_update(
         self, issue_num: str, target_status: str = "In Progress"
     ) -> None:
         """Update Project Board status for an issue."""
-        self.record_step(issue_num, "board-status-update")
+        self.record_step(issue_num, "project-board-status-update")
 
         if not issue_num or not re.match(r"^\d+$", issue_num):
             return
 
         # Delegate to bash for gh CLI interactions (avoid duplicating complex gh logic)
         result = subprocess.run(
-            ["bash", str(self.scripts_root / "chain-runner.sh"), "board-status-update", issue_num, target_status],
+            ["bash", str(self.scripts_root / "chain-runner.sh"), "project-board-status-update", issue_num, target_status],
             env={**os.environ, "AUTOPILOT_DIR": str(self.autopilot_dir)},
             capture_output=False,
         )
         if result.returncode != 0:
-            self._skip("board-status-update", "更新失敗")
+            self._skip("project-board-status-update", "更新失敗")
 
     # ------------------------------------------------------------------
     # Step: ac-extract
@@ -1149,7 +1150,7 @@ def main(argv: list[str] | None = None) -> int:
         print("Usage: python3 -m twl.autopilot.chain <step-name> [args...]", file=sys.stderr)
         print("Steps: init, next-step, quick-guard, check, change-id-resolve,", file=sys.stderr)
         print("       all-pass-check, prompt-compliance, ts-preflight, pr-test, pr-cycle-report,", file=sys.stderr)
-        print("       board-status-update, ac-extract,", file=sys.stderr)
+        print("       project-board-status-update, ac-extract,", file=sys.stderr)
         print("       autopilot-detect, quick-detect, resolve-next-workflow", file=sys.stderr)
         return 1
 
@@ -1216,7 +1217,7 @@ def main(argv: list[str] | None = None) -> int:
             runner.step_pr_cycle_report(pr_num, report)
             return 0
 
-        elif step == "board-status-update":
+        elif step == "project-board-status-update":
             issue_num = rest[0] if rest else ""
             target = rest[1] if len(rest) > 1 else "In Progress"
             runner.step_board_status_update(issue_num, target)

--- a/cli/twl/src/twl/autopilot/mergegate_guards.py
+++ b/cli/twl/src/twl/autopilot/mergegate_guards.py
@@ -101,7 +101,7 @@ def _board_update(issue: str, scripts_root: Path, status: str = "Done") -> None:
     runner = scripts_root / "chain-runner.sh"
     if runner.exists():
         subprocess.run(
-            ["bash", str(runner), "board-status-update", issue, status],
+            ["bash", str(runner), "project-board-status-update", issue, status],
             check=False,
         )
 

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -256,11 +256,11 @@ class TestNextStepDirect:
 
 class TestValidateTransition:
     def test_forward_transition_ok(self, runner: ChainRunner) -> None:
-        runner.validate_transition("1", "init", "board-status-update")
+        runner.validate_transition("1", "init", "project-board-status-update")
 
     def test_backward_transition_raises(self, runner: ChainRunner) -> None:
         with pytest.raises(ChainError, match="不正な遷移"):
-            runner.validate_transition("1", "board-status-update", "init")
+            runner.validate_transition("1", "project-board-status-update", "init")
 
     def test_same_step_transition_raises(self, runner: ChainRunner) -> None:
         with pytest.raises(ChainError):


### PR DESCRIPTION
## 概要

Phase C W1 Sub-B1 (safe) で #853 の chain integrity 違反のうち、**chain.py と chain-steps.sh の step 名 mismatch 1 件** を解消。

## Closes

- Closes #867 (chain.py と deps.yaml/chain-steps.sh の step 名 drift 解消)
- Closes #869 (chain.py L26 `# SSOT — mirrors chain-steps.sh` コメント訂正を同時処理)

## 関連

- Part of #866 (Phase C Epic)
- Refs: #853
- Spin-off: #878 (残 3 drift: worktree-create / arch-ref 移動 / pr-merge 拡張)
- Phase A Wave 3 memory 2939e418 訂正: #876 (Closed)

## 変更内容

1. `cli/twl/src/twl/autopilot/chain.py`:
   - CHAIN_STEPS / STEP_TO_WORKFLOW / CHAIN_STEP_DISPATCH および実装関数内の step 名を rename
   - L26 の SSOT コメント訂正 (chain.py SSoT の位置付けを明文化)
2. `cli/twl/src/twl/autopilot/mergegate_guards.py`:
   - `_board_update` の bash arg を新名称に
3. `cli/twl/tests/test_autopilot_chain.py`:
   - validate_transition 関連 2 test を新名称に更新

## 背景

2026-04-13 commit `59ed897` (#591) で `board-status-update` → `project-board-status-update` rename が chain-steps.sh + deps.yaml のみに適用、chain.py が取り残されていた。Phase A Wave 3 memory `2939e418` が「chain.py も rename された」と誤記していたため Phase B 全期間で未検出だった。

## Sub-B1 scope について

#867 の AC `twl check --deps-integrity errors=0` は **Sub-B1 では未達成**。残 3 drift:

```
deps.yaml.chains.setup.steps: +worktree-create
deps.yaml.chains.test-ready.steps: +arch-ref (setup からの移動)
deps.yaml.chains.pr-merge.steps: +e2e-screening, +pr-cycle-analysis, +merge-gate, +auto-merge
```

これらの step は chain-runner.sh で orchestrate されておらず、workflow-pr-fix / workflow-pr-merge / workflow-arch-review の Skill が個別 orchestrate。chain.py への全面統合には ADR + dispatch mode 再設計が必要なため、Phase D scope (#878) に分離。

## Verification

- `twl check --deps-integrity` は 4 errors → 3 errors (step 名 mismatch 解消確認)
- pytest tests/test_autopilot_chain.py + tests/test_chain_validate.py + tests/autopilot/test_nonterminal_chain_recovery.py: 123 PASS
- pre-existing failure (`test_566_validate_violations::TestSuObserverSpawnController`) は main HEAD でも失敗確認済、本 PR とは無関係

## AC

- [x] chain.py の全 10 参照箇所を rename
- [x] mergegate_guards.py 1 箇所 rename
- [x] 関連 test update
- [x] chain-runner.sh は alias (L1497-1498) で両名称 handle 済のため変更不要
- [x] #878 スピンオフで残 drift を追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)