### PR TITLE
refactor(#Z15): chain.py QUICK_SKIP_STEPS + quick関数群 + state.py is_quick/is_direct削除

### DIFF
--- a/cli/twl/src/twl/autopilot/chain.py
+++ b/cli/twl/src/twl/autopilot/chain.py
@@ -7,8 +7,8 @@ CLI usage:
 
 Steps: init, worktree-create, project-board-status-update, board-archive, ac-extract,
        arch-ref, next-step, ts-preflight, pr-test,
-       ac-verify, all-pass-check, pr-cycle-report, check, quick-guard,
-       autopilot-detect, quick-detect, resolve-next-workflow
+       ac-verify, all-pass-check, pr-cycle-report, check,
+       autopilot-detect, resolve-next-workflow
 """
 
 from __future__ import annotations
@@ -44,15 +44,6 @@ CHAIN_STEPS: list[str] = [
     "all-pass-check",
     "pr-cycle-report",
 ]
-
-QUICK_SKIP_STEPS: frozenset[str] = frozenset([
-    "crg-auto-build",
-    "arch-ref",
-    "ac-extract",
-    "test-scaffold",
-    "check",
-    "prompt-compliance",
-])
 
 DIRECT_SKIP_STEPS: frozenset[str] = frozenset()
 
@@ -197,14 +188,6 @@ def export_chain_steps_sh() -> str:
     lines.append(")")
     lines.append("")
 
-    lines.append("# quick Issue でスキップするステップの一覧（SSOT）")
-    lines.append("QUICK_SKIP_STEPS=(")
-    for step in CHAIN_STEPS:
-        if step in QUICK_SKIP_STEPS:
-            lines.append(f"  {step}")
-    lines.append(")")
-    lines.append("")
-
     lines.append("# direct モード（scope/direct ラベル）でスキップするステップの一覧（SSOT）")
     lines.append("DIRECT_SKIP_STEPS=(")
     for step in CHAIN_STEPS:
@@ -268,21 +251,18 @@ class ChainRunner:
     # ------------------------------------------------------------------
 
     def next_step(self, issue_num: str, current_step: str) -> str:
-        """Return next step name given current step, respecting is_quick/mode skips.
+        """Return next step name given current step, respecting mode skips.
 
         Returns 'done' if all steps are complete.
         """
         if not issue_num or not re.match(r"^\d+$", issue_num):
             raise ChainError(f"issue_num は正の整数で指定してください: {issue_num!r}")
 
-        is_quick = self._read_state_field(issue_num, "is_quick") == "true"
         mode = self._read_state_field(issue_num, "mode")  # "direct" | "propose" | "apply" | ""
 
         found = False
         for step in CHAIN_STEPS:
             if found:
-                if is_quick and step in QUICK_SKIP_STEPS:
-                    continue
                 if mode == "direct" and step in DIRECT_SKIP_STEPS:
                     continue
                 return step
@@ -336,38 +316,6 @@ class ChainRunner:
         print(f"IS_AUTOPILOT={value}")
 
     # ------------------------------------------------------------------
-    # Step: quick-detect
-    # ------------------------------------------------------------------
-
-    def step_quick_detect(self) -> None:
-        """Print eval-able IS_QUICK=true/false to stdout."""
-        issue_num = self._resolve_issue_num()
-        if not issue_num:
-            print("IS_QUICK=false")
-            return
-        is_quick = self._read_state_field(issue_num, "is_quick")
-        if not is_quick:
-            is_quick = self._detect_quick_label(issue_num)
-        value = "true" if is_quick == "true" else "false"
-        print(f"IS_QUICK={value}")
-
-    # ------------------------------------------------------------------
-    # Step: quick-guard
-    # ------------------------------------------------------------------
-
-    def step_quick_guard(self) -> int:
-        """Return 0 if non-quick, 1 if quick Issue."""
-        issue_num = self._resolve_issue_num()
-        if not issue_num:
-            return 0
-
-        is_quick = self._read_state_field(issue_num, "is_quick")
-        if not is_quick:
-            is_quick = self._detect_quick_label(issue_num)
-
-        return 1 if is_quick == "true" else 0
-
-    # ------------------------------------------------------------------
     # Step: init
     # ------------------------------------------------------------------
 
@@ -377,33 +325,26 @@ class ChainRunner:
 
         branch = self._git_current_branch()
         labels = self._fetch_labels(issue_num) if issue_num else []
-        is_quick = "true" if "quick" in labels else "false"
         is_direct = "true" if "scope/direct" in labels else "false"
 
-        # Persist is_quick and is_direct to state
         if issue_num and re.match(r"^\d+$", issue_num):
-            self._write_state_field(issue_num, f"is_quick={is_quick}")
             self._write_state_field(issue_num, f"is_direct={is_direct}")
 
         if branch in ("main", "master"):
             result = {
                 "recommended_action": "worktree",
                 "branch": branch,
-                "is_quick": is_quick == "true",
             }
-            self._ok("init", f"recommended_action=worktree (branch={branch}, is_quick={is_quick})")
+            self._ok("init", f"recommended_action=worktree (branch={branch})")
             return result
 
-        # quick or scope/direct label → direct
-        if is_quick == "true" or is_direct == "true":
-            reason = "quick" if is_quick == "true" else "scope/direct label"
+        if is_direct == "true":
             result = {
                 "recommended_action": "direct",
                 "branch": branch,
-                "is_quick": is_quick == "true",
                 "is_direct": is_direct == "true",
             }
-            self._ok("init", f"recommended_action=direct ({reason}, is_quick={is_quick})")
+            self._ok("init", "recommended_action=direct (scope/direct label)")
             if issue_num and re.match(r"^\d+$", issue_num):
                 self._write_state_field(issue_num, "mode=direct")
             return result
@@ -411,9 +352,8 @@ class ChainRunner:
         result = {
             "recommended_action": "implement",
             "branch": branch,
-            "is_quick": is_quick == "true",
         }
-        self._ok("init", f"recommended_action=implement (branch={branch}, is_quick={is_quick})")
+        self._ok("init", f"recommended_action=implement (branch={branch})")
         return result
 
     # ------------------------------------------------------------------
@@ -740,16 +680,14 @@ class ChainRunner:
         self,
         current_workflow: str,
         is_autopilot: bool,
-        is_quick: bool,
     ) -> str:
         """Return next workflow skill name from deps.yaml meta_chains.
 
         Reads plugins/twl/deps.yaml meta_chains.worker-lifecycle.flow and
-        evaluates conditions based on is_autopilot and is_quick.
+        evaluates conditions based on is_autopilot.
 
         Returns:
             - Next workflow skill name (e.g. "workflow-test-ready")
-            - "quick-path" for the quick-path node (no skill field)
             - "" for terminal nodes or stop conditions
         """
         flow = self._load_worker_lifecycle_flow()
