### PR TITLE
feat: Phase 0 β — CLI 互換 wrapper 設計 (cli.py if-chain リファクタ) #963

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -65,7 +65,14 @@ def main():
                                 help='Hash-verify chain.py ↔ deps.yaml ↔ chain-steps.sh (blocks on drift)')
         sub_args = sub_parser.parse_args(sys.argv[2:])
         plugin_root, deps, graph, plugin_name = _load_plugin_context()
-        sys.exit(handle_check(sub_args, graph, deps, plugin_root, plugin_name))
+        sys.exit(handle_check(
+            format=sub_args.format,
+            deps_integrity=sub_args.deps_integrity,
+            graph=graph,
+            deps=deps,
+            plugin_root=plugin_root,
+            plugin_name=plugin_name,
+        ))
 
     # refine サブコマンド
     if len(sys.argv) >= 2 and sys.argv[1] == 'refine':
@@ -105,6 +112,8 @@ def main():
     parser.add_argument('--target', help='Show dependencies for target')
     parser.add_argument('--reverse', help='Show reverse dependencies for target')
     parser.add_argument('--check', action='store_true', help='Check file existence')
+    parser.add_argument('--deps-integrity', action='store_true',
+                        help='Hash-verify chain.py ↔ deps.yaml ↔ chain-steps.sh (use with --check)')
     parser.add_argument('--validate', action='store_true', help='Validate type rules (can_spawn/spawnable_by)')
     parser.add_argument('--list', action='store_true', help='List all nodes')
     parser.add_argument('--update-readme', action='store_true', help='Update README.md with SVG graph and Entry Points table')
@@ -169,10 +178,23 @@ def main():
         sys.exit(0 if success else 1)
 
     if args.check:
-        sys.exit(handle_check(args, graph, deps, plugin_root, plugin_name))
+        sys.exit(handle_check(
+            format=args.format,
+            deps_integrity=args.deps_integrity,
+            graph=graph,
+            deps=deps,
+            plugin_root=plugin_root,
+            plugin_name=plugin_name,
+        ))
 
     if args.validate:
-        handle_validate(args, deps, graph, plugin_root, plugin_name)
+        sys.exit(handle_validate(
+            format=args.format,
+            deps=deps,
+            graph=graph,
+            plugin_root=plugin_root,
+            plugin_name=plugin_name,
+        ))
 
     if args.orphans:
         handle_orphans(args, graph, deps)
@@ -180,7 +202,13 @@ def main():
     if args.deep_validate:
         handle_deep_validate(args, deps, graph, plugin_root, plugin_name)
     elif args.audit:
-        handle_audit(args, deps, plugin_root, plugin_name)
+        sys.exit(handle_audit(
+            format=args.format,
+            section=args.section,
+            deps=deps,
+            plugin_root=plugin_root,
+            plugin_name=plugin_name,
+        ))
     elif args.list:
         handle_list(args, graph)
     elif args.target:

--- a/cli/twl/src/twl/cli_dispatch.py
+++ b/cli/twl/src/twl/cli_dispatch.py
@@ -58,7 +58,7 @@ def handle_tokens(args, graph):
     print(f"=== Total: {total_tokens:,} tokens ===")
 
 
-def handle_check(args, graph, deps, plugin_root, plugin_name):
+def handle_check(*, format=None, deps_integrity=False, graph, deps, plugin_root, plugin_name):
     from twl.chain.integrity import check_deps_integrity
 
     results, check_xref_warnings = check_files(graph, plugin_root)
@@ -75,14 +75,13 @@ def handle_check(args, graph, deps, plugin_root, plugin_name):
         cv_criticals_check, cv_warnings_check, cv_infos_check = chain_validate(deps, plugin_root)
         chain_items = deep_validate_to_items(cv_criticals_check, cv_warnings_check, cv_infos_check)
 
-    # deps-integrity: always run; blocking only when --deps-integrity is specified
+    # deps-integrity: always run; blocking only when deps_integrity=True is specified
     di_errors, di_warnings = check_deps_integrity(plugin_root)
-    deps_integrity_flag = getattr(args, 'deps_integrity', False)
-    integrity_blocks = deps_integrity_flag and bool(di_errors)
+    integrity_blocks = deps_integrity and bool(di_errors)
 
     exit_code = 1 if (missing_count > 0 or cv_criticals_check or integrity_blocks) else 0
 
-    if args.format == 'json':
+    if format == 'json':
         items = check_results_to_items(results)
         items.extend(violations_to_items(check_xref_warnings, "warning"))
         items.extend(chain_items)
