### PR TITLE
fix(chain-runner): resolve_project_root() の || pwd フォールバック撤廃 (#966)

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-027-pwd-fallback-forbidden.md
+++ b/plugins/twl/architecture/decisions/ADR-027-pwd-fallback-forbidden.md
@@ -1,0 +1,79 @@
+# ADR-027: resolve_project_root() での pwd フォールバック禁止
+
+**Status**: Accepted
+**Date**: 2026-04-25
+**Issue**: #966
+
+## Context
+
+`plugins/twl/scripts/chain-runner.sh` の `resolve_project_root()` は `git rev-parse --show-toplevel 2>/dev/null || pwd` というシンプルな実装だった。`git rev-parse` 失敗時に `|| pwd` でカレントワーキングディレクトリ（CWD）を project root として採用していた。
+
+Wave AA.3（2026-04-24）の Phase 1 で以下の permission prompt が発火した:
+
+```
+Bash command: mkdir -p /home/shuu5/.claude/plugins/twl/.dev-session/issue-955
+Claude requested permissions to edit /home/shuu5/.claude/plugins/twl/.dev-session/issue-955
+which is a sensitive file.
+```
+
+期待される書き込み先は `<worktree>/.dev-session/issue-955/` だが、Worker の CWD が git 管理外のパスになった場合、`|| pwd` フォールバックがその CWD を root として採用し、user-global 領域へ誤書き込みする危険があった。doobidoo hash `b81b1962` に詳細を記録済み。
+
+`resolve_project_root()` は chain-runner.sh 内の 7 つの呼出点（L231/L406/L475/L712/L794/L1227/L1241）で使われており、誤 root 採用による副作用は `.dev-session/` 書き込みから `cd "$root"` によるディレクトリ変更まで幅広い。
+
+## Decision
+
+`resolve_project_root()` に 3 段 fallback を採用し、`pwd` フォールバックを構造的に撤廃する:
+
+```bash
+resolve_project_root() {
+  local root
+  # tier 1: 現 CWD から rev-parse
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+  if [[ -n "$root" ]]; then
+    echo "$root"
+    return 0
+  fi
+  # tier 2: script 位置から rev-parse（Worker CWD が git 管理外でも救済）
+  local script_root
+  script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || script_root=""
+  if [[ -n "$script_root" ]]; then
+    echo "$script_root"
+    return 0
+  fi
+  # tier 3: fallback 失敗 → stderr + return 1（pwd 誤採用を構造的に不可能化）
+  echo "[chain-runner] FATAL: resolve_project_root failed (cwd=$(pwd), script=${BASH_SOURCE[0]})" >&2
+  return 1
+}
+```
+
+| tier | trigger 条件 | 救済対象 |
+|---|---|---|
+| 1 (primary) | CWD が git worktree 内 | 通常動作 |
+| 2 (script-path) | CWD が git 管理外 だが script は worktree 内 | Worker CWD が `/tmp` 等に逸脱してもスクリプトが symlink 経由で worktree 内に常駐していれば救済 |
+| 3 (fail-fast) | script 自体も worktree 外に配置 | 明示的 error で誤動作を構造的に防止 |
+
+## Consequences
+
+**Positive**:
+- `|| pwd` による user-global 書き込みが構造的に不可能化される
+- tier 3 の `return 1` により、呼出点の `set -euo pipefail` が fail-fast を発動し、誤 root での後続書き込みを防止できる
+- tier 2 は `~/.claude/plugins/twl/scripts/` symlink → `main/plugins/twl/scripts/` → git rev-parse で実測救済可能（verified）
+
+**Negative**:
+- tier 3 発動時に Worker が abort する。ただし誤 root での副作用よりはるかに安全
+- script が worktree 外に配置される異常状態（tier 3 が唯一の出口）は想定外の運用に対応できないが、現行設計では script は常に worktree 内 symlink 経由で配置される
+
+## Alternatives Considered
+
+**(a) `exit 1` 単独**: caller 修正コストが高い。fallback なしで legitimate Worker CWD 逸脱で即死するため UX が悪い。却下。
+
+**(b) `git worktree list --porcelain` fallback 単独**: Phase 4 specialist 検証で判明 — `cd /tmp && git worktree list --porcelain` は `fatal: not a git repository`, exit 128 で失敗する。tier 1 が fail する状況では同条件で fail するため dead code。却下。
+
+**(c) 本 Decision = script-path fallback**: `(cd ~/.claude/plugins/twl/scripts && git rev-parse --show-toplevel)` が `main` worktree を返すことを実測確認済み。CWD が完全に非 git でも救済可能。採用。
+
+## References
+
+- Issue #966: `resolve_project_root()` の pwd フォールバック撤廃
+- Issue #938: per-issue namespace（`.dev-session/issue-N/`）実装（直接の動機）
+- doobidoo `b81b1962`: Wave AA.3 Phase 1 permission prompt 発火記録
+- `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md` §14

--- a/plugins/twl/architecture/decisions/ADR-027-pwd-fallback-forbidden.md
+++ b/plugins/twl/architecture/decisions/ADR-027-pwd-fallback-forbidden.md
@@ -18,7 +18,7 @@ which is a sensitive file.
 
 期待される書き込み先は `<worktree>/.dev-session/issue-955/` だが、Worker の CWD が git 管理外のパスになった場合、`|| pwd` フォールバックがその CWD を root として採用し、user-global 領域へ誤書き込みする危険があった。doobidoo hash `b81b1962` に詳細を記録済み。
 
-`resolve_project_root()` は chain-runner.sh 内の 7 つの呼出点（L231/L406/L475/L712/L794/L1227/L1241）で使われており、誤 root 採用による副作用は `.dev-session/` 書き込みから `cd "$root"` によるディレクトリ変更まで幅広い。
+`resolve_project_root()` は chain-runner.sh 内の 7 つの呼出点（L247/L422/L491/L728/L810/L1243/L1257、修正後の行番号）で使われており、誤 root 採用による副作用は `.dev-session/` 書き込みから `cd "$root"` によるディレクトリ変更まで幅広い。
 
 ## Decision
 
@@ -74,6 +74,7 @@ resolve_project_root() {
 ## References
 
 - Issue #966: `resolve_project_root()` の pwd フォールバック撤廃
+- `cli/twl/src/twl/autopilot/project.py` の `_resolve_project_root(project_type, explicit_root)` は別の Python 関数（プロジェクト作成時のディレクトリ解決のみを担う）。bash の `resolve_project_root()` とは無関係。
 - Issue #938: per-issue namespace（`.dev-session/issue-N/`）実装（直接の動機）
 - doobidoo `b81b1962`: Wave AA.3 Phase 1 permission prompt 発火記録
 - `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md` §14

--- a/plugins/twl/commands/cleanup-orphan-snapshots.md
+++ b/plugins/twl/commands/cleanup-orphan-snapshots.md
@@ -1,0 +1,63 @@
+---
+type: atomic
+tools: [Bash]
+effort: low
+maxTurns: 5
+---
+# .dev-session 孤児スナップショット cleanup
+
+`.dev-session/` 直下（`issue-N/` namespace 外）に残存する孤児ファイル・空ディレクトリを検出・削除する。
+
+**対象ディレクトリ**: `~/.claude/plugins/twl/.dev-session/` のみ。  
+**`autopilot-cleanup.sh` との違い**: `autopilot-cleanup.sh` は `.autopilot/` が対象。両者は重複しない。
+
+## 前提チェック（MUST）
+
+symlink であることを確認してから操作する:
+
+```bash
+readlink ~/.claude/plugins/twl 2>/dev/null \
+  || { echo "ERROR: ~/.claude/plugins/twl は symlink ではありません"; exit 1; }
+```
+
+## Step 1: 孤児検出（dry-run、デフォルト）
+
+```bash
+DEV_SESSION_DIR=~/.claude/plugins/twl/.dev-session
+
+echo "=== namespace 外の孤児ファイル（--apply で削除） ==="
+find "$DEV_SESSION_DIR" -maxdepth 1 -type f 2>/dev/null || echo "(なし)"
+
+echo ""
+echo "=== 7日以上古い孤児ファイル ==="
+find "$DEV_SESSION_DIR" -maxdepth 1 -type f -mtime +7 2>/dev/null || echo "(なし)"
+
+echo ""
+echo "=== 空の issue-*/ ディレクトリ ==="
+find "$DEV_SESSION_DIR" -maxdepth 1 -type d -name 'issue-*' -empty 2>/dev/null || echo "(なし)"
+```
+
+## Step 2: 削除（--apply のみ実行）
+
+`--apply` フラグなしではこのステップをスキップすること。
+
+```bash
+# Wave AA.3 残骸（既知の孤児、実測存在確認済み 2026-04-25）
+rm -f ~/.claude/plugins/twl/.dev-session/07.3-pattern-analysis.md
+rm -f ~/.claude/plugins/twl/.dev-session/ac-test-mapping.yaml
+
+# 一般パターン: 7日以上古いファイル
+find ~/.claude/plugins/twl/.dev-session/ -maxdepth 1 -type f -mtime +7 -delete
+
+# 一般パターン: 空の issue-*/ ディレクトリ
+find ~/.claude/plugins/twl/.dev-session/ -maxdepth 1 -type d -name 'issue-*' -empty -delete
+
+echo "✓ cleanup 完了"
+```
+
+## 禁止事項（MUST NOT）
+
+- `--apply` なしで削除コマンドを実行してはならない（dry-run がデフォルト）
+- `~/.claude/plugins/twl` の symlink target（worktree 内部）を直接削除・移動してはならない
+- `issue-N/` namespace 内のファイルを削除してはならない（per-issue 設計 #938 準拠）
+- `.autopilot/` ディレクトリを操作してはならない（`autopilot-cleanup.sh` の責務）

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -62,6 +62,9 @@ resolve_project_root() {
     return 0
   fi
   # tier 2: script 位置から rev-parse（Worker CWD が git 管理外でも救済）
+  # cd 失敗時は 2>/dev/null で抑制し || script_root="" に収束 → tier 3 へ。
+  # BASH_SOURCE[0] 未設定時（非 bash 実行等）は dirname が "." を返して cd が CWD に留まり
+  # git rev-parse が tier 1 と同結果を返す。CWD 非 git なら失敗 → tier 3 へ（安全）。
   local script_root
   script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || script_root=""
   if [[ -n "$script_root" ]]; then

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -54,7 +54,23 @@ ensure_pythonpath() {
 
 # worktree のプロジェクトルートを解決
 resolve_project_root() {
-  git rev-parse --show-toplevel 2>/dev/null || pwd
+  local root
+  # tier 1: 現 CWD から rev-parse
+  root=$(git rev-parse --show-toplevel 2>/dev/null) || root=""
+  if [[ -n "$root" ]]; then
+    echo "$root"
+    return 0
+  fi
+  # tier 2: script 位置から rev-parse（Worker CWD が git 管理外でも救済）
+  local script_root
+  script_root=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null) || script_root=""
+  if [[ -n "$script_root" ]]; then
+    echo "$script_root"
+    return 0
+  fi
+  # tier 3: fallback 失敗 → stderr + return 1（pwd 誤採用を構造的に不可能化）
+  echo "[chain-runner] FATAL: resolve_project_root failed (cwd=$(pwd), script=${BASH_SOURCE[0]})" >&2
+  return 1
 }
 
 
@@ -1343,6 +1359,7 @@ main() {
     check)               step_check "$@" ;;
     autopilot-detect)    step_autopilot_detect "$@" ;;
     resolve-issue-num)   resolve_issue_num ;;
+    resolve-project-root) resolve_project_root ;;
     *)
       echo "ERROR: 未知のステップ: $step" >&2
       echo "利用可能: init, worktree-create, board-status-update, project-board-status-update," >&2