@@ -772,7 +710,7 @@ class ChainRunner:
         goto: str | None = None
         for cond_entry in current_node.get("next", []):
             condition = cond_entry.get("condition", "")
-            if self._eval_workflow_condition(condition, is_autopilot, is_quick):
+            if self._eval_workflow_condition(condition, is_autopilot):
                 if cond_entry.get("stop", False):
                     return ""
                 goto = cond_entry.get("goto") or None
@@ -803,7 +741,6 @@ class ChainRunner:
         if next_node.get("terminal", False):
             return ""
 
-        # Node without skill and non-terminal (e.g. quick-path) → return node ID
         return goto
 
     def _load_worker_lifecycle_flow(self) -> list[dict[str, Any]]:
@@ -830,11 +767,11 @@ class ChainRunner:
         )
 
     def _eval_workflow_condition(
-        self, condition: str, is_autopilot: bool, is_quick: bool
+        self, condition: str, is_autopilot: bool
     ) -> bool:
         """Evaluate a workflow condition string against runtime flags.
 
-        Supported tokens: autopilot, quick (prefix ! for negation).
+        Supported tokens: autopilot (prefix ! for negation).
         Multiple tokens joined by && must all be true.
         Empty condition → always matches.
         """
@@ -848,8 +785,6 @@ class ChainRunner:
             name = token.lstrip("!").strip()
             if name == "autopilot":
                 value = is_autopilot
-            elif name == "quick":
-                value = is_quick
             else:
                 return False
             if negate:
@@ -972,10 +907,6 @@ class ChainRunner:
             pass
         return []
 
-    def _detect_quick_label(self, issue_num: str) -> str:
-        """Return 'true' if issue has quick label, else 'false'."""
-        return "true" if "quick" in self._fetch_labels(issue_num) else "false"
-
     def _has_command(self, cmd: str) -> bool:
         try:
             subprocess.check_output(["which", cmd], stderr=subprocess.DEVNULL)
@@ -1002,10 +933,10 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args:
         print("Usage: python3 -m twl.autopilot.chain <step-name> [args...]", file=sys.stderr)
-        print("Steps: init, next-step, quick-guard, check,", file=sys.stderr)
+        print("Steps: init, next-step, check,", file=sys.stderr)
         print("       all-pass-check, prompt-compliance, ts-preflight, pr-test, pr-cycle-report,", file=sys.stderr)
         print("       project-board-status-update, ac-extract,", file=sys.stderr)
-        print("       autopilot-detect, quick-detect, resolve-next-workflow", file=sys.stderr)
+        print("       autopilot-detect, resolve-next-workflow", file=sys.stderr)
         return 1
 
     step = args[0]
@@ -1025,14 +956,6 @@ def main(argv: list[str] | None = None) -> int:
         elif step == "autopilot-detect":
             runner.step_autopilot_detect()
             return 0
-
-        elif step == "quick-detect":
-            runner.step_quick_detect()
-            return 0
-
-        elif step == "quick-guard":
-            code = runner.step_quick_guard()
-            return code  # 0=非quick, 1=quick
 
         elif step == "init":
             issue_num = rest[0] if rest else ""
@@ -1083,17 +1006,13 @@ def main(argv: list[str] | None = None) -> int:
                 print("ERROR: resolve-next-workflow には workflow-id が必要です", file=sys.stderr)
                 return 1
             workflow_id = rest[0]
-            # Read is_autopilot and is_quick from issue state
             issue_num = runner._resolve_issue_num()
             if issue_num:
                 autopilot_val = runner._read_state_field(issue_num, "status")
                 is_autopilot = autopilot_val == "running"
-                quick_val = runner._read_state_field(issue_num, "is_quick")
-                is_quick = quick_val == "true"
             else:
                 is_autopilot = False
-                is_quick = False
-            result = runner.resolve_next_workflow(workflow_id, is_autopilot, is_quick)
+            result = runner.resolve_next_workflow(workflow_id, is_autopilot)
             print(result)
             return 0
 

--- a/cli/twl/src/twl/chain/integrity.py
+++ b/cli/twl/src/twl/chain/integrity.py
@@ -26,7 +26,7 @@ def _hash_set(items: set[str] | frozenset[str]) -> str:
 
 
 def _load_chain_py_constants(plugin_root: Path) -> Optional[dict]:
-    """Parse CHAIN_STEPS, QUICK_SKIP_STEPS, DIRECT_SKIP_STEPS, STEP_TO_WORKFLOW from chain.py via AST."""
+    """Parse CHAIN_STEPS, DIRECT_SKIP_STEPS, STEP_TO_WORKFLOW from chain.py via AST."""
     candidates = [
         plugin_root.parent.parent / "cli" / "twl" / "src" / "twl" / "autopilot" / "chain.py",
         plugin_root.parent / "cli" / "twl" / "src" / "twl" / "autopilot" / "chain.py",
@@ -57,7 +57,7 @@ def _load_chain_py_constants(plugin_root: Path) -> Optional[dict]:
                 e.value for e in value.elts
                 if isinstance(e, ast.Constant) and isinstance(e.value, str)
             ]
-        elif name in ("QUICK_SKIP_STEPS", "DIRECT_SKIP_STEPS") and value is not None:
+        elif name == "DIRECT_SKIP_STEPS" and value is not None:
             elts = None
             if isinstance(value, (ast.List, ast.Set)):
                 elts = value.elts
@@ -114,7 +114,6 @@ def check_deps_integrity(plugin_root: Path) -> tuple[list[str], list[str]]:
         return errors, warnings
 
     py_chain_steps: list[str] = constants.get("CHAIN_STEPS", [])
-    py_quick_skip: frozenset[str] = constants.get("QUICK_SKIP_STEPS", frozenset())
     py_direct_skip: frozenset[str] = constants.get("DIRECT_SKIP_STEPS", frozenset())
     py_step_to_workflow: dict[str, str] = constants.get("STEP_TO_WORKFLOW", {})
 
@@ -133,17 +132,6 @@ def check_deps_integrity(plugin_root: Path) -> tuple[list[str], list[str]]:
                 f"[deps-integrity] CHAIN_STEPS mismatch: chain.py vs chain-steps.sh\n"
                 f"  chain.py:       {py_chain_steps}\n"
                 f"  chain-steps.sh: {sh_chain_steps}\n"
