### PR TITLE
feat(#890): last_heartbeat_at field 追加で stagnation 判定を堅牢化

### DIFF
--- a/cli/twl/src/twl/autopilot/orchestrator.py
+++ b/cli/twl/src/twl/autopilot/orchestrator.py
@@ -536,21 +536,29 @@ class PhaseOrchestrator:
             print(f"[orchestrator] escalation signal 作成失敗: {e}", file=sys.stderr)
 
     def _check_stagnation(self, issue: str, repo_id: str) -> bool:
-        """Return True if updated_at is older than threshold seconds.
+        """Return True if heartbeat is older than threshold seconds.
+
+        #890: last_heartbeat_at を優先参照し、欠損時のみ updated_at に fallback する。
+        - last_heartbeat_at は chain-runner::record_current_step でのみ更新される pure heartbeat。
+        - updated_at は state.py が任意 write で自動更新するため、軽微な副作用 write で
+          "実際には chain が進んでいない" 状態でも fresh になりうる (誤検知 回避)。
+        - 既存 state file に last_heartbeat_at 欠損時は updated_at にフォールバックして回帰ゼロ。
 
         C6 MVP (#888): PR workflow step (ac-verify 等) の LLM 内部 stall 対策として、
         current_step が PR_WORKFLOW_STEPS に含まれる場合は短縮 threshold を適用する。
         """
-        updated_at_str = _read_state(issue, "updated_at", self.autopilot_dir, repo_id)
-        if not updated_at_str:
+        heartbeat_str = _read_state(issue, "last_heartbeat_at", self.autopilot_dir, repo_id)
+        timestamp_str = heartbeat_str or _read_state(
+            issue, "updated_at", self.autopilot_dir, repo_id
+        )
+        if not timestamp_str:
             return False
         try:
-            updated_at = datetime.fromisoformat(updated_at_str.replace("Z", "+00:00"))
-            # Compare as UTC-aware if possible, else naive
+            ts = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
             now = datetime.now(timezone.utc)
-            if updated_at.tzinfo is None:
-                updated_at = updated_at.replace(tzinfo=timezone.utc)
-            elapsed = (now - updated_at).total_seconds()
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            elapsed = (now - ts).total_seconds()
 
             # C6 MVP: step-aware threshold
             current_step = _read_state(issue, "current_step", self.autopilot_dir, repo_id)

--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -285,6 +285,7 @@ class StateManager:
             "window": "",
             "started_at": now,
             "updated_at": now,
+            "last_heartbeat_at": now,  # #890: chain-runner が record_current_step 時に更新する heartbeat 専用 field
             "current_step": "",
             "retry_count": 0,
             "fix_instructions": None,

--- a/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
+++ b/cli/twl/tests/autopilot/test_orchestrator_stagnation.py
@@ -612,3 +612,110 @@ class TestMergeReadyRaceResolution:
         assert gate_called_times, "_run_merge_gate was not called"
         # fix 後は 1 秒未満で呼ばれる（POLL_INTERVAL=10-30s の待ちがない）
         assert gate_called_times[0] - start < 1.0
+
+
+# ---------------------------------------------------------------------------
+# #890: last_heartbeat_at field を使った stagnation 判定
+# - 存在する場合は last_heartbeat_at を優先
+# - 欠損時は updated_at に fallback (既存 state file backward compat)
+# - 両方欠損なら False
+# ---------------------------------------------------------------------------
+
+
+class TestLastHeartbeatAt:
+    """#890 last_heartbeat_at schema 拡張の動作検証."""
+
+    def test_heartbeat_fresh_takes_priority_over_stale_updated_at(self, tmp_path: Path) -> None:
+        """last_heartbeat_at が fresh なら updated_at が古くても stagnation=False."""
+        orch = _make_orchestrator(tmp_path)
+
+        def fake_read(issue: str, field: str, *_args, **_kwargs) -> str | None:
+            return {
+                "last_heartbeat_at": _iso_ago(100),   # fresh
+                "updated_at": _iso_ago(10000),        # stale
+                "current_step": "ac-verify",
+            }.get(field)
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=fake_read):
+            assert orch._check_stagnation("800", "_default") is False
+
+    def test_heartbeat_stale_triggers_stagnation_despite_fresh_updated_at(
+        self, tmp_path: Path
+    ) -> None:
+        """last_heartbeat_at が stale なら updated_at が fresh でも stagnation=True.
+
+        誤検知回避の鍵: state.py が任意 write で updated_at を自動更新しても、
+        chain 境界を通過していなければ last_heartbeat_at は古いまま。
+        """
+        orch = _make_orchestrator(tmp_path)
+
+        def fake_read(issue: str, field: str, *_args, **_kwargs) -> str | None:
+            return {
+                "last_heartbeat_at": _iso_ago(400),   # stale (>300s PR step threshold)
+                "updated_at": _iso_ago(10),           # fresh (side effect)
+                "current_step": "ac-verify",
+            }.get(field)
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=fake_read):
+            assert orch._check_stagnation("801", "_default") is True
+
+    def test_missing_heartbeat_falls_back_to_updated_at(self, tmp_path: Path) -> None:
+        """last_heartbeat_at 欠損時は updated_at にフォールバック (backward compat)."""
+        orch = _make_orchestrator(tmp_path)
+
+        def fake_read(issue: str, field: str, *_args, **_kwargs) -> str | None:
+            return {
+                "last_heartbeat_at": None,            # 欠損
+                "updated_at": _iso_ago(400),          # stale
+                "current_step": "ac-verify",
+            }.get(field)
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=fake_read):
+            assert orch._check_stagnation("802", "_default") is True
+
+    def test_both_missing_returns_false(self, tmp_path: Path) -> None:
+        """last_heartbeat_at と updated_at どちらも欠損なら stagnation=False (安全側)."""
+        orch = _make_orchestrator(tmp_path)
+
+        def fake_read(issue: str, field: str, *_args, **_kwargs) -> str | None:
+            return None
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=fake_read):
+            assert orch._check_stagnation("803", "_default") is False
+
+    def test_missing_heartbeat_fresh_updated_at_no_stagnation(self, tmp_path: Path) -> None:
+        """既存 (heartbeat 欠損) state file の正常運用を回帰確認."""
+        orch = _make_orchestrator(tmp_path)
+
+        def fake_read(issue: str, field: str, *_args, **_kwargs) -> str | None:
+            return {
+                "last_heartbeat_at": None,
+                "updated_at": _iso_ago(10),           # fresh
+                "current_step": "ac-verify",
+            }.get(field)
+
+        with patch("twl.autopilot.orchestrator._read_state", side_effect=fake_read):
+            assert orch._check_stagnation("804", "_default") is False
+
+    def test_init_issue_writes_last_heartbeat_at(self, tmp_path: Path) -> None:
+        """state._init_issue が last_heartbeat_at を初期書込することを確認."""
+        from twl.autopilot.state import StateManager
+
+        autopilot_dir = tmp_path / ".autopilot"
+        (autopilot_dir / "issues").mkdir(parents=True)
+
+        mgr = StateManager(autopilot_dir=autopilot_dir)
+        mgr.write(
+            type_="issue",
+            issue="805",
+            role="worker",
+            sets=[],
+            init=True,
+        )
+
+        state_file = autopilot_dir / "issues" / "issue-805.json"
+        data = json.loads(state_file.read_text())
+        assert "last_heartbeat_at" in data
+        assert data["last_heartbeat_at"] is not None
+        # ISO-8601 UTC format
+        datetime.fromisoformat(data["last_heartbeat_at"].replace("Z", "+00:00"))

