### PR TITLE
refactor(deps): remove quick/scope-direct refs from deps.yaml (#914)

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2715,7 +2715,7 @@ scripts:
     calls:
       - script: resolve-issue-num
       - script: checkpoint-read
-    description: "phase-review 必須チェック（merge-gate）: phase-review 不在時は REJECT。scope/direct / quick ラベルはスキップ"
+    description: "phase-review 必須チェック（merge-gate）: phase-review 不在時は REJECT"
 
   # su-observer controller spawn wrapper (Phase A 2026-04-21)
   # [起動経路 B] spawn-controller.sh co-autopilot: su-observer が Pilot セッション全体を spawn する経路。


### PR DESCRIPTION
refactor(deps): remove quick/scope-direct refs from deps.yaml (#914)

- merge-gate-check-phase-review description: remove 'scope/direct / quick ラベルはスキップ'
- AC: grep -rE 'quick|scope/direct|scope-direct' plugins/twl/deps.yaml → 0 件
- twl check --deps-integrity: OK (283 files)

Closes #914