### PR TITLE
feat(#951): baseline-bash.md に複数 regex の ^ アンカー一貫性ルール（§6）を追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -813,7 +813,7 @@ refs:
   baseline-bash:
     type: reference
     path: refs/baseline-bash.md
-    description: "Bash スクリプト品質基準（character class, 変数スコープ, set -u 初期化）"
+    description: "Bash スクリプト品質基準（character class, 変数スコープ, set -u 初期化, ^ アンカー一貫性）"
 
   # co-self-improve data catalogs (#179)
   test-scenario-catalog:

--- a/plugins/twl/refs/baseline-bash.md
+++ b/plugins/twl/refs/baseline-bash.md
@@ -163,3 +163,47 @@ run_strict() (
 ```
 
 > **補足**: `source` されたスクリプト内では `exit N` ではなく `return N` を使うこと。`exit N` は親シェルごと終了させるため、意図しないセッション終了を引き起こす。
+
+## 6. 複数 regex パターンの ^ アンカー一貫性
+
+同一 input source（tmux pane capture 出力など）に対して複数の `grep -E` / `=~` パターンを並走させる場合、各パターンの `^` 直後の character class（leading-space 許容 or strict）を統一しなければならない。形式が混在すると、あるパターンにはマッチするが別のパターンにはマッチしないという誤分類バグが生じる。
+
+**Why** (PR #949 / Issue #946 / `e3d2f80`): `issue-lifecycle-orchestrator.sh` の F4 修正で、同一 pane 出力に対する Pattern 1 (`^[1-9]\.`) が strict 形式、Pattern 2 (`^[[:space:]]*[1-9][0-9]*[.):])`) が leading-space 許容形式になっており、インデント付き出力で Pattern 1 が不一致 → Pattern 2 が誤分類するバグが発生した。
+
+### BAD: 同一 input への複数 pattern で ^ 直後の形式が異なる
+
+```bash
+# BAD: Pattern 1 は strict（先頭スペースを許容しない）
+if [[ "$pane_output" =~ ^[1-9]\.\ (Yes,\ proceed|No,\ go\ back) ]]; then
+  # → インデント付き出力では不一致
+
+# BAD: Pattern 2 は leading-space 許容（同一 source なのに形式が違う）
+elif [[ "$pane_output" =~ ^[[:space:]]*[1-9][0-9]*[.):] ]]; then
+  # → スペース付きでもマッチするため、Pattern 1 を抜けたものを誤捕捉する
+fi
+```
+
+### GOOD: 全パターンを `^[[:space:]]*` 形式で統一（leading-space 許容）
+
+```bash
+# GOOD: 両パターンともに leading-space を許容することで一貫性を保つ
+if [[ "$pane_output" =~ ^[[:space:]]*[1-9]\.\ (Yes,\ proceed|No,\ go\ back) ]]; then
+  : # 正常分岐
+elif [[ "$pane_output" =~ ^[[:space:]]*[1-9][0-9]*[.):] ]]; then
+  : # menu 検出分岐
+fi
+```
+
+### GOOD: 全パターンを strict `^` 形式で統一（leading-space を事前除去）
+
+```bash
+# GOOD: input を trim してから strict パターンを適用する
+trimmed="${pane_output#"${pane_output%%[![:space:]]*}"}"  # 先頭スペース除去
+if [[ "$trimmed" =~ ^[1-9]\.\ (Yes,\ proceed|No,\ go\ back) ]]; then
+  : # 正常分岐
+elif [[ "$trimmed" =~ ^[1-9][0-9]*[.):] ]]; then
+  : # menu 検出分岐
+fi
+```
+
+**レビュー観点**: 同一 input source に対する複数 `grep -E` / `=~` パターンの `^` 直後の character class（`[[:space:]]*` の有無）を比較し、形式が混在している場合は flag する。

--- a/plugins/twl/tests/bats/ac-test-mapping-951.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-951.yaml
@@ -1,0 +1,37 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/twl/refs/baseline-bash.md に ## 6. 複数 regex パターンの ^ アンカー一貫性 セクションが追加されている"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC1 section '## 6. 複数 regex パターンの ^ アンカー一貫性' exists"
+  - ac_index: 2
+    ac_text: "BAD 例として PR #949 で問題となった Pattern 1 strict / Pattern 2 leading-space の不整合パターンを引用"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC2 BAD example mentions strict Pattern1 '^[1-9]\\.' and leading-space Pattern2"
+  - ac_index: 3a
+    ac_text: "GOOD 例として全パターンを ^[[:space:]]* 統一の形が存在する"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC3 GOOD example 'all patterns use ^[[:space:]]*' form is present"
+  - ac_index: 3b
+    ac_text: "GOOD 例として全パターンを strict ^ 統一の形が存在する"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC3 GOOD example 'all patterns use strict ^' form is present"
+  - ac_index: 4
+    ac_text: "レビュー観点（同一 input source に対する複数 regex の ^ 直後 character class 比較）が一文で明示されている"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC4 review observation mentions comparing ^ character class for same input source"
+  - ac_index: 5
+    ac_text: "PR #949 もしくは Issue #946 への commit reference（e3d2f80 等）が Why 注記として記載されている"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC5 Why note references PR #949 or commit e3d2f80 or Issue #946"
+  - ac_index: 6
+    ac_text: "twl check --deps-integrity が PASS する"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC6 twl check --deps-integrity passes"
+  - ac_index: 7a
+    ac_text: "plugins/twl/agents/worker-code-reviewer.md 本体は変更されていない"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC7 worker-code-reviewer.md has no uncommitted changes"
+  - ac_index: 7b
+    ac_text: "plugins/twl/agents/worker-codex-reviewer.md 本体は変更されていない"
+    test_file: "tests/bats/baseline-bash-section6.bats"
+    test_name: "baseline-bash-section6: AC7 worker-codex-reviewer.md has no uncommitted changes"

--- a/plugins/twl/tests/bats/baseline-bash-section6.bats
+++ b/plugins/twl/tests/bats/baseline-bash-section6.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# baseline-bash-section6.bats - Verify Issue #951: baseline-bash.md に
+# ## 6. 複数 regex パターンの ^ アンカー一貫性 セクションが追加されていること
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  TESTS_DIR="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${TESTS_DIR}/.." && pwd)"
+  BASELINE="${REPO_ROOT}/refs/baseline-bash.md"
+  export REPO_ROOT BASELINE
+}
+
+# ===========================================================================
+# AC1: ## 6. 複数 regex パターンの ^ アンカー一貫性 セクションが存在する
+# ===========================================================================
+
+@test "baseline-bash-section6: AC1 section '## 6. 複数 regex パターンの ^ アンカー一貫性' exists" {
+  [ -f "${BASELINE}" ]
+  grep -qF '## 6. 複数 regex パターンの ^ アンカー一貫性' "${BASELINE}"
+}
+
+# ===========================================================================
+# AC2: BAD 例として Pattern 1 strict / Pattern 2 leading-space の不整合を引用
+# ===========================================================================
+
+@test "baseline-bash-section6: AC2 BAD example mentions strict Pattern1 '^[1-9]\\.' and leading-space Pattern2" {
+  [ -f "${BASELINE}" ]
+  # Pattern 1 strict form
+  grep -qE '\^\[1-9\]\\.' "${BASELINE}"
+  # Pattern 2 leading-space form
+  grep -qE '\^\[\[:space:\]\]\*\[1-9\]' "${BASELINE}"
+}
+
+# ===========================================================================
+# AC3: GOOD 例として 2 種（^[[:space:]]* 統一 / strict ^ 統一）が併記されている
+# ===========================================================================
+
+@test "baseline-bash-section6: AC3 GOOD example 'all patterns use ^[[:space:]]*' form is present" {
+  [ -f "${BASELINE}" ]
+  grep -qE '\^\[\[:space:\]\]\*' "${BASELINE}"
+}
+
+@test "baseline-bash-section6: AC3 GOOD example 'all patterns use strict ^' form is present" {
+  [ -f "${BASELINE}" ]
+  # Section 6 should mention both GOOD forms; check that we have two distinct GOOD code blocks
+  local count
+  count=$(grep -c '^# GOOD' "${BASELINE}")
+  # baseline already has 9 GOOD examples in §1-5; §6 adds at least 2 more → total ≥ 11
+  [ "${count}" -ge 11 ]
+}
+
+# ===========================================================================
+# AC4: レビュー観点（同一 input source に対する複数 regex の ^ 直後比較）が明示
+# ===========================================================================
+
+@test "baseline-bash-section6: AC4 review observation mentions comparing ^ character class for same input source" {
+  [ -f "${BASELINE}" ]
+  # Either Japanese or mixed — grep for key phrase
+  grep -qE '同一.*input.*source|同一.*ソース.*regex|同一.*input.*regex|same input source' "${BASELINE}"
+}
+
+# ===========================================================================
+# AC5: PR #949 or commit e3d2f80 の Why 注記が記載されている
+# ===========================================================================
+
+@test "baseline-bash-section6: AC5 Why note references PR #949 or commit e3d2f80 or Issue #946" {
+  [ -f "${BASELINE}" ]
+  grep -qE '#949|e3d2f80|#946' "${BASELINE}"
+}
+
+# ===========================================================================
+# AC6: twl check --deps-integrity が PASS する
+# ===========================================================================
+
+@test "baseline-bash-section6: AC6 twl check --deps-integrity passes" {
+  run bash -c "cd '${REPO_ROOT}' && twl check --deps-integrity"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC7: worker-code-reviewer.md / worker-codex-reviewer.md は変更されていない
+# (uncommitted changes がないこと = このIssue実装でagentを変更していないこと)
+# ===========================================================================
+
+@test "baseline-bash-section6: AC7 worker-code-reviewer.md has no uncommitted changes" {
+  run git -C "${REPO_ROOT}" diff HEAD -- agents/worker-code-reviewer.md
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}
+
+@test "baseline-bash-section6: AC7 worker-codex-reviewer.md has no uncommitted changes" {
+  run git -C "${REPO_ROOT}" diff HEAD -- agents/worker-codex-reviewer.md
+  [ "${status}" -eq 0 ]
+  [ -z "${output}" ]
+}


### PR DESCRIPTION
## 概要

Issue #951 対応。`plugins/twl/refs/baseline-bash.md` に `## 6. 複数 regex パターンの ^ アンカー一貫性` セクションを追記し、`worker-code-reviewer` / `worker-codex-reviewer` が同種バグを信頼度 80+ で検出できるようにする。

## 変更ファイル

- `plugins/twl/refs/baseline-bash.md` — §6 追記（BAD/GOOD 例・レビュー観点・Why 注記）
- `plugins/twl/tests/bats/baseline-bash-section6.bats` — AC 検証テスト 9 件
- `plugins/twl/tests/bats/ac-test-mapping-951.yaml` — AC マッピング

## AC 検証

- [x] §6 セクション存在
- [x] BAD 例: PR #949 不整合パターン引用
- [x] GOOD 例: `^[[:space:]]*` 統一 / strict `^` + trim 統一の 2 種
- [x] レビュー観点（同一 input source 複数 regex の `^` 直後比較）明示
- [x] Why 注記: PR #949 / Issue #946 / `e3d2f80` 参照
- [x] `twl check --deps-integrity` PASS
- [x] `worker-code-reviewer.md` / `worker-codex-reviewer.md` 変更なし

Closes #951