@@ -1350,7 +1367,8 @@ main() {
       echo "         phase-review, scope-judge, pr-test, ac-verify, all-pass-check, pr-cycle-report, auto-merge," >&2
       echo "         pr-comment-findings, pr-comment-fix-summary, pr-comment-final, check," >&2
       echo "         autopilot-detect, resolve-issue-num," >&2
-      echo "         dispatch-info, llm-delegate, llm-complete, chain-status" >&2
+      echo "         dispatch-info, llm-delegate, llm-complete, chain-status," >&2
+      echo "         resolve-project-root" >&2
       exit 1
       ;;
   esac

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -429,3 +429,24 @@ gate deny (1 回目) → STOP（即時停止、追加試行禁止）→ AskUserQ
 - observer が Worker に直接介入する場合 → `session-comm.sh inject`（`spawn-controller.sh` 経由でない）
 
 詳細: `co-autopilot SKILL.md §Step 3.5 起動経路比較`
+
+---
+
+## 14. git 管理外実行時の pwd フォールバック禁止（#966 文書化）
+
+`chain-runner.sh` の `resolve_project_root()` が `git rev-parse --show-toplevel 2>/dev/null || pwd` を実装していた時期に、Worker の CWD が git 管理外になると `pwd` が project root として誤採用され user-global 書き込みが発生した（Wave AA.3 Phase 1、doobidoo `b81b1962`）。
+
+**症状**: Worker が `~/.claude/plugins/twl/.dev-session/issue-N/` に書き込もうとして permission prompt が発火する。本来の書き込み先は `<worktree>/.dev-session/issue-N/`。
+
+| # | Pitfall | 観察パターン | 対策 |
+|---|---------|------------|------|
+| 14.1 | `resolve_project_root()` が `\|\| pwd` で CWD を誤 root として採用する | Worker の permission prompt が `~/.claude/plugins/twl/.dev-session/issue-N` への mkdir を要求。CWD が `/tmp` や非 git パスになっている | **`\|\| pwd` は禁止**。ADR-027 の 3 段 fallback（tier 1: CWD rev-parse → tier 2: script-path rev-parse → tier 3: `return 1`）を使うこと |
+| 14.2 | Worker CWD が git 管理外になる経路 | `bash -c "cd /tmp && ..."` などで呼び出された chain-runner.sh が tier 1 失敗後に `pwd` = `/tmp` を採用する | tier 2 (script-path fallback) が `BASH_SOURCE[0]` のディレクトリから git rev-parse を試みる。script が worktree 内 symlink 経由で常駐している前提で救済可能 |
+| 14.3 | script 自体が worktree 外に配置される異常状態（tier 2 も fail） | script が `/tmp` にコピーされた状態で実行される | tier 3 が `[chain-runner] FATAL: resolve_project_root failed (cwd=..., script=...)` を stderr に出力し `return 1` で abort。誤 root への書き込みは構造的に不可能 |
+
+**正しい設計原則**:
+- `resolve_project_root()` で `pwd` を fallback として使ってはならない（ADR-027）
+- 他の `resolve_*` 関数（例: `resolve_autopilot_dir()`）でも同様の `|| pwd` fallback は禁止
+- 残骸 cleanup: `~/.claude/plugins/twl/.dev-session/` に孤児ファイルが残る場合は `plugins/twl/commands/cleanup-orphan-snapshots.md` の手順を参照
+
+**参照**: ADR-027, Issue #966, Issue #938 (per-issue namespace), doobidoo `b81b1962`

--- a/plugins/twl/tests/bats/scripts/resolve-project-root-fallback.bats
+++ b/plugins/twl/tests/bats/scripts/resolve-project-root-fallback.bats
@@ -1,0 +1,373 @@
+#!/usr/bin/env bats
+# resolve-project-root-fallback.bats - TDD RED tests for Issue #966
+#
+# Spec: Issue #966 — chain-runner.sh の resolve_project_root() が
+#       || pwd フォールバックで誤 root を返す問題の修正
+#
+# 修正後の実装（3 段 fallback）:
+#   tier 1: git rev-parse --show-toplevel（CWD が git repo 内）
+#   tier 2: script dir から git rev-parse --show-toplevel（CWD 非 git でも script は worktree 内）
+#   tier 3: 両方失敗 → stderr に FATAL msg 出力して exit 1
+#
+# テスト方法: bash chain-runner.sh resolve-project-root サブコマンドを呼び出す
+#   - 実装前: dispatch が "resolve-project-root" を未知ステップとして ERROR → 全 7 テスト RED
+#   - 実装後: resolve_project_root が正しく動作 → 全 7 テスト GREEN
+#
+# 全テストは実装前に FAIL（RED）する。
+# 実装（AC1/AC2/AC3）完了後に GREEN になること。
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  # resolve-project.sh stub（chain-runner.sh が source する場合に備えて）
+  mkdir -p "$SANDBOX/scripts/lib"
+  cat > "$SANDBOX/scripts/lib/resolve-project.sh" <<'RESOLVE_PROJECT'
+#!/usr/bin/env bash
+resolve_project() {
+  echo "6 PVT_project_id shuu5 twill-ecosystem shuu5/twill"
+}
+RESOLVE_PROJECT
+  chmod +x "$SANDBOX/scripts/lib/resolve-project.sh"
+
+  # python3 stub: chain-runner.sh 初期化時に import twl が呼ばれる可能性
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"-c"*"import twl"*)
+    exit 0 ;;
+  *"twl.autopilot.state"*|*"twl.autopilot.github"*)
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# case 1 (normal: CWD が main worktree)
+#
+# 通常ケース: CWD が git worktree 内のとき tier 1 で解決される。
+# 期待: stdout = $SANDBOX, exit 0
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しないため
+#   "ERROR: 未知のステップ: resolve-project-root" と出力して exit 1 する
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case1: CWD が main worktree のとき resolve_project_root → stdout=worktree_root, exit 0" {
+  # git stub: CWD=$SANDBOX で tier 1 成功
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$SANDBOX"'" ;;
+      *"branch --show-current"*)
+        echo "main" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/main\n" "'"$SANDBOX"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" resolve-project-root
+  assert_success
+  assert_output "$SANDBOX"
+}
+
+# ---------------------------------------------------------------------------
+# case 2 (normal: CWD が feature worktree)
+#
+# feature worktree から呼び出した場合も tier 1 で正しく解決される。
+# 各 worktree の git rev-parse --show-toplevel は その worktree root を返す。
+# 期待: stdout = feature_worktree_root, exit 0
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case2: CWD が feature worktree のとき resolve_project_root → stdout=feature_worktree_root, exit 0" {
+  local feature_wt="$SANDBOX/feature-worktree"
+  mkdir -p "$feature_wt/scripts"
+  # chain-runner.sh を feature_wt にコピー
+  cp "$SANDBOX/scripts/chain-runner.sh" "$feature_wt/scripts/" 2>/dev/null || true
+  cp -r "$SANDBOX/scripts/lib" "$feature_wt/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/chain-steps.sh" "$feature_wt/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/resolve-issue-num.sh" "$feature_wt/scripts/" 2>/dev/null || true
+
+  # git stub: feature worktree から呼び出し → feature_wt を返す
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$feature_wt"'" ;;
+      *"branch --show-current"*)
+        echo "fix/966-feature-test" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/fix/966-feature-test\n" "'"$feature_wt"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$feature_wt/scripts/chain-runner.sh" resolve-project-root
+  assert_success
+  assert_output "$feature_wt"
+}
+
+# ---------------------------------------------------------------------------
+# case 3 (script-path fallback: CWD 非 git、script は worktree 内)
+#
+# cd /tmp で chain-runner.sh を呼び出す。
+# tier 1: CWD=/tmp → git rev-parse 失敗
+# tier 2: script dir=$SANDBOX/scripts → git rev-parse 成功 → $SANDBOX を返す
+# 期待: stdout = $SANDBOX, exit 0
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case3: CWD 非 git、script は worktree 内 → tier 2 発動、stdout=script_worktree_root, exit 0" {
+  # git stub: CWD=/tmp では失敗、script dir では成功
+  # BASH_SOURCE[0] のディレクトリ($SANDBOX/scripts)で git を実行するとき pwd=$SANDBOX/scripts
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        cwd="$(pwd)"
+        if [[ "$cwd" == /tmp* || "$cwd" == /var/tmp* ]]; then
+          exit 128
+        fi
+        echo "'"$SANDBOX"'"
+        ;;
+      *"branch --show-current"*)
+        echo "fix/966-script-fallback" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/fix/966-script-fallback\n" "'"$SANDBOX"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  # CWD を /tmp にして実行（bash -c でサブシェルを使い絶対パスで chain-runner.sh を指定）
+  run bash -c "cd /tmp && bash '$SANDBOX/scripts/chain-runner.sh' resolve-project-root"
+  assert_success
+  assert_output "$SANDBOX"
+}
+
+# ---------------------------------------------------------------------------
+# case 4 (fail-fast: CWD 非 git、script も非 git)
+#
+# cd /tmp で呼び出し、かつ script dir も git 外。
+# tier 1: CWD=/tmp → git rev-parse 失敗
+# tier 2: script dir も非 git → git rev-parse 失敗
+# tier 3: FATAL msg を stderr に出力し exit 1
+# 期待: exit 1, stderr に "[chain-runner] FATAL: resolve_project_root failed", stdout は空
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case4: CWD 非 git、script も非 git → tier 3 発動、stderr に FATAL msg, exit 1, stdout 空" {
+  # git stub: rev-parse --show-toplevel は全パスで失敗
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        exit 128 ;;
+      *"branch --show-current"*)
+        echo "fix/966-all-fail" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  local stderr_file
+  stderr_file="$SANDBOX/case4_stderr.txt"
+
+  # run の 3-arg 形式: run --separate-stderr bash -c "..." は bats 1.5+ で使える
+  # ここでは手動で stdout/stderr を分離して捕捉する
+  set +e
+  actual_stdout="$(cd /tmp && bash "$SANDBOX/scripts/chain-runner.sh" resolve-project-root 2>"$stderr_file")"
+  actual_exit=$?
+  set -e
+
+  actual_stderr="$(cat "$stderr_file" 2>/dev/null || echo "")"
+
+  # exit 1 であること（実装前: dispatch エラーも exit 1）
+  [[ "$actual_exit" -ne 0 ]] || {
+    echo "FAIL: exit 0 が返った。exit 1 が期待される"
+    false
+  }
+
+  # stdout に /tmp が含まれないこと（|| pwd 撤廃確認）
+  [[ "$actual_stdout" != /tmp* && "$actual_stdout" != /var/tmp* ]] || {
+    echo "FAIL: stdout に /tmp パスが含まれる（|| pwd fallback が残っている）: $actual_stdout"
+    false
+  }
+
+  # 実装後: stderr に FATAL msg が含まれること
+  # 実装前 RED 理由: dispatch エラーは "ERROR: 未知のステップ" を stderr に出すが
+  #   "FATAL: resolve_project_root failed" というメッセージは出力しない
+  #   → この assertion が fail して RED となる
+  [[ "$actual_stderr" == *"FATAL: resolve_project_root failed"* ]] || {
+    echo "FAIL: stderr に 'FATAL: resolve_project_root failed' が含まれない"
+    echo "actual_stderr: $actual_stderr"
+    false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# case 5 (detached HEAD worktree)
+#
+# detached HEAD 状態の worktree から呼び出す。
+# detached HEAD でも git rev-parse --show-toplevel は worktree root を返す。
+# 期待: tier 1 で正常解決、stdout = $SANDBOX, exit 0
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case5: detached HEAD worktree から呼び出し → tier 1 で正常解決, exit 0" {
+  # git stub: detached HEAD 状態（branch --show-current は空を返す）
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$SANDBOX"'" ;;
+      *"branch --show-current"*)
+        echo "" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nHEAD abc1234567890abcdef1234567890abcdef12345678\ndetached\n" "'"$SANDBOX"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$SANDBOX/scripts/chain-runner.sh" resolve-project-root
+  assert_success
+  assert_output "$SANDBOX"
+}
+
+# ---------------------------------------------------------------------------
+# case 6 (multi-worktree)
+#
+# 複数 worktree が存在する場合、各 worktree から呼び出すと
+# 各自の worktree root が正しく返る。
+# 期待: worktree-A からは worktree-A root、worktree-B からは worktree-B root
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case6: 複数 worktree 存在時に各 worktree から呼び出すと各自の root が返る" {
+  local wt_a="$SANDBOX/worktree-a"
+  local wt_b="$SANDBOX/worktree-b"
+  mkdir -p "$wt_a/scripts" "$wt_b/scripts"
+
+  # worktree-a に chain-runner.sh をコピー
+  cp "$SANDBOX/scripts/chain-runner.sh" "$wt_a/scripts/" 2>/dev/null || true
+  cp -r "$SANDBOX/scripts/lib" "$wt_a/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/chain-steps.sh" "$wt_a/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/resolve-issue-num.sh" "$wt_a/scripts/" 2>/dev/null || true
+
+  # worktree-b に chain-runner.sh をコピー
+  cp "$SANDBOX/scripts/chain-runner.sh" "$wt_b/scripts/" 2>/dev/null || true
+  cp -r "$SANDBOX/scripts/lib" "$wt_b/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/chain-steps.sh" "$wt_b/scripts/" 2>/dev/null || true
+  cp "$SANDBOX/scripts/resolve-issue-num.sh" "$wt_b/scripts/" 2>/dev/null || true
+
+  # worktree-a テスト用 git stub
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$wt_a"'" ;;
+      *"branch --show-current"*)
+        echo "fix/966-wt-a" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/fix/966-wt-a\n" "'"$wt_a"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$wt_a/scripts/chain-runner.sh" resolve-project-root
+  assert_success
+  assert_output "$wt_a"
+
+  # worktree-b テスト用 git stub（$wt_b を返す）
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        echo "'"$wt_b"'" ;;
+      *"branch --show-current"*)
+        echo "fix/966-wt-b" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/fix/966-wt-b\n" "'"$wt_b"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash "$wt_b/scripts/chain-runner.sh" resolve-project-root
+  assert_success
+  assert_output "$wt_b"
+}
+
+# ---------------------------------------------------------------------------
+# case 7 (pwd 非採用 assertion — || pwd 撤廃の regression guard)
+#
+# cd /tmp で chain-runner.sh を呼び出したとき、返値が /tmp または
+# /var/tmp で始まらないことを explicit assert する。
+# tier 3 発動（exit 1）または tier 2 発動（script root 返却）のいずれでも
+# /tmp が stdout に出てはならない。
+# 期待: stdout が /tmp* または /var/tmp* で始まらない
+#
+# 実装前 RED 理由: dispatch に "resolve-project-root" エントリが存在しない
+#   実装直後で || pwd が残っている場合: stdout = /tmp で fail する（regression guard）
+# ---------------------------------------------------------------------------
+
+@test "#966-AC3 case7: cd /tmp で呼び出し → stdout が /tmp で始まらない（|| pwd 撤廃 regression guard）" {
+  # git stub: CWD=/tmp では失敗、script dir ($SANDBOX/scripts) では成功
+  # → tier 2 発動で $SANDBOX が返るはず
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*)
+        cwd="$(pwd)"
+        if [[ "$cwd" == /tmp* || "$cwd" == /var/tmp* ]]; then
+          exit 128
+        fi
+        echo "'"$SANDBOX"'"
+        ;;
+      *"branch --show-current"*)
+        echo "fix/966-pwd-regression" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/fix/966-pwd-regression\n" "'"$SANDBOX"'" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  run bash -c "cd /tmp && bash '$SANDBOX/scripts/chain-runner.sh' resolve-project-root"
+
+  # tier 2 発動なら exit 0 で $SANDBOX が返ること（実装前は exit 1）
+  # RED: dispatch に resolve-project-root が存在しないため exit 1 → assert_success が fail
+  assert_success
+
+  # stdout が /tmp または /var/tmp で始まらないこと（|| pwd 撤廃の explicit assert）
+  if [[ "$output" == /tmp* || "$output" == /var/tmp* ]]; then
+    fail "stdout が /tmp または /var/tmp で始まる: '$output' — || pwd が残っている可能性（regression）"
+  fi
+}


