### PR TITLE
feat(#868): install-git-hooks.sh で pre-commit hook セットアップ提供

### DIFF
--- a/plugins/twl/CLAUDE.md
+++ b/plugins/twl/CLAUDE.md
@@ -65,6 +65,16 @@ chain 定義変更  → chain.py 編集   → twl check --deps-integrity → cha
 
 commit 前に `twl check --deps-integrity` を実行し、chain.py CHAIN_STEPS と deps.yaml.chains・chain-steps.sh の整合性を確認する（MUST）。
 
+### Pre-commit hook セットアップ (optional)
+
+deps-integrity drift をローカル commit 時点で検知するため、以下 1 回実行で pre-commit hook を設置できる:
+
+```bash
+bash plugins/twl/scripts/install-git-hooks.sh
+```
+
+hook は `chain.py` / `chain-steps.sh` / `deps.yaml` のいずれかが staged のとき `twl check --deps-integrity` を実行し、errors 検出時に commit を abort する。`git commit --no-verify` で bypass 可能（user 裁量）。
+
 ## specialist-audit JSON 出力契約
 
 `specialist-audit.sh` はデフォルトで JSON を stdout に出力し、`su-observer/SKILL.md` の Wave 完了ステップは `grep -q '"status":"FAIL"'` でこの出力を判定する。`--summary` フラグは非推奨（`2bd9130` で SKILL.md から除去済み）。将来 `--summary` 形式に戻した場合、この grep 契約が破綻するため、変更時は `plugins/twl/tests/bats/scripts/su-observer-specialist-audit-grep.bats` の全 PASS を確認すること。

--- a/plugins/twl/scripts/install-git-hooks.sh
+++ b/plugins/twl/scripts/install-git-hooks.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# install-git-hooks.sh — twl プロジェクトの git hooks をローカルに設置
+#
+# Usage:
+#   bash plugins/twl/scripts/install-git-hooks.sh        # install (idempotent)
+#   bash plugins/twl/scripts/install-git-hooks.sh --dry-run  # 差分のみ表示
+#
+# Hook: pre-commit
+#   - chain.py / deps.yaml / chain-steps.sh 編集時に `twl check --deps-integrity` を実行
+#   - errors 発生時 commit を abort (drift 再発防止, #868)
+#   - --no-verify で bypass 可能 (user 裁量)
+set -euo pipefail
+
+DRY_RUN=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    -h|--help)
+      sed -n '2,12p' "$0"
+      exit 0
+      ;;
+  esac
+done
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+GIT_COMMON_DIR="$(git rev-parse --git-common-dir)"
+HOOKS_DIR="$GIT_COMMON_DIR/hooks"
+HOOK_SOURCE="$REPO_ROOT/plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh"
+HOOK_TARGET="$HOOKS_DIR/pre-commit"
+
+if [[ ! -f "$HOOK_SOURCE" ]]; then
+  echo "✗ Hook source not found: $HOOK_SOURCE" >&2
+  exit 1
+fi
+
+chmod +x "$HOOK_SOURCE"
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "[dry-run] would ensure: $HOOKS_DIR/ exists"
+  echo "[dry-run] would symlink: $HOOK_TARGET -> $HOOK_SOURCE"
+  if [[ -L "$HOOK_TARGET" ]]; then
+    echo "[dry-run] current symlink: $(readlink "$HOOK_TARGET")"
+  elif [[ -e "$HOOK_TARGET" ]]; then
+    echo "[dry-run] current file exists (non-symlink)"
+  else
+    echo "[dry-run] no existing hook"
+  fi
+  exit 0
+fi
+
+mkdir -p "$HOOKS_DIR"
+
+if [[ -L "$HOOK_TARGET" ]]; then
+  CURRENT="$(readlink "$HOOK_TARGET")"
+  if [[ "$CURRENT" == "$HOOK_SOURCE" ]]; then
+    echo "✓ pre-commit hook already installed"
+    exit 0
+  fi
+  echo "⚠ existing symlink replaced: $CURRENT -> $HOOK_SOURCE"
+  rm "$HOOK_TARGET"
+elif [[ -e "$HOOK_TARGET" ]]; then
+  BACKUP="$HOOK_TARGET.bak-$(date +%s)"
+  echo "⚠ existing pre-commit backed up: $HOOK_TARGET -> $BACKUP"
+  mv "$HOOK_TARGET" "$BACKUP"
+fi
+
+ln -s "$HOOK_SOURCE" "$HOOK_TARGET"
+echo "✓ pre-commit hook installed: $HOOK_TARGET -> $HOOK_SOURCE"
+echo ""
+echo "To verify: edit cli/twl/src/twl/autopilot/chain.py and run 'git commit'"
+echo "To bypass: git commit --no-verify (user discretion)"


### PR DESCRIPTION
## Summary

#868 の AC 達成。既存 `plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh` を install する自動化スクリプトを追加し、ローカル commit 時点で drift 検知できるようにする。

## 変更内容

### `plugins/twl/scripts/install-git-hooks.sh` (新規)

- `git rev-parse --git-common-dir` で bare repo 構造 (`.bare/hooks/`) を正しく識別
- idempotent (既 install 済みなら no-op)
- 既存 hook 上書き時は `.bak-<ts>` にバックアップ
- `--dry-run` flag で差分確認可能
- chmod +x を明示的に実行

### `plugins/twl/CLAUDE.md` に setup 手順追記

```bash
bash plugins/twl/scripts/install-git-hooks.sh
```

## AC 達成確認

- [x] `.git/hooks/pre-commit` (=`.bare/hooks/pre-commit`) が install されれば実行可能 — install script で chmod +x 実行
- [x] chain.py のみ編集で integrity violation 時 commit abort — 既存 hook script で対応
- [x] deps.yaml / chain-steps.sh 修正後 → hook pass — 既存 hook script で対応
- [x] hook は他 commit に影響しない — 既存 hook script が chain/deps 関連 staged file のみ grep 判定

## 動作確認

```
$ bash plugins/twl/scripts/install-git-hooks.sh --dry-run
[dry-run] would ensure: /home/shuu5/projects/local-projects/twill/.bare/hooks/ exists
[dry-run] would symlink: .../pre-commit -> .../git-pre-commit-deps-integrity.sh
[dry-run] no existing hook
```

## 参照

- Issue: #868
- 既存 hook: `plugins/twl/scripts/hooks/git-pre-commit-deps-integrity.sh` (Phase A/B で作成済)

Closes #868