### PR TITLE
fix(#872): branch protection precheck で C4 stall を fail-fast

### DIFF
--- a/cli/twl/src/twl/autopilot/mergegate_ops.py
+++ b/cli/twl/src/twl/autopilot/mergegate_ops.py
@@ -359,7 +359,38 @@ class MergeGateOperationsMixin:
     # ------------------------------------------------------------------
 
     def _run_merge(self: _MergeGateHost, gh_repo_flag: list[str]) -> bool:
-        """Execute gh pr merge --squash. Returns True on success."""
+        """Execute gh pr merge --squash. Returns True on success.
+
+        #872: DEV_AUTOPILOT_MERGEABILITY_PRECHECK=true 時、gh pr view で
+        mergeStateStatus を事前確認し、BLOCKED/UNSTABLE/BEHIND の場合は
+        failure.reason=branch_protection_* で即時 fail-fast (C4 対策)。
+        """
+        if os.environ.get("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", "false").lower() == "true":
+            precheck = subprocess.run(
+                ["gh", "pr", "view", self.pr_number, *gh_repo_flag, "--json", "mergeStateStatus"],
+                capture_output=True,
+                text=True,
+            )
+            if precheck.returncode == 0:
+                try:
+                    state = json.loads(precheck.stdout).get("mergeStateStatus", "")
+                    if state in ("UNSTABLE", "BLOCKED", "BEHIND"):
+                        failure = json.dumps({
+                            "reason": f"branch_protection_{state.lower()}",
+                            "details": f"gh pr view mergeStateStatus={state}",
+                            "step": "merge-gate-precheck",
+                            "pr": f"#{self.pr_number}",
+                        })
+                        _state_write(self.issue, "pilot", status="failed", failure=failure)
+                        print(
+                            f"[merge-gate] Issue #{self.issue}: branch protection block "
+                            f"(mergeStateStatus={state}) - Pilot 介入が必要",
+                            file=sys.stderr,
+                        )
+                        return False
+                except (json.JSONDecodeError, ValueError):
+                    pass  # precheck parse 失敗時は従来の merge flow に fallback
+
         result = subprocess.run(
             ["gh", "pr", "merge", self.pr_number, *gh_repo_flag, "--squash"],
             capture_output=True,

--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -179,6 +179,18 @@ fi
 # ============================================================
 echo "[auto-merge] Issue #${ISSUE_NUM}: PR #${PR_NUMBER} の squash merge を実行..."
 
+# #872: DEV_AUTOPILOT_MERGEABILITY_PRECHECK=true 時、mergeStateStatus 事前確認で
+# branch protection block を fail-fast (C4 対策)。
+if [[ "${DEV_AUTOPILOT_MERGEABILITY_PRECHECK:-false}" == "true" ]]; then
+  MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo "")
+  case "$MERGE_STATE" in
+    BLOCKED|UNSTABLE|BEHIND)
+      echo "[auto-merge] ⚠️ branch protection block: mergeStateStatus=$MERGE_STATE (Pilot 介入が必要)" >&2
+      exit 1
+      ;;
+  esac
+fi
+
 MERGE_ERROR_LOG=$(mktemp /tmp/auto-merge-error-XXXXXX.log)
 trap 'rm -f "${MERGE_ERROR_LOG:-}"' EXIT
 if ! gh pr merge "$PR_NUMBER" --squash 2>"$MERGE_ERROR_LOG"; then


### PR DESCRIPTION
## 概要

Phase C W2 audit (#871) で判明した Phase B stall 主因 C4 (57%、#853 deps-integrity CI UNSTABLE) に対して、gh pr view --json mergeStateStatus の事前確認で fail-fast 化。

**Closes #872**

## 変更

- `cli/twl/src/twl/autopilot/mergegate_ops.py`: _run_merge 冒頭に mergeability precheck 追加
- `plugins/twl/scripts/auto-merge.sh`: 非 autopilot 側にも同等の bash precheck 追加

## Feature Flag

`DEV_AUTOPILOT_MERGEABILITY_PRECHECK=false` (default、既存動作維持)
`DEV_AUTOPILOT_MERGEABILITY_PRECHECK=true` で precheck 有効化

## 期待効果

stall rate 100% → 50-60% (C4 fail-fast + observer escalate 明確化)

## Regression

- mergegate 関連 test 84 PASS (filter `-k mergegate or merge_gate`)
- test_orchestrator_stagnation は main HEAD でも失敗する pre-existing bug (本 PR 無関係)

Refs: #871, #866, #853

🤖 Generated with [Claude Code](https://claude.com/claude-code)