### PR TITLE
fix(#873): orchestrator _poll_phase で merge-ready race を即時解消 (C3 対策)

### DIFF
--- a/cli/twl/src/twl/autopilot/orchestrator.py
+++ b/cli/twl/src/twl/autopilot/orchestrator.py
@@ -419,6 +419,21 @@ class PhaseOrchestrator:
                         cleaned_up.add(entry)
                     continue
                 elif status == "merge-ready":
+                    # #873: merge-ready 検出時は即時 merge-gate 実行で race 解消
+                    # (従来は _run_batch L268-282 の後処理まで待たされ、最大 POLL_INTERVAL 分の
+                    # 滞留が発生していた。C3 stall の 24% を解消)
+                    if entry not in cleaned_up:
+                        self._run_merge_gate(entry)
+                        status_after = _read_state(issue, "status", self.autopilot_dir, repo_id)
+                        if status_after == "done":
+                            self._cleanup_worker(issue, entry)
+                            cleaned_up.add(entry)
+                        elif status_after == "failed":
+                            retry = _read_state(issue, "retry_count", self.autopilot_dir, repo_id)
+                            failure_reason = _read_state(issue, "failure.reason", self.autopilot_dir, repo_id)
+                            if int(retry or "0") >= 1 or failure_reason == "merge_gate_rejected_final":
+                                self._cleanup_worker(issue, entry)
+                                cleaned_up.add(entry)
                     continue
                 elif status == "running":
                     all_resolved = False


### PR DESCRIPTION
## 概要

Phase C W2 audit で判明した stall の 24% (C3: archive 5 件) を解消。`_poll_phase` が merge-ready を検出時 `continue` するため、loop 完了まで merge-gate が発火しない race 窓を即時 merge-gate 実行で解消。

**Closes #873**

## 変更

`cli/twl/src/twl/autopilot/orchestrator.py:_poll_phase L421-422`:
- merge-ready 検出時に即時 `_run_merge_gate` 実行
- post-merge 判定 (`_run_batch` L268-282 同等ロジック) で cleanup/retry 制御
- `cleaned_up` set で重複実行防止

## 効果

- race 窓 POLL_INTERVAL (30s) → 即時
- C3 (24%) 解消

## Regression

- orchestrator test 16 PASS
- pre-existing fail (`test_orchestrator_stagnation`) は本 PR 無関係 (main 同条件)

Refs: #871, #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)