### PR TITLE
test(#875): 6-category stall test — Python C2/C3/C4 で MVP validation 網羅完成

### DIFF
--- a/cli/twl/tests/autopilot/test_mergegate_precheck.py
+++ b/cli/twl/tests/autopilot/test_mergegate_precheck.py
@@ -1,0 +1,167 @@
+"""Unit tests for MergeGateOperationsMixin._run_merge() PRECHECK + conflict branches.
+
+Covers #875 failure categories driven by MVP flag #872 (PRECHECK):
+  - C2 (merge_conflict): `gh pr merge --squash` 失敗時に stderr が conflict を示すと
+    failure.reason=merge_conflict, status=conflict が記録される
+  - C4 (branch_protection): DEV_AUTOPILOT_MERGEABILITY_PRECHECK=true + gh pr view の
+    mergeStateStatus ∈ {UNSTABLE, BLOCKED, BEHIND} で fail-fast (failure.reason=branch_protection_*)
+
+C1 (poll_timeout) は test_orchestrator_stagnation.py でカバー済み、
+C3 (merge-ready race) / C5 (inject_exhausted) / C6 (LLM stall) は bats / observer 手順側担当。
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from twl.autopilot.mergegate import MergeGate
+
+
+@pytest.fixture
+def gate(tmp_path: Path) -> MergeGate:
+    autopilot_dir = tmp_path / ".autopilot"
+    (autopilot_dir / "issues").mkdir(parents=True)
+    (autopilot_dir / "checkpoints").mkdir()
+    scripts_root = tmp_path / "scripts"
+    scripts_root.mkdir()
+    return MergeGate(
+        issue="875",
+        pr_number="900",
+        branch="feat/875-bats-six-category",
+        autopilot_dir=autopilot_dir,
+        scripts_root=scripts_root,
+    )
+
+
+def _mock_run_sequence(results: list[MagicMock]) -> MagicMock:
+    """subprocess.run の side_effect で順次 MagicMock を返す iterator."""
+    it = iter(results)
+    return MagicMock(side_effect=lambda *a, **kw: next(it))
+
+
+class TestPrecheckBranchProtection:
+    """C4: DEV_AUTOPILOT_MERGEABILITY_PRECHECK=true で branch protection fail-fast."""
+
+    @pytest.mark.parametrize("state,expected_reason", [
+        ("UNSTABLE", "branch_protection_unstable"),
+        ("BLOCKED", "branch_protection_blocked"),
+        ("BEHIND", "branch_protection_behind"),
+    ])
+    def test_precheck_blocks_protected_state(
+        self, gate: MergeGate, state: str, expected_reason: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", "true")
+        precheck_result = MagicMock(returncode=0, stdout=json.dumps({"mergeStateStatus": state}))
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=precheck_result) as mock_run, \
+             patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
+            ret = gate._run_merge([])
+
+        assert ret is False
+        # precheck のみが呼ばれ、gh pr merge には進まない
+        assert mock_run.call_count == 1
+        call_args = mock_run.call_args_list[0].args[0]
+        assert call_args[:4] == ["gh", "pr", "view", gate.pr_number]
+        assert "mergeStateStatus" in call_args
+        # _state_write が failed + 正しい reason で呼ばれる
+        mock_write.assert_called_once()
+        kwargs = mock_write.call_args.kwargs
+        assert kwargs["status"] == "failed"
+        failure_payload = json.loads(kwargs["failure"])
+        assert failure_payload["reason"] == expected_reason
+        assert failure_payload["step"] == "merge-gate-precheck"
+
+    def test_precheck_skipped_when_flag_off(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        merge_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result) as mock_run:
+            ret = gate._run_merge([])
+
+        assert ret is True
+        # precheck スキップされ、gh pr merge のみが直接呼ばれる
+        assert mock_run.call_count == 1
+        assert mock_run.call_args_list[0].args[0][:3] == ["gh", "pr", "merge"]
+
+    def test_precheck_clean_proceeds_to_merge(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """CLEAN 等 OK 状態なら precheck を通過して merge 実行."""
+        monkeypatch.setenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", "true")
+        precheck_result = MagicMock(returncode=0, stdout=json.dumps({"mergeStateStatus": "CLEAN"}))
+        merge_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch(
+            "twl.autopilot.mergegate_ops.subprocess.run",
+            new=_mock_run_sequence([precheck_result, merge_result]),
+        ):
+            ret = gate._run_merge([])
+
+        assert ret is True
+
+
+class TestMergeConflictClassification:
+    """C2: gh pr merge --squash 失敗を conflict vs merge_failed に分類."""
+
+    @pytest.mark.parametrize("stderr_msg", [
+        "this branch has conflicts",
+        "Pull request is not mergeable: conflict",
+        "merge conflict detected",
+    ])
+    def test_merge_conflict_records_conflict_reason(
+        self, gate: MergeGate, stderr_msg: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        merge_result = MagicMock(returncode=1, stdout="", stderr=stderr_msg)
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+             patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
+            ret = gate._run_merge([])
+
+        assert ret is False
+        mock_write.assert_called_once()
+        kwargs = mock_write.call_args.kwargs
+        assert kwargs["status"] == "conflict"
+        failure_payload = json.loads(kwargs["failure"])
+        assert failure_payload["reason"] == "merge_conflict"
+        assert failure_payload["step"] == "merge-gate"
+
+    def test_non_conflict_failure_records_merge_failed(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        merge_result = MagicMock(
+            returncode=1, stdout="", stderr="GraphQL: Required status check \"build\" is pending."
+        )
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+             patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
+            ret = gate._run_merge([])
+
+        assert ret is False
+        mock_write.assert_called_once()
+        kwargs = mock_write.call_args.kwargs
+        assert kwargs["status"] == "failed"
+        failure_payload = json.loads(kwargs["failure"])
+        assert failure_payload["reason"] == "merge_failed"
+
+    def test_credentials_masked_in_failure_details(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        merge_result = MagicMock(
+            returncode=1, stdout="",
+            stderr="auth failed with ghp_abcdef123456 not mergeable conflict",
+        )
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+             patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
+            gate._run_merge([])
+
+        failure_payload = json.loads(mock_write.call_args.kwargs["failure"])
+        assert "ghp_abcdef123456" not in failure_payload["details"]
+        assert "ghp_***MASKED***" in failure_payload["details"]

--- a/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
+++ b/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
@@ -524,3 +524,91 @@ class TestStepAwareThreshold:
         assert "merge-gate" in orchestrator_mod.PR_WORKFLOW_STEPS
         assert "init" not in orchestrator_mod.PR_WORKFLOW_STEPS
         assert "worktree-create" not in orchestrator_mod.PR_WORKFLOW_STEPS
+
+
+# ---------------------------------------------------------------------------
+# #875 C3: merge-ready race 解消 (#873 fix) の unit test
+# orchestrator._poll_phase で status=merge-ready 検知時、即時 _run_merge_gate を
+# 呼び出して POLL_INTERVAL 分の滞留を回避する動作を validate する。
+# ---------------------------------------------------------------------------
+
+
+class TestMergeReadyRaceResolution:
+    """C3 (merge-ready race 解消, #873 fix). _poll_phase branch validation."""
+
+    def test_merge_ready_triggers_immediate_merge_gate(self, tmp_path: Path) -> None:
+        """status=merge-ready の issue を _poll_phase で検出したら即時 _run_merge_gate が呼ばれる."""
+        orch = _make_orchestrator(tmp_path)
+        entry = "_default:700"
+
+        with patch.object(orch, "_run_merge_gate") as mock_gate, \
+             patch.object(orch, "_cleanup_worker") as mock_cleanup, \
+             patch("twl.autopilot.orchestrator._read_state") as mock_read:
+            # 最初の read: status=merge-ready で分岐 L437 へ入る
+            # _run_merge_gate 実行後の read: status=done で cleanup_worker へ進む
+            mock_read.side_effect = ["merge-ready", "done"]
+
+            orch._poll_phase([entry])
+
+            mock_gate.assert_called_once_with(entry)
+            mock_cleanup.assert_called_once_with("700", entry)
+
+    def test_merge_ready_then_failed_final_triggers_cleanup(self, tmp_path: Path) -> None:
+        """merge_gate_rejected_final は retry_count=0 でも即 cleanup (#229 + #873 合流)."""
+        orch = _make_orchestrator(tmp_path)
+        entry = "_default:701"
+
+        with patch.object(orch, "_run_merge_gate") as mock_gate, \
+             patch.object(orch, "_cleanup_worker") as mock_cleanup, \
+             patch("twl.autopilot.orchestrator._read_state") as mock_read:
+            mock_read.side_effect = [
+                "merge-ready",         # 初回 status 読み (L429)
+                "failed",              # _run_merge_gate 後の status_after
+                "0",                   # retry_count
+                "merge_gate_rejected_final",  # failure.reason
+            ]
+            orch._poll_phase([entry])
+
+            mock_gate.assert_called_once_with(entry)
+            mock_cleanup.assert_called_once_with("701", entry)
+
+    def test_merge_ready_transient_failure_skips_cleanup(self, tmp_path: Path) -> None:
+        """retry_count=0 + reason != merge_gate_rejected_final なら cleanup せず継続."""
+        orch = _make_orchestrator(tmp_path)
+        entry = "_default:702"
+
+        with patch.object(orch, "_run_merge_gate") as mock_gate, \
+             patch.object(orch, "_cleanup_worker") as mock_cleanup, \
+             patch("twl.autopilot.orchestrator._read_state") as mock_read:
+            mock_read.side_effect = [
+                "merge-ready",     # 初回 status 読み
+                "failed",          # _run_merge_gate 後
+                "0",               # retry_count
+                "merge_conflict",  # failure.reason (transient)
+            ]
+            orch._poll_phase([entry])
+
+            mock_gate.assert_called_once_with(entry)
+            # transient な失敗では cleanup しない
+            mock_cleanup.assert_not_called()
+
+    def test_merge_ready_race_fix_does_not_wait_poll_interval(self, tmp_path: Path) -> None:
+        """#873 fix 確認: _run_merge_gate が POLL_INTERVAL sleep なしに即実行される."""
+        orch = _make_orchestrator(tmp_path)
+        entry = "_default:703"
+
+        gate_called_times: list[float] = []
+
+        def record_time(_entry: str) -> None:
+            gate_called_times.append(time.monotonic())
+
+        start = time.monotonic()
+        with patch.object(orch, "_run_merge_gate", side_effect=record_time), \
+             patch.object(orch, "_cleanup_worker"), \
+             patch("twl.autopilot.orchestrator._read_state") as mock_read:
+            mock_read.side_effect = ["merge-ready", "done"]
+            orch._poll_phase([entry])
+
+        assert gate_called_times, "_run_merge_gate was not called"
+        # fix 後は 1 秒未満で呼ばれる（POLL_INTERVAL=10-30s の待ちがない）
+        assert gate_called_times[0] - start < 1.0


### PR DESCRIPTION
## Summary

#875 の 6 failure category 再現テストを、MVP 実装 (#872/#873/#888) に合わせて網羅完成させる。既存 coverage と整合する位置に **Python unit test を 3 category 分**（C2 merge_conflict / C3 merge-ready race / C4 branch_protection）新規追加。bats/Python のハイブリッド配置で既存 coverage を再利用。

## 6-category coverage map

| cat | reason/message             | test file                                                      | 本 PR |
|-----|----------------------------|----------------------------------------------------------------|------|
| C1  | \`poll_timeout\`             | \`tests/autopilot/test_orchestrator_stagnation.py\` 既存         | 既存 |
| C2  | \`merge_conflict\`           | \`tests/autopilot/test_mergegate_precheck.py\` **NEW**           | ✅ |
| C3  | merge-ready race (#873)    | \`test_orchestrator_stagnation.py::TestMergeReadyRaceResolution\` **NEW** | ✅ |
| C4  | \`branch_protection_*\`      | \`tests/autopilot/test_mergegate_precheck.py\` **NEW**           | ✅ |
| C5  | \`inject_exhausted_pr_merge\`| \`plugins/twl/tests/unit/inject-next-workflow/pr-merge-skip-guard.bats\` Scenario (c) 4 test 既存 | 既存 |
| C6  | LLM stall \`stagnation_timeout\`| \`test_orchestrator_stagnation.py::TestStepAwareThreshold\` (#888) | 既存 |

## 追加内容

### \`cli/twl/tests/autopilot/test_mergegate_precheck.py\` (NEW、10 test)

- **C4 \`TestPrecheckBranchProtection\`** (5 test):
  - parametrize で \`UNSTABLE/BLOCKED/BEHIND\` 各 state が \`failure.reason=branch_protection_{state}\` を記録することを検証
  - \`DEV_AUTOPILOT_MERGEABILITY_PRECHECK=false\` では precheck がスキップされ直接 merge に進むこと
  - \`CLEAN\` 等 OK 状態では precheck 通過して merge 実行

- **C2 \`TestMergeConflictClassification\`** (5 test):
  - parametrize で 3 種類の conflict stderr キーワードで \`failure.reason=merge_conflict\`, \`status=conflict\` 記録を検証
  - non-conflict な失敗では \`failure.reason=merge_failed\`, \`status=failed\`
  - credentials (\`ghp_xxx\`) が masking される

### \`cli/twl/tests/autopilot/test_orchestrator_stagnation.py\` (TestMergeReadyRaceResolution 追加、4 test)

- C3 race 解消 (#873 fix) 検証:
  - \`_poll_phase\` で status=merge-ready を検出 → 即時 \`_run_merge_gate\` call
  - \`merge_gate_rejected_final\` では retry_count=0 でも cleanup 実行 (#229 + #873 合流)
  - transient failure (\`merge_conflict\` 等) では cleanup を skip
  - timing assertion: gate call が 1 秒未満（POLL_INTERVAL 待ちがない）

## AC

- [x] \`pytest cli/twl/tests/autopilot/test_mergegate_precheck.py\` 10/10 PASS
- [x] \`pytest ...::TestMergeReadyRaceResolution\` 4/4 PASS
- [x] 6 category の coverage map 明記
- [x] #875 bats 新規作成 scope は、現実の test 配置に合わせて Python unit 側で網羅 (本 PR Closes)

## Note

\`test_stagnation_detected_sends_nudge\` (pre-existing): 本 PR とは独立の bug (context manager 外で mock 属性参照)。別 Issue で追跡予定。

## 関連

- Epic: #866 (Phase C W2)
- MVP 前提: #872 / #873 / #888

Closes #875