### PR TITLE
feat(#939): twl chain validate サブコマンドを実装する

### DIFF
--- a/cli/twl/src/twl/chain/validate.py
+++ b/cli/twl/src/twl/chain/validate.py
@@ -576,3 +576,47 @@ def chain_validate(deps: dict, plugin_root: Path) -> Tuple[List[str], List[str],
                 ok_count += 1
 
     return criticals, warnings, infos
+
+
+def handle_chain_validate_subcommand(argv: list[str]) -> int:
+    """CLI wrapper for chain_validate()."""
+    import argparse
+    import json
+
+    from twl.core.plugin import get_plugin_root, load_deps
+
+    parser = argparse.ArgumentParser(
+        prog='twl chain validate',
+        description='Validate chain/step semantic integrity',
+    )
+    parser.add_argument('--format', choices=['json'], help='Output format')
+    parser.add_argument('--integrity', action='store_true',
+                        help='Also run deps-integrity hash check')
+    args = parser.parse_args(argv)
+
+    plugin_root = get_plugin_root()
+    deps = load_deps(plugin_root)
+
+    criticals, warnings, infos = chain_validate(deps, plugin_root)
+
+    if args.integrity:
+        from twl.chain.integrity import check_deps_integrity
+        di_errors, di_warnings = check_deps_integrity(plugin_root)
+        criticals.extend(f"[deps-integrity] {e}" for e in di_errors)
+        warnings.extend(f"[deps-integrity] {w}" for w in di_warnings)
+
+    if args.format == 'json':
+        print(json.dumps({
+            'criticals': criticals,
+            'warnings': warnings,
+            'infos': infos,
+        }))
+    else:
+        for msg in criticals:
+            print(f"CRITICAL {msg}")
+        for msg in warnings:
+            print(f"WARNING {msg}")
+        for msg in infos:
+            print(f"INFO {msg}")
+
+    return 1 if criticals else 0

--- a/cli/twl/src/twl/chain/validate.py
+++ b/cli/twl/src/twl/chain/validate.py
@@ -602,8 +602,8 @@ def handle_chain_validate_subcommand(argv: list[str]) -> int:
     if args.integrity:
         from twl.chain.integrity import check_deps_integrity
         di_errors, di_warnings = check_deps_integrity(plugin_root)
-        criticals.extend(f"[deps-integrity] {e}" for e in di_errors)
-        warnings.extend(f"[deps-integrity] {w}" for w in di_warnings)
+        criticals = criticals + [f"[deps-integrity] {e}" for e in di_errors]
+        warnings = warnings + [f"[deps-integrity] {w}" for w in di_warnings]
 
     if args.format == 'json':
         print(json.dumps({

--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -83,6 +83,9 @@ def main():
         elif len(sys.argv) >= 3 and sys.argv[2] == 'export':
             from twl.chain.export import handle_chain_export_subcommand
             sys.exit(handle_chain_export_subcommand(sys.argv[3:]))
+        elif len(sys.argv) >= 3 and sys.argv[2] == 'validate':
+            from twl.chain.validate import handle_chain_validate_subcommand
+            sys.exit(handle_chain_validate_subcommand(sys.argv[3:]))
         else:
             print(f"Error: unknown chain subcommand '{sys.argv[2] if len(sys.argv) >= 3 else ''}'", file=sys.stderr)
             print("Usage: twl chain generate <chain-name> [--write]", file=sys.stderr)
@@ -91,6 +94,7 @@ def main():
             print("       twl chain viz --update-arch", file=sys.stderr)
             print("       twl chain export --yaml [--write]", file=sys.stderr)
             print("       twl chain export --shell [--write]", file=sys.stderr)
+            print("       twl chain validate [--integrity] [--format json]", file=sys.stderr)
             sys.exit(1)
 
     parser = argparse.ArgumentParser(description='Analyze plugin dependencies')

--- a/cli/twl/tests/test_chain_validate.py
+++ b/cli/twl/tests/test_chain_validate.py
@@ -1007,6 +1007,149 @@ class TestChainStepSync:
         assert "dispatch_mode mismatch" not in result.stdout
 
 
+# ===========================================================================
+# AC#939: twl chain validate CLI エントリポイント
+# RED フェーズ: 以下のテストは twl chain validate サブコマンドが未実装の間は FAIL する
+# ===========================================================================
+
+import json as _json
+
+
+class TestChainValidateCLI(_ChainTestBase):
+    """twl chain validate CLI エントリポイントの RED テスト群 (Issue #939 AC1-AC3)"""
+
+    # --- AC1: twl chain validate が chain_validate() を呼び exit 0 を返す ---
+
+    def test_ac1_chain_validate_exit0_on_valid_deps(self):
+        """AC1: twl chain validate CLI エントリが存在し、valid な deps.yaml では exit 0 を返す。
+
+        RED: cli.py に 'chain validate' 分岐がない間は
+        "unknown chain subcommand 'validate'" エラーで exit 1 になる。
+        """
+        result = run_engine(self.plugin_dir, "chain", "validate")
+        assert result.returncode == 0, (
+            f"twl chain validate should exit 0 on valid deps (AC1).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_ac1_chain_validate_exit1_on_critical(self):
+        """AC1: CRITICAL がある deps.yaml では twl chain validate が exit 1 を返す。
+
+        RED: 実装前はそもそも 'validate' サブコマンドが存在しないため
+        別の理由で exit 1 になるが、実装後は chain-bidir CRITICAL が原因の exit 1 になる。
+        """
+        def mutator(deps):
+            del deps["commands"]["ac-extract"]["chain"]
+        self._modify_deps(mutator)
+
+        result = run_engine(self.plugin_dir, "chain", "validate")
+        # exit 1 自体は現在も起きるが、chain-bidir メッセージがない
+        assert result.returncode != 0, (
+            "twl chain validate should exit 1 when CRITICAL exists (AC1)"
+        )
+        assert "[chain-bidir]" in result.stdout, (
+            f"Expected [chain-bidir] in stdout (AC1).\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # --- AC2: --integrity flag で check_deps_integrity() も併走させる ---
+
+    def test_ac2_integrity_flag_runs_alongside_chain_validate(self):
+        """AC2: --integrity flag を渡すと check_deps_integrity() が chain_validate() と並走する。
+
+        RED: --integrity フラグが未実装の間はオプション解析エラーまたは無視される。
+        実装後は deps-integrity 関連の出力または正常 exit が期待される。
+        """
+        result = run_engine(self.plugin_dir, "chain", "validate", "--integrity")
+        assert result.returncode == 0, (
+            f"twl chain validate --integrity should exit 0 on valid deps (AC2).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    def test_ac2_integrity_flag_does_not_subsume_chain_validate(self):
+        """AC2: --integrity は chain_validate() の結果を置き換えず、両者が並存する。
+
+        RED: 実装前は --integrity フラグ自体が存在しないため unknown option エラーになる。
+        実装後は chain-bidir CRITICAL が存在すると exit 1 かつ両方の結果が出力される。
+        """
+        def mutator(deps):
+            del deps["commands"]["ac-extract"]["chain"]
+        self._modify_deps(mutator)
+
+        result = run_engine(self.plugin_dir, "chain", "validate", "--integrity")
+        assert result.returncode != 0, (
+            "twl chain validate --integrity should exit 1 when chain CRITICAL exists (AC2)"
+        )
+        assert "[chain-bidir]" in result.stdout, (
+            f"chain_validate() result should still appear with --integrity (AC2).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+    # --- AC3: --format json で JSON 出力対応 ---
+
+    def test_ac3_format_json_produces_valid_json(self):
+        """AC3: --format json を渡すと stdout が parse 可能な JSON になる。
+
+        RED: --format json フラグが未実装の間は JSON でない出力またはエラーになる。
+        """
+        result = run_engine(self.plugin_dir, "chain", "validate", "--format", "json")
+        assert result.returncode == 0, (
+            f"twl chain validate --format json should exit 0 on valid deps (AC3).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        try:
+            data = _json.loads(result.stdout)
+        except _json.JSONDecodeError as e:
+            raise AssertionError(
+                f"stdout is not valid JSON (AC3): {e}\nstdout: {result.stdout!r}"
+            )
+        return data  # 次のテストで再利用しない（独立テスト）
+
+    def test_ac3_format_json_schema_has_required_keys(self):
+        """AC3: JSON 出力に criticals/warnings/infos キーが含まれる。
+
+        RED: --format json 未実装の間はキーが存在しない。
+        実装後は {"criticals": [...], "warnings": [...], "infos": [...]} 形式の JSON になる。
+        """
+        result = run_engine(self.plugin_dir, "chain", "validate", "--format", "json")
+        assert result.returncode == 0, (
+            f"twl chain validate --format json should exit 0 on valid deps (AC3).\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        try:
+            data = _json.loads(result.stdout)
+        except _json.JSONDecodeError as e:
+            raise AssertionError(
+                f"stdout is not valid JSON (AC3): {e}\nstdout: {result.stdout!r}"
+            )
+        assert "criticals" in data, f"JSON missing 'criticals' key (AC3): {data}"
+        assert "warnings" in data, f"JSON missing 'warnings' key (AC3): {data}"
+        assert "infos" in data, f"JSON missing 'infos' key (AC3): {data}"
+
+    def test_ac3_format_json_criticals_populated_on_error(self):
+        """AC3: CRITICAL がある場合、JSON の criticals 配列にメッセージが入る。
+
+        RED: --format json 未実装の間は JSON キーが存在しない。
+        """
+        def mutator(deps):
+            del deps["commands"]["ac-extract"]["chain"]
+        self._modify_deps(mutator)
+
+        result = run_engine(self.plugin_dir, "chain", "validate", "--format", "json")
+        assert result.returncode != 0, (
+            "twl chain validate --format json should exit 1 when CRITICAL exists (AC3)"
+        )
+        try:
+            data = _json.loads(result.stdout)
+        except _json.JSONDecodeError as e:
+            raise AssertionError(
+                f"stdout is not valid JSON (AC3): {e}\nstdout: {result.stdout!r}"
+            )
+        assert "criticals" in data, f"JSON missing 'criticals' key (AC3): {data}"
+        assert len(data["criticals"]) > 0, (
+            f"criticals should be non-empty when CRITICAL exists (AC3): {data}"
+        )
+
+
 if __name__ == "__main__":
     import traceback
 
@@ -1019,6 +1162,7 @@ if __name__ == "__main__":
         TestTwlCheckIntegration,
         TestChainValidateEdgeCases,
         TestChainStepSync,
+        TestChainValidateCLI,
     ]
     passed = 0
     failed = 0

--- a/plugins/twl/tests/scenarios/chain-definition.test.sh
+++ b/plugins/twl/tests/scenarios/chain-definition.test.sh
@@ -264,8 +264,7 @@ test_twl_chain_validate() {
     return 1
   fi
   local output
-  # twl chain validate は wrapper 未対応のため twl validate で chain 検証
-  output=$(cd "${PROJECT_ROOT}" && twl validate 2>&1)
+  output=$(cd "${PROJECT_ROOT}" && twl chain validate 2>&1)
   # Check no chain-bidir or chain-type errors related to setup chain
   if echo "$output" | grep -qP "\[chain-bidir\]|\[chain-type\]|\[step-order\]"; then
     echo "$output" | grep -P "\[chain" >&2
@@ -286,7 +285,7 @@ test_twl_chain_validate_no_warnings() {
     return 1
   fi
   local output
-  output=$(cd "${PROJECT_ROOT}" && twl validate 2>&1)
+  output=$(cd "${PROJECT_ROOT}" && twl chain validate 2>&1)
   if echo "$output" | grep -qP "\[chain.*WARNING\].*setup|setup.*\[chain.*WARNING\]"; then
     return 1
   fi


### PR DESCRIPTION
## 概要

Issue #939 の実装。既存 `chain_validate()` 関数を `twl chain validate` CLI エントリから呼び出せるようにする CLI wrapper を追加。

## 変更内容

- **cli.py**: chain dispatcher に `validate` 分岐追加
- **validate.py**: `handle_chain_validate_subcommand(argv)` CLI wrapper 追加（--integrity / --format json 対応）
- **test_chain_validate.py**: `TestChainValidateCLI` クラス追加（AC1〜AC3、7 tests）
- **chain-definition.test.sh**: `twl validate` → `twl chain validate` 置換（AC4）

## AC

- [x] AC1: `twl chain validate` CLI エントリ追加、exit 0/1 対応
- [x] AC2: `--integrity` flag で `check_deps_integrity()` 並走
- [x] AC3: `--format json` で JSON 出力対応
- [x] AC4: chain-definition.test.sh の 2 箇所を `twl chain validate` に置換、コメント除去
- [x] AC5: Issue body 訂正済み（PR 対象外）

Closes #939