@@ -130,7 +129,7 @@ def handle_check(args, graph, deps, plugin_root, plugin_name):
         print()
         print("=== Deps Integrity Results ===")
         if di_errors:
-            label = "Error" if deps_integrity_flag else "Warning"
+            label = "Error" if deps_integrity else "Warning"
             for e in di_errors:
                 print(f"  [{label}] {e}")
         for w in di_warnings:
@@ -139,7 +138,7 @@ def handle_check(args, graph, deps, plugin_root, plugin_name):
     return exit_code
 
 
-def handle_validate(args, deps, graph, plugin_root, plugin_name):
+def handle_validate(*, format=None, deps, graph, plugin_root, plugin_name):
     ok_count, violations, xref_warnings = validate_types(deps, graph, plugin_root)
     body_ok, body_violations = validate_body_refs(deps, plugin_root)
     ok_count += body_ok
@@ -153,12 +152,12 @@ def handle_validate(args, deps, graph, plugin_root, plugin_name):
 
     exit_code = 1 if violations else 0
 
-    if args.format == 'json':
+    if format == 'json':
         items = violations_to_items(violations)
         items.extend(violations_to_items(xref_warnings, "warning"))
         envelope = build_envelope("validate", get_deps_version(deps), plugin_name, items, exit_code)
         output_json(envelope)
-        sys.exit(exit_code)
+        return exit_code
 
     print(f"=== Type Validation Results ===")
     print(f"OK: {ok_count}, Violations: {len(violations)}")
@@ -174,9 +173,10 @@ def handle_validate(args, deps, graph, plugin_root, plugin_name):
         print("Violations:")
         for v in violations:
             print(f"  - {v}")
-        sys.exit(1)
+        return 1
     else:
         print("All type constraints satisfied.")
+    return 0
 
 
 def handle_orphans(args, graph, deps):
@@ -275,8 +275,8 @@ def handle_deep_validate(args, deps, graph, plugin_root, plugin_name):
         sys.exit(1)
 
 
-def handle_audit(args, deps, plugin_root, plugin_name):
-    section_filter = getattr(args, 'section', None)
+def handle_audit(*, format=None, section=None, deps, plugin_root, plugin_name):
+    section_filter = section
     section_name_map = {
         1: 'controller_size',
         2: 'inline_implementation',
@@ -290,7 +290,7 @@ def handle_audit(args, deps, plugin_root, plugin_name):
         10: 'cross_layer_consistency',
     }
 
-    if args.format == 'json':
+    if format == 'json':
         items = audit_collect(deps, plugin_root)
         if section_filter is not None:
             target_section = section_name_map.get(section_filter)
@@ -299,7 +299,7 @@ def handle_audit(args, deps, plugin_root, plugin_name):
         exit_code = 1 if any(i['severity'] == 'critical' for i in items) else 0
         envelope = build_envelope("audit", get_deps_version(deps), plugin_name, items, exit_code)
         output_json(envelope)
-        sys.exit(exit_code)
+        return exit_code
 
     if section_filter == 9:
         from twl.validation.audit import audit_chain_integrity
@@ -332,9 +332,7 @@ def handle_audit(args, deps, plugin_root, plugin_name):
         print(f"| CRITICAL | {criticals} |")
         print(f"| WARNING  | {warnings} |")
         print(f"| OK       | {oks} |")
-        if criticals > 0:
-            sys.exit(1)
-        return
+        return 1 if criticals > 0 else 0
 
     if section_filter == 10:
         from twl.validation.audit import audit_cross_layer_consistency, _detect_monorepo_root
@@ -381,15 +379,12 @@ def handle_audit(args, deps, plugin_root, plugin_name):
         print(f"| CRITICAL | {criticals} |")
         print(f"| WARNING  | {warnings} |")
         print(f"| OK       | {oks} |")
-        if criticals > 0:
-            sys.exit(1)
-        return
+        return 1 if criticals > 0 else 0
 
     print("=== TWiLL Compliance Audit ===")
     print()
     audit_criticals, audit_warnings, audit_oks = audit_report(deps, plugin_root)
-    if audit_criticals > 0:
-        sys.exit(1)
+    return 1 if audit_criticals > 0 else 0
 
 
 def handle_list(args, graph):

