### PR TITLE
refactor(#910): refs/+ architecture contexts + domain/model + pre-compact-checkpoint.sh から deltaspec 削除

### DIFF
--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -102,20 +102,15 @@ flowchart TD
 
     subgraph setup["setup chain"]
         setup__init["init"]:::script
-        setup__worktree_create["worktree-create"]:::script
         setup__project_board_status_update["project-board-status-update"]:::script
         setup__crg_auto_build["crg-auto-build"]:::llm
-        setup__change_propose["change-propose"]:::llm
+        setup__arch_ref["arch-ref"]:::script
         setup__ac_extract["ac-extract"]:::script
     end
 
     subgraph test_ready["test-ready chain"]
-        test_ready__arch_ref["arch-ref"]
-        test_ready__change_id_resolve["change-id-resolve"]
         test_ready__test_scaffold["test-scaffold"]:::llm
-        test_ready__check["check"]
-        test_ready__change_apply["change-apply"]:::llm
-        test_ready__post_change_apply["post-change-apply"]
+        test_ready__check["check"]:::script
     end
 
     subgraph pr_verify["pr-verify chain"]
@@ -142,16 +137,11 @@ flowchart TD
         pr_merge__auto_merge["auto-merge"]:::script
     end
 
-    setup__init --> setup__worktree_create
-    setup__worktree_create --> setup__project_board_status_update
+    setup__init --> setup__project_board_status_update
     setup__project_board_status_update --> setup__crg_auto_build
-    setup__crg_auto_build --> setup__change_propose
-    setup__change_propose --> setup__ac_extract
-    test_ready__arch_ref --> test_ready__change_id_resolve
-    test_ready__change_id_resolve --> test_ready__test_scaffold
+    setup__crg_auto_build --> setup__arch_ref
+    setup__arch_ref --> setup__ac_extract
     test_ready__test_scaffold --> test_ready__check
-    test_ready__check --> test_ready__change_apply
-    test_ready__change_apply --> test_ready__post_change_apply
     pr_verify__prompt_compliance --> pr_verify__ts_preflight
     pr_verify__ts_preflight --> pr_verify__phase_review
     pr_verify__phase_review --> pr_verify__scope_judge
@@ -165,8 +155,8 @@ flowchart TD
     pr_merge__all_pass_check --> pr_merge__merge_gate
     pr_merge__merge_gate --> pr_merge__auto_merge
 
-    setup__ac_extract -->|"Pilot inject"| test_ready__arch_ref
-    test_ready__post_change_apply -->|"Pilot inject"| pr_verify__prompt_compliance
+    setup__ac_extract -->|"Pilot inject"| test_ready__test_scaffold
+    test_ready__check -->|"Pilot inject"| pr_verify__prompt_compliance
     pr_verify__ac_verify -->|"Pilot inject"| pr_fix__fix_phase
     pr_fix__warning_fix -->|"Pilot inject"| pr_merge__e2e_screening
 
@@ -237,18 +227,6 @@ status=$(jq -r '.status // "null"' issue-N.json)
 - **制約 AP-2**: Emergency Bypass 条件を除き、trivial change であっても co-autopilot を bypass してはならない（SHALL）
 
 ## Rules
-
-### DeltaSpec 適用ポリシー
-
-Worker が DeltaSpec を使用すべきかどうかの判断基準:
-
-| 条件 | 動作 | 根拠 |
-|------|------|------|
-| `quick` ラベル | direct | コスト対効果 |
-| `scope/direct` ラベル | direct | 明示的 opt-out |
-| 上記以外 | propose → apply | 仕様駆動（デフォルト） |
-
-**デフォルト動作**: 判断に迷った場合は `propose → apply` パスを選択する。`deltaspec/` の存在有無は判定条件に含まれない。DeltaSpec は常にデフォルトパスであり、`scope/direct` ラベルで明示的に opt-out できる（ADR-015）。
 
 ### Pilot / Worker 役割分担
 
@@ -369,7 +347,7 @@ tmux send-keys -t "<WORKER_WINDOW>" "/twl:workflow-test-ready" Enter
 | 種別 | コンポーネント | 役割 |
 |------|--------------|------|
 | **controller** | co-autopilot | Issue 群の自律実装オーケストレーター |
-| **workflow** | workflow-setup | DeltaSpec 提案 + テスト準備（worktree は Pilot が事前作成済み） |
+| **workflow** | workflow-setup | 開発準備（AC 抽出・arch-ref まで）（worktree は Pilot が事前作成済み） |
 | **workflow** | workflow-test-ready | テスト生成 + 準備確認 |
 | **workflow** | workflow-pr-verify | PR 検証（preflight → review → scope → test） |
 | **workflow** | workflow-pr-fix | PR 修正（fix → post-fix-verify → warning-fix） |

--- a/plugins/twl/architecture/domain/model.md
+++ b/plugins/twl/architecture/domain/model.md
@@ -300,20 +300,15 @@ flowchart TD
 
     subgraph setup["setup chain"]
         setup__init["init"]:::script
-        setup__worktree_create["worktree-create"]:::script
         setup__project_board_status_update["project-board-status-update"]:::script
         setup__crg_auto_build["crg-auto-build"]:::llm
-        setup__change_propose["change-propose"]:::llm
+        setup__arch_ref["arch-ref"]:::script
         setup__ac_extract["ac-extract"]:::script
     end
 
     subgraph test_ready["test-ready chain"]
-        test_ready__arch_ref["arch-ref"]
-        test_ready__change_id_resolve["change-id-resolve"]
         test_ready__test_scaffold["test-scaffold"]:::llm
-        test_ready__check["check"]
-        test_ready__change_apply["change-apply"]:::llm
-        test_ready__post_change_apply["post-change-apply"]
+        test_ready__check["check"]:::script
     end
 
     subgraph pr_verify["pr-verify chain"]
@@ -340,16 +335,11 @@ flowchart TD
         pr_merge__auto_merge["auto-merge"]:::script
     end
 
-    setup__init --> setup__worktree_create
-    setup__worktree_create --> setup__project_board_status_update
+    setup__init --> setup__project_board_status_update
     setup__project_board_status_update --> setup__crg_auto_build
-    setup__crg_auto_build --> setup__change_propose
-    setup__change_propose --> setup__ac_extract
-    test_ready__arch_ref --> test_ready__change_id_resolve
-    test_ready__change_id_resolve --> test_ready__test_scaffold
+    setup__crg_auto_build --> setup__arch_ref
+    setup__arch_ref --> setup__ac_extract
     test_ready__test_scaffold --> test_ready__check
-    test_ready__check --> test_ready__change_apply
-    test_ready__change_apply --> test_ready__post_change_apply
     pr_verify__prompt_compliance --> pr_verify__ts_preflight
     pr_verify__ts_preflight --> pr_verify__phase_review
     pr_verify__phase_review --> pr_verify__scope_judge
@@ -363,8 +353,8 @@ flowchart TD
     pr_merge__all_pass_check --> pr_merge__merge_gate
     pr_merge__merge_gate --> pr_merge__auto_merge
 
-    setup__ac_extract --> test_ready__arch_ref
-    test_ready__post_change_apply --> pr_verify__prompt_compliance
+    setup__ac_extract --> test_ready__test_scaffold
+    test_ready__check --> pr_verify__prompt_compliance
     pr_verify__ac_verify --> pr_fix__fix_phase
     pr_fix__warning_fix --> pr_merge__e2e_screening
 

--- a/plugins/twl/refs/observation-pattern-catalog.md
+++ b/plugins/twl/refs/observation-pattern-catalog.md
@@ -95,13 +95,6 @@ hist-ac-shrinking:
 ## bug-reproduction patterns
 
 ```yaml
-bug-deltaspec-archive:
-  regex: 'archive.*fail|fail.*archive|Error.*archive|deltaspec.*archive.*error'
-  severity: error
-  category: deltaspec-archive-failure
-  description: "deltaspec archive 失敗検出 (#436 関連)"
-  related_issue: "436"
-
 bug-chain-stall:
   regex: 'chain.*stall|polling.*timeout|transition.*stop|chain.*stop'
   severity: error

--- a/plugins/twl/refs/ref-architecture-spec.md
+++ b/plugins/twl/refs/ref-architecture-spec.md
@@ -9,7 +9,7 @@ disable-model-invocation: true
 
 # Architecture Spec 仕様
 
-プロジェクトレベルの設計意図（前方参照）を管理するディレクトリ構造。DeltaSpec（後方参照）とは独立した概念。
+プロジェクトレベルの設計意図（前方参照）を管理するディレクトリ構造。
 
 ## ディレクトリ構造
 
@@ -158,12 +158,3 @@ architecture/
 ```
 
 Status 値: `planned` | `in-progress` | `done`
-
-## DeltaSpec との関係
-
-| 側面 | Architecture Spec | DeltaSpec |
-|------|------------------|---------|
-| 方向 | 前方参照（設計意図） | 後方参照（実装仕様） |
-| 粒度 | プロジェクトレベル | 変更レベル |
-| 独立性 | DeltaSpec から独立 | Architecture Spec から独立 |
-| 相互参照 | DeltaSpec change の「根拠」として参照可能 | Architecture Spec の Context を参照可能 |

--- a/plugins/twl/refs/ref-auto-issue-board-ops.md
+++ b/plugins/twl/refs/ref-auto-issue-board-ops.md
@@ -10,7 +10,7 @@ autopilot Worker が実装中に自動起票した Issue（tech-debt / self-impr
 Board Status が **"Todo"** で追加されるべきである。
 これらの Issue は実装が完了していないため、In Progress にしてはならない。
 
-仕様制約（`deltaspec/specs/issue-lifecycle.md`）:
+注意:
 > `chain-runner.sh board-status-update` を直接呼ばない（デフォルトが In Progress のため）
 
 ## 自動起票フローの正しい Board Status
@@ -58,5 +58,4 @@ bash "$CR" board-status-update <ISSUE_NUM> "Todo"
 | `commands/scope-judge.md` | Deferred Issue 作成後 `project-board-sync` を呼ぶ |
 | `commands/warning-fix.md` | 未修正 WARNING Issue 作成後 `project-board-sync` を呼ぶ |
 | `commands/prompt-audit-apply.md` | FAIL Issue 作成後 `project-board-sync` を呼ぶ |
-| `deltaspec/specs/issue-lifecycle.md:93` | 自動起票時の仕様制約 |
 | `tests/bats/scripts/board-merge-done-transition.bats` | Done 遷移テスト（自動起票 Issue は Done に遷移しない） |

--- a/plugins/twl/refs/ref-dci.md
+++ b/plugins/twl/refs/ref-dci.md
@@ -21,7 +21,6 @@ disable-model-invocation: true
 | ISSUE_NUM | Issue | [BANG]`source "${CLAUDE_PLUGIN_ROOT}/scripts/resolve-issue-num.sh" 2>/dev/null \|\| true; resolve_issue_num 2>/dev/null \|\| echo ""` | `""` | state file（AUTOPILOT_DIR）または branch から解決した Issue 番号 |
 | REPO_MODE | Repo mode | [BANG]`[ -d ".git" ] && echo "standard" \|\| echo "worktree"` | `"standard"` | リポジトリ形式 |
 | PR_NUMBER | PR | [BANG]`gh pr view --json number -q '.number' 2>/dev/null \|\| echo "none"` | `"none"` | PR 番号 |
-| CHANGE_ID | Change ID | [BANG]`ls deltaspec/changes/ 2>/dev/null \| grep -v archive \| head -1 \|\| echo ""` | `""` | DeltaSpec change ID |
 | PROJECT_ROOT | Project root | [BANG]`git rev-parse --show-toplevel 2>/dev/null \|\| echo "."` | `"."` | プロジェクトルートパス |
 
 **注**: `[BANG]` は実際の適用時には `!` に置換する。本ドキュメント内ではコードフェンス内誤実行バグ（claude-code Issue #12781）回避のためプレースホルダーを使用。
@@ -67,12 +66,11 @@ allowed-tools: Bash, Read, Write
 | コマンド | 注入変数 |
 |---------|---------|
 | ac-extract | BRANCH, ISSUE_NUM |
-| auto-merge | BRANCH, ISSUE_NUM, PR_NUMBER, CHANGE_ID, REPO_MODE |
+| auto-merge | BRANCH, ISSUE_NUM, PR_NUMBER, REPO_MODE |
 | all-pass-check | BRANCH, ISSUE_NUM, PR_NUMBER |
 | scope-judge | PR_NUMBER |
 | check | PROJECT_ROOT |
 | init | BRANCH, REPO_MODE |
-| change-apply | BRANCH, ISSUE_NUM |
 | pr-cycle-analysis | PR_NUMBER |
 | controller-autopilot | REPO_MODE |
 | env:rebuild | BRANCH |

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -9,7 +9,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 本ドキュメントは不変条件 A-M の **SSoT（Single Source of Truth）** であり、各 invariant の定義・意味は本ドキュメント自身で自己完結する。
 
 - **「根拠」欄の役割**: 設計判断の出典 ADR または導入された背景を示す。ADR が invariant の詳細仕様を個別定義しない場合でも、invariant の実装整合性は **検証方法欄の bats test** と **影響範囲欄の実装ファイル** で維持される。
-- **ADR-023 継承について**: 不変条件 D/E/F/G/I/J/K は旧 DeltaSpec spec scenario が根拠文書として機能していたが、Phase Z (#901) で DeltaSpec 廃止に伴い [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md) に継承された。ADR-023 は chain 構造変更の ADR であり individual invariant の詳細仕様は持たないが、invariant の意味定義は本ドキュメント自身が SSoT として保持し、検証は bats test (`../tests/bats/invariants/autopilot-invariants.bats`) が担保する。
+- **ADR-023 継承について**: 不変条件 D/E/F/G/I/J/K は Phase Z (#901) の chain 再設計に伴い [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md) に継承された。ADR-023 は chain 構造変更の ADR であり individual invariant の詳細仕様は持たないが、invariant の意味定義は本ドキュメント自身が SSoT として保持し、検証は bats test (`../tests/bats/invariants/autopilot-invariants.bats`) が担保する。
 - **不変条件 B の 2 根拠保持**: 不変条件 B のみ ADR-008 + ADR-023 の 2 根拠を明示しているのは、ADR-008 が Worktree ライフサイクル単独の独立 ADR として成立しているため。他の invariant (D/E/F/G/I/J/K) は対応する独立 ADR が存在しないため、ADR-023 を継承先として単一参照する。
 
 ---
@@ -28,7 +28,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 B: Worktree ライフサイクル Pilot 専任
 
 - **定義**: Worktree の作成・削除は Pilot が行わなければならない（SHALL）。Worker は使用のみ。
-- **根拠**: [ADR-008: Worktree Lifecycle Pilot Ownership](../architecture/decisions/ADR-008-worktree-lifecycle-pilot-ownership.md) / [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (DeltaSpec 除去後も本不変条件は ADR-008 に継承)
+- **根拠**: [ADR-008: Worktree Lifecycle Pilot Ownership](../architecture/decisions/ADR-008-worktree-lifecycle-pilot-ownership.md) / [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-B: worktree-delete rejects worker role`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-B: Worker chain (chain-steps.sh) does not include worktree-create`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/worktree-delete.sh`
@@ -52,7 +52,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 D: 依存先 fail 時の skip 伝播
 
 - **定義**: Phase N で fail した Issue に依存する Issue は自動 skip されなければならない（SHALL）。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 D は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-D: single dependency fail causes skip`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-D: multiple deps with one failed causes skip`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/autopilot-plan.sh`
@@ -63,7 +63,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 E: merge-gate リトライ制限
 
 - **定義**: merge-gate のリトライは最大 1 回でなければならない（SHALL）。2 回目リジェクト = 確定失敗。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 E の retry 制限と merge-gate REJECT 2 回目確定失敗は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-E: first retry allowed`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-E: second retry rejected`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
@@ -74,7 +74,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 F: squash merge API 失敗時 rebase 禁止
 
 - **定義**: `gh pr merge --squash` API 呼び出し失敗後は rebase を禁止しなければならない（SHALL）。停止のみ。merge 前のコンフリクト事前検知とは別概念。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 F は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-F: merge-gate-execute uses --squash flag`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
@@ -85,7 +85,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 G: クラッシュ検知保証
 
 - **定義**: Worker の crash/timeout は必ず検知されなければならない（SHALL）。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 G の Worker crash 検知は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-G: crash-detect transitions to failed when pane absent`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/crash-detect.sh`
@@ -107,7 +107,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 I: 循環依存拒否
 
 - **定義**: plan.yaml 生成時に循環依存を検出した場合、拒否しなければならない（SHALL）。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 I の循環依存拒否は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-I: direct circular dependency (A->B->A) rejected`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-I: indirect circular dependency (A->B->C->A) rejected`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/autopilot-plan.sh`
@@ -117,7 +117,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 J: merge 前 base drift 検知
 
 - **定義**: merge-gate 実行前に origin/main に対する silent deletion を検知し、検出時は merge を停止しなければならない（SHALL）。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 J の merge 前 base drift 検知は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-J: silent file deletion (no commit) is detected as base drift`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-J: intentional deletion (has commit) is not flagged`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/scripts/merge-gate-checkpoint-merge.sh`
@@ -127,7 +127,7 @@ twill autopilot システムの不変条件 A-M（13 件）の正典定義。各
 ## 不変条件 K: Pilot 実装禁止
 
 - **定義**: Pilot は Issue の実装（コード変更・PR 作成）を直接行ってはならない（SHALL）。実装は常に Worker 経由。Emergency Bypass 時も `mergegate merge --force` 経由のみ許可。
-- **根拠**: [ADR-023: deltaspec-free chain と TDD 直行 flow](../architecture/decisions/ADR-023-tdd-direct-flow.md) (不変条件 K の Pilot 実装禁止は DeltaSpec spec scenario から ADR-023 に継承)
+- **根拠**: [ADR-023](../architecture/decisions/ADR-023-tdd-direct-flow.md)
 - **検証方法**: [`invariant-K: ref-invariants.md defines invariant K (Pilot 実装禁止)`](../tests/bats/invariants/autopilot-invariants.bats), [`invariant-K: pilot cannot write implementation-only field`](../tests/bats/invariants/autopilot-invariants.bats)
 - **影響範囲**:
   - `plugins/twl/skills/co-autopilot/SKILL.md`

--- a/plugins/twl/refs/test-scenario-catalog.md
+++ b/plugins/twl/refs/test-scenario-catalog.md
@@ -200,7 +200,7 @@ regression-002:
 ```yaml
 regression-003:
   level: regression
-  description: "DeltaSpec + medium complexity Issue で setup→test-ready→pr-verify→pr-merge の full-chain 遷移を検証"
+  description: "medium complexity Issue で setup→test-ready→pr-verify→pr-merge の full-chain 遷移を検証"
   issues_count: 1
   expected_duration_min: 15
   expected_duration_max: 35
@@ -208,54 +208,22 @@ regression-003:
   expected_pr_count: 1
   observer_polling_interval: 15
   issue_templates:
-    - title: "[Test] add greet() function with DeltaSpec"
+    - title: "[Test] add greet() function"
       body: |
         ## Goal
-        test-target plugin に `greet(name)` 関数を追加する。DeltaSpec を使用して実装すること。
+        test-target plugin に `greet(name)` 関数を追加する。
 
         ## AC
         - [ ] `scripts/greet.sh` が新規作成され `echo "Hello, $1"` を実行する
-        - [ ] `deltaspec/changes/` に DeltaSpec change が存在する
         - [ ] chmod +x が設定されている
       labels: [test, scope/test-target, complexity-medium]
       complexity: medium
 ```
 
-### regression-004: Bug #436 再現（issue: フィールド欠落）
+### regression-004: Bug #438 再現（Orchestrator polling timeout）
 
 ```yaml
 regression-004:
-  level: regression
-  description: "twl spec new が .deltaspec.yaml に issue: フィールドを生成しない Bug #436 の再現シナリオ"
-  issues_count: 1
-  expected_duration_min: 10
-  expected_duration_max: 20
-  expected_conflicts: 0
-  expected_pr_count: 1
-  observer_polling_interval: 15
-  issue_templates:
-    - title: "[Test] add farewell() function with DeltaSpec (Bug436 repro)"
-      body: |
-        ## Goal
-        test-target plugin に `farewell(name)` 関数を追加する。DeltaSpec を使用して実装すること。
-
-        ## Bug 再現条件
-        この Issue は Bug #436 の再現用シナリオ。autopilot が `twl spec new` を呼び出した後、
-        生成される `.deltaspec.yaml` に `issue:` フィールドが存在するかを検証する。
-        `issue:` フィールドが欠落した場合、orchestrator の `grep "^issue:"` が 0 件ヒットし
-        archive フェーズで失敗する。
-
-        ## AC
-        - [ ] `scripts/farewell.sh` が新規作成され `echo "Goodbye, $1"` を実行する
-        - [ ] `deltaspec/changes/*.yaml` に `issue:` フィールドが存在する（Bug #436 修正検証）
-      labels: [test, scope/test-target, complexity-medium]
-      complexity: medium
-```
-
-### regression-005: Bug #438 再現（Orchestrator polling timeout）
-
-```yaml
-regression-005:
   level: regression
   description: "Orchestrator polling loop が Bash timeout 120秒で停止し inject_next_workflow() が呼ばれない Bug #438 の再現シナリオ"
   issues_count: 1
@@ -272,8 +240,8 @@ regression-005:
         時間がかかる処理を含む（複数ファイルの生成とループ処理）。
 
         ## Bug 再現条件
-        この Issue は Bug #438 の再現用シナリオ。workflow-setup フェーズで change-propose が
-        120 秒以上かかる処理を含む場合、Orchestrator の polling loop が Bash timeout で停止し、
+        この Issue は Bug #438 の再現用シナリオ。workflow-setup フェーズで長時間かかる処理を
+        含む場合、Orchestrator の polling loop が Bash timeout で停止し、
         `inject_next_workflow()` が呼ばれず chain 遷移が停止することを検証する。
 
         ## AC
@@ -284,10 +252,10 @@ regression-005:
       complexity: medium
 ```
 
-### regression-006: Bug #439 再現（merge-gate phase-review チェック欠落）
+### regression-005: Bug #439 再現（merge-gate phase-review チェック欠落）
 
 ```yaml
-regression-006:
+regression-005:
   level: regression
   description: "merge-gate が phase-review.json の存在を検査しない Bug #439 の再現シナリオ"
   issues_count: 1

--- a/plugins/twl/scripts/hooks/pre-compact-checkpoint.sh
+++ b/plugins/twl/scripts/hooks/pre-compact-checkpoint.sh
@@ -71,9 +71,6 @@ CONTEXT_FILE="${CONTEXT_DIR}/issue-${ISSUE_NUM}-context.md"
 mkdir -p "$CONTEXT_DIR" 2>/dev/null || true
 
 # state から重要変数を取得
-CHANGE_ID="$(python3 -m twl.autopilot.state read \
-  --type issue --issue "$ISSUE_NUM" --field change_id \
-  2>/dev/null || echo "")"
 PR_NUMBER="$(python3 -m twl.autopilot.state read \
   --type issue --issue "$ISSUE_NUM" --field pr_number \
   2>/dev/null || echo "")"
@@ -86,7 +83,6 @@ COMPACT_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")"
   echo ""
   echo "## compaction_checkpoint (${COMPACT_AT})"
   echo "current_step: ${CURRENT_STEP}"
-  [[ -n "$CHANGE_ID" ]] && echo "change_id: ${CHANGE_ID}"
   [[ -n "$PR_NUMBER" ]] && echo "pr_number: ${PR_NUMBER}"
   [[ -n "$MODE" ]] && echo "mode: ${MODE}"
 } >> "$CONTEXT_FILE" 2>/dev/null || true


### PR DESCRIPTION
refactor(#910): refs/+ architecture contexts + domain/model + pre-compact-checkpoint.sh から deltaspec 削除

- refs/ref-architecture-spec.md: DeltaSpec との関係セクション削除
- refs/ref-auto-issue-board-ops.md: deltaspec/specs/issue-lifecycle.md 参照削除
- refs/ref-dci.md: CHANGE_ID 変数・change-apply エントリ削除
- refs/ref-invariants.md: DeltaSpec spec scenario 根拠テキスト削除、ADR-023 リンクテキスト短縮
- refs/test-scenario-catalog.md: regression-003/004 (DeltaSpec scenarios) 削除・renumber
- refs/observation-pattern-catalog.md: bug-deltaspec-archive パターン削除
- architecture/domain/contexts/autopilot.md: mermaid chain 図更新（DeltaSpec steps 除去）、DeltaSpec 適用ポリシー削除
- architecture/domain/model.md: mermaid chain 図更新（DeltaSpec steps 除去）
- scripts/hooks/pre-compact-checkpoint.sh: change_id 取得・記録削除

Closes #910