### PR TITLE
feat(#891): ac-verify LLM timeout + retry safety net 実装

### DIFF
--- a/cli/twl/src/twl/autopilot/state.py
+++ b/cli/twl/src/twl/autopilot/state.py
@@ -288,6 +288,7 @@ class StateManager:
             "last_heartbeat_at": now,  # #890: chain-runner が record_current_step 時に更新する heartbeat 専用 field
             "current_step": "",
             "retry_count": 0,
+            "ac_verify_call_count": 0,  # #891: step_ac_verify 呼出回数 (max retry safety net)
             "fix_instructions": None,
             "merged_at": None,
             "files_changed": [],

--- a/plugins/twl/commands/ac-verify.md
+++ b/plugins/twl/commands/ac-verify.md
@@ -15,6 +15,15 @@ PR diff・テスト結果・レビュー結果を Issue の受け入れ基準（
 
 本コマンドは LLM 判断ステップ（chain-runner.sh の `step_ac_verify` がマーカーとして位置を記録する）。
 
+### Timeout 方針（#891、MUST）
+
+**ac-verify は 3 分以内に結論を出すこと**。以下のガードレールを守る:
+
+- 各 AC 項目の判定は対応する test 結果 / diff キーワード照合で即決する (LLM 深読み禁止)
+- 判定に時間がかかる AC (e.g., 複雑な UI/副作用) は **手動確認要 (severity=WARNING)** にマークして先に進む。全 AC を完璧判定しようとして stall しない
+- 調査が 3 分で収束しない場合、未完了 AC を `manual_verification_required` finding として列挙して checkpoint を書く。merge-gate が WARNING を確認できれば OK
+- `chain-runner.sh::step_ac_verify` が retry 上限 (2 回) を超えた呼出を機械的に fail する safety net を持つ (#891 MVP)
+
 ## 入力
 
 - AC チェックリスト: `${SNAPSHOT_DIR}/01.5-ac-checklist.md`（ac-extract の出力。`SNAPSHOT_DIR` 未設定時は `.dev-session/`）

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1031,7 +1031,33 @@ step_ac_verify() {
     skip "ac-verify" "Issue 番号なし — スキップ"
     return 0
   fi
-  echo "[chain-runner] ac-verify は LLM ステップです。" >&2
+
+  # #891: ac-verify call count で retry safety net。orchestrator が stagnation 検知で
+  # ac-verify を再 inject するのは許容（retry 1 回まで）。max+1 を超えた呼出で
+  # LLM stall が回復不能と判断し、status=failed, failure.reason=ac_verify_llm_timeout に確定。
+  ensure_pythonpath || true
+  local _max_retry="${DEV_AUTOPILOT_AC_VERIFY_MAX_RETRY:-1}"  # retry 上限（default 1 = 最大 2 回呼出）
+  local _call_count
+  _call_count=$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --field ac_verify_call_count 2>/dev/null || echo "0")
+  [[ -z "$_call_count" || ! "$_call_count" =~ ^[0-9]+$ ]] && _call_count=0
+  local _new_count=$((_call_count + 1))
+  python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker \
+    --set "ac_verify_call_count=${_new_count}" 2>/dev/null || true
+
+  if (( _new_count > _max_retry + 1 )); then
+    echo "[chain-runner] ac-verify call_count=${_new_count} > max=$((_max_retry + 1)) — ac_verify_llm_timeout で failed に確定 (Issue #$issue_num)" >&2
+    local _failure
+    _failure=$(printf '{"reason":"ac_verify_llm_timeout","retry_count":%d,"step":"ac-verify"}' "$((_new_count - 1))")
+    # worker role で書込（step_ac_verify は worktree 内で実行されるため、
+    # role=pilot だと不変条件 C で拒否される）
+    python3 -m twl.autopilot.state write --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$issue_num" --role worker \
+      --set "status=failed" \
+      --set "failure=${_failure}" 2>/dev/null || true
+    err "ac-verify" "LLM timeout retry 上限超過 (call_count=${_new_count}) — failed 確定"
+    return 2  # force-exit: 呼び出し元は通常の LLM step 遷移を行わない
+  fi
+
+  echo "[chain-runner] ac-verify は LLM ステップです。(call_count=${_new_count}/$((_max_retry + 1)))" >&2
   echo "[chain-runner] commands/ac-verify.md を Read して実行してください。" >&2
   echo "[chain-runner] 入力: AC checklist + PR diff + pr-test checkpoint" >&2
   echo "[chain-runner] 出力: .autopilot/checkpoints/ac-verify.json (merge-gate が読む)" >&2

--- a/plugins/twl/tests/bats/scripts/chain-runner-ac-verify.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-ac-verify.bats
@@ -155,3 +155,95 @@ teardown() {
   assert_success
   assert_output "OK"
 }
+
+# ---------------------------------------------------------------------------
+# #891: ac-verify LLM timeout retry safety net
+# - 1 回目呼出: ac_verify_call_count 0 → 1、正常に ok 返却
+# - 2 回目呼出: 1 → 2 (retry 許容範囲)、正常に ok 返却
+# - 3 回目呼出: 2 → 3 (max+1 超過)、status=failed + failure.reason=ac_verify_llm_timeout
+# ---------------------------------------------------------------------------
+
+@test "ac-verify[#891]: 初回呼出は ac_verify_call_count を 1 に更新して ok" {
+  local file="$SANDBOX/.autopilot/issues/issue-134.json"
+  mkdir -p "$(dirname "$file")"
+  jq -n '{
+    issue: 134, status: "running", branch: "feat/134-ac-verify",
+    pr: null, window: "", started_at: "2026-04-07T00:00:00Z",
+    current_step: "pr-test", retry_count: 0, ac_verify_call_count: 0,
+    fix_instructions: null, merged_at: null, files_changed: [], failure: null
+  }' > "$file"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" ac-verify
+  assert_success
+  echo "$output" | grep -q "call_count=1"
+
+  local count status
+  count="$(jq -r '.ac_verify_call_count' "$file")"
+  status="$(jq -r '.status' "$file")"
+  [ "$count" = "1" ]
+  [ "$status" = "running" ]
+}
+
+@test "ac-verify[#891]: 2 回目呼出は call_count=2 で retry 許容範囲 (ok)" {
+  local file="$SANDBOX/.autopilot/issues/issue-134.json"
+  mkdir -p "$(dirname "$file")"
+  jq -n '{
+    issue: 134, status: "running", branch: "feat/134-ac-verify",
+    pr: null, window: "", started_at: "2026-04-07T00:00:00Z",
+    current_step: "pr-test", retry_count: 0, ac_verify_call_count: 1,
+    fix_instructions: null, merged_at: null, files_changed: [], failure: null
+  }' > "$file"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" ac-verify
+  assert_success
+
+  local count status
+  count="$(jq -r '.ac_verify_call_count' "$file")"
+  status="$(jq -r '.status' "$file")"
+  [ "$count" = "2" ]
+  [ "$status" = "running" ]
+}
+
+@test "ac-verify[#891]: 3 回目呼出 (max+1 超過) で status=failed + ac_verify_llm_timeout" {
+  local file="$SANDBOX/.autopilot/issues/issue-134.json"
+  mkdir -p "$(dirname "$file")"
+  jq -n '{
+    issue: 134, status: "running", branch: "feat/134-ac-verify",
+    pr: null, window: "", started_at: "2026-04-07T00:00:00Z",
+    current_step: "pr-test", retry_count: 0, ac_verify_call_count: 2,
+    fix_instructions: null, merged_at: null, files_changed: [], failure: null
+  }' > "$file"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" ac-verify
+  # exit 2 (force-exit): err 関数が非 0 exit を返す
+  [ "$status" -ne 0 ]
+
+  local count state reason
+  count="$(jq -r '.ac_verify_call_count' "$file")"
+  state="$(jq -r '.status' "$file")"
+  reason="$(jq -r '.failure.reason' "$file")"
+  [ "$count" = "3" ]
+  [ "$state" = "failed" ]
+  [ "$reason" = "ac_verify_llm_timeout" ]
+}
+
+@test "ac-verify[#891]: DEV_AUTOPILOT_AC_VERIFY_MAX_RETRY=2 で上限拡張される" {
+  local file="$SANDBOX/.autopilot/issues/issue-134.json"
+  mkdir -p "$(dirname "$file")"
+  jq -n '{
+    issue: 134, status: "running", branch: "feat/134-ac-verify",
+    pr: null, window: "", started_at: "2026-04-07T00:00:00Z",
+    current_step: "pr-test", retry_count: 0, ac_verify_call_count: 2,
+    fix_instructions: null, merged_at: null, files_changed: [], failure: null
+  }' > "$file"
+
+  DEV_AUTOPILOT_AC_VERIFY_MAX_RETRY=2 run bash "$SANDBOX/scripts/chain-runner.sh" ac-verify
+  # max=2 → max+1=3、call_count=3 は上限内 → ok
+  assert_success
+
+  local count state
+  count="$(jq -r '.ac_verify_call_count' "$file")"
+  state="$(jq -r '.status' "$file")"
+  [ "$count" = "3" ]
+  [ "$state" = "running" ]
+}


