### PR TITLE
docs(architecture): ADR-015 を Superseded にマーク (#902 / Phase Z Wave A 1/3)

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-015-deltaspec-auto-init.md
+++ b/plugins/twl/architecture/decisions/ADR-015-deltaspec-auto-init.md
@@ -1,18 +1,35 @@
 # ADR-015: DeltaSpec 自動初期化と direct モード分離
 
-## Status
+**Status**: Superseded
+**Date**: 2026-04-10
+**Issue**: #784
+**Supersedes**:
+**Superseded-By**: [ADR-023-tdd-direct-flow](ADR-023-tdd-direct-flow.md)
+**Related**: ADR-019 (spec implementation category — DeltaSpec と直交、KEEP)
 
-Accepted
+---
+
+> ⚠️ **Superseded by ADR-023** — 2026-04-23 (Epic #901 Phase Z Wave A / Issue #902)
+>
+> 本 ADR の方針 (`deltaspec/` 自動初期化 + `propose` デフォルト化) は、Phase Z で **DeltaSpec 機能を CLI + plugin から完全除去する決定** ([ADR-023-tdd-direct-flow](ADR-023-tdd-direct-flow.md)) により無効化された。co-autopilot は `Issue → TDD → PR` の直行フローに再構成され、`change-propose` / `change-apply` / `change-id-resolve` / `test-scaffold` の DeltaSpec chain step は削除される。
+
+### DeltaSpec 再導入の禁止
+
+Phase Z 完了後、本リポジトリにおける DeltaSpec 機能の再導入は以下の理由で **禁止する**:
+
+1. **実運用で未使用** — 本 ADR 適用後も Worker が自発的に `propose` mode を活用した記録はゼロ件。`direct` ラベル opt-out 前提の設計であり、デフォルト `propose` は Worker の認知負荷を一方的に増加させただけで、品質担保への寄与が観測されなかった。
+2. **SSoT triangle 同期コストが恒常負担** — `chain.py CHAIN_STEPS` / `deps.yaml.chains` / `chain-steps.sh` の 3 面同期に DeltaSpec 5 step (`change-propose` / `change-id-resolve` / `change-apply` / `post-change-apply` / `test-scaffold`) が含まれ、ADR-020/ADR-022 の整理対象を恒常的に拡大させていた。
+3. **TDD 直行フローへの代替** — Acceptance Criteria-based の `ac-scaffold-tests` + `worker-codex-reviewer` の AC coverage 検証 + RED/GREEN/REFACTOR 誘導により、DeltaSpec が担おうとしていた「仕様駆動による品質担保」はより低コストで実現される (ADR-023 D-2/D-3)。
+4. **再導入時は新 ADR を起票** — 将来 spec-driven 開発が本リポジトリで必要となった場合は、本 ADR の revert ではなく、新規 ADR として設計の是非を再評価すること。
+
+---
 
 ## Review
 
 - 2026-04-21: Issue #784 の phase-review プロセス（worker-arch-doc-reviewer / worker-code-reviewer / worker-issue-pr-alignment / worker-security-reviewer）で Accept 判断基準4軸を検証し、全て PASS を確認した。これが co-architect レビュー合意 (plan Q2=B 準拠) に相当する。
+- 2026-04-23: Epic #901 Phase Z Wave A にて本 ADR を Superseded にマーク。後続 ADR-023 が deltaspec-free TDD 直行フローを定義する。
 
-## Date
-
-2026-04-10
-
-## Context
+## Context（Superseded 時点での記録）
 
 47件の Issue 実行で DeltaSpec が**一度も使われなかった**。全て `direct` モード（コード一発生成）。
 

--- a/plugins/twl/architecture/decisions/ADR-015-deltaspec-auto-init.md
+++ b/plugins/twl/architecture/decisions/ADR-015-deltaspec-auto-init.md
@@ -3,22 +3,27 @@
 **Status**: Superseded
 **Date**: 2026-04-10
 **Issue**: #784
-**Supersedes**:
 **Superseded-By**: [ADR-023-tdd-direct-flow](ADR-023-tdd-direct-flow.md)
-**Related**: ADR-019 (spec implementation category — DeltaSpec と直交、KEEP)
+**Related**: ADR-019 (spec implementation category — DeltaSpec と直交、KEEP)、ADR-022 (chain SSoT 境界)
 
 ---
 
 > ⚠️ **Superseded by ADR-023** — 2026-04-23 (Epic #901 Phase Z Wave A / Issue #902)
 >
-> 本 ADR の方針 (`deltaspec/` 自動初期化 + `propose` デフォルト化) は、Phase Z で **DeltaSpec 機能を CLI + plugin から完全除去する決定** ([ADR-023-tdd-direct-flow](ADR-023-tdd-direct-flow.md)) により無効化された。co-autopilot は `Issue → TDD → PR` の直行フローに再構成され、`change-propose` / `change-apply` / `change-id-resolve` / `test-scaffold` の DeltaSpec chain step は削除される。
+> 本 ADR の方針 (`deltaspec/` 自動初期化 + `propose` デフォルト化) は、Phase Z で **DeltaSpec 機能を CLI + plugin から完全除去する決定** ([ADR-023-tdd-direct-flow](ADR-023-tdd-direct-flow.md)) により無効化された。co-autopilot は `Issue → TDD → PR` の直行フローに再構成される。
+>
+> **決定理由（要旨）**: 本 ADR 適用後の実運用で Worker が `propose` mode を自発使用した記録はゼロ件。`direct` ラベル opt-out 前提の設計が維持コストに見合わないと判断された。
+>
+> **Dangling link 許容（Phase Z Wave A 厳密逐次）**: 本 ADR が参照する `ADR-023-tdd-direct-flow.md` は、Wave A 後続 Issue #903 で作成される（Wave A は #902 → #903 → #904 の厳密逐次であり、#902 で supersede-by link を先行記載する設計）。#903 merge 完了をもって本 link が解決する。
+>
+> **DeltaSpec chain step の除去タイミング**: `change-propose` / `change-apply` / `change-id-resolve` / `post-change-apply` / `test-scaffold` の 5 step は ADR-023 で削除が定義され、Epic #901 Wave B (#Z-CORE) 以降で `chain.py` / `chain-steps.sh` / `deps.yaml.chains` から除去される。本 PR 時点ではこれらの step は実装上残存する。
 
-### DeltaSpec 再導入の禁止
+## DeltaSpec 再導入の禁止
 
 Phase Z 完了後、本リポジトリにおける DeltaSpec 機能の再導入は以下の理由で **禁止する**:
 
 1. **実運用で未使用** — 本 ADR 適用後も Worker が自発的に `propose` mode を活用した記録はゼロ件。`direct` ラベル opt-out 前提の設計であり、デフォルト `propose` は Worker の認知負荷を一方的に増加させただけで、品質担保への寄与が観測されなかった。
-2. **SSoT triangle 同期コストが恒常負担** — `chain.py CHAIN_STEPS` / `deps.yaml.chains` / `chain-steps.sh` の 3 面同期に DeltaSpec 5 step (`change-propose` / `change-id-resolve` / `change-apply` / `post-change-apply` / `test-scaffold`) が含まれ、ADR-020/ADR-022 の整理対象を恒常的に拡大させていた。
+2. **SSoT 同期コストが恒常負担** — DeltaSpec 5 step (`change-propose` / `change-id-resolve` / `change-apply` / `post-change-apply` / `test-scaffold`) が、ADR-022 で定義された chain SSoT 境界（chain.py `CHAIN_STEPS` を runner step SSoT、chain-steps.sh は chain.py からの一方向 export、deps.yaml.chains は workflow orchestrate 含む独立 SSoT）の整理対象を恒常的に拡大させていた。
 3. **TDD 直行フローへの代替** — Acceptance Criteria-based の `ac-scaffold-tests` + `worker-codex-reviewer` の AC coverage 検証 + RED/GREEN/REFACTOR 誘導により、DeltaSpec が担おうとしていた「仕様駆動による品質担保」はより低コストで実現される (ADR-023 D-2/D-3)。
 4. **再導入時は新 ADR を起票** — 将来 spec-driven 開発が本リポジトリで必要となった場合は、本 ADR の revert ではなく、新規 ADR として設計の是非を再評価すること。
 


### PR DESCRIPTION
## Summary

Epic #901 Phase Z (DeltaSpec 完全除去) Wave A の 1/3。
ADR-015 (DeltaSpec 自動初期化) を新 ADR-023 (deltaspec-free chain + TDD 直行 flow) に supersede する。

Closes #902

## Changes

`plugins/twl/architecture/decisions/ADR-015-deltaspec-auto-init.md`:

- **frontmatter を ADR-022 形式に統一**
  - \`Status: Accepted\` → \`Status: Superseded\`
  - \`Supersedes:\` (空) 追加
  - \`Superseded-By: ADR-023-tdd-direct-flow\` 追加
  - \`Related: ADR-019\` 追加（直交関係の明示、KEEP List 反映）
- **本文冒頭に supersede note を追加**（blockquote）
- **DeltaSpec 再導入禁止理由 4 項目を明記**
  1. 実運用で未使用（propose mode 自発使用 0 件）
  2. SSoT triangle 同期コストが恒常負担
  3. TDD 直行フローへの代替（ADR-023 D-2/D-3）
  4. 再導入時は新 ADR を起票（revert ではなく再評価）
- Review 履歴に 2026-04-23 Supersede マーク追加

## Observer 先行記載について

ADR-023 の実体は **#903 (Phase Z Wave A 2/3) で作成する**。本 PR では Superseded-By link の先行記載のみ行う（observer 指示順序）。#903 マージ後に link が解決する。

## AC (#902 から転記)

- [x] ADR-015 frontmatter の Status=Superseded
- [x] supersede-by link が ADR-023 を指す
- [x] 再導入禁止理由 3-5 行で記載（4 項目）
- [ ] ADR lint 通過 → CI で検証

## 依存

- **先行**: なし（Wave A 先頭）
- **後続**: #903 (ADR-023 作成) → #904 (refs 清掃)

Refs: #901, #902