### PR TITLE
fix(#898): auto-merge.sh に Worker window kill safety net を追加

### DIFF
--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -251,6 +251,17 @@ fi
 if [[ "$REPO_MODE" == "worktree" ]]; then
   WORKTREE_PATH=$(git worktree list --porcelain | awk -v target="branch refs/heads/${BRANCH}" '/^worktree / { wt=substr($0, 10) } $0 == target { print wt; exit }')
   if [[ -n "$WORKTREE_PATH" ]]; then
+    # #898: Worker window 生存確認 + kill (worktree 削除前の cwd 消失事故防止)
+    # 不変条件 B の defensive 実装: 呼び手 (_cleanup_worker) が Worker window kill を
+    # skip していた場合でも、auto-merge.sh 自身が safety net として機能する。
+    WORKER_WINDOW=$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$ISSUE_NUM" --field window 2>/dev/null || echo "")
+    if [[ -n "$WORKER_WINDOW" ]] && tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qxF "$WORKER_WINDOW"; then
+      echo "[auto-merge] Issue #${ISSUE_NUM}: Worker window (${WORKER_WINDOW}) 生存確認 — worktree 削除前に kill"
+      if ! tmux kill-window -t "$WORKER_WINDOW" 2>/dev/null; then
+        echo "[auto-merge] Issue #${ISSUE_NUM}: ERROR: Worker window kill 失敗 — worktree 削除中止 (unsafe state)" >&2
+        exit 1
+      fi
+    fi
     if git worktree remove --force "$WORKTREE_PATH" 2>/dev/null; then
       echo "[auto-merge] Issue #${ISSUE_NUM}: worktree 削除成功: ${WORKTREE_PATH}"
     else

--- a/plugins/twl/tests/bats/scripts/auto-merge-worker-kill.bats
+++ b/plugins/twl/tests/bats/scripts/auto-merge-worker-kill.bats
@@ -1,0 +1,228 @@
+#!/usr/bin/env bats
+# auto-merge-worker-kill.bats - #898 Worker window kill safety net
+#
+# Spec: Issue #898 — auto-merge.sh に Worker window kill safety net (cwd 消失事故防止)
+#
+# Coverage (3 scenario per AC, 1 edge case):
+#   (a) Worker window 生存 + kill 成功 → worktree 削除続行
+#   (b) Worker window 不在 (tmux list に無い) → safety net skip、通常動作
+#   (c) Worker window kill 失敗 → exit 1 で abort (worktree 削除せず)
+#   (d) state.window 空 (Pilot 既に cleanup 済) → safety net skip、通常動作
+#
+# 不変条件 B の defensive 実装を検証する。呼び手 (_cleanup_worker 等) が
+# Worker window kill を skip していた場合でも auto-merge.sh 自身が安全側に倒す。
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  # 非 autopilot 経路に誘導するための python3 stub
+  # --field status → "done" (IS_AUTOPILOT=false)
+  # --field is_quick → "false"
+  # --field current_step → ""
+  # --field window → デフォルトは "ap-#898" (テストで override 可能)
+  WINDOW_FIELD_OUT="${WINDOW_FIELD_OUT:-ap-#898}"
+  export WINDOW_FIELD_OUT
+
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+# auto-merge.sh から呼ばれる `python3 -m twl.autopilot.state` の mock
+case "$*" in
+  *"state read"*"--field status"*) echo "done" ;;
+  *"state read"*"--field is_quick"*) echo "false" ;;
+  *"state read"*"--field current_step"*) echo "" ;;
+  *"state read"*"--field window"*) echo "${WINDOW_FIELD_OUT:-ap-#898}" ;;
+  *"state write"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+
+  # gh stub: pr merge --squash を成功させる
+  stub_command "gh" '
+    case "$*" in
+      *"pr merge"*"--squash"*) exit 0 ;;
+      *"pr view"*"mergeStateStatus"*) echo "CLEAN" ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  # git stub: worktree 判定に必要な最小限を提供
+  # - rev-parse --git-dir → worktree モード (".git" 以外を返す)
+  # - worktree list --porcelain → resolve_autopilot_dir 用 (main branch) +
+  #   WORKTREE_PATH 計算用 (feature branch)
+  # - worktree remove --force → 成功
+  # - checkout main / pull origin main / push origin --delete → 成功
+  cat > "$STUB_BIN/git" <<GITSTUB
+#!/usr/bin/env bash
+case "\$*" in
+  "rev-parse --git-dir")
+    # worktree モードにするため絶対パスを返す (".git" 以外)
+    echo "$SANDBOX/.bare/worktrees/feat898" ;;
+  "rev-parse --show-toplevel")
+    echo "$SANDBOX" ;;
+  "worktree list --porcelain")
+    cat <<PORCELAIN
+worktree $SANDBOX/main
+branch refs/heads/main
+
+worktree $SANDBOX/worktrees/feat898
+branch refs/heads/feat/898-test
+
+PORCELAIN
+    ;;
+  "worktree remove --force "*)
+    # WORKTREE_REMOVE_FAIL=true のときは失敗
+    if [[ "\${WORKTREE_REMOVE_FAIL:-false}" == "true" ]]; then exit 1; fi
+    exit 0 ;;
+  "checkout main"|"pull origin main")
+    exit 0 ;;
+  "push origin --delete "*|"branch -D "*)
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+GITSTUB
+  chmod +x "$STUB_BIN/git"
+
+  # tmux stub: display-message / list-windows / kill-window を mock
+  # TMUX_KILL_WINDOW_LOG に kill-window 呼出履歴を記録
+  # TMUX_WINDOW_LIST_OUT で list-windows の出力を制御 (デフォルトは window 生存)
+  # TMUX_KILL_FAIL=true のときは kill-window を失敗させる
+  TMUX_KILL_WINDOW_LOG="$SANDBOX/tmux-kill-window.log"
+  export TMUX_KILL_WINDOW_LOG
+  : > "$TMUX_KILL_WINDOW_LOG"
+
+  TMUX_WINDOW_LIST_OUT="${TMUX_WINDOW_LIST_OUT:-ap-#898}"
+  export TMUX_WINDOW_LIST_OUT
+
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+case "\$1" in
+  display-message)
+    # auto-merge.sh L125: tmux display-message -p '#W' → non-ap window
+    echo "main" ;;
+  list-windows)
+    # '\${TMUX_WINDOW_LIST_OUT}' の複数行を出力 (window 名一覧)
+    printf '%s\n' "\${TMUX_WINDOW_LIST_OUT:-}" ;;
+  kill-window)
+    printf '%s\n' "\$*" >> "\${TMUX_KILL_WINDOW_LOG}"
+    if [[ "\${TMUX_KILL_FAIL:-false}" == "true" ]]; then exit 1; fi
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+
+  # twl stub (DeltaSpec archive をスキップさせる)
+  stub_command "twl" 'exit 0'
+
+  # auto-merge.sh を sandbox に配置 (common_setup でコピー済みのはずだが念のため確認)
+  if [[ ! -f "$SANDBOX/scripts/auto-merge.sh" ]]; then
+    mkdir -p "$SANDBOX/scripts/lib"
+    cp "$REPO_ROOT/scripts/auto-merge.sh" "$SANDBOX/scripts/auto-merge.sh"
+    cp "$REPO_ROOT/scripts/lib/python-env.sh" "$SANDBOX/scripts/lib/python-env.sh" 2>/dev/null || true
+  fi
+
+  # issue-N.json が存在しないことを保証 (フォールバックガード回避)
+  rm -f "$SANDBOX/.autopilot/issues/issue-898.json"
+
+  # CWD を sandbox の main worktree に移動 (Layer 2 CWD ガード回避)
+  # bats 自体が worktrees/ 配下で実行される場合があるため必須
+  mkdir -p "$SANDBOX/main"
+  cd "$SANDBOX/main"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (a): Worker window 生存 + kill 成功 → worktree 削除続行
+# ---------------------------------------------------------------------------
+
+@test "#898 (a): Worker window 生存 + kill 成功で worktree 削除続行" {
+  export WINDOW_FIELD_OUT="ap-#898"
+  export TMUX_WINDOW_LIST_OUT="ap-#898
+main
+other-window"
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
+
+  assert_success
+  # safety net 発火確認
+  echo "$output" | grep -qF "Worker window (ap-#898) 生存確認"
+  # kill-window 呼出記録確認
+  [ -f "$TMUX_KILL_WINDOW_LOG" ]
+  grep -qF "kill-window -t ap-#898" "$TMUX_KILL_WINDOW_LOG"
+  # worktree 削除成功メッセージ
+  echo "$output" | grep -qF "worktree 削除成功"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (b): Worker window 不在 (tmux list に無い) → safety net skip
+# ---------------------------------------------------------------------------
+
+@test "#898 (b): Worker window 不在 (既 cleanup 済) でも通常動作継続" {
+  export WINDOW_FIELD_OUT="ap-#898"
+  # tmux list-windows の出力に ap-#898 を含めない
+  export TMUX_WINDOW_LIST_OUT="main
+other-window"
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
+
+  assert_success
+  # safety net の「生存確認」メッセージは出ない
+  ! echo "$output" | grep -qF "Worker window (ap-#898) 生存確認"
+  # kill-window は呼ばれていない
+  if [[ -s "$TMUX_KILL_WINDOW_LOG" ]]; then
+    ! grep -qF "kill-window" "$TMUX_KILL_WINDOW_LOG"
+  fi
+  # worktree 削除は成功
+  echo "$output" | grep -qF "worktree 削除成功"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (c): Worker window kill 失敗 → exit 1 で abort
+# ---------------------------------------------------------------------------
+
+@test "#898 (c): Worker window kill 失敗で exit 1、worktree 削除せず abort" {
+  export WINDOW_FIELD_OUT="ap-#898"
+  export TMUX_WINDOW_LIST_OUT="ap-#898
+main"
+  export TMUX_KILL_FAIL="true"
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
+
+  assert_failure
+  # ERROR メッセージ出力
+  echo "$output" | grep -qF "ERROR: Worker window kill 失敗"
+  # "unsafe state" キーワード
+  echo "$output" | grep -qF "unsafe state"
+  # worktree 削除は実行されていない (delete 成功メッセージ不在)
+  ! echo "$output" | grep -qF "worktree 削除成功"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (d): state.window 空 (Pilot 既に cleanup 済) → safety net skip
+# ---------------------------------------------------------------------------
+
+@test "#898 (d): state.window 空のときは safety net skip (Pilot 通常経路)" {
+  export WINDOW_FIELD_OUT=""
+  export TMUX_WINDOW_LIST_OUT="main
+other-window"
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
+
+  assert_success
+  # safety net は発火しない
+  ! echo "$output" | grep -qF "生存確認"
+  # kill-window は呼ばれていない
+  if [[ -s "$TMUX_KILL_WINDOW_LOG" ]]; then
+    ! grep -qF "kill-window" "$TMUX_KILL_WINDOW_LOG"
+  fi
+  # worktree 削除は成功
+  echo "$output" | grep -qF "worktree 削除成功"
+}


### PR DESCRIPTION
Closes #898

## Summary

`auto-merge.sh` の worktree 削除直前に、`state.window` で記録された Worker tmux window の生存を確認し、生存している場合は kill してから削除に進む safety net を追加。不変条件 B (worktree ライフサイクルは Pilot 専任) の defensive 実装。

## 発火契機

2026-04-22 co-autopilot 実 e2e (twill-sandbox Issue #16) で observer が Pilot 代行として `auto-merge.sh` を直接実行した際、Worker window kill を skip したまま worktree 削除に突入。Worker claude CLI が cwd 消失で Stop hook 実行不能となり stuck した事故。

rescue evidence: `.audit/1776820710_cl50/sandbox-issue-16-rescue/worker-pane-scrollback.txt` (2358 行、Stop hook ENOENT エラー記録)

## 実装

`plugins/twl/scripts/auto-merge.sh` 非 autopilot mode、`git worktree remove --force` の直前に挿入:

```bash
WORKER_WINDOW=$(python3 -m twl.autopilot.state read ... --field window 2>/dev/null || echo "")
if [[ -n "$WORKER_WINDOW" ]] && tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qxF "$WORKER_WINDOW"; then
  echo "[auto-merge] Worker window (${WORKER_WINDOW}) 生存確認 — worktree 削除前に kill"
  if ! tmux kill-window -t "$WORKER_WINDOW" 2>/dev/null; then
    echo "[auto-merge] ERROR: Worker window kill 失敗 — worktree 削除中止 (unsafe state)" >&2
    exit 1
  fi
fi
```

## 挙動

- (a) Worker window 生存 + kill 成功 → worktree 削除続行
- (b) Worker window 不在 (既 cleanup 済) → そのまま続行
- (c) Worker window kill 失敗 → exit 1 で abort (unsafe state 防止)
- (d) state.window 空 (Pilot 通常経路) → safety net skip

## Tests

**新規**: `plugins/twl/tests/bats/scripts/auto-merge-worker-kill.bats` (4 scenario)

```
1..4
ok 1 #898 (a): Worker window 生存 + kill 成功で worktree 削除続行
ok 2 #898 (b): Worker window 不在 (既 cleanup 済) でも通常動作継続
ok 3 #898 (c): Worker window kill 失敗で exit 1、worktree 削除せず abort
ok 4 #898 (d): state.window 空のときは safety net skip (Pilot 通常経路)
```

## AC

- [x] auto-merge.sh 非 autopilot mode で worktree 削除前に Worker window 生存確認 + kill
- [x] Worker window field (state.window) が空/不在でも安全継続
- [x] Worker window kill 失敗時は worktree 削除を中止して exit 1
- [x] bats で 3 scenario 検証 (+ edge case 1)

## Design note

本 fix は **defensive implementation**: Pilot 側 `_cleanup_worker` を削除するものではなく、auto-merge.sh 自身が「呼び手が cleanup し忘れる」リスクに対して safety net を張る。observer 代行時 / orchestrator bug 時 / 手動運用時 の全経路で cwd 消失事故を防止。

## 関連

- Issue #897 (audit bootstrap、observability 観点での補完)
- 不変条件 B: `plugins/twl/refs/ref-invariants.md`