--- a/cli/twl/tests/test_layer1_dispatch_parity.py
+++ b/cli/twl/tests/test_layer1_dispatch_parity.py
@@ -1,0 +1,230 @@
+"""test_layer1_dispatch_parity.py
+
+Issue #963: Phase 0 β — CLI 互換 wrapper 設計 (cli.py if-chain リファクタ)
+
+AC4: 3 subcommands × 2 paths (CLI subprocess vs pure function direct call) で
+     正規化後の出力が一致することを検証する。
+
+RED phase:
+  AC3 が未実装の今、handle_validate/handle_audit/handle_check は positional 'args'
+  を要求するため、keyword-only 呼び出しは TypeError → このファイル内のテストは全て FAIL する。
+"""
+
+import inspect
+import io
+import json
+import subprocess
+import sys
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Plugin context fixture
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_PLUGIN_ROOT = _REPO_ROOT / "plugins" / "twl"
+
+
+@pytest.fixture(scope="module")
+def plugin_ctx():
+    """Build plugin_ctx without CWD inference (AC4 requirement)."""
+    from twl.core.plugin import load_deps, build_graph, get_plugin_name
+    deps = load_deps(_PLUGIN_ROOT)
+    graph = build_graph(deps, _PLUGIN_ROOT)
+    plugin_name = get_plugin_name(deps, _PLUGIN_ROOT)
+    return {
+        "deps": deps,
+        "graph": graph,
+        "plugin_root": _PLUGIN_ROOT,
+        "plugin_name": plugin_name,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _normalize(data: dict) -> dict:
+    """Remove timestamps/paths, stable-sort items for comparison."""
+    result = {k: v for k, v in data.items() if k not in ("timestamp",)}
+    if "items" in result and isinstance(result["items"], list):
+        result = dict(result)
+        result["items"] = sorted(
+            result["items"],
+            key=lambda x: json.dumps(x, sort_keys=True),
+        )
+    return result
+
+
+def _run_cli_json(args: list) -> dict:
+    """Run twl via subprocess, parse stdout as JSON."""
+    result = subprocess.run(
+        ["twl"] + args,
+        capture_output=True,
+        text=True,
+        cwd=str(_PLUGIN_ROOT),
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# AC3: pure kwargs — function signature checks
+# ---------------------------------------------------------------------------
+
+def test_ac3_handle_validate_no_positional_args():
+    """AC3: handle_validate must not have a positional 'args' parameter."""
+    from twl.cli_dispatch import handle_validate
+    sig = inspect.signature(handle_validate)
+    params = list(sig.parameters.keys())
+    assert "args" not in params, (
+        "handle_validate still has positional 'args' — AC3 (pure kwargs) not implemented"
+    )
+    assert "format" in params, "handle_validate missing 'format' keyword parameter"
+
+
+def test_ac3_handle_audit_no_positional_args():
+    """AC3: handle_audit must not have a positional 'args' parameter."""
+    from twl.cli_dispatch import handle_audit
+    sig = inspect.signature(handle_audit)
+    params = list(sig.parameters.keys())
+    assert "args" not in params, (
+        "handle_audit still has positional 'args' — AC3 (pure kwargs) not implemented"
+    )
+    assert "format" in params, "handle_audit missing 'format' keyword parameter"
+    assert "section" in params, "handle_audit missing 'section' keyword parameter"
+
+
+def test_ac3_handle_check_no_positional_args():
+    """AC3: handle_check must not have a positional 'args' parameter."""
+    from twl.cli_dispatch import handle_check
+    sig = inspect.signature(handle_check)
+    params = list(sig.parameters.keys())
+    assert "args" not in params, (
+        "handle_check still has positional 'args' — AC3 (pure kwargs) not implemented"
+    )
+    assert "format" in params, "handle_check missing 'format' keyword parameter"
+    assert "deps_integrity" in params, "handle_check missing 'deps_integrity' keyword parameter"
+
+
+def test_ac3_handle_validate_returns_int_not_sys_exit(plugin_ctx):
+    """AC3(b): handle_validate must return exit_code (int), not call sys.exit()."""
+    from twl.cli_dispatch import handle_validate
+    ctx = plugin_ctx
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result = handle_validate(
+            format=None,
+            deps=ctx["deps"],
+            graph=ctx["graph"],
+            plugin_root=ctx["plugin_root"],
+            plugin_name=ctx["plugin_name"],
+        )
+    assert isinstance(result, int), (
+        f"handle_validate returned {type(result).__name__!r}, expected int — "
+        "sys.exit() must be moved to cli.py caller layer (AC3b)"
+    )
+
+
+def test_ac3_handle_audit_returns_int_not_sys_exit(plugin_ctx):
+    """AC3(b): handle_audit must return exit_code (int), not call sys.exit()."""
+    from twl.cli_dispatch import handle_audit
+    ctx = plugin_ctx
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        result = handle_audit(
+            format="json",
+            section=7,
+            deps=ctx["deps"],
+            plugin_root=ctx["plugin_root"],
+            plugin_name=ctx["plugin_name"],
+        )
+    assert isinstance(result, int), (
+        f"handle_audit returned {type(result).__name__!r}, expected int — "
+        "sys.exit() must be moved to cli.py caller layer (AC3b)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4: CLI subprocess vs pure function direct call — parity tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("label,cli_args,direct_fn,direct_kwargs_keys", [
+    (
+        "validate",
+        ["--validate", "--format", "json"],
+        "handle_validate",
+        {"format": "json"},
+    ),
+    (
+        "audit_section7",
+        ["--audit", "--section", "7", "--format", "json"],
+        "handle_audit",
+        {"format": "json", "section": 7},
+    ),
+    (
+        # CLI side uses subcommand style (twl check --deps-integrity) because flag-style
+        # --check does not yet accept --deps-integrity (AC1 in-scope).
+        # Direct call tests the keyword-only signature (AC3 RED).
+        "check_deps_integrity",
+        ["check", "--deps-integrity", "--format", "json"],
+        "handle_check",
+        {"format": "json", "deps_integrity": True},
+    ),
+])
+def test_ac4_cli_vs_direct_parity(label, cli_args, direct_fn, direct_kwargs_keys, plugin_ctx):
+    """AC4: CLI subprocess and pure function direct call produce equal normalized JSON."""
+    import importlib
+    ctx = plugin_ctx
+
+    # CLI path
+    cli_data = _normalize(_run_cli_json(cli_args))
+
+    # Direct call path — build kwargs from ctx + direct_kwargs_keys
+    module = importlib.import_module("twl.cli_dispatch")
+    fn = getattr(module, direct_fn)
+    kwargs = dict(direct_kwargs_keys)
+    if "graph" in inspect.signature(fn).parameters:
+        kwargs["graph"] = ctx["graph"]
+    kwargs["deps"] = ctx["deps"]
+    kwargs["plugin_root"] = ctx["plugin_root"]
+    kwargs["plugin_name"] = ctx["plugin_name"]
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        exit_code = fn(**kwargs)
+    direct_data = _normalize(json.loads(buf.getvalue()))
+
+    assert cli_data.get("command") == direct_data.get("command"), (
+        f"[{label}] command field mismatch: {cli_data.get('command')!r} vs {direct_data.get('command')!r}"
+    )
+    assert cli_data.get("exit_code") == direct_data.get("exit_code"), (
+        f"[{label}] exit_code mismatch: CLI={cli_data.get('exit_code')} vs direct={direct_data.get('exit_code')}"
+    )
+    cli_items = cli_data.get("items", [])
+    direct_items = direct_data.get("items", [])
+    assert len(cli_items) == len(direct_items), (
+        f"[{label}] items count mismatch: CLI={len(cli_items)} vs direct={len(direct_items)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6: architecture docs — twill-integration.md contains hybrid pattern section
+# ---------------------------------------------------------------------------
+
+def test_ac6_twill_integration_docs_hybrid_pattern():
+    """AC6: twill-integration.md must document the hybrid pattern."""
+    doc_path = _PLUGIN_ROOT / "architecture" / "domain" / "contexts" / "twill-integration.md"
+    assert doc_path.exists(), f"Architecture doc not found: {doc_path}"
+    content = doc_path.read_text()
+    assert "hybrid pattern" in content.lower(), (
+        "twill-integration.md missing 'hybrid pattern' section (AC6a)"
+    )
+    assert "pure" in content.lower() and "ssot" in content.lower(), (
+        "twill-integration.md missing 'pure function SSOT' concept (AC6b)"
+    )
+    assert "mcp" in content.lower(), (
+        "twill-integration.md missing MCP tool shared codepath diagram (AC6c)"
+    )

--- a/plugins/twl/architecture/domain/contexts/twill-integration.md
+++ b/plugins/twl/architecture/domain/contexts/twill-integration.md
@@ -166,6 +166,60 @@ flowchart TD
 | reference | skills | ref-types, ref-architecture-spec 等 | 11 |
 | script | scripts | autopilot-plan.sh 等 | 18 |
 
+## Phase 0 β: Hybrid Pattern と Pure Function SSOT（#963）
+
+### Hybrid Pattern — External/Internal 責務分離
+
+Phase 0 β で導入した **hybrid pattern** は、CLI の external interface（flag 形式）を 100% 維持しつつ、内部で subparser routing を導入する設計。
+
+```
+External Interface (unchanged):         Internal Routing (refactored):
+  twl --validate                  →     handle_validate(format=None, deps, graph, ...)
+  twl --audit --section 7         →     handle_audit(format='json', section=7, deps, ...)
+  twl --check --deps-integrity    →     handle_check(deps_integrity=True, graph, deps, ...)
+```
+
+**責務の分離**:
+- `cli.py` （caller 層）: argparse で args を受け取り、kwargs に変換して handler を呼ぶ。`sys.exit()` もここで担当
+- `cli_dispatch.py` （handler 層）: pure kwargs 関数。argparse 依存なし。`return exit_code` で終了
+
+### Pure Function SSOT — cli_dispatch の handler 設計
+
+`handle_validate` / `handle_audit` / `handle_check` は **keyword-only pure 関数**：
+
+```python
+# Before (argparse 依存)
+def handle_validate(args, deps, graph, plugin_root, plugin_name):
+    if args.format == 'json': ...
+    sys.exit(exit_code)
+
+# After (pure kwargs — Phase 0 β)
+def handle_validate(*, format=None, deps, graph, plugin_root, plugin_name):
+    if format == 'json': ...
+    return exit_code  # caller (cli.py) が sys.exit() を担う
+```
+
+### MCP Tool との共有コードパス図
+
+Phase 0 α（#962）の MCP server は、β が確立した pure 関数 SSOT を直接 import できる：
+
+```
+                    twl CLI (cli.py)
+                         │ args → kwargs
+                         ▼
+              cli_dispatch.handle_validate(*, format, ...)
+                    ▲              ▲
+                    │              │
+           CLI subprocess    MCP tool (α #962)
+           (external user)   from twl.cli_dispatch import handle_validate
+```
+
+### Phase 0 β 固有の Interface 互換ルール
+
+- `twl --validate` / `twl --audit [--section N]` / `twl --check [--deps-integrity]` の外部 interface は **変更禁止**
+- `plugins/twl/scripts/chain-runner.sh` / `hooks/post-tool-use-validate.sh` / `hooks/pre-bash-commit-validate.sh` の呼出元 4 ファイルは **無変更動作 MUST**
+- bash wrapper (`cli/twl/twl`) は変更しない
+
 ## Dependencies
 
 - **Open Host Service -> 全 Context**: validate / audit / chain 結果を提供


### PR DESCRIPTION
## Summary

Phase 0 β: `cli.py` の dispatch 構造を refactor し、MCP server と同一コードパスを共有する SSOT 基盤を確立する。

## Changes

### cli_dispatch.py (AC3: pure kwargs SSOT)
- `handle_validate` / `handle_audit` / `handle_check` を keyword-only pure 関数に変換
- `args.*` 参照をすべて kwargs に展開し argparse 依存を cli.py に閉じ込める
- `sys.exit()` を呼出し層 (cli.py) に移譲し `return exit_code` に統一 (AC3b)
- α (#962) の MCP tool wrap が `from twl.cli_dispatch import handle_validate` で直接 import 可能に

### cli.py (AC1: hybrid dispatch)
- flag-style argparse で kwargs 変換層を追加
- `--deps-integrity` を flag-style parser に追加
- `twl check` subcommand path も keyword args 呼び出しに更新

### Architecture docs (AC6)
- `twill-integration.md` に Phase 0 β hybrid pattern セクションを追記
- external/internal 責務分離、pure 関数 SSOT 概念図、MCP tool 共有コードパス図

## Tests

### New tests (AC4)
- `cli/twl/tests/test_layer1_dispatch_parity.py` — 9 tests all GREEN
  - AC3: signature checks (no 'args' param, keyword-only)
  - AC3b: return int instead of sys.exit()
  - AC4: 3 subcommands × 2 paths (CLI subprocess vs direct call) parity

### Regression (AC5)
- Pre-existing failures unchanged (48 → 39, reduction from 9 RED tests going GREEN)
- All tests introduced by this PR pass

## Interface Compatibility (AC2)
- `twl --validate` / `twl --audit` / `twl --check` external interface unchanged
- `chain-runner.sh:791` / `post-tool-use-validate.sh` / `pre-bash-commit-validate.sh` callers unmodified

Closes #963