### PR DESCRIPTION
## Summary

Issue #966: chain-runner.sh の `resolve_project_root()` が `|| pwd` フォールバックで user-global path を誤解決する問題を修正。

## Changes

### AC1/AC2: resolve_project_root() 3 段 fallback 実装（chain-runner.sh L56-70）
- **tier 1**: 現 CWD から `git rev-parse --show-toplevel`（通常動作）
- **tier 2**: `BASH_SOURCE[0]` 位置から `git rev-parse`（Worker CWD が非 git でも救済）
- **tier 3**: 両方失敗 → stderr に `[chain-runner] FATAL: resolve_project_root failed` + `return 1`
- `resolve-project-root` サブコマンド追加（dispatch、AC3 テスト用）

### AC3: bats テスト 7 cases 新規作成
- `plugins/twl/tests/bats/scripts/resolve-project-root-fallback.bats`
- case 1-7 全件 GREEN

### AC5: ADR-027 新規作成
- `plugins/twl/architecture/decisions/ADR-027-pwd-fallback-forbidden.md`
- Context / Decision / Consequences / Alternatives considered

### AC6: pitfalls-catalog.md §14 新設
- git 管理外実行時の pwd fallback 禁止（Wave AA.3 doobidoo `b81b1962` 参照）

### AC7: cleanup-orphan-snapshots.md 新規作成
- `plugins/twl/commands/cleanup-orphan-snapshots.md`
- dry-run default、`.dev-session/` 限定 scope

### AC8: impact radius 確認
- `chain-runner.sh` 外から bash `resolve_project_root` を source・呼出するコードなし
- `cli/twl/src/twl/autopilot/project.py` の `_resolve_project_root` は別の Python 関数

## AC4: 既存テスト回帰
- `chain-runner-audit-snapshot.bats` test 1 は本 PR 前から失敗している pre-existing 失敗（本 PR の変更と無関係）
- その他の既存 chain-runner-*.bats 全件 PASS

Closes #966