### PR TITLE
tech-debt(#874): INJECT_PR_MERGE_WARN を DEBUG 降格 (red-herring 解消)

### DIFF
--- a/plugins/twl/scripts/lib/inject-next-workflow.sh
+++ b/plugins/twl/scripts/lib/inject-next-workflow.sh
@@ -66,13 +66,16 @@ inject_next_workflow() {
     echo "[${_trace_ts}] issue=${issue} skill=INVALID result=skip reason=\"invalid skill name\"" >> "$_trace_log" 2>/dev/null || true
     return 1
   fi
-  # AC-4 #744: pr-merge inject 時に status を確認し、merge-ready 未成立なら WARNING
+  # AC-4 (#744, #874): workflow-pr-merge は merge-ready 状態を「作成する」skill のため、
+  # inject 時点で status != "merge-ready" は正常動作 (AC-4 設計意図通り)。
+  # 以前は WARNING レベルで記録していたが、Phase C #871 audit で Pilot stall 原因と誤診断
+  # されていたことが判明 (#874: red-herring 解消、DEBUG 降格)。
   if [[ "$_skill_safe" == "/twl:workflow-pr-merge" ]]; then
     local _pr_merge_status
     _pr_merge_status=$(python3 -m twl.autopilot.state read --type issue --issue "$issue" --field status 2>/dev/null || echo "")
     if [[ "$_pr_merge_status" != "merge-ready" ]]; then
-      echo "[orchestrator] Issue #${issue}: WARNING: pr-merge inject — status=${_pr_merge_status} (not merge-ready). Worker chain が all-pass-check 未到達の可能性" >&2
-      echo "[${_trace_ts}] issue=${issue} category=INJECT_PR_MERGE_WARN skill=${_skill_safe} status=${_pr_merge_status} result=warn reason=\"status not merge-ready, injecting workflow-pr-merge\"" >> "$_trace_log" 2>/dev/null || true
+      echo "[AUTOPILOT_DEBUG] [orchestrator] Issue #${issue}: pr-merge inject — status=${_pr_merge_status} (AC-4 通り、merge-ready 未成立は仕様)" >&2
+      echo "[${_trace_ts}] issue=${issue} category=INJECT_PR_MERGE_DEBUG skill=${_skill_safe} status=${_pr_merge_status} result=debug reason=\"status not merge-ready, AC-4 expected behavior\"" >> "$_trace_log" 2>/dev/null || true
     fi
   fi
 


### PR DESCRIPTION
## 概要

Phase C W2 #871 audit で INJECT_PR_MERGE_WARN は AC-4 (#744) 仕様通りの正常動作と確定。以前は WARNING level で記録されて Pilot stall 原因と誤診断されていたため DEBUG 降格。

**Closes #874**

## 変更

- stderr echo prefix: `WARNING` → `[AUTOPILOT_DEBUG] [orchestrator]`
- 文言: "未到達の可能性" → "AC-4 通り、merge-ready 未成立は仕様"
- trace log category: `INJECT_PR_MERGE_WARN` → `INJECT_PR_MERGE_DEBUG`, result: `warn` → `debug`
- AC-4 設計意図コメント追加

## 参照

- Audit: `.audit/pilot-stall-report.md` (PR #880)
- Design: AC-4 (#744)
- Phase C Epic: #866

Refs: #871, #744, #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)