-                f"  {fix_hint}"
-            )
-
-        sh_quick = _parse_bash_array(content, "QUICK_SKIP_STEPS")
-        if sh_quick is None:
-            warnings.append("[deps-integrity] QUICK_SKIP_STEPS not found in chain-steps.sh")
-        elif _hash_set(py_quick_skip) != _hash_set(set(sh_quick)):
-            errors.append(
-                f"[deps-integrity] QUICK_SKIP_STEPS mismatch: chain.py vs chain-steps.sh\n"
-                f"  chain.py:       {sorted(py_quick_skip)}\n"
-                f"  chain-steps.sh: {sorted(sh_quick)}\n"
                 f"  {fix_hint}"
             )
 

--- a/cli/twl/src/twl/chain/viz.py
+++ b/cli/twl/src/twl/chain/viz.py
@@ -34,25 +34,6 @@ def _safe_mermaid_label(text: str) -> str:
     """Escape text for use inside Mermaid node labels (quoted form)."""
     return text.replace('"', "'").replace("[", "&#91;").replace("]", "&#93;")
 
-# QUICK_SKIP_STEPS は autopilot.chain からインポート（循環回避のためローカル定義も保持）
-_QUICK_SKIP_STEPS_FALLBACK: frozenset = frozenset([
-    "crg-auto-build",
-    "arch-ref",
-    "ac-extract",
-    "test-scaffold",
-    "check",
-    "prompt-compliance",
-])
-
-
-def _get_quick_skip_steps() -> frozenset:
-    try:
-        from twl.autopilot.chain import QUICK_SKIP_STEPS
-        return QUICK_SKIP_STEPS
-    except ImportError:
-        return _QUICK_SKIP_STEPS_FALLBACK
-
-
 def _safe_node_id(chain_name: str, step_name: str) -> str:
     """Mermaid ノード ID をサニタイズ"""
     chain_safe = re.sub(r'[^a-zA-Z0-9]', '_', chain_name)
@@ -91,7 +72,6 @@ def chain_viz_single(deps: dict, chain_name: str) -> str:
         steps = []
 
     all_components = _build_all_components(deps)
-    quick_skip = _get_quick_skip_steps()
 
     lines: List[str] = []
     lines.append("```mermaid")
@@ -122,46 +102,11 @@ def chain_viz_single(deps: dict, chain_name: str) -> str:
         dst_id = _safe_node_id(chain_name, valid_steps[i + 1])
         lines.append(f"    {src_id} --> {dst_id}")
 
-    # quick バイパス（破線）: quick_skip ステップを迂回する矢印
-    # 先頭の非スキップ → 連続スキップ後の非スキップ への破線
-    _append_quick_bypasses(lines, chain_name, valid_steps, quick_skip)
-
     lines.append("")
     _append_classdefs(lines)
     lines.append("```")
 
     return "\n".join(lines)
-
-
-def _append_quick_bypasses(
-    lines: List[str],
-    chain_name: str,
-    steps: List[str],
-    quick_skip: frozenset,
-) -> None:
-    """quick バイパス（破線）矢印を追加する。
-
-    連続する quick_skip ステップ群の直前→直後ノードへ破線を引く。
-    """
-    if not steps:
-        return
-
-    i = 0
-    while i < len(steps):
-        if steps[i] not in quick_skip:
-            # steps[i] が非スキップ。この直後に quick_skip が始まるか確認
-            j = i + 1
-            while j < len(steps) and steps[j] in quick_skip:
-                j += 1
-            # i+1 から j-1 が全て quick_skip、j が次の非スキップ
-            if j > i + 1 and j < len(steps):
-                # バイパス矢印: steps[i] → steps[j]
-                src_id = _safe_node_id(chain_name, steps[i])
-                dst_id = _safe_node_id(chain_name, steps[j])
-                lines.append(f"    {src_id} -. quick .-> {dst_id}")
-            i = j
-        else:
-            i += 1
 
 
 def chain_viz_all(deps: dict) -> str:
@@ -171,7 +116,6 @@ def chain_viz_all(deps: dict) -> str:
         return "# No chains found\n"
 
     all_components = _build_all_components(deps)
-    quick_skip = _get_quick_skip_steps()
 
     lines: List[str] = []
     lines.append("```mermaid")
@@ -217,8 +161,6 @@ def chain_viz_all(deps: dict) -> str:
             src_id = _safe_node_id(chain_name, valid_steps[i])
             dst_id = _safe_node_id(chain_name, valid_steps[i + 1])
             lines.append(f"    {src_id} --> {dst_id}")
-
-        _append_quick_bypasses(lines, chain_name, valid_steps, quick_skip)
 
     lines.append("")
 