### PR DESCRIPTION
## Summary

Phase D C6 系の ac-verify 特化対策。#888 step-aware stagnation (300s) の上に、ac-verify step 特有の retry safety net を追加。baseline で ac-verify 3/10 の stall を計測、本対策で機械的 fail-fast → Pilot 介入促進。

## 実装

### \`plugins/twl/commands/ac-verify.md\`
- **Timeout 方針** セクションを追加 (MUST):
  - 3 分以内に結論を出すこと
  - 判定困難な AC は \`manual_verification_required\` finding として WARNING で先に進む
  - chain-runner safety net が max+1 超過で機械的に failed 確定することを明示

### \`plugins/twl/scripts/chain-runner.sh::step_ac_verify\`
- \`ac_verify_call_count\` を state に書込 (role=worker、worktree 不変条件 C 準拠)
- \`DEV_AUTOPILOT_AC_VERIFY_MAX_RETRY\` (default=1) で retry 上限制御
- call_count が max+1 を超えた場合 (3 回目以降 default):
  - status=failed
  - failure={\`reason\`: ac_verify_llm_timeout, \`retry_count\`: N, \`step\`: ac-verify}
  - return 2 で force-exit → 呼び出し元は LLM step 遷移を行わない

### \`cli/twl/src/twl/autopilot/state.py::_init_issue\`
- \`ac_verify_call_count: 0\` を初期 schema に追加

## テスト

\`plugins/twl/tests/bats/scripts/chain-runner-ac-verify.bats\` に 4 test 追加、**bats 10/10 PASS** (既存 6 + 新規 4):

| test | 検証 |
|------|------|
| 初回呼出は call_count を 1 に更新して ok | 通常フロー |
| 2 回目呼出は call_count=2 で retry 許容範囲 (ok) | retry 1 回は通る |
| 3 回目呼出 (max+1 超過) で status=failed + ac_verify_llm_timeout | **safety net 発火 (core)** |
| DEV_AUTOPILOT_AC_VERIFY_MAX_RETRY=2 で上限拡張される | env override |

Python autopilot test suite 109 PASS (pre-existing bug 1 件は独立、本 PR 対象外)。

## AC

- [x] ac-verify 内 LLM timeout が設定される (3 分、prompt instruction)
- [x] timeout 検知時に retry (max 1 回 default、env override 可能)
- [x] 2 回目失敗で \`status=failed\`, \`failure.reason=ac_verify_llm_timeout\`
- [x] bats で retry ロジック検証 (4 test PASS)

## Design note

worker role で status=failed を書込するのは、step_ac_verify が worktree 内 (Worker) で実行されるため。role=pilot は不変条件 C により worktree cwd から拒否される (state.py L430-438)。Worker が自己の completion/failure を書込する既存 pattern (e.g., status=merge-ready) と同類。

## 関連

- Depends on: #888 (C6 MVP、先行 merged), #890 (last_heartbeat_at schema、先行 merged)
- Parent tracking: Phase D C6 対策系

Closes #891