### PR TITLE
fix(#878): chain SSoT 境界明確化 — deps.yaml.chains を独立 SSoT に分離 (ADR-022)

### DIFF
--- a/cli/twl/src/twl/chain/integrity.py
+++ b/cli/twl/src/twl/chain/integrity.py
@@ -1,4 +1,12 @@
-"""deps-integrity: hash-compare chain.py (SSoT) vs chain-steps.sh and deps.yaml.chains."""
+"""deps-integrity: hash-compare chain.py (SSoT) vs chain-steps.sh and deps.yaml.chains.
+
+SSoT 境界 (ADR-022):
+- chain.py CHAIN_STEPS は chain-runner.sh dispatch 対象 step の SSoT (完全一致検証)
+- chain-steps.sh は chain.py の bash mirror (完全一致検証)
+- deps.yaml.chains は workflow skill 内 orchestrate step を含む拡張 metadata
+  (step の chain 所属・順序は workflow skill 概念順として別 SSoT。
+  chain.py CHAIN_STEPS が deps.yaml 全 chain flatten の step 集合に包含されることのみ検証)
+"""
 
 from __future__ import annotations
 
@@ -164,24 +172,24 @@ def check_deps_integrity(plugin_root: Path) -> tuple[list[str], list[str]]:
         return errors, warnings
 
     actual_chains = deps.get("chains", {})
-    expected = _expected_chains(py_step_to_workflow, py_chain_steps)
 
-    for chain_name, exp_steps in expected.items():
-        actual = actual_chains.get(chain_name)
-        if actual is None:
-            errors.append(
-                f"[deps-integrity] deps.yaml.chains.{chain_name}: missing\n"
-                f"  expected steps: {exp_steps}\n"
-                f"  {fix_hint}"
-            )
-            continue
-        act_steps = actual.get("steps", []) if isinstance(actual, dict) else list(actual)
-        if _hash_list(exp_steps) != _hash_list(act_steps):
-            errors.append(
-                f"[deps-integrity] deps.yaml.chains.{chain_name}.steps mismatch\n"
-                f"  expected: {exp_steps}\n"
-                f"  actual:   {act_steps}\n"
-                f"  {fix_hint}"
-            )
+    # ADR-022: chain.py CHAIN_STEPS (runner dispatch 対象 step の SSoT) が
+    # deps.yaml.chains 全 chain flatten の step 集合に包含されているか検証する。
+    # deps.yaml.chains の step 所属・順序は workflow skill 概念順として別 SSoT。
+    actual_all_steps: set[str] = set()
+    for chain_data in actual_chains.values():
+        steps = chain_data.get("steps", []) if isinstance(chain_data, dict) else list(chain_data)
+        actual_all_steps.update(steps)
+
+    expected_set = set(py_step_to_workflow.keys()) & set(py_chain_steps)
+    missing = sorted(expected_set - actual_all_steps)
+    if missing:
+        errors.append(
+            f"[deps-integrity] deps.yaml.chains missing chain.py SSoT step(s)\n"
+            f"  expected (chain.py CHAIN_STEPS ∩ STEP_TO_WORKFLOW): {sorted(expected_set)}\n"
+            f"  actual (union of deps.yaml.chains.*.steps):       {sorted(actual_all_steps)}\n"
+            f"  missing from actual:                               {missing}\n"
+            f"  {fix_hint}"
+        )
 
     return errors, warnings

--- a/cli/twl/tests/test_chain_integrity.py
+++ b/cli/twl/tests/test_chain_integrity.py
@@ -157,18 +157,49 @@ class TestCheckDepsIntegrity:
         assert any("DIRECT_SKIP_STEPS mismatch" in e for e in errors)
 
     def test_deps_yaml_chain_drift_detected(self, plugin_dir):
+        """chain.py CHAIN_STEPS に含まれる step が deps.yaml 全 chain から欠落すると error。"""
         import yaml
         deps = {
             "version": "3.0",
             "chains": {
                 "setup": {"steps": ["init"]},
-                "test-ready": {"steps": ["wrong-step"]},  # drift
+                "test-ready": {"steps": ["wrong-step"]},  # "check" が全 chain から missing
                 "pr-merge": {"steps": ["done"]},
             },
         }
         (plugin_dir / "deps.yaml").write_text(yaml.dump(deps))
         errors, _ = check_deps_integrity(plugin_dir)
-        assert any("test-ready" in e and "mismatch" in e for e in errors)
+        assert any("missing" in e and "check" in e for e in errors)
+
+    def test_deps_yaml_extra_step_allowed(self, plugin_dir):
+        """ADR-022: deps.yaml に chain.py にない step (workflow skill 内 orchestrate) は許容。"""
+        import yaml
+        deps = {
+            "version": "3.0",
+            "chains": {
+                "setup": {"steps": ["init", "extra-workflow-step"]},  # extra 許容
+                "test-ready": {"steps": ["check", "another-extra"]},  # extra 許容
+                "pr-merge": {"steps": ["done", "merge-gate", "auto-merge"]},  # extra 許容
+            },
+        }
+        (plugin_dir / "deps.yaml").write_text(yaml.dump(deps))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert errors == [], f"Extra steps should be allowed: {errors}"
+
+    def test_deps_yaml_chain_reassignment_allowed(self, plugin_dir):
+        """ADR-022: step が別 chain に移動しても、全 chain flatten で包含されれば OK。"""
+        import yaml
+        deps = {
+            "version": "3.0",
+            "chains": {
+                "setup": {"steps": ["init", "check"]},  # "check" を setup に移動
+                "test-ready": {"steps": []},            # test-ready は空でも
+                "pr-merge": {"steps": ["done"]},
+            },
+        }
+        (plugin_dir / "deps.yaml").write_text(yaml.dump(deps))
+        errors, _ = check_deps_integrity(plugin_dir)
+        assert errors == [], f"Chain reassignment should be allowed: {errors}"
 
     def test_missing_chain_py_returns_warning(self, plugin_dir):
         import shutil

--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -16,7 +16,10 @@ Claude Code twl plugin（chain-driven + autopilot-first）。TWiLL モノリポ 
 
 deps.yaml v3.0 がプラグイン構成（コンポーネント定義）の唯一の情報源。
 
-**chain.py = chain / workflow 遷移の SSoT。deps.yaml.chains と chain-steps.sh は `twl chain export` の computed artifact**
+**chain SSoT 境界 (ADR-022)**:
+- chain.py `CHAIN_STEPS` = chain-runner.sh dispatch 対象 step (runner step) の SSoT
+- chain-steps.sh = chain.py の bash mirror (`twl chain export` computed artifact)
+- deps.yaml.chains = workflow skill 内 orchestrate step を含む拡張 metadata (独立 SSoT)
 
 ### Controller は7つ
 

--- a/plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md
+++ b/plugins/twl/architecture/decisions/ADR-020-chain-ssot-refinement.md
@@ -1,10 +1,11 @@
 # ADR-020: chain SSoT refinement — chain.py を真の SSoT 化する具体手順
 
-**Status**: Proposed
+**Status**: Proposed (D-2, D-5 は Superseded by ADR-022)
 **Date**: 2026-04-21
 **Issue**: #790
 **Supersedes**: —
-**Related**: ADR-0007 (chain SSOT 2 レイヤー責務分離)、ADR-018 (state schema SSoT)、ADR-021 (pilot-driven workflow loop)
+**Partially Superseded by**: ADR-022 (D-2 CHAIN_META 導入、D-5 差分ゼロ検証のみ)
+**Related**: ADR-0007 (chain SSOT 2 レイヤー責務分離)、ADR-018 (state schema SSoT)、ADR-021 (pilot-driven workflow loop)、ADR-022 (chain SSoT 境界明確化)
 
 ---
 

--- a/plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md
+++ b/plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md
@@ -1,0 +1,89 @@
+# ADR-022: chain SSoT 境界明確化 — deps.yaml.chains は workflow skill 概念順の独立 SSoT
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Issue**: #878
+**Partially Supersedes**: ADR-020 (D-2 CHAIN_META、D-5 差分ゼロ検証)
+**Related**: ADR-0007 (chain SSOT 2 レイヤー責務分離)、ADR-020 (chain SSoT refinement)、ADR-021 (pilot-driven workflow loop)
+
+---
+
+## Context
+
+Phase C #867 (step 名 rename) 実施後、`twl check --deps-integrity` で以下 3 drift が未解消であることが発覚した (#878):
+
+1. **setup.steps**: chain.py が `arch-ref` を setup 所属 (STEP_TO_WORKFLOW) に記述しているが、deps.yaml は test-ready.steps に置いている
+2. **pr-merge.steps 順序**: chain.py CHAIN_STEPS L48-49 は `all-pass-check → pr-cycle-report` 順、deps.yaml と workflow-pr-merge SKILL は `pr-cycle-report → all-pass-check` 順 (workflow skill 側が実装として使用している順序)
+3. **deps.yaml に chain.py 非保有 step**: deps.yaml.chains に `worktree-create`、`e2e-screening`、`merge-gate`、`auto-merge`、`fix-phase`、`post-fix-verify`、`warning-fix`、`pr-cycle-analysis`、`arch-phase-review`、`arch-fix-phase` の 10 step が存在するが、これらは `workflow-pr-fix` / `workflow-pr-merge` / `workflow-arch-review` SKILL が内部 orchestrate しており、`chain-runner.sh` は dispatch しない (dispatch_mode = llm/trigger)
+
+ADR-020 は Proposed 状態で、以下の方針を提案していた:
+- **D-2**: `CHAIN_META: dict[str, dict[str, str]]` を chain.py に追加し、llm/trigger step を含む全 step の `{chain, dispatch_mode}` を chain.py 側で保有
+- **D-5**: `twl chain validate` で `CHAIN_STEPS ∪ CHAIN_META` set == deps.yaml.chains 全 step set (差分ゼロ) を検証
+
+しかし ADR-020 D-2 を実装すると、以下のリスクが発生する:
+
+- chain.py CHAIN_STEPS に `worktree-create`、`merge-gate`、`auto-merge` 等を追加した場合、`chain-runner.sh` の `next-step` API が「次に実行すべき step」として返す可能性があり、runner がそれらの未実装 step を dispatch しようとして runtime 破綻
+- llm/trigger step の dispatch_mode を chain.py 側で正確管理するには、workflow skill 各々の内部実行順を chain.py にエンコードする必要があり、workflow skill の refactor が波及する
+
+## Decision
+
+**chain.py CHAIN_STEPS の SSoT 範囲を「chain-runner.sh dispatch 対象の runner step のみ」に限定し、deps.yaml.chains は workflow skill 内 orchestrate 順含む拡張 metadata として独立 SSoT とする。**
+
+### D-1: SSoT 境界の明文化
+
+| レイヤー | SSoT 対象 | 保有者 |
+|---------|----------|--------|
+| chain-runner.sh が dispatch する step の **存在と名前** | chain.py `CHAIN_STEPS` | chain.py (SSoT) |
+| chain-runner.sh が dispatch する step の **bash mirror** | chain-steps.sh `CHAIN_STEPS` | chain.py からの export (computed artifact) |
+| workflow skill 内 orchestrate の **step 所属 chain・実行順序** | deps.yaml.chains / workflow-*/SKILL.md | deps.yaml + SKILL.md (独立 SSoT) |
+
+### D-2: deps-integrity 検証の緩和
+
+`twl check --deps-integrity` は以下のみ検証する:
+
+- chain.py `CHAIN_STEPS` == chain-steps.sh `CHAIN_STEPS` (完全一致、既存維持)
+- chain.py `QUICK_SKIP_STEPS` == chain-steps.sh `QUICK_SKIP_STEPS` (完全一致、既存維持)
+- chain.py `DIRECT_SKIP_STEPS` == chain-steps.sh `DIRECT_SKIP_STEPS` (完全一致、既存維持)
+- **chain.py `CHAIN_STEPS ∩ STEP_TO_WORKFLOW.keys()`** ⊆ **deps.yaml.chains 全 chain flatten の step 集合** (包含のみ、所属 chain・順序は検証しない)
+
+### D-3: ADR-020 D-2/D-5 の部分 Superseded
+
+ADR-020 以下の提案は本 ADR により **Superseded**:
+
+- **D-2 CHAIN_META 導入**: llm/trigger step の chain 所属・dispatch_mode を chain.py 側で保有する方針 → **棄却**。workflow skill 側の SSoT として維持
+- **D-5 差分ゼロ検証**: `CHAIN_STEPS ∪ CHAIN_META` set == deps.yaml.chains 全 step set → **棄却**。chain.py CHAIN_STEPS ⊆ deps.yaml flatten に緩和
+
+ADR-020 D-1 (名称正規化)、D-3 (export API)、D-4 (feature flag) は本 ADR の Scope 外で維持。
+
+### D-4: workflow skill 内 orchestrate step の取扱い
+
+`worktree-create`、`e2e-screening`、`merge-gate`、`auto-merge`、`fix-phase`、`post-fix-verify`、`warning-fix`、`pr-cycle-analysis`、`arch-phase-review`、`arch-fix-phase` の 10 step は **workflow-*/SKILL.md が SSoT**。deps.yaml.chains は workflow skill の orchestrate 順序を反映した metadata として維持する。
+
+## Consequences
+
+### 利点
+
+- **Runtime 破綻リスク回避**: chain-runner.sh が未実装 step を dispatch する可能性を排除
+- **現運用と整合**: 既存の workflow skill (pr-fix / pr-merge / arch-review) の orchestrate 実態を改変せず、integrity check を緩和するだけで errors=0 達成
+- **実装工数最小**: `chain/integrity.py` の比較ロジック変更 (26 行) のみで完結。chain.py / deps.yaml / SKILL.md の改変不要
+- **SSoT の概念明確化**: runner dispatch と workflow orchestrate の責務境界が ADR で明文化
+
+### 懸念 / 代償
+
+- **chain.py と deps.yaml の順序が乖離する可能性**: `chain.py CHAIN_STEPS` の `all-pass-check → pr-cycle-report` 順と、deps.yaml + workflow-pr-merge SKILL の `pr-cycle-report → all-pass-check` 順が不整合のまま許容される。これは workflow-pr-merge SKILL が内部で step を順に bash invoke するため runtime 上は問題ないが、chain.py の `next-step` API が workflow 順を反映しない可能性がある (Phase D 追加 Issue で調査)
+- **viz tool との整合**: deps.yaml ベースで生成される chain-flow 図は workflow 概念順を反映する (chain.py CHAIN_STEPS 順ではない)。既存の仕様通り
+
+### ロールバック手順
+
+本 ADR の方針を revert する場合 (ADR-020 D-2/D-5 方針へ戻す):
+
+1. `cli/twl/src/twl/chain/integrity.py` の flatten check を chain_name 単位の完全一致比較に戻す
+2. chain.py に `CHAIN_META` 導入 (ADR-020 D-2 実装)
+3. deps.yaml.chains の step 所属・順序を chain.py SSoT に揃える
+4. workflow skill の内部 orchestrate を chain.py CHAIN_STEPS 順に合わせる
+
+## Non-goal
+
+- **chain.py と workflow-pr-merge SKILL の step 順序整合化**: `all-pass-check` と `pr-cycle-report` の順序不整合は別 Issue (Phase D) で調査する。本 ADR のスコープ外
+- **CHAIN_META の将来導入**: step メタデータ (dispatch_mode, 所属 chain) が必要になった場合は、chain.py の新規 dict として追加検討 (本 ADR で廃案にしたわけではなく、必要性が再確認された時点で再提案)
+- **deps.yaml.chains の step 順序検証**: workflow skill 概念順の正しさは bats テスト (#870 chain-export-drift.bats) で verify する方針 (本 ADR のスコープ外)


### PR DESCRIPTION
## Summary

#878 残 3 drift を Option B (SSoT 分離) 方針で解消。Phase D Epic の先頭 Issue。

## 変更内容

### ADR-022 起票
- chain.py `CHAIN_STEPS` = chain-runner.sh dispatch 対象 step の SSoT
- chain-steps.sh = chain.py の bash mirror (computed artifact)
- deps.yaml.chains = workflow skill 内 orchestrate step 含む拡張 metadata (**独立 SSoT**)

### ADR-020 部分 Superseded
- D-2 CHAIN_META 導入 → 棄却 (workflow skill SSoT として維持)
- D-5 差分ゼロ検証 → 棄却 (flatten 包含検証に緩和)
- D-1 (名称正規化) / D-3 (export API) / D-4 (feature flag) は維持

### integrity.py 緩和
- 旧: chain_name 単位の完全一致比較 (順序 + 所属 chain 両方)
- 新: **全 chain flatten の step 集合包含**のみ検証
  ```python
  expected_set = set(py_step_to_workflow.keys()) & set(py_chain_steps)
  missing = sorted(expected_set - actual_all_steps)
  ```

### test 更新
- `test_deps_yaml_chain_drift_detected`: 新 error メッセージ形式に対応
- `test_deps_yaml_extra_step_allowed`: ADR-022 核心検証 (workflow skill step 許容)
- `test_deps_yaml_chain_reassignment_allowed`: step 所属変更を許容 (flatten 比較)

## 結果

```
Before: errors=3 (setup/test-ready/pr-merge mismatch)
After:  errors=0
```

21/21 test PASS (既存 17 + 新 1 + 更新 3)

## 影響範囲

- Runtime 破綻リスク回避: chain-runner.sh が未実装 step を dispatch する可能性を排除
- 現運用の workflow skill (pr-fix / pr-merge / arch-review) 改変不要
- integrity check のみ緩和、chain.py / deps.yaml の値は現状維持

## Non-goal (Phase D 別 Issue)

- workflow-pr-merge SKILL の `all-pass-check / pr-cycle-report` 順序と chain.py 順序の乖離調査
- CHAIN_META 将来検討 (必要性再確認時)
- deps.yaml.chains の step 順序検証 (#870 bats で別管理)

## 参照

- Issue: #878
- ADR: `plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md`
- Partially supersedes: ADR-020 (D-2, D-5)

Closes #878