### PR TITLE
fix(#848): intervention-catalog パターン 8 と不変条件 L の整合性を明示

### DIFF
--- a/plugins/twl/refs/intervention-catalog.md
+++ b/plugins/twl/refs/intervention-catalog.md
@@ -74,15 +74,16 @@ Supervisor の介入判断ルール定義。Wave 1-5 の実績を反映した介
 - **事後**: InterventionRecord を `.observation/` に記録
 - **部分一致フォールバック**: state stagnate のみで `>>> 実装完了:` が確認できない場合は **パターン4（Layer 1 Confirm: Worker 長時間 idle）** として処理する
 
-### パターン 8: Pilot auto-merge stall → 手動 squash-merge（Wave 1-5 実績）
+### パターン 8: Pilot auto-merge stall → 手動 squash-merge（Wave 1-5 + Phase B 実績）
 
-- **Wave 実績**: Wave 1-5 で Pilot auto-merge stall 率 92%（9 PR 連続）。observer が手動 squash-merge を代行した実績に基づき Auto 層に追加
+- **Wave 実績**: Wave 1-5 で Pilot auto-merge stall 率 92%、Phase B で 100% (0/19 自律 merge)。observer が手動 squash-merge を代行した実績に基づき Auto 層に追加。Phase C W2 audit (#871) で C3 (merge-ready race) + C4 (branch protection UNSTABLE) が真主因と確定
 - **検出条件**: PR が "merge-ready" 状態で 10 分以上マージされない、かつ `gh pr view <N> --json mergeStateStatus` が `CLEAN` であること
 - **修復手順**:
   1. `gh pr view <N> --json mergeStateStatus,mergeable` でマージ可能状態を確認
-  2. `gh pr merge <N> --squash --auto` を実行
+  2. `gh pr merge <N> --squash --auto` を実行（UNSTABLE の場合は `--admin --squash`）
 - **前提条件**: PR が CLEAN 状態かつ全 CI チェック通過済みであること
 - **リスク評価**: 低（squash-merge は merge-gate 通過済み前提、reversible = git revert 可）
+- **不変条件 L 整合性**: Supervisor による観察介入は不変条件 L の適用対象外（#848 で ref-invariants.md に明示）。本操作は Supervisor 監視責務に基づく例外として許可される
 - **事後**: InterventionRecord を `.observation/` に記録
 
 ### パターン 9: session-comm.sh inject による confirmation プロンプト解消（yes/Enter 自動応答）

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -131,11 +131,13 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 L: autopilot マージ実行責務
 
 - **定義**: autopilot 時のマージ実行は Orchestrator の `mergegate.py` 経由のみでなければならない（SHALL）。Worker chain の auto-merge ステップは `merge-ready` 宣言のみを行い、マージは実行しない。
+- **適用範囲**: Worker chain および Orchestrator の autopilot 実行パス。**Supervisor (su-observer) による観察介入 (intervention-catalog.md Layer 0/1) は対象外**。stall 回復のための手動 squash merge 等は Supervisor の監視責務に基づく例外として許可される (#848)。
 - **根拠**: ADR なし — 慣習的制約
 - **検証方法**: [`invariant-L: ref-invariants.md defines invariant L (autopilot マージ実行責務)`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-L: auto-merge.sh sets merge-ready without merging in autopilot mode`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `cli/twl/src/twl/autopilot/mergegate.py`
   - `plugins/twl/scripts/auto-merge.sh`
+  - `plugins/twl/refs/intervention-catalog.md` (Supervisor 観察介入の例外定義)
 
 ---
 


### PR DESCRIPTION
## 概要

#848 (intervention-catalog.md パターン8 の `gh pr merge` 直接実行 vs 不変条件 L の `mergegate.py` 経由制約) を Option 2 (Supervisor 観察介入例外) で解消。Phase C W2 合流。

**Closes #848**

## 解決方針

不変条件 L は Worker chain + Orchestrator の autopilot 実行パスに限定される慣習的制約であり、Supervisor (su-observer) の観察介入は監視責務に基づく明示的例外として許可。

- Option 1 (コマンド統一): 不採用 (--admin --squash が Phase B で必要だった実用的理由)
- Option 2 (例外明示): **採用**
- Option 3 (ADR-018 修正): 範囲外、将来 ADR で決定

## 変更

- `plugins/twl/refs/ref-invariants.md` 不変条件 L: 適用範囲に Supervisor 例外追記、影響範囲に intervention-catalog.md 追加
- `plugins/twl/refs/intervention-catalog.md` パターン 8: Phase B/C 実績追記、UNSTABLE 時の --admin 明示、不変条件 L 整合性セクション新設

## Regression

- `autopilot-invariants.bats` 28 test 全 PASS (invariant L 含む)

Refs: #871, #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)