### PR TITLE
feat(#897): Worker 起動時に cross-repo audit + pipe-pane + snapshot hook を自動 bootstrap

### DIFF
--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -366,6 +366,45 @@ if [[ "${TWL_AUDIT:-}" == "1" ]]; then
   fi
 fi
 
+# --- #897-A: cross-repo audit 自動 bootstrap ---
+# Worker の LAUNCH_DIR が observer main と異なる project（例: twill-sandbox）の場合、
+# Worker 側で audit が非 active のままだと state write / checkpoint が監査対象外となる。
+# parent (observer) の run_id を引き継いで自動 bootstrap する。
+#
+# 挙動:
+#   1. LAUNCH_DIR で `twl audit status` をチェック
+#   2. active なら何もしない（既存セッション継続）
+#   3. 非 active なら PARENT_RUN を解決して `audit on --run-id auto-<parent>-<issue>` 実行
+#
+# PARENT_RUN 解決順:
+#   a. env TWL_AUDIT_PARENT_RUN
+#   b. parent (SCRIPTS_ROOT) の .audit/.active から run_id
+#   c. fallback: "parent" 固定文字列
+WORKER_AUDIT_DIR=""
+if [[ -n "$_TWL_SRC" ]]; then
+  WORKER_AUDIT_STATUS_OUTPUT=$(cd "$LAUNCH_DIR" && PYTHONPATH="$_TWL_SRC" python3 -m twl.autopilot.audit status 2>/dev/null || echo "active: false")
+  WORKER_AUDIT_ACTIVE=$(echo "$WORKER_AUDIT_STATUS_OUTPUT" | awk -F': ' '/^active:/ {print $2; exit}')
+  if [[ "$WORKER_AUDIT_ACTIVE" == "true" ]]; then
+    WORKER_AUDIT_DIR=$(echo "$WORKER_AUDIT_STATUS_OUTPUT" | awk -F': ' '/^audit_dir:/ {print $2; exit}')
+  else
+    PARENT_RUN="${TWL_AUDIT_PARENT_RUN:-}"
+    if [[ -z "$PARENT_RUN" ]]; then
+      _PARENT_TOPLEVEL=$(git -C "$SCRIPTS_ROOT" rev-parse --show-toplevel 2>/dev/null || echo "")
+      if [[ -n "$_PARENT_TOPLEVEL" ]]; then
+        _PARENT_STATUS=$(cd "$_PARENT_TOPLEVEL" && PYTHONPATH="$_TWL_SRC" python3 -m twl.autopilot.audit status 2>/dev/null || echo "")
+        PARENT_RUN=$(echo "$_PARENT_STATUS" | awk -F': ' '/^run_id:/ {print $2; exit}')
+      fi
+    fi
+    # sanitize run_id (alphanumeric + hyphen + underscore only)
+    AUTO_RUN_ID=$(printf 'auto-%s-issue-%s' "${PARENT_RUN:-parent}" "$ISSUE" | tr -c '[:alnum:]_-' '_')
+    if (cd "$LAUNCH_DIR" && PYTHONPATH="$_TWL_SRC" python3 -m twl.autopilot.audit on --run-id "$AUTO_RUN_ID" >/dev/null 2>&1); then
+      echo "[autopilot-launch] audit bootstrap: run_id=$AUTO_RUN_ID (parent=${PARENT_RUN:-none}) in $LAUNCH_DIR"
+      WORKER_AUDIT_STATUS_OUTPUT=$(cd "$LAUNCH_DIR" && PYTHONPATH="$_TWL_SRC" python3 -m twl.autopilot.audit status 2>/dev/null || echo "")
+      WORKER_AUDIT_DIR=$(echo "$WORKER_AUDIT_STATUS_OUTPUT" | awk -F': ' '/^audit_dir:/ {print $2; exit}')
+    fi
+  fi
+fi
+
 # --- コンテキスト引数構築 (Task 1.9) ---
 CONTEXT_ARGS=""
 if [[ -n "$CONTEXT" ]]; then
@@ -391,6 +430,20 @@ QUOTED_PROMPT=$(printf '%q' "$PROMPT")
 # プロンプトは positional arg で渡す。-p/--print は禁止（非対話モードで即終了する）
 tmux new-window -d -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
   "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} ${PYTHONPATH_ENV} ${CLD_ENV_FILE_ENV} ${EFFORT_ENV} ${AUDIT_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
+
+# --- #897-B: pipe-pane で Worker 会話履歴を audit dir に永続化 ---
+# tmux scrollback のみでは window kill で消失するため、pipe-pane で
+# pane 出力を audit dir 配下の panes/<window>.log にファイル追記する。
+# audit が非 active のまま bootstrap 失敗した場合は skip（regression 防止）。
+if [[ -n "$WORKER_AUDIT_DIR" ]] && [[ -d "$WORKER_AUDIT_DIR" ]]; then
+  WORKER_PANE_LOG_DIR="${WORKER_AUDIT_DIR}/panes"
+  mkdir -p "$WORKER_PANE_LOG_DIR" 2>/dev/null || true
+  WORKER_PANE_LOG="${WORKER_PANE_LOG_DIR}/${WINDOW_NAME}.log"
+  QUOTED_PANE_LOG=$(printf '%q' "$WORKER_PANE_LOG")
+  if tmux pipe-pane -t "$WINDOW_NAME" -o "cat >> $QUOTED_PANE_LOG" 2>/dev/null; then
+    echo "[autopilot-launch] pipe-pane 永続化: $WORKER_PANE_LOG"
+  fi
+fi
 
 # --- クラッシュ検知フック設定 (Task 1.10) ---
 tmux set-option -t "$WINDOW_NAME" remain-on-exit on

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1415,10 +1415,34 @@ step_auto_merge() {
   fi
   if "$auto_merge_script" "$@"; then
     ok "auto-merge" "auto-merge.sh 完了"
+    # #897-C: auto-merge 成功時に audit snapshot を自動取得
+    # .autopilot/ 配下の checkpoints/issues/trace を audit dir に永続化し、
+    # 後続の worktree 削除で消失する中間成果物を保全する。
+    _audit_snapshot_autopilot
   else
     local rc=$?
     err "auto-merge" "auto-merge.sh 失敗 (exit=$rc)"
     return $rc
+  fi
+}
+
+# #897-C: audit snapshot hook
+# auto-merge 完了時に .autopilot/ を audit dir 配下にコピー
+# audit が非 active な場合は silent no-op（regression 防止）
+_audit_snapshot_autopilot() {
+  local autopilot_dir issue_num label
+  autopilot_dir="$(resolve_autopilot_dir 2>/dev/null || echo "")"
+  issue_num="$(resolve_issue_num 2>/dev/null || echo "")"
+  if [[ -z "$autopilot_dir" ]] || [[ ! -d "$autopilot_dir" ]]; then
+    return 0
+  fi
+  if [[ -z "$issue_num" ]]; then
+    label="autopilot-merged"
+  else
+    label="issue-${issue_num}"
+  fi
+  if python3 -m twl.autopilot.audit snapshot --source-dir "$autopilot_dir" --label "$label" >/dev/null 2>&1; then
+    echo "[chain-runner] audit snapshot: label=$label (source=$autopilot_dir)"
   fi
 }
 

--- a/plugins/twl/tests/bats/scripts/autopilot-launch-audit-bootstrap.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-launch-audit-bootstrap.bats
@@ -1,0 +1,217 @@
+#!/usr/bin/env bats
+# autopilot-launch-audit-bootstrap.bats - #897-A + #897-B
+#
+# Spec: Issue #897 — autopilot-launch.sh で Worker 起動時に cross-repo audit + pipe-pane を自動 bootstrap
+#
+# Coverage:
+#   (A1) Worker cwd で audit 非 active → bootstrap で audit on --run-id auto-<parent>-issue-<N>
+#   (A2) Worker cwd で既に audit active → bootstrap skip (既存セッション継続)
+#   (B1) audit active → tmux pipe-pane で pane log 永続化
+#   (B2) audit bootstrap 失敗 → pipe-pane skip (regression 防止)
+#
+# pattern: autopilot-launch-merge-context.bats と同じ standard repo setup
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  # tmux stub: new-window / pipe-pane / set-option / set-hook / display-message / list-windows を記録
+  TMUX_LOG="$SANDBOX/tmux-calls.log"
+  export TMUX_LOG
+  : > "$TMUX_LOG"
+
+  cat > "$STUB_BIN/tmux" <<'TMUXSTUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$TMUX_LOG"
+case "$1" in
+  display-message) echo "main" ;;
+  list-windows) echo "" ;;
+  *) exit 0 ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+
+  # cld stub
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$STUB_BIN/cld"
+  chmod +x "$STUB_BIN/cld"
+
+  # gh stub: quick label なし
+  stub_command "gh" '
+    case "$*" in
+      *"issue view"*"--json labels"*) echo "" ;;
+      *) echo "{}" ;;
+    esac
+  '
+
+  # git stub
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse"*) echo "$SANDBOX" ;;
+      *"worktree list"*) echo "" ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  # python3 stub: audit status / audit on / state write / worktree create を制御
+  AUDIT_BOOTSTRAP_LOG="$SANDBOX/audit-bootstrap.log"
+  export AUDIT_BOOTSTRAP_LOG
+  : > "$AUDIT_BOOTSTRAP_LOG"
+
+  AUDIT_BOOTSTRAPPED_FLAG="$SANDBOX/audit-bootstrapped.flag"
+  export AUDIT_BOOTSTRAPPED_FLAG
+
+  # シナリオ制御変数 (テスト毎に export で override)
+  AUDIT_WORKER_ACTIVE="${AUDIT_WORKER_ACTIVE:-false}"
+  AUDIT_PARENT_ACTIVE="${AUDIT_PARENT_ACTIVE:-true}"
+  AUDIT_BOOTSTRAP_SUCCESS="${AUDIT_BOOTSTRAP_SUCCESS:-true}"
+  AUDIT_DIR_AFTER_BOOTSTRAP="${AUDIT_DIR_AFTER_BOOTSTRAP:-$SANDBOX/.audit/auto-parent-run-issue-897}"
+  AUDIT_WORKER_DIR="${AUDIT_WORKER_DIR:-$SANDBOX/.audit/existing-worker-run}"
+  export AUDIT_WORKER_ACTIVE AUDIT_PARENT_ACTIVE AUDIT_BOOTSTRAP_SUCCESS AUDIT_DIR_AFTER_BOOTSTRAP AUDIT_WORKER_DIR
+
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"twl.autopilot.worktree create"*) exit 1 ;;
+  *"twl.autopilot.audit status"*)
+    _CWD=$(pwd)
+    # SCRIPTS_ROOT (git toplevel = SANDBOX/scripts) からの呼出 → parent
+    # TEST_PROJECT_DIR (SANDBOX/project) からの呼出 → Worker
+    if [[ "$_CWD" == *"/project"* ]]; then
+      # Worker cwd audit status
+      if [[ -f "${AUDIT_BOOTSTRAPPED_FLAG:-/nonexistent}" ]]; then
+        echo "active: true"
+        echo "run_id: auto-parent-run-issue-897"
+        echo "audit_dir: ${AUDIT_DIR_AFTER_BOOTSTRAP}"
+      elif [[ "${AUDIT_WORKER_ACTIVE:-false}" == "true" ]]; then
+        echo "active: true"
+        echo "run_id: existing-worker-run"
+        echo "audit_dir: ${AUDIT_WORKER_DIR}"
+      else
+        echo "active: false"
+      fi
+    else
+      # parent (SCRIPTS_ROOT) audit status
+      if [[ "${AUDIT_PARENT_ACTIVE:-true}" == "true" ]]; then
+        echo "active: true"
+        echo "run_id: parent-run"
+        echo "audit_dir: $SANDBOX/parent-audit-dir"
+      else
+        echo "active: false"
+      fi
+    fi
+    exit 0 ;;
+  *"twl.autopilot.audit on"*)
+    _RUN_ID=""
+    _NEXT=false
+    for _ARG in "$@"; do
+      if [[ "$_NEXT" == "true" ]]; then _RUN_ID="$_ARG"; break; fi
+      if [[ "$_ARG" == "--run-id" ]]; then _NEXT=true; fi
+    done
+    echo "audit on run_id=$_RUN_ID cwd=$(pwd)" >> "$AUDIT_BOOTSTRAP_LOG"
+    if [[ "${AUDIT_BOOTSTRAP_SUCCESS:-true}" == "true" ]]; then
+      touch "${AUDIT_BOOTSTRAPPED_FLAG}" 2>/dev/null || true
+      exit 0
+    fi
+    exit 1 ;;
+  *"twl.autopilot.state"*) exit 0 ;;
+  *) exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+
+  # test project: standard repo (not bare)
+  mkdir -p "$SANDBOX/project/.git"
+  mkdir -p "$SANDBOX/.autopilot/trace"
+  cat > "$SANDBOX/.autopilot/session.json" <<JSON
+{"session_id": "test-897-session", "started_at": "2026-04-23T00:00:00Z"}
+JSON
+  TEST_PROJECT_DIR="$SANDBOX/project"
+  export TEST_PROJECT_DIR
+
+  # 既存 audit dir を用意
+  mkdir -p "$AUDIT_WORKER_DIR"
+  mkdir -p "$AUDIT_DIR_AFTER_BOOTSTRAP"
+}
+
+teardown() {
+  common_teardown
+}
+
+_run_launch() {
+  local issue="${1:-897}"
+  run bash "$SANDBOX/scripts/autopilot-launch.sh" \
+    --issue "$issue" \
+    --project-dir "$TEST_PROJECT_DIR" \
+    --autopilot-dir "$SANDBOX/.autopilot" \
+    --context "test context"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (A1): Worker cwd audit 非 active → bootstrap で audit on 発火
+# ---------------------------------------------------------------------------
+
+@test "#897-A (A1): Worker cwd audit 非 active で parent run 引継ぎ audit on" {
+  export AUDIT_WORKER_ACTIVE="false"
+  export AUDIT_PARENT_ACTIVE="true"
+
+  _run_launch 897
+  assert_success
+
+  # audit bootstrap 呼出記録を確認
+  [ -f "$AUDIT_BOOTSTRAP_LOG" ]
+  grep -qE "run_id=auto-parent-run-issue-897" "$AUDIT_BOOTSTRAP_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (A2): Worker cwd 既に audit active → bootstrap skip
+# ---------------------------------------------------------------------------
+
+@test "#897-A (A2): Worker cwd 既に audit active なら bootstrap skip" {
+  export AUDIT_WORKER_ACTIVE="true"
+
+  _run_launch 897
+  assert_success
+
+  # audit on は呼ばれていない
+  if [[ -s "$AUDIT_BOOTSTRAP_LOG" ]]; then
+    ! grep -qE "run_id=auto-" "$AUDIT_BOOTSTRAP_LOG"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (B1): audit bootstrap 成功 → pipe-pane 実行
+# ---------------------------------------------------------------------------
+
+@test "#897-B (B1): audit bootstrap 成功後 tmux pipe-pane で pane log 永続化" {
+  export AUDIT_WORKER_ACTIVE="false"
+  export AUDIT_PARENT_ACTIVE="true"
+  export AUDIT_BOOTSTRAP_SUCCESS="true"
+
+  _run_launch 897
+  assert_success
+
+  # tmux pipe-pane が呼ばれた
+  [ -f "$TMUX_LOG" ]
+  grep -qE "^pipe-pane" "$TMUX_LOG"
+  # pane log path に audit dir が含まれる
+  grep -qF "$AUDIT_DIR_AFTER_BOOTSTRAP" "$TMUX_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (B2): bootstrap 失敗で audit dir 解決できない → pipe-pane skip
+# ---------------------------------------------------------------------------
+
+@test "#897-B (B2): bootstrap 失敗時は pipe-pane skip (regression 防止)" {
+  export AUDIT_WORKER_ACTIVE="false"
+  export AUDIT_PARENT_ACTIVE="false"
+  export AUDIT_BOOTSTRAP_SUCCESS="false"
+
+  _run_launch 897
+  assert_success
+
+  # pipe-pane は呼ばれていない
+  if [[ -s "$TMUX_LOG" ]]; then
+    ! grep -qE "^pipe-pane" "$TMUX_LOG"
+  fi
+}

--- a/plugins/twl/tests/bats/scripts/chain-runner-audit-snapshot.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-audit-snapshot.bats
@@ -1,0 +1,127 @@
+#!/usr/bin/env bats
+# chain-runner-audit-snapshot.bats - #897-C audit snapshot hook
+#
+# Spec: Issue #897 — autopilot-launch.sh で Worker 起動時に cross-repo audit + pipe-pane を自動 bootstrap
+#   Scope C: checkpoint snapshot hook (auto-merge 完了時に twl audit snapshot 発火)
+#
+# Coverage:
+#   (C1) step_auto_merge 成功時に audit snapshot が呼ばれる
+#   (C2) step_auto_merge 失敗時は snapshot を呼ばない
+#   (C3) .autopilot dir 不在時は snapshot skip (no-op)
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*)
+        echo "feat/897-test" ;;
+      *"rev-parse --show-toplevel"*)
+        echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*)
+        echo "$SANDBOX/.git" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/main\n" "$SANDBOX" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+  stub_command "gh" 'exit 0'
+
+  # auto-merge.sh を成功 stub に置換
+  cat > "$SANDBOX/scripts/auto-merge.sh" <<'AMSTUB'
+#!/usr/bin/env bash
+echo "[auto-merge-stub] merge 完了 ok"
+exit 0
+AMSTUB
+  chmod +x "$SANDBOX/scripts/auto-merge.sh"
+
+  # python3 stub: audit snapshot と state write/read を record
+  AUDIT_SNAPSHOT_LOG="$SANDBOX/audit-snapshot.log"
+  export AUDIT_SNAPSHOT_LOG
+  : > "$AUDIT_SNAPSHOT_LOG"
+
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"audit snapshot"*)
+    echo "$*" >> "$AUDIT_SNAPSHOT_LOG"
+    exit 0 ;;
+  *"state write"*|*"state read"*)
+    # chain-runner.sh の record_current_step や resolve_issue_num で呼ばれる
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (C1): step_auto_merge 成功時に audit snapshot hook 発火
+# ---------------------------------------------------------------------------
+
+@test "#897-C (C1): auto-merge 成功時に audit snapshot が呼ばれる" {
+  create_issue_json 897 "running"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" auto-merge --issue 897 --pr 900 --branch feat/897-test
+  assert_success
+
+  # snapshot 呼出記録を確認
+  [ -f "$AUDIT_SNAPSHOT_LOG" ]
+  # snapshot コマンドラインに "issue-897" label が含まれる
+  grep -qF "audit snapshot" "$AUDIT_SNAPSHOT_LOG"
+  grep -qF "issue-897" "$AUDIT_SNAPSHOT_LOG"
+  # chain-runner 出力に snapshot メッセージ
+  echo "$output" | grep -qF "audit snapshot"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (C2): auto-merge.sh 失敗時は snapshot を呼ばない
+# ---------------------------------------------------------------------------
+
+@test "#897-C (C2): auto-merge 失敗時は snapshot hook が発火しない" {
+  # auto-merge.sh を失敗 stub に置換
+  cat > "$SANDBOX/scripts/auto-merge.sh" <<'AMSTUB'
+#!/usr/bin/env bash
+echo "[auto-merge-stub] merge 失敗" >&2
+exit 1
+AMSTUB
+  chmod +x "$SANDBOX/scripts/auto-merge.sh"
+
+  create_issue_json 897 "running"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" auto-merge --issue 897 --pr 900 --branch feat/897-test
+  assert_failure
+
+  # snapshot は呼ばれていない
+  if [[ -s "$AUDIT_SNAPSHOT_LOG" ]]; then
+    ! grep -qF "audit snapshot" "$AUDIT_SNAPSHOT_LOG"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Scenario (C3): .autopilot dir 不在時は snapshot skip
+# ---------------------------------------------------------------------------
+
+@test "#897-C (C3): .autopilot dir 不在時は snapshot skip (no-op、regression 防止)" {
+  # .autopilot dir を削除
+  rm -rf "$SANDBOX/.autopilot"
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" auto-merge --issue 897 --pr 900 --branch feat/897-test
+
+  # auto-merge 自体は成功
+  assert_success
+  # snapshot は skip (no record)
+  if [[ -s "$AUDIT_SNAPSHOT_LOG" ]]; then
+    ! grep -qF "audit snapshot" "$AUDIT_SNAPSHOT_LOG"
+  fi
+}


### PR DESCRIPTION
Closes #897

## Summary

autopilot-launch.sh と chain-runner.sh に 3 機能を追加し、co-autopilot 実 Worker の監査ギャップを根絶する。

2026-04-22 session の twill-sandbox Issue #16 co-autopilot e2e で判明した問題:
1. Worker cwd が親 observer と別 project の場合、cwd の `.audit/.active` が無いため Worker の state write / checkpoint が audit 対象外
2. Worker pane の会話履歴は tmux scrollback のみで window kill で消失
3. `.autopilot/checkpoints/issues/trace` は worktree 削除で消失し snapshot が残らない

## A. cross-repo audit 自動 bootstrap (`autopilot-launch.sh`)

Worker 起動前に `LAUNCH_DIR` で `twl audit status` をチェック。非 active なら parent (SCRIPTS_ROOT 基準) の `run_id` を引き継いで `audit on --run-id auto-<parent>-issue-<N>` を発火。既に active なセッションは継続。

解決順: `TWL_AUDIT_PARENT_RUN` env → parent `.audit/.active` → `parent` fallback。

## B. pipe-pane による Worker 会話履歴永続化 (`autopilot-launch.sh`)

`tmux new-window` 直後に `tmux pipe-pane` で pane 出力を `$AUDIT_DIR/panes/<window>.log` に追記。tmux scrollback の size limit と window kill 消失を回避。audit 非 active / bootstrap 失敗時は skip（regression 防止）。

## C. checkpoint snapshot hook (`chain-runner.sh`)

`step_auto_merge` 成功時に `_audit_snapshot_autopilot` hook を発火し、`twl audit snapshot --source-dir .autopilot --label issue-<N>` で checkpoints/issues/trace を audit dir に永続化。

## Tests

新規 bats 7 scenario（全 PASS 確認）:

```
1..7
ok 1 #897-A (A1): Worker cwd audit 非 active で parent run 引継ぎ audit on
ok 2 #897-A (A2): Worker cwd 既に audit active なら bootstrap skip
ok 3 #897-B (B1): audit bootstrap 成功後 tmux pipe-pane で pane log 永続化
ok 4 #897-B (B2): bootstrap 失敗時は pipe-pane skip (regression 防止)
ok 5 #897-C (C1): auto-merge 成功時に audit snapshot が呼ばれる
ok 6 #897-C (C2): auto-merge 失敗時は snapshot hook が発火しない
ok 7 #897-C (C3): .autopilot dir 不在時は snapshot skip (no-op、regression 防止)
```

既存 autopilot-launch-merge-context (15 tests) + chain-runner-ac-verify (14 tests) で regression 0 件確認。

## AC

- [x] sandbox Worker state write が audit log に記録される (cross-repo 自動 bootstrap) — A
- [x] Worker pane 会話履歴が audit dir の `panes/` に永続化される — B
- [x] auto-merge 完了時に checkpoint snapshot が自動取得される — C
- [x] 既存 single-project audit flow への回帰なし (既存 bats 29 件 PASS)
- [x] bats で bootstrap / pipe-pane / snapshot hook を検証 (7 scenario)

## Design note

- audit 非 active 時は silent no-op で既存 flow に干渉しない (defensive)
- PARENT_RUN 解決は 3 段階フォールバック (env → parent .active → "parent") で堅牢
- pipe-pane は `is_audit_active()` 不要 (WORKER_AUDIT_DIR 存在チェックで等価判定)
- snapshot hook は `resolve_issue_num` + `resolve_autopilot_dir` で chain-runner.sh の既存 helper を活用

## 関連

- 発見 session: 2026-04-22 twill-sandbox Issue #16 co-autopilot e2e
- rescue evidence: `.audit/1776820710_cl50/sandbox-issue-16-rescue/worker-pane-scrollback.txt` (2358 行)
- 関連 fix: PR #899 (#898) auto-merge.sh Worker window kill safety net