### PR TITLE
feat(#888): C6 MVP — PR workflow step で stagnation 短縮 threshold (300s)

### DIFF
--- a/cli/twl/src/twl/autopilot/orchestrator.py
+++ b/cli/twl/src/twl/autopilot/orchestrator.py
@@ -35,8 +35,24 @@ MAX_POLL = int(os.environ.get("DEV_AUTOPILOT_MAX_POLL", "360"))
 MAX_NUDGE = int(os.environ.get("DEV_AUTOPILOT_MAX_NUDGE", "3"))
 NUDGE_TIMEOUT = int(os.environ.get("DEV_AUTOPILOT_NUDGE_TIMEOUT", "30"))
 STAGNATION_THRESHOLD = int(os.environ.get("AUTOPILOT_STAGNATE_SEC", os.environ.get("DEV_AUTOPILOT_STAGNATION_THRESHOLD", "900")))
+STAGNATION_THRESHOLD_PR_STEP = int(os.environ.get("DEV_AUTOPILOT_STAGNATION_SEC_PR_STEP", "300"))
 MAX_STAGNATION_NUDGE = int(os.environ.get("DEV_AUTOPILOT_MAX_STAGNATION_NUDGE", "3"))
 POLL_INTERVAL = 10
+
+# C6 MVP (#888): step-aware stagnation threshold
+# PR workflow (pr-verify / pr-fix / pr-merge) 内の step は LLM 内部 stall が発生しやすく、
+# 短縮 threshold を適用する。ADR-022 に基づき workflow skill 内 orchestrate step も含む。
+PR_WORKFLOW_STEPS = frozenset({
+    # pr-verify (STEP_TO_WORKFLOW)
+    "prompt-compliance", "ts-preflight", "phase-review",
+    "scope-judge", "pr-test", "ac-verify",
+    # pr-merge (STEP_TO_WORKFLOW)
+    "all-pass-check", "pr-cycle-report",
+    # workflow skill 内 orchestrate (ADR-022 deps.yaml SSoT, chain.py CHAIN_STEPS 外)
+    "e2e-screening", "pr-cycle-analysis", "merge-gate", "auto-merge",
+    # pr-fix (workflow skill 内 dynamic orchestrate)
+    "fix-phase", "post-fix-verify", "warning-fix",
+})
 
 _BRANCH_RE = re.compile(r"^[a-zA-Z0-9._/\-]+$")
 
@@ -520,7 +536,11 @@ class PhaseOrchestrator:
             print(f"[orchestrator] escalation signal 作成失敗: {e}", file=sys.stderr)
 
     def _check_stagnation(self, issue: str, repo_id: str) -> bool:
-        """Return True if updated_at is older than STAGNATION_THRESHOLD seconds."""
+        """Return True if updated_at is older than threshold seconds.
+
+        C6 MVP (#888): PR workflow step (ac-verify 等) の LLM 内部 stall 対策として、
+        current_step が PR_WORKFLOW_STEPS に含まれる場合は短縮 threshold を適用する。
+        """
         updated_at_str = _read_state(issue, "updated_at", self.autopilot_dir, repo_id)
         if not updated_at_str:
             return False
@@ -531,7 +551,15 @@ class PhaseOrchestrator:
             if updated_at.tzinfo is None:
                 updated_at = updated_at.replace(tzinfo=timezone.utc)
             elapsed = (now - updated_at).total_seconds()
-            return elapsed >= STAGNATION_THRESHOLD
+
+            # C6 MVP: step-aware threshold
+            current_step = _read_state(issue, "current_step", self.autopilot_dir, repo_id)
+            threshold = (
+                STAGNATION_THRESHOLD_PR_STEP
+                if current_step in PR_WORKFLOW_STEPS
+                else STAGNATION_THRESHOLD
+            )
+            return elapsed >= threshold
         except (ValueError, TypeError):
             return False
 

--- a/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
+++ b/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
@@ -459,3 +459,68 @@ class TestStagnationThresholdBehavior:
 
         # 元に戻す
         importlib.reload(orchestrator_mod)
+
+
+class TestStepAwareThreshold:
+    """C6 MVP (#888): PR workflow step に対する短縮 threshold 検証."""
+
+    def test_pr_workflow_step_uses_short_threshold(self, tmp_path: Path) -> None:
+        """ac-verify で elapsed=400s → short threshold (300s) で stagnation 検知."""
+        orch = _make_orchestrator(tmp_path)
+        stale_at = _iso_ago(400)  # > PR_STEP(300s), < default(900s)
+
+        def mock_read_state(iss, field, autopilot_dir, repo_id=""):
+            if field == "updated_at":
+                return stale_at
+            if field == "current_step":
+                return "ac-verify"
+            return ""
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=mock_read_state):
+            assert orch._check_stagnation("501", "_default") is True
+
+    def test_non_pr_step_uses_default_threshold(self, tmp_path: Path) -> None:
+        """init で elapsed=400s → default threshold (900s) 未満、stagnation 非検知."""
+        orch = _make_orchestrator(tmp_path)
+        stale_at = _iso_ago(400)
+
+        def mock_read_state(iss, field, autopilot_dir, repo_id=""):
+            if field == "updated_at":
+                return stale_at
+            if field == "current_step":
+                return "init"
+            return ""
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=mock_read_state):
+            assert orch._check_stagnation("502", "_default") is False
+
+    def test_pr_step_short_threshold_not_exceeded(self, tmp_path: Path) -> None:
+        """ac-verify で elapsed=200s → short threshold (300s) 未満、stagnation 非検知."""
+        orch = _make_orchestrator(tmp_path)
+        fresh_at = _iso_ago(200)
+
+        def mock_read_state(iss, field, autopilot_dir, repo_id=""):
+            if field == "updated_at":
+                return fresh_at
+            if field == "current_step":
+                return "ac-verify"
+            return ""
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=mock_read_state):
+            assert orch._check_stagnation("503", "_default") is False
+
+    def test_pr_workflow_step_env_override(self) -> None:
+        """DEV_AUTOPILOT_STAGNATION_SEC_PR_STEP=60 で PR step の閾値が 60s に変更."""
+        with patch.dict(os.environ, {"DEV_AUTOPILOT_STAGNATION_SEC_PR_STEP": "60"}):
+            reloaded = importlib.reload(orchestrator_mod)
+            assert reloaded.STAGNATION_THRESHOLD_PR_STEP == 60
+        # 元に戻す
+        importlib.reload(orchestrator_mod)
+
+    def test_pr_workflow_steps_includes_ac_verify(self) -> None:
+        """PR_WORKFLOW_STEPS に主要な LLM 判断 step が含まれる."""
+        assert "ac-verify" in orchestrator_mod.PR_WORKFLOW_STEPS
+        assert "pr-cycle-report" in orchestrator_mod.PR_WORKFLOW_STEPS
+        assert "merge-gate" in orchestrator_mod.PR_WORKFLOW_STEPS
+        assert "init" not in orchestrator_mod.PR_WORKFLOW_STEPS
+        assert "worktree-create" not in orchestrator_mod.PR_WORKFLOW_STEPS