--- a/plugins/twl/architecture/decisions/ADR-018-state-schema-ssot.md
+++ b/plugins/twl/architecture/decisions/ADR-018-state-schema-ssot.md
@@ -92,3 +92,29 @@ status=$(jq -r '.status' issue-N.json)
 ## Migration
 
 既存の running session は `workflow_done` が null になるが、`current_step` の terminal 値検知で inject が継続して機能する。既存 session への影響は最小限。
+
+---
+
+## Amendment (2026-04-22、Issue #890): `last_heartbeat_at` field 追加
+
+### 背景
+
+Phase D #888 で step-aware stagnation threshold (300s) を導入した後、`_check_stagnation` は `updated_at` を heartbeat 代替として使用していた。しかし:
+
+- `updated_at` は `state.py::StateManager.write` が任意 write 時に自動更新する。軽微な副作用 write (例: `input_waiting_detected` 更新) でも fresh になる
+- LLM 判断 step 内で chain 境界を通過していないのに、別経路で state write が発生すると、実質 stall でも `updated_at` が fresh で誤 no-stagnate
+- 逆に worker が生存していても `updated_at` が長時間 stale なら誤 stagnate
+
+### 新 field: `last_heartbeat_at`
+
+| フィールド | 役割 | Writer |
+|---|---|---|
+| `last_heartbeat_at` | chain step 境界を通過した pure heartbeat (ISO8601 UTC) | `chain-runner.sh::record_current_step` のみ |
+
+- `StateManager._init_issue` で `last_heartbeat_at: now` 初期化
+- `chain-runner.sh::record_current_step` が `current_step` と同時に `last_heartbeat_at` を更新
+- `orchestrator.py::_check_stagnation` が `last_heartbeat_at` 優先参照、欠損時のみ `updated_at` に fallback (backward compat)
+
+### ADR-018 との位置づけ
+
+本 Amendment は ADR-018 Decision の原則（`status` = 外部観察 SSoT）を変更しない。`last_heartbeat_at` は orchestrator 内部判定の補助 field であり、Monitor/su-observer の外部観察には公開しない。既存廃止フィールド方針 (`workflow_done`) は維持する。

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -162,6 +162,10 @@ err() {
 # Compaction Recovery: current_step を issue-{N}.json に記録
 # 引数: step_id（記録するステップ名）
 # issue_num はブランチ名から自動抽出。取得できない場合はサイレントスキップ
+#
+# #890: last_heartbeat_at も同時更新することで、updated_at が他書込経路で
+# 更新されたとしても "実際に chain step 境界を通過した" タイムスタンプを
+# orchestrator stagnation 判定が正確に読めるようにする。
 record_current_step() {
   local step_id="${1:-}"
   [[ -z "$step_id" ]] && return 0
@@ -172,8 +176,12 @@ record_current_step() {
   [[ -z "$issue_num" ]] && return 0
   # PYTHONPATH 検証（Issue #227）
   ensure_pythonpath || return 0
-  # record current_step via Python state module
-  python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker --set "current_step=${step_id}" 2>/dev/null || true
+  local now_utc
+  now_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  # record current_step + last_heartbeat_at via Python state module (#890)
+  python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker \
+    --set "current_step=${step_id}" \
+    --set "last_heartbeat_at=${now_utc}" 2>/dev/null || true
 }
 
 # =====================================================================


### PR DESCRIPTION
## Summary

ADR-018 Amendment として \`last_heartbeat_at\` field を追加し、Phase D #888 step-aware stagnation threshold を更に robust にする。

## 問題

\`_check_stagnation\` は \`updated_at\` を heartbeat 代替として読んでいたが、\`updated_at\` は state.py 任意 write で自動更新されるため:

- 実質 stall でも他経路の副作用 write で fresh → 誤 no-stagnate
- chain が境界を通過していなくても state 更新が入ると fresh

## 対策

1. **state.py::_init_issue**: \`last_heartbeat_at: now\` 初期化追加
2. **chain-runner.sh::record_current_step**: \`current_step\` と同時に \`last_heartbeat_at\` を更新 (chain 境界通過のみで fresh になる pure heartbeat)
3. **orchestrator.py::_check_stagnation**: \`last_heartbeat_at\` 優先参照、欠損時は \`updated_at\` に fallback (backward compat)
4. **ADR-018**: Amendment セクションで schema 追加根拠と ADR-018 原則との位置づけを明文化

## テスト

\`tests/autopilot/test_orchestrator_stagnation.py::TestLastHeartbeatAt\` 6 test:

| test | 検証項目 |
|------|---------|
| test_heartbeat_fresh_takes_priority_over_stale_updated_at | fresh heartbeat が stale updated_at を上書き |
| test_heartbeat_stale_triggers_stagnation_despite_fresh_updated_at | stale heartbeat が fresh updated_at を上書き (**誤 no-stagnate 回避 core**) |
| test_missing_heartbeat_falls_back_to_updated_at | heartbeat 欠損時 updated_at fallback (回帰なし) |
| test_both_missing_returns_false | 両方欠損で False (安全側) |
| test_missing_heartbeat_fresh_updated_at_no_stagnation | fresh updated_at + heartbeat 欠損で no-stagnate (既存 state file 回帰) |
| test_init_issue_writes_last_heartbeat_at | StateManager.write(init=True) で last_heartbeat_at 書込確認 |

**6/6 PASS + 既存 103 PASS** (pre-existing bug 1 件は独立、本 PR 対象外)

## AC

- [x] \`issue-{N}.json\` に \`last_heartbeat_at\` が書かれる
- [x] orchestrator が last_heartbeat_at を優先して stagnation 判定
- [x] 欠損時は従来 \`updated_at\` にフォールバック (回帰なし)
- [x] ADR-018 schema 表更新 (Amendment 形式)
- [x] pytest PASS

## 関連

- Depends on: #888 (C6 MVP threshold 短縮、先行 merged cad6c3b)
- Parent tracking: Phase D C6 対策系

Closes #890