--- a/cli/twl/tests/autopilot/test_chain_e2e_transition.py
+++ b/cli/twl/tests/autopilot/test_chain_e2e_transition.py
@@ -36,18 +36,10 @@ WORKER_LIFECYCLE_FLOW: list[dict] = [
         "id": "setup",
         "chain": "setup",
         "next": [
-            {"condition": "quick && autopilot", "goto": "quick-path"},
-            {"condition": "!quick && autopilot", "goto": "test-ready"},
+            {"condition": "autopilot", "goto": "test-ready"},
             {"condition": "!autopilot", "stop": True,
              "message": "setup chain 完了。次: /twl:workflow-test-ready"},
         ],
-    },
-    {
-        "id": "quick-path",
-        "chain": None,
-        "description": "quick Issue の短縮パス",
-        "inline_steps": ["直接実装 → commit → push", "PR 作成", "ac-verify", "merge-gate"],
-        "next": [{"goto": "done"}],
     },
     {
         "id": "test-ready",
@@ -132,7 +124,6 @@ def _write_issue_state(autopilot_dir: Path, issue_num: int, current_workflow: st
         "failure": None,
         "implementation_pr": None,
         "deltaspec_mode": None,
-        "is_quick": False,
     }
     f = issues_dir / f"issue-{issue_num}.json"
     f.write_text(json.dumps(data, ensure_ascii=False, indent=2))
@@ -165,7 +156,7 @@ class TestSetupToTestReadyTransition:
     def test_setup_returns_test_ready(self, patched_runner: ChainRunner) -> None:
         """current_workflow=setup で resolve_next_workflow が workflow-test-ready を返す。"""
         result = patched_runner.resolve_next_workflow(
-            "setup", is_autopilot=True, is_quick=False
+            "setup", is_autopilot=True
         )
         _assert_no_inject_skip(result, "setup")
         assert result == "workflow-test-ready", (
@@ -183,7 +174,7 @@ class TestTestReadyToPrVerifyTransition:
     def test_test_ready_returns_pr_verify(self, patched_runner: ChainRunner) -> None:
         """current_workflow=test-ready で resolve_next_workflow が workflow-pr-verify を返す。"""
         result = patched_runner.resolve_next_workflow(
-            "test-ready", is_autopilot=True, is_quick=False
+            "test-ready", is_autopilot=True
         )
         _assert_no_inject_skip(result, "test-ready")
         assert result == "workflow-pr-verify", (
@@ -201,7 +192,7 @@ class TestPrVerifyTransition:
     def test_pr_verify_returns_pr_fix(self, patched_runner: ChainRunner) -> None:
         """current_workflow=pr-verify (autopilot=True) で workflow-pr-fix を返す。"""
         result = patched_runner.resolve_next_workflow(
-            "pr-verify", is_autopilot=True, is_quick=False
+            "pr-verify", is_autopilot=True
         )
         # pr-verify → pr-fix (not terminal in autopilot mode)
         assert result == "workflow-pr-fix", (
@@ -211,7 +202,7 @@ class TestPrVerifyTransition:
     def test_pr_verify_autopilot_false_stops(self, patched_runner: ChainRunner) -> None:
         """current_workflow=pr-verify (autopilot=False) で停止（空を返す）。"""
         result = patched_runner.resolve_next_workflow(
-            "pr-verify", is_autopilot=False, is_quick=False
+            "pr-verify", is_autopilot=False
         )
         assert result == "", (
             f"autopilot=False の pr-verify は停止すべきだが {result!r} を返した"
@@ -241,7 +232,7 @@ def test_three_issues_no_inject_skip(
     runner = _make_runner(tmp_path)
     _write_issue_state(runner.autopilot_dir, issue_num=issue_num, current_workflow=current_workflow)
     with patch.object(runner, "_load_worker_lifecycle_flow", return_value=WORKER_LIFECYCLE_FLOW):
-        result = runner.resolve_next_workflow(current_workflow, is_autopilot=True, is_quick=False)
+        result = runner.resolve_next_workflow(current_workflow, is_autopilot=True)
     _assert_no_inject_skip(result, current_workflow)
     assert result == expected_next, (
         f"issue #{issue_num}: current_workflow={current_workflow!r} → expected {expected_next!r}, got {result!r}"
@@ -267,7 +258,7 @@ class TestInjectSkipDetection:
     def test_unknown_workflow_returns_empty(self, patched_runner: ChainRunner) -> None:
         """未知の current_workflow は空文字を返す（inject-skip として正しく検出される）。"""
         result = patched_runner.resolve_next_workflow(
-            "unknown-workflow", is_autopilot=True, is_quick=False
+            "unknown-workflow", is_autopilot=True
         )
         assert result == "", (
             f"未知の workflow に対して空文字を期待したが {result!r} を返した"
@@ -289,7 +280,7 @@ class TestFullChainSequence:
         ]
         for current_workflow, expected_next in chain_sequence:
             result = patched_runner.resolve_next_workflow(
-                current_workflow, is_autopilot=True, is_quick=False
+                current_workflow, is_autopilot=True
             )
             _assert_no_inject_skip(result, current_workflow)
             assert result == expected_next, (

--- a/cli/twl/tests/autopilot/test_nonterminal_chain_recovery.py
+++ b/cli/twl/tests/autopilot/test_nonterminal_chain_recovery.py
@@ -305,7 +305,7 @@ class TestWorkflowChainMapping:
             return_value=_minimal_flow(),
         ):
             result = chain_runner.resolve_next_workflow(
-                "test-ready", is_autopilot=True, is_quick=False
+                "test-ready", is_autopilot=True
             )
         # The method returns skill name (without /twl: prefix)
         assert result == "workflow-pr-verify", (
@@ -322,7 +322,7 @@ class TestWorkflowChainMapping:
             return_value=_minimal_flow(),
         ):
             result = chain_runner.resolve_next_workflow(
-                "", is_autopilot=True, is_quick=False
+                "", is_autopilot=True
             )
         assert result == ""
 

--- a/cli/twl/tests/test_autopilot_chain.py
+++ b/cli/twl/tests/test_autopilot_chain.py
@@ -2,10 +2,8 @@
 
 Covers:
   - Normal step transitions (happy path)
-  - quick Issue step skipping
   - Crash recovery / invalid transition rejection
   - CHAIN_STEPS ordering and completeness
-  - QUICK_SKIP_STEPS coverage
 """
 
 from __future__ import annotations
@@ -22,7 +20,6 @@ import pytest
 from twl.autopilot.chain import (
     CHAIN_STEPS,
     DIRECT_SKIP_STEPS,
-    QUICK_SKIP_STEPS,
     ChainError,
     ChainRunner,
 )
@@ -77,12 +74,6 @@ class TestChainStepsDefinition:
         essential = {"init", "check", "all-pass-check", "pr-cycle-report"}
         assert essential.issubset(set(CHAIN_STEPS))
 
-    def test_quick_skip_steps_subset_of_chain_steps(self) -> None:
-        assert QUICK_SKIP_STEPS.issubset(set(CHAIN_STEPS))
-
-    def test_quick_skip_steps_not_empty(self) -> None:
-        assert len(QUICK_SKIP_STEPS) > 0
-
     def test_direct_skip_steps_subset_of_chain_steps(self) -> None:
         assert DIRECT_SKIP_STEPS.issubset(set(CHAIN_STEPS))
 
@@ -112,7 +103,7 @@ class TestNextStepNormal:
         assert result == expected
 
     def test_step_sequence_all(self, runner: ChainRunner, state: StateManager) -> None:
-        """Verify the full sequence of non-quick steps."""
+        """Verify the full sequence of steps."""
         _init_issue(state, "2")
         for i, step in enumerate(CHAIN_STEPS[:-1]):
             next_s = runner.next_step("2", step)
@@ -130,59 +121,6 @@ class TestNextStepNormal:
 
 
 # ===========================================================================
-# Quick Issue skipping
-# ===========================================================================
-
-
-class TestNextStepQuick:
-    def _make_quick_issue(self, state: StateManager, autopilot_dir: Path, issue: str = "10") -> None:
-        _init_issue(state, issue)
-        state.write(type_="issue", role="worker", issue=issue, sets=["is_quick=true"])
-
-    def test_quick_skips_quick_skip_steps(
-        self, runner: ChainRunner, state: StateManager, autopilot_dir: Path
-    ) -> None:
-        self._make_quick_issue(state, autopilot_dir, "10")
-        # After init, quick issues skip QUICK_SKIP_STEPS
-        current = "init"
-        result = runner.next_step("10", current)
-        # Should skip any QUICK_SKIP_STEPS
-        assert result not in QUICK_SKIP_STEPS
-
-    def test_quick_full_sequence_no_skipped_steps(
-        self, runner: ChainRunner, state: StateManager, autopilot_dir: Path
-    ) -> None:
-        self._make_quick_issue(state, autopilot_dir, "11")
-        seen_steps: list[str] = []
-        current = ""
-        for _ in range(len(CHAIN_STEPS) + 2):
-            next_s = runner.next_step("11", current)
-            if next_s == "done":
-                break
-            seen_steps.append(next_s)
-            current = next_s
-        # None of the seen steps should be in QUICK_SKIP_STEPS
-        skipped_in_path = [s for s in seen_steps if s in QUICK_SKIP_STEPS]
-        assert not skipped_in_path, f"Quick Issue should skip: {skipped_in_path}"
-
-    def test_non_quick_includes_all_steps(
-        self, runner: ChainRunner, state: StateManager, autopilot_dir: Path
-    ) -> None:
-        _init_issue(state, "12")
-        state.write(type_="issue", role="worker", issue="12", sets=["is_quick=false"])
-        seen: list[str] = []
-        current = ""
-        for _ in range(len(CHAIN_STEPS) + 2):
-            next_s = runner.next_step("12", current)
-            if next_s == "done":
-                break
-            seen.append(next_s)
-            current = next_s
-        for step in QUICK_SKIP_STEPS:
-            assert step in seen, f"Non-quick Issue should include {step}"
-
-
-# ===========================================================================
 # Direct mode step skipping
 # ===========================================================================
 
@@ -190,11 +128,11 @@ class TestNextStepQuick:
 class TestNextStepDirect:
     def _make_direct_issue(self, state: StateManager, issue: str = "20") -> None:
         _init_issue(state, issue)
-        state.write(type_="issue", role="worker", issue=issue, sets=["is_quick=false", "mode=direct"])
+        state.write(type_="issue", role="worker", issue=issue, sets=["mode=direct"])
 
     def _make_propose_issue(self, state: StateManager, issue: str = "21") -> None:
         _init_issue(state, issue)
-        state.write(type_="issue", role="worker", issue=issue, sets=["is_quick=false", "mode=propose"])
+        state.write(type_="issue", role="worker", issue=issue, sets=["mode=propose"])
 
     def test_direct_skips_direct_skip_steps(
         self, runner: ChainRunner, state: StateManager, autopilot_dir: Path
@@ -230,7 +168,6 @@ class TestNextStepDirect:
         self, runner: ChainRunner, state: StateManager, autopilot_dir: Path
     ) -> None:
         _init_issue(state, "22")
-        state.write(type_="issue", role="worker", issue="22", sets=["is_quick=false"])
         seen: list[str] = []
         current = ""
         for _ in range(len(CHAIN_STEPS) + 2):
@@ -317,9 +254,7 @@ class TestNextStepValidation:
     def test_zero_issue_num_raises(self, runner: ChainRunner) -> None:
         # "0" is technically a digit but issue numbers are positive
         # Currently the validator checks ^\d+$ so "0" passes — document actual behavior
-        # If it reads empty state, returns first step
         result = runner.next_step("0", "init")
-        # Should return next step (is_quick defaults to false when state not found)
         assert result in CHAIN_STEPS
 
 
@@ -374,10 +309,10 @@ class TestStepInit:
         scripts_root.mkdir(exist_ok=True)
         return ChainRunner(scripts_root=scripts_root, autopilot_dir=autopilot_dir)
 
-    def test_non_quick_non_direct_on_feature_branch_returns_implement(
+    def test_non_direct_on_feature_branch_returns_implement(
         self, tmp_path: Path, autopilot_dir: Path
     ) -> None:
-        """quick なし + direct なし → implement."""
+        """direct なし → implement."""
         runner = self._make_runner(tmp_path, autopilot_dir)
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
@@ -407,10 +342,10 @@ class TestStepInit:
     # Issue #784: step_init auto_init パス — issue_num あり
     # ------------------------------------------------------------------
 
-    def test_issue_num_writes_is_quick_and_is_direct(
+    def test_issue_num_writes_is_direct(
         self, tmp_path: Path, autopilot_dir: Path
     ) -> None:
-        """issue_num='784' → _write_state_field が is_quick/is_direct を書く."""
+        """issue_num='784' → _write_state_field が is_direct を書く."""
         runner = self._make_runner(tmp_path, autopilot_dir)
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/784-branch"),
@@ -421,16 +356,14 @@ class TestStepInit:
             result = runner.step_init("784")
 
         assert result["recommended_action"] == "implement"
-        assert result.get("is_quick") is False
 
         call_kvs = [call.args[1] for call in mock_write.call_args_list]
-        assert "is_quick=false" in call_kvs
         assert "is_direct=false" in call_kvs
 
     def test_issue_num_writes_state_before_result(
         self, tmp_path: Path, autopilot_dir: Path
     ) -> None:
-        """issue_num あり → is_quick/is_direct が state に書かれる."""
+        """issue_num あり → is_direct が state に書かれる."""
         runner = self._make_runner(tmp_path, autopilot_dir)
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/784-branch"),
@@ -441,7 +374,6 @@ class TestStepInit:
             runner.step_init("784")
 
         call_kvs = [call.args[1] for call in mock_write.call_args_list]
-        assert "is_quick=false" in call_kvs
         assert "is_direct=false" in call_kvs
 
     def test_issue_num_passed_to_write_state_field(
@@ -460,10 +392,10 @@ class TestStepInit:
         for call in mock_write.call_args_list:
             assert call.args[0] == "784", f"issue_num が '784' でない: {call.args[0]!r}"
 
-    def test_empty_issue_num_no_is_quick_write(
+    def test_empty_issue_num_no_is_direct_write(
         self, tmp_path: Path, autopilot_dir: Path
     ) -> None:
-        """issue_num='' のとき is_quick/is_direct を state に書かない."""
+        """issue_num='' のとき is_direct を state に書かない."""
         runner = self._make_runner(tmp_path, autopilot_dir)
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/some-branch"),
@@ -475,12 +407,12 @@ class TestStepInit:
 
         assert result["recommended_action"] == "implement"
         call_kvs = [call.args[1] for call in mock_write.call_args_list]
-        assert "is_quick=false" not in call_kvs, "issue_num='' では is_quick 書き込み不可"
+        assert "is_direct=false" not in call_kvs, "issue_num='' では is_direct 書き込み不可"
 
-    def test_non_numeric_issue_num_no_is_quick_write(
+    def test_non_numeric_issue_num_no_is_direct_write(
         self, tmp_path: Path, autopilot_dir: Path
     ) -> None:
-        """issue_num が数字でない場合は is_quick/is_direct を state に書かない."""
+        """issue_num が数字でない場合は is_direct を state に書かない."""
         runner = self._make_runner(tmp_path, autopilot_dir)
         with (
             patch.object(runner, "_git_current_branch", return_value="feat/abc-test"),
@@ -492,7 +424,7 @@ class TestStepInit:
 
         assert result["recommended_action"] == "implement"
         call_kvs = [call.args[1] for call in mock_write.call_args_list]
-        assert "is_quick=false" not in call_kvs, "非数値 issue_num では is_quick 書き込み不可"
+        assert "is_direct=false" not in call_kvs, "非数値 issue_num では is_direct 書き込み不可"
 
 
 # ---------------------------------------------------------------------------

--- a/cli/twl/tests/test_chain_export.py
+++ b/cli/twl/tests/test_chain_export.py
@@ -105,10 +105,6 @@ class TestExportChainStepsSh:
             assert f"  {step}\n" in result or f"  {step}" in result, \
                 f"Step '{step}' not found in chain-steps.sh output"
 
-    def test_contains_quick_skip_steps(self) -> None:
-        result = export_chain_steps_sh()
-        assert "QUICK_SKIP_STEPS=(" in result
-
     def test_contains_direct_skip_steps(self) -> None:
         result = export_chain_steps_sh()
         assert "DIRECT_SKIP_STEPS=(" in result

--- a/cli/twl/tests/test_chain_integrity.py
+++ b/cli/twl/tests/test_chain_integrity.py
@@ -42,10 +42,6 @@ class TestParseBashArray:
         result = _parse_bash_array(content, "CHAIN_STEPS")
         assert result == ["init", "check"]
 
-    def test_quick_skip(self):
-        content = "QUICK_SKIP_STEPS=(\n  crg-auto-build\n  arch-ref\n)"
-        result = _parse_bash_array(content, "QUICK_SKIP_STEPS")
-        assert result == ["crg-auto-build", "arch-ref"]
 
 
 class TestExpectedChains:
@@ -78,7 +74,6 @@ class TestCheckDepsIntegrity:
         cli_path.mkdir(parents=True)
         (cli_path / "chain.py").write_text(textwrap.dedent("""\
             CHAIN_STEPS: list[str] = ["init", "check", "done"]
-            QUICK_SKIP_STEPS: frozenset[str] = frozenset(["check"])
             DIRECT_SKIP_STEPS: frozenset[str] = frozenset(["done"])
             STEP_TO_WORKFLOW: dict[str, str] = {
                 "init": "setup",
@@ -95,9 +90,6 @@ class TestCheckDepsIntegrity:
               init
               check
               done
-            )
-            QUICK_SKIP_STEPS=(
-              check
             )
             DIRECT_SKIP_STEPS=(
               done
@@ -132,22 +124,12 @@ class TestCheckDepsIntegrity:
               extra-step
               done
             )
-            QUICK_SKIP_STEPS=(
-              check
-            )
             DIRECT_SKIP_STEPS=(
               done
             )
         """))
         errors, _ = check_deps_integrity(plugin_dir)
         assert any("CHAIN_STEPS mismatch" in e for e in errors)
-
-    def test_quick_skip_drift_detected(self, plugin_dir):
-        sh = plugin_dir / "scripts" / "chain-steps.sh"
-        original = sh.read_text()
-        sh.write_text(original.replace("QUICK_SKIP_STEPS=(\n  check\n)", "QUICK_SKIP_STEPS=(\n  init\n)"))
-        errors, _ = check_deps_integrity(plugin_dir)
-        assert any("QUICK_SKIP_STEPS mismatch" in e for e in errors)
 
     def test_direct_skip_drift_detected(self, plugin_dir):
         sh = plugin_dir / "scripts" / "chain-steps.sh"

--- a/cli/twl/tests/test_chain_viz.py
+++ b/cli/twl/tests/test_chain_viz.py
@@ -90,12 +90,12 @@ class TestChainVizSingle:
         self._tmpdir_obj = tempfile.TemporaryDirectory()
         self.tmpdir = Path(self._tmpdir_obj.name)
         self.plugin_dir = make_viz_fixture(self.tmpdir)
-
-    def teardown_method(self):
-        self._tmpdir_obj.cleanup()
         deps_path = self.plugin_dir / "deps.yaml"
         with open(deps_path, encoding="utf-8") as f:
             self.deps = yaml.safe_load(f)
+
+    def teardown_method(self):
+        self._tmpdir_obj.cleanup()
 
     def test_single_chain_returns_mermaid_fenced(self):
         from twl.chain.viz import chain_viz_single
@@ -128,23 +128,19 @@ class TestChainVizSingle:
         # llm → llm class
         assert ":::llm" in output
 
-    def test_quick_bypass_dashed_arrow(self):
+    def test_classdefs_present_no_quick(self):
         from twl.chain.viz import chain_viz_single
         output = chain_viz_single(self.deps, "setup")
-        # crg-auto-build, change-propose, ac-extract are in QUICK_SKIP_STEPS
-        # init is not → should have bypass from init to next non-skip step
-        # But all steps after init are quick_skip, so no target exists
-        # Let's just verify the classdefs exist
         assert "classDef script" in output
         assert "classDef llm" in output
 
     def test_classdefs_present(self):
         from twl.chain.viz import chain_viz_single
         output = chain_viz_single(self.deps, "setup")
-        assert "classDef script fill:#c8e6c9" in output
-        assert "classDef llm fill:#bbdefb" in output
-        assert "classDef composite fill:#e1bee7" in output
-        assert "classDef marker fill:#eeeeee" in output
+        assert "classDef script fill:#2e7d32" in output
+        assert "classDef llm fill:#1565c0" in output
+        assert "classDef composite fill:#7b1fa2" in output
+        assert "classDef marker fill:#616161" in output
 
     def test_unknown_chain_returns_error_comment(self):
         from twl.chain.viz import chain_viz_single
@@ -163,12 +159,12 @@ class TestChainVizAll:
         self._tmpdir_obj = tempfile.TemporaryDirectory()
         self.tmpdir = Path(self._tmpdir_obj.name)
         self.plugin_dir = make_viz_fixture(self.tmpdir)
-
-    def teardown_method(self):
-        self._tmpdir_obj.cleanup()
         deps_path = self.plugin_dir / "deps.yaml"
         with open(deps_path, encoding="utf-8") as f:
             self.deps = yaml.safe_load(f)
+
+    def teardown_method(self):
+        self._tmpdir_obj.cleanup()
 
     def test_all_chains_returns_mermaid(self):
         from twl.chain.viz import chain_viz_all
@@ -193,50 +189,6 @@ class TestChainVizAll:
         assert "No chains" in output
 
 
-class TestQuickBypass:
-    def test_quick_bypass_inserted_when_skip_steps_in_middle(self):
-        from twl.chain.viz import chain_viz_single
-        # Create deps where init (non-skip) → crg-auto-build (skip) → final-step (non-skip)
-        deps = {
-            "version": "3.0",
-            "plugin": "test",
-            "chains": {
-                "mychain": {
-                    "steps": ["init", "crg-auto-build", "final-step"],
-                },
-            },
-            "commands": {
-                "init": {"type": "atomic", "dispatch_mode": "runner", "path": "x.md"},
-                "crg-auto-build": {"type": "atomic", "dispatch_mode": "runner", "path": "x.md"},
-                "final-step": {"type": "atomic", "dispatch_mode": "runner", "path": "x.md"},
-            },
-            "skills": {},
-            "agents": {},
-        }
-        output = chain_viz_single(deps, "mychain")
-        # Should have a quick bypass arrow (dashed)
-        assert "-." in output and "quick" in output
-
-    def test_no_quick_bypass_when_no_skip_steps(self):
-        from twl.chain.viz import chain_viz_single
-        deps = {
-            "version": "3.0",
-            "plugin": "test",
-            "chains": {
-                "mychain": {
-                    "steps": ["step-a", "step-b"],
-                },
-            },
-            "commands": {
-                "step-a": {"type": "atomic", "dispatch_mode": "runner", "path": "x.md"},
-                "step-b": {"type": "atomic", "dispatch_mode": "runner", "path": "x.md"},
-            },
-            "skills": {},
-            "agents": {},
-        }
-        output = chain_viz_single(deps, "mychain")
-        # No quick bypass since no quick_skip steps
-        assert "quick" not in output
 
 
 class TestUpdateReadme:

--- a/cli/twl/tests/test_resolve_next_workflow.py
+++ b/cli/twl/tests/test_resolve_next_workflow.py
@@ -25,18 +25,10 @@ WORKER_LIFECYCLE_FLOW: list[dict] = [
         "id": "setup",
         "chain": "setup",
         "next": [
-            {"condition": "quick && autopilot", "goto": "quick-path"},
-            {"condition": "!quick && autopilot", "goto": "test-ready"},
+            {"condition": "autopilot", "goto": "test-ready"},
             {"condition": "!autopilot", "stop": True,
              "message": "setup chain 完了。次: /twl:workflow-test-ready"},
         ],
-    },
-    {
-        "id": "quick-path",
-        "chain": None,
-        "description": "quick Issue の短縮パス",
-        "inline_steps": ["直接実装 → commit → push", "PR 作成", "ac-verify", "merge-gate"],
-        "next": [{"goto": "done"}],
     },
     {
         "id": "test-ready",
@@ -99,22 +91,16 @@ def patched_runner(runner: ChainRunner):
 
 
 # ===========================================================================
-# AC: setup → "workflow-test-ready" (autopilot=True, quick=False)
+# AC: setup → "workflow-test-ready"
 # ===========================================================================
 
 class TestSetupTransitions:
-    def test_setup_autopilot_true_quick_false(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("setup", is_autopilot=True, is_quick=False)
+    def test_setup_autopilot_true(self, patched_runner: ChainRunner) -> None:
+        result = patched_runner.resolve_next_workflow("setup", is_autopilot=True)
         assert result == "workflow-test-ready"
 
-    def test_setup_autopilot_true_quick_true(self, patched_runner: ChainRunner) -> None:
-        # AC: setup + quick=true + autopilot=true → "quick-path"
-        result = patched_runner.resolve_next_workflow("setup", is_autopilot=True, is_quick=True)
-        assert result == "quick-path"
-
     def test_setup_autopilot_false(self, patched_runner: ChainRunner) -> None:
-        # AC: setup + autopilot=false → "" (stop 条件)
-        result = patched_runner.resolve_next_workflow("setup", is_autopilot=False, is_quick=False)
+        result = patched_runner.resolve_next_workflow("setup", is_autopilot=False)
         assert result == ""
 
 
@@ -124,11 +110,11 @@ class TestSetupTransitions:
 
 class TestPrVerifyTransition:
     def test_pr_verify_autopilot_true(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("pr-verify", is_autopilot=True, is_quick=False)
+        result = patched_runner.resolve_next_workflow("pr-verify", is_autopilot=True)
         assert result == "workflow-pr-fix"
 
     def test_pr_verify_autopilot_false(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("pr-verify", is_autopilot=False, is_quick=False)
+        result = patched_runner.resolve_next_workflow("pr-verify", is_autopilot=False)
         assert result == ""
 
 
@@ -138,11 +124,11 @@ class TestPrVerifyTransition:
 
 class TestPrFixTransition:
     def test_pr_fix_autopilot_true(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("pr-fix", is_autopilot=True, is_quick=False)
+        result = patched_runner.resolve_next_workflow("pr-fix", is_autopilot=True)
         assert result == "workflow-pr-merge"
 
     def test_pr_fix_autopilot_false(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("pr-fix", is_autopilot=False, is_quick=False)
+        result = patched_runner.resolve_next_workflow("pr-fix", is_autopilot=False)
         assert result == ""
 
 
@@ -152,14 +138,13 @@ class TestPrFixTransition:
 
 class TestPrMergeTransition:
     def test_pr_merge_returns_empty(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("pr-merge", is_autopilot=True, is_quick=False)
+        result = patched_runner.resolve_next_workflow("pr-merge", is_autopilot=True)
         assert result == ""
 
     def test_pr_merge_any_flags_returns_empty(self, patched_runner: ChainRunner) -> None:
         for autopilot in (True, False):
-            for quick in (True, False):
-                result = patched_runner.resolve_next_workflow("pr-merge", autopilot, quick)
-                assert result == "", f"pr-merge should return '' (autopilot={autopilot}, quick={quick})"
+            result = patched_runner.resolve_next_workflow("pr-merge", autopilot)
+            assert result == "", f"pr-merge should return '' (autopilot={autopilot})"
 
 
 # ===========================================================================
@@ -168,16 +153,16 @@ class TestPrMergeTransition:
 
 class TestEdgeCases:
     def test_unknown_workflow_returns_empty(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("nonexistent", is_autopilot=True, is_quick=False)
+        result = patched_runner.resolve_next_workflow("nonexistent", is_autopilot=True)
         assert result == ""
 
     def test_done_node_returns_empty(self, patched_runner: ChainRunner) -> None:
-        result = patched_runner.resolve_next_workflow("done", is_autopilot=True, is_quick=False)
+        result = patched_runner.resolve_next_workflow("done", is_autopilot=True)
         assert result == ""
 
     def test_return_type_is_str(self, patched_runner: ChainRunner) -> None:
         for workflow in ("setup", "pr-verify", "pr-fix", "pr-merge", "done", "nonexistent"):
-            result = patched_runner.resolve_next_workflow(workflow, is_autopilot=True, is_quick=False)
+            result = patched_runner.resolve_next_workflow(workflow, is_autopilot=True)
             assert isinstance(result, str), f"Expected str for {workflow}, got {type(result)}"
 
 
@@ -187,37 +172,19 @@ class TestEdgeCases:
 
 class TestEvalWorkflowCondition:
     def test_empty_condition_always_true(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("", True, True) is True
-        assert runner._eval_workflow_condition("", False, False) is True
+        assert runner._eval_workflow_condition("", True) is True
+        assert runner._eval_workflow_condition("", False) is True
 
     def test_autopilot_true(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("autopilot", True, False) is True
-        assert runner._eval_workflow_condition("autopilot", False, False) is False
+        assert runner._eval_workflow_condition("autopilot", True) is True
+        assert runner._eval_workflow_condition("autopilot", False) is False
 
     def test_not_autopilot(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("!autopilot", False, False) is True
-        assert runner._eval_workflow_condition("!autopilot", True, False) is False
-
-    def test_quick_flag(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("quick", True, True) is True
-        assert runner._eval_workflow_condition("quick", True, False) is False
-
-    def test_not_quick(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("!quick", True, False) is True
-        assert runner._eval_workflow_condition("!quick", True, True) is False
-
-    def test_compound_quick_and_autopilot(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("quick && autopilot", True, True) is True
-        assert runner._eval_workflow_condition("quick && autopilot", True, False) is False
-        assert runner._eval_workflow_condition("quick && autopilot", False, True) is False
-
-    def test_compound_not_quick_and_autopilot(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("!quick && autopilot", True, False) is True
-        assert runner._eval_workflow_condition("!quick && autopilot", True, True) is False
-        assert runner._eval_workflow_condition("!quick && autopilot", False, False) is False
+        assert runner._eval_workflow_condition("!autopilot", False) is True
+        assert runner._eval_workflow_condition("!autopilot", True) is False
 
     def test_unknown_token_returns_false(self, runner: ChainRunner) -> None:
-        assert runner._eval_workflow_condition("unknown", True, True) is False
+        assert runner._eval_workflow_condition("unknown", True) is False
 
 
 # ===========================================================================

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -26,6 +26,7 @@ entry_points:
 # チェーン（chain.py から生成 — twl chain export --yaml で再生成）
 # チェーン（chain.py から生成 — twl chain export --yaml で再生成）
 # チェーン（chain.py から生成 — twl chain export --yaml で再生成）
+# チェーン（chain.py から生成 — twl chain export --yaml で再生成）
 chains:
   setup:
     type: "A"
@@ -70,24 +71,11 @@ meta_chains:
       - id: setup
         chain: setup
         next:
-          - condition: "quick && autopilot"
-            goto: quick-path
-          - condition: "!quick && autopilot"
+          - condition: "autopilot"
             goto: test-ready
           - condition: "!autopilot"
             stop: true
             message: "setup chain 完了。次: /twl:workflow-test-ready"
-
-      - id: quick-path
-        chain: null
-        description: "quick Issue の短縮パス"
-        inline_steps:
-          - "直接実装 → commit → push"
-          - "PR 作成"
-          - "ac-verify"
-          - "merge-gate"
-        next:
-          - goto: done
 
       - id: test-ready
         chain: test-ready
@@ -2406,9 +2394,7 @@ scripts:
       - pr-cycle-report
       - auto-merge
       - check
-      - quick-guard
       - autopilot-detect
-      - quick-detect
     description: "機械的 chain ステップを実行（Python: python3 -m twl.autopilot.chain; ChainRunner クラス）"
 
   worker-terminal-guard:
@@ -2464,7 +2450,7 @@ scripts:
   chain-steps:
     type: script
     path: ../../cli/twl/src/twl/autopilot/chain.py
-    description: "chain ステップ順序の共有定義（SSOT）— CHAIN_STEPS / QUICK_SKIP_STEPS / STEP_TO_WORKFLOW / WORKFLOW_NEXT_SKILL 定数は chain.py で管理。chain-steps.sh はミラー"
+    description: "chain ステップ順序の共有定義（SSOT）— CHAIN_STEPS / STEP_TO_WORKFLOW / WORKFLOW_NEXT_SKILL 定数は chain.py で管理。chain-steps.sh はミラー"
 
   su-precompact:
     type: script

--- a/plugins/twl/scripts/chain-steps.sh
+++ b/plugins/twl/scripts/chain-steps.sh
@@ -25,16 +25,6 @@ CHAIN_STEPS=(
   pr-cycle-report
 )
 
-# quick Issue でスキップするステップの一覧（SSOT）
-QUICK_SKIP_STEPS=(
-  crg-auto-build
-  arch-ref
-  ac-extract
-  test-scaffold
-  check
-  prompt-compliance
-)
-
 # direct モード（scope/direct ラベル）でスキップするステップの一覧（SSOT）
 DIRECT_SKIP_STEPS=(
 )


### PR DESCRIPTION
refactor(#Z15): chain.py QUICK_SKIP_STEPS + quick関数群 + state.py is_quick/is_direct削除

- chain.py: QUICK_SKIP_STEPS定数削除
- chain.py: step_quick_detect / step_quick_guard 関数削除
- chain.py: _detect_quick_label 削除
- chain.py: _eval_workflow_condition から quick トークン削除
- chain.py: step_init から is_quick 処理削除
- chain.py: resolve_next_workflow から is_quick パラメータ削除
- chain.py: next_step から is_quick 読み取り削除
- chain.py: export_chain_steps_sh から QUICK_SKIP_STEPS エクスポート削除
- integrity.py: QUICK_SKIP_STEPS チェック削除
- viz.py: _append_quick_bypasses / _get_quick_skip_steps 削除
- deps.yaml: worker-lifecycle.flow quick-path ノード削除
- deps.yaml: chain-runner の quick-guard / quick-detect 削除
- chain-steps.sh: QUICK_SKIP_STEPS セクション削除 (twl chain export 再生成)
- テスト: quick関連テスト削除・更新

Closes #911