--- a/plugins/twl/skills/workflow-pr-merge/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-merge/SKILL.md
@@ -61,6 +61,14 @@ THEN
   Pilot に手動介入を要求。
 ```
 
+### Step-aware stagnation 防止（C6 MVP、#888）
+
+orchestrator の stagnation 検知は PR workflow step（ac-verify / pr-cycle-report / merge-gate / e2e-screening / pr-cycle-analysis / auto-merge / all-pass-check / fix-phase / post-fix-verify / warning-fix / prompt-compliance / ts-preflight / phase-review / scope-judge / pr-test）で **300 秒**（5 分）の短縮 threshold を適用する（default 900 秒）。
+
+- **機械的 step**（pr-cycle-report / all-pass-check / auto-merge）は `chain-runner.sh <step>` 呼出で `record_current_step` が自動的に `updated_at` を更新（heartbeat 役割）
+- **LLM 判断 step**（e2e-screening / pr-cycle-analysis / merge-gate）は 5 分以内に結論を出すこと。詳細調査が必要な場合は stagnation timeout で自動 failed 化するのを待たず、Pilot に手動介入を escalate する
+- env override: `DEV_AUTOPILOT_STAGNATION_SEC_PR_STEP=600` 等で threshold を調整可能
+
 ## chain 実行指示（MUST — 全ステップを順に実行せよ。途中で停止するな）
 
 **重要**: 以下の全ステップを上から順に実行すること。各ステップ完了後、**即座に**次のステップに進むこと。プロンプトで停止してはならない。


### PR DESCRIPTION
## Summary

Phase C #871 audit で判明した **C6 (LLM 内部 stall, 19%)** への MVP 対策。Phase B 実測で 4/21 issue が `running` 滞留、内訳 ac-verify 3件 (75%) / pr-cycle-report 1件 (25%)。

## 変更内容

### `orchestrator.py`

- `PR_WORKFLOW_STEPS` frozenset (15 step、pr-verify / pr-fix / pr-merge 横断):
  ```
  pr-verify: prompt-compliance, ts-preflight, phase-review, scope-judge, pr-test, ac-verify
  pr-merge:  all-pass-check, pr-cycle-report
  skill内:   e2e-screening, pr-cycle-analysis, merge-gate, auto-merge (ADR-022 deps.yaml SSoT)
  pr-fix:    fix-phase, post-fix-verify, warning-fix
  ```
- `STAGNATION_THRESHOLD_PR_STEP` env var (default **300s**, env: `DEV_AUTOPILOT_STAGNATION_SEC_PR_STEP`)
- `_check_stagnation` が `current_step` を読み step-aware に判定

### `workflow-pr-merge/SKILL.md`

ドメインルール節に **Step-aware stagnation 防止** 追加:
- 機械的 step は `chain-runner.sh` 呼出で `record_current_step` 自動更新
- LLM 判断 step (e2e-screening / pr-cycle-analysis / merge-gate) は 5 分以内に結論、長引けば Pilot escalate
- env override で threshold 調整可能

### pytest

`TestStepAwareThreshold` 5 test (**全 PASS**):
- pr_workflow_step で short threshold 使用
- non_pr_step で default threshold 使用
- 境界条件 (200s, 400s)
- env override
- PR_WORKFLOW_STEPS 内容検証

## 効果 (期待)

- ac-verify 等の LLM 判断 step が 5 分で stagnation 検知可能
- 既存 `MAX_STAGNATION_NUDGE=3` 経由の自動 failed 化で C6 stall を自律回復
- 非 PR step (init 等) は従来 900s 維持、**回帰なし**

## Non-goal (spin-off)

- `last_heartbeat_at` field schema 拡張 (ADR-018 拡張要、別 Issue)
- ac-verify timeout + retry 実装 (別 Issue)
- bats sandbox 検証 (**#875**、twill-sandbox bare 化後)

## 参照

- Issue: #888
- 関連 audit: `.audit/pilot-stall-report.md` §3 C6
- Phase C merged: #883 (C3), #882 (C4 precheck), #881 (C6 WARN 降格)

Closes #888