### PR TITLE
feat(#1019): Phase 1 β — AI 失敗率測定プロトコル + 実証 (AC8 binomial proportion test)

### DIFF
--- a/cli/twl/tests/ac-test-mapping-1019.yaml
+++ b/cli/twl/tests/ac-test-mapping-1019.yaml
@@ -1,0 +1,78 @@
+mappings:
+  # AC1: 測定プロトコル文書化 (N=240 設計)
+  - ac_index: 1
+    ac_text: "新規ファイル plugins/twl/architecture/phases/phase1-ai-failure-rate-protocol.md を作成し、N=240 根拠 (20/操作 × 6 操作 × 2 経路)、power analysis、対象 6 操作、goldfile 定義、CLI/MCP 経路定義、前提 verify を文書化する"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC1ProtocolDocument::test_ac1_protocol_doc_exists"
+      - "TestAC1ProtocolDocument::test_ac1_n240_justification_present"
+      - "TestAC1ProtocolDocument::test_ac1_power_analysis_mentioned"
+      - "TestAC1ProtocolDocument::test_ac1_six_operations_documented"
+      - "TestAC1ProtocolDocument::test_ac1_cli_route_defined"
+      - "TestAC1ProtocolDocument::test_ac1_mcp_route_defined"
+      - "TestAC1ProtocolDocument::test_ac1_goldfile_definition_present"
+      - "TestAC1ProtocolDocument::test_ac1_prerequisite_verify_documented"
+    red_reason: "phase1-ai-failure-rate-protocol.md が未作成のため全件 NotImplementedError で FAIL"
+
+  # AC2: 測定環境ガードレール (cold-start + prompt 標準化 + 両経路強制)
+  - ac_index: 2
+    ac_text: "cold-start session 必須、prompt 標準化、forced subset 設計 (CLI 5 + MCP 5 per 操作、forced 30+30+free 120=240)、environment fingerprint 7 フィールド記録を文書化・実測データ CSV として残す"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC2MeasurementGuardrails::test_ac2_cold_start_requirement_documented"
+      - "TestAC2MeasurementGuardrails::test_ac2_prompt_standardization_documented"
+      - "TestAC2MeasurementGuardrails::test_ac2_forced_subset_design_documented"
+      - "TestAC2MeasurementGuardrails::test_ac2_trial_total_matches_240"
+      - "TestAC2MeasurementGuardrails::test_ac2_environment_fingerprint_fields_present"
+      - "TestAC2MeasurementGuardrails::test_ac2_data_csv_exists"
+    red_reason: "プロトコル文書・実測 CSV が未作成のため全件 NotImplementedError で FAIL"
+
+  # AC3: 4 失敗パターン分類 + state での具体化
+  - ac_index: 3
+    ac_text: "分類ルーブリック (pattern 1: PYTHONPATH 未設定 / pattern 2: subcommand 名間違い / pattern 3: enum 表記ゆれ / pattern 4: 必須オプション漏れ) + MECE 保証 + 分子定義 (pattern 1-4 のみ) + 分類器実装"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC3FailurePatternClassification::test_ac3_pattern1_pythonpath_not_set"
+      - "TestAC3FailurePatternClassification::test_ac3_pattern2_subcommand_name_error"
+      - "TestAC3FailurePatternClassification::test_ac3_pattern3_enum_notation_error"
+      - "TestAC3FailurePatternClassification::test_ac3_pattern4_missing_required_option"
+      - "TestAC3FailurePatternClassification::test_ac3_mece_guarantee_pattern5_out_of_scope"
+      - "TestAC3FailurePatternClassification::test_ac3_numerator_definition_excludes_pattern5"
+    red_reason: "失敗パターン分類器が未実装のため全件 NotImplementedError で FAIL"
+
+  # AC4: 統計判定 (one-sided proportion test, α=0.05)
+  - ac_index: 4
+    ac_text: "アプローチ A: 線形結合 z-test (H0: p_mcp - 0.5×p_cli >= 0、delta method SE)、アプローチ B: bootstrap 比率比検定 (B>=10000)、Bonferroni 補正 (α/6=0.0083)、overall 判定 (全達成/部分達成/未達成)、goldfiles 12 件 (6 操作 × 2 経路) を実装・作成する"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC4StatisticalTest::test_ac4_significance_script_exists"
+      - "TestAC4StatisticalTest::test_ac4_script_accepts_csv_input"
+      - "TestAC4StatisticalTest::test_ac4_script_outputs_json"
+      - "TestAC4StatisticalTest::test_ac4_approach_a_linear_combination_ztest"
+      - "TestAC4StatisticalTest::test_ac4_approach_b_bootstrap_ratio_test"
+      - "TestAC4StatisticalTest::test_ac4_bonferroni_correction_applied"
+      - "TestAC4StatisticalTest::test_ac4_overall_judgment_categories"
+      - "TestAC4StatisticalTest::test_ac4_goldfiles_exist_for_all_operations_and_routes"
+    red_reason: "ac8_significance_test.py および goldfiles が未作成のため全件 NotImplementedError で FAIL"
+
+  # AC5: 実証結果を doobidoo memory に記録
+  - ac_index: 5
+    ac_text: "各試行の raw data を mcp__doobidoo__memory_store で記録 (tags: [phase1, ac8, ai-failure-rate, <route>, <operation>])。集計後サマリーを別 hash で記録"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC5DoobidooMemoryRecord::test_ac5_raw_trial_data_recorded"
+      - "TestAC5DoobidooMemoryRecord::test_ac5_tags_include_required_fields"
+      - "TestAC5DoobidooMemoryRecord::test_ac5_summary_hash_recorded"
+    red_reason: "実測・doobidoo memory 記録が未完了のため全件 NotImplementedError で FAIL"
+
+  # AC6: PR merge 完遂
+  - ac_index: 6
+    ac_text: "測定プロトコル文書・検定スクリプト・実測 CSV・goldfiles を含む PR が main にマージ。merge-gate specialist 全件 pass。doobidoo memory に AC8 達成判定結果が記録"
+    test_file: "cli/twl/tests/test_issue_1019_ac8_binomial.py"
+    test_names:
+      - "TestAC6PRMergeComplete::test_ac6_protocol_doc_in_repo"
+      - "TestAC6PRMergeComplete::test_ac6_significance_script_in_repo"
+      - "TestAC6PRMergeComplete::test_ac6_measured_csv_in_repo"
+      - "TestAC6PRMergeComplete::test_ac6_goldfiles_in_repo"
+      - "TestAC6PRMergeComplete::test_ac6_doobidoo_memory_ac8_judgment_recorded"
+    red_reason: "PR 未マージ・実測未完了のため全件 NotImplementedError で FAIL"

--- a/cli/twl/tests/test_issue_1019_ac8_binomial.py
+++ b/cli/twl/tests/test_issue_1019_ac8_binomial.py
@@ -12,10 +12,6 @@ AC5: 実証結果を doobidoo memory に記録
 AC6: PR merge 完遂
 """
 
-import csv
-import json
-import subprocess
-import sys
 from pathlib import Path
 
 import pytest
@@ -33,8 +29,8 @@ SIGNIFICANCE_SCRIPT = CLI_TWL_DIR / "tests" / "scripts" / "ac8_significance_test
 AC8_DATA_DIR = CLI_TWL_DIR / "tests" / "scripts" / "ac8_data"
 AC8_GOLDFILES_DIR = CLI_TWL_DIR / "tests" / "scripts" / "ac8_goldfiles"
 
-# AC1 で必要な 6 操作の定義
-REQUIRED_OPERATIONS = [
+# GREEN フェーズ実装ガイド: 以下の定数を各テストメソッドの検証ロジックで使用する
+REQUIRED_OPERATIONS = [  # AC1: 6 操作 (test_ac1_six_operations_documented で使用)
     "issue_init",
     "read_field",
     "status_transition",
@@ -43,8 +39,7 @@ REQUIRED_OPERATIONS = [
     "sets_nested_key",
 ]
 
-# AC2 で必要な環境フィンガープリントフィールド
-REQUIRED_FINGERPRINT_FIELDS = [
+REQUIRED_FINGERPRINT_FIELDS = [  # AC2: environment fingerprint (test_ac2_environment_fingerprint_fields_present で使用)
     "host",
     "git_HEAD",
     "python_version",
@@ -54,16 +49,14 @@ REQUIRED_FINGERPRINT_FIELDS = [
     "timestamp",
 ]
 
-# AC3 で必要な 4 失敗パターン
-FAILURE_PATTERN_KEYS = [
+FAILURE_PATTERN_KEYS = [  # AC3: 4 失敗パターン (test_ac3_pattern* で使用)
     "pythonpath_not_set",
     "subcommand_name_error",
     "enum_notation_error",
     "missing_required_option",
 ]
 
-# AC4 の CSV 必須カラム
-REQUIRED_CSV_COLUMNS = [
+REQUIRED_CSV_COLUMNS = [  # AC4: CSV 必須カラム (test_ac4_script_accepts_csv_input で使用)
     "operation",
     "route",
     "trial_index",

--- a/cli/twl/tests/test_issue_1019_ac8_binomial.py
+++ b/cli/twl/tests/test_issue_1019_ac8_binomial.py
@@ -1,0 +1,342 @@
+"""
+RED tests for Issue #1019 AC8 — AI 失敗率測定プロトコル + 実証 (binomial proportion test)
+
+TDD RED フェーズ用テストスタブ。
+実装前は全件 FAIL する（意図的 RED）。
+
+AC1: 測定プロトコル文書化 (N=240 設計)
+AC2: 測定環境ガードレール (cold-start + prompt 標準化 + 両経路強制)
+AC3: 4 失敗パターン分類 + state での具体化
+AC4: 統計判定 (one-sided proportion test, α=0.05)
+AC5: 実証結果を doobidoo memory に記録
+AC6: PR merge 完遂
+"""
+
+import csv
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# パス定義
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CLI_TWL_DIR = REPO_ROOT / "cli" / "twl"
+PLUGINS_TWL_DIR = REPO_ROOT / "plugins" / "twl"
+
+# AC1 対象
+PROTOCOL_DOC = PLUGINS_TWL_DIR / "architecture" / "phases" / "phase1-ai-failure-rate-protocol.md"
+
+# AC4 対象
+SIGNIFICANCE_SCRIPT = CLI_TWL_DIR / "tests" / "scripts" / "ac8_significance_test.py"
+AC8_DATA_DIR = CLI_TWL_DIR / "tests" / "scripts" / "ac8_data"
+AC8_GOLDFILES_DIR = CLI_TWL_DIR / "tests" / "scripts" / "ac8_goldfiles"
+
+# AC1 で必要な 6 操作の定義
+REQUIRED_OPERATIONS = [
+    "issue_init",
+    "read_field",
+    "status_transition",
+    "rbac_violation",
+    "failed_done_force",
+    "sets_nested_key",
+]
+
+# AC2 で必要な環境フィンガープリントフィールド
+REQUIRED_FINGERPRINT_FIELDS = [
+    "host",
+    "git_HEAD",
+    "python_version",
+    "fastmcp_version",
+    "mcp_server_pid",
+    "session_id",
+    "timestamp",
+]
+
+# AC3 で必要な 4 失敗パターン
+FAILURE_PATTERN_KEYS = [
+    "pythonpath_not_set",
+    "subcommand_name_error",
+    "enum_notation_error",
+    "missing_required_option",
+]
+
+# AC4 の CSV 必須カラム
+REQUIRED_CSV_COLUMNS = [
+    "operation",
+    "route",
+    "trial_index",
+    "success",
+    "failure_pattern",
+    "session_id",
+    "timestamp",
+]
+
+
+class TestAC1ProtocolDocument:
+    """AC1: 測定プロトコル文書化 (N=240 設計)
+
+    phase1-ai-failure-rate-protocol.md が未作成の現状では全件 FAIL する。
+    """
+
+    def test_ac1_protocol_doc_exists(self):
+        # AC: plugins/twl/architecture/phases/phase1-ai-failure-rate-protocol.md が存在する
+        # RED: ファイル未作成のため AssertionError で FAIL
+        raise NotImplementedError("AC #1 未実装: phase1-ai-failure-rate-protocol.md が存在しない")
+
+    def test_ac1_n240_justification_present(self):
+        # AC: N=240 の根拠 (20/操作 × 6 操作 × 2 経路) が明示されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: N=240 根拠の文書化が未完了")
+
+    def test_ac1_power_analysis_mentioned(self):
+        # AC: power analysis が文書内に含まれている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: power analysis の文書化が未完了")
+
+    def test_ac1_six_operations_documented(self):
+        # AC: 6 操作 (issue_init/read_field/status_transition/rbac_violation/
+        #      failed_done_force/sets_nested_key) が全て文書化されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: 6 操作の文書化が未完了")
+
+    def test_ac1_cli_route_defined(self):
+        # AC: CLI 経路 = `python3 -m twl.autopilot.state ...` が明示されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: CLI 経路の定義が未完了")
+
+    def test_ac1_mcp_route_defined(self):
+        # AC: MCP 経路 = `mcp__twl__twl_state_read` / `twl_state_write` が明示されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: MCP 経路の定義が未完了")
+
+    def test_ac1_goldfile_definition_present(self):
+        # AC: goldfile (success criterion) の定義 — 各操作 × 各経路 — が文書化されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: goldfile 定義の文書化が未完了")
+
+    def test_ac1_prerequisite_verify_documented(self):
+        # AC: α #1018 PR merge 後の MCP server 動作確認が前提として文書化されている
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError("AC #1 未実装: 前提 verify の文書化が未完了")
+
+
+class TestAC2MeasurementGuardrails:
+    """AC2: 測定環境ガードレール (cold-start + prompt 標準化 + 両経路強制)
+
+    ガードレール実装・文書・データが存在しない現状では全件 FAIL する。
+    """
+
+    def test_ac2_cold_start_requirement_documented(self):
+        # AC: cold-start session 必須 (新規 cld セッション × 各試行) が文書化されている
+        # RED: プロトコル文書未作成のため FAIL
+        raise NotImplementedError("AC #2 未実装: cold-start 要件の文書化が未完了")
+
+    def test_ac2_prompt_standardization_documented(self):
+        # AC: prompt 標準化 (free choice subset) が文書化されている
+        # RED: プロトコル文書未作成のため FAIL
+        raise NotImplementedError("AC #2 未実装: prompt 標準化の文書化が未完了")
+
+    def test_ac2_forced_subset_design_documented(self):
+        # AC: forced subset 設計 (CLI 5 + MCP 5 per 操作、合計 forced 30+30+free 120=240) が文書化
+        # RED: プロトコル文書未作成のため FAIL
+        raise NotImplementedError("AC #2 未実装: forced subset 設計の文書化が未完了")
+
+    def test_ac2_trial_total_matches_240(self):
+        # AC: forced 30 (CLI) + 30 (MCP) + free 120 = 240 試行 の内訳が一致する
+        # RED: 実測データ CSV が存在しないため FAIL
+        raise NotImplementedError("AC #2 未実装: 試行数合計 240 の検証が未完了")
+
+    def test_ac2_environment_fingerprint_fields_present(self):
+        # AC: environment fingerprint に必須 7 フィールド全て含まれる
+        # RED: 実測データ CSV が存在しないため FAIL
+        raise NotImplementedError("AC #2 未実装: environment fingerprint フィールドの検証が未完了")
+
+    def test_ac2_data_csv_exists(self):
+        # AC: ac8_data/<timestamp>.csv が 1 件以上存在する
+        # RED: scripts/ac8_data/ ディレクトリ・CSV ファイル未作成のため FAIL
+        raise NotImplementedError("AC #2 未実装: ac8_data CSV ファイルが存在しない")
+
+
+class TestAC3FailurePatternClassification:
+    """AC3: 4 失敗パターン分類 + state での具体化
+
+    分類ルーブリック実装・MECE 保証・分類器が存在しない現状では全件 FAIL する。
+    """
+
+    def test_ac3_pattern1_pythonpath_not_set(self):
+        # AC: PYTHONPATH 未設定パターンを stderr の ModuleNotFoundError で検出できる
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: PYTHONPATH 未設定パターン (pattern 1) の分類器が存在しない"
+        )
+
+    def test_ac3_pattern2_subcommand_name_error(self):
+        # AC: subcommand 名間違い (exit_code != 0 かつ stderr に 'unknown'/'invalid choice') を検出できる
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: subcommand 名間違いパターン (pattern 2) の分類器が存在しない"
+        )
+
+    def test_ac3_pattern3_enum_notation_error(self):
+        # AC: enum 値の表記ゆれ (StateArgError exit 2 + stderr に 'invalid'+'expected') を検出できる
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: enum 表記ゆれパターン (pattern 3) の分類器が存在しない"
+        )
+
+    def test_ac3_pattern4_missing_required_option(self):
+        # AC: 必須オプション漏れ (StateArgError exit 2 + stderr に 'required'/'missing') を検出できる
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: 必須オプション漏れパターン (pattern 4) の分類器が存在しない"
+        )
+
+    def test_ac3_mece_guarantee_pattern5_out_of_scope(self):
+        # AC: logic error (StateError exit 1) は pattern 5 (out-of-scope) として分類され分子に含まれない
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: MECE 保証 (pattern 5 out-of-scope 除外) の実装が存在しない"
+        )
+
+    def test_ac3_numerator_definition_excludes_pattern5(self):
+        # AC: 分子定義がパターン 1-4 のみであり、パターン 5 (logic error) を除外する
+        # RED: 分類器実装が存在しないため FAIL
+        raise NotImplementedError(
+            "AC #3 未実装: 分子定義 (pattern 1-4 のみ) の実装が存在しない"
+        )
+
+
+class TestAC4StatisticalTest:
+    """AC4: 統計判定 (one-sided proportion test, α=0.05)
+
+    検定スクリプト ac8_significance_test.py が存在しない現状では全件 FAIL する。
+    """
+
+    def test_ac4_significance_script_exists(self):
+        # AC: cli/twl/tests/scripts/ac8_significance_test.py が存在する
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: ac8_significance_test.py が存在しない"
+        )
+
+    def test_ac4_script_accepts_csv_input(self):
+        # AC: ac8_significance_test.py が CSV ファイルを入力として受け付ける
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: CSV 入力インタフェースが実装されていない"
+        )
+
+    def test_ac4_script_outputs_json(self):
+        # AC: ac8_significance_test.py が JSON 形式で結果を出力する
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: JSON 出力インタフェースが実装されていない"
+        )
+
+    def test_ac4_approach_a_linear_combination_ztest(self):
+        # AC: アプローチ A — 線形結合の z-test: H0: p_mcp - 0.5 × p_cli >= 0
+        #     z = (p̂_mcp - 0.5 × p̂_cli) / SE (SE は delta method)
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: アプローチ A (線形結合 z-test) が実装されていない"
+        )
+
+    def test_ac4_approach_b_bootstrap_ratio_test(self):
+        # AC: アプローチ B — bootstrap 比率比検定 (B>=10000 resampling で 1-sided 95% CI)
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: アプローチ B (bootstrap 比率比検定) が実装されていない"
+        )
+
+    def test_ac4_bonferroni_correction_applied(self):
+        # AC: Bonferroni 補正 (α/6 = 0.0083) が適用されている
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: Bonferroni 補正 (α/6=0.0083) が実装されていない"
+        )
+
+    def test_ac4_overall_judgment_categories(self):
+        # AC: overall 判定が 全達成 / 部分達成 / 未達成 の 3 カテゴリで出力される
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: overall 判定 (全達成/部分達成/未達成) が実装されていない"
+        )
+
+    def test_ac4_goldfiles_exist_for_all_operations_and_routes(self):
+        # AC: ac8_goldfiles/<op>_<route>.txt が 6 操作 × 2 経路 = 12 件存在する
+        # RED: goldfiles ディレクトリ・ファイル未作成のため FAIL
+        raise NotImplementedError(
+            "AC #4 未実装: goldfiles (12 件: 6 操作 × 2 経路) が存在しない"
+        )
+
+
+class TestAC5DoobidooMemoryRecord:
+    """AC5: 実証結果を doobidoo memory に記録
+
+    実測データおよび doobidoo memory への記録が存在しない現状では全件 FAIL する。
+    """
+
+    def test_ac5_raw_trial_data_recorded(self):
+        # AC: 各試行の raw data が mcp__doobidoo__memory_store で記録されている
+        # RED: 実測前のため FAIL
+        raise NotImplementedError(
+            "AC #5 未実装: 各試行の raw data が doobidoo memory に記録されていない"
+        )
+
+    def test_ac5_tags_include_required_fields(self):
+        # AC: tags に ["phase1", "ac8", "ai-failure-rate", "<route>", "<operation>"] が含まれる
+        # RED: 実測前のため FAIL
+        raise NotImplementedError(
+            "AC #5 未実装: 必須 tags フィールドが doobidoo memory に記録されていない"
+        )
+
+    def test_ac5_summary_hash_recorded(self):
+        # AC: 集計後サマリーが別 hash で doobidoo memory に記録されている
+        # RED: 実測前のため FAIL
+        raise NotImplementedError(
+            "AC #5 未実装: 集計サマリー hash が doobidoo memory に記録されていない"
+        )
+
+
+class TestAC6PRMergeComplete:
+    """AC6: PR merge 完遂
+
+    PR が main にマージされていない現状では全件 FAIL する。
+    """
+
+    def test_ac6_protocol_doc_in_repo(self):
+        # AC: 測定プロトコル文書 (phase1-ai-failure-rate-protocol.md) が main にマージ済み
+        # RED: ファイル未作成のため FAIL
+        raise NotImplementedError(
+            "AC #6 未実装: phase1-ai-failure-rate-protocol.md が存在しない (PR 未マージ)"
+        )
+
+    def test_ac6_significance_script_in_repo(self):
+        # AC: 検定スクリプト (ac8_significance_test.py) が main にマージ済み
+        # RED: スクリプト未作成のため FAIL
+        raise NotImplementedError(
+            "AC #6 未実装: ac8_significance_test.py が存在しない (PR 未マージ)"
+        )
+
+    def test_ac6_measured_csv_in_repo(self):
+        # AC: 実測 CSV (ac8_data/<timestamp>.csv) が main にマージ済み
+        # RED: 実測データ未作成のため FAIL
+        raise NotImplementedError(
+            "AC #6 未実装: 実測 CSV が存在しない (PR 未マージ)"
+        )
+
+    def test_ac6_goldfiles_in_repo(self):
+        # AC: goldfiles (ac8_goldfiles/<op>_<route>.txt) が main にマージ済み
+        # RED: goldfiles 未作成のため FAIL
+        raise NotImplementedError(
+            "AC #6 未実装: goldfiles が存在しない (PR 未マージ)"
+        )
+
+    def test_ac6_doobidoo_memory_ac8_judgment_recorded(self):
+        # AC: doobidoo memory に AC8 達成判定結果が記録されている
+        # RED: 実測・判定が未完了のため FAIL
+        raise NotImplementedError(
+            "AC #6 未実装: doobidoo memory に AC8 達成判定結果が記録されていない"
+        )


### PR DESCRIPTION
## 概要

Epic #945 Phase 1 β: AI 失敗率測定プロトコルの文書化・実証スクリプト・統計検定実装。

Closes #1019

## 変更内容

- `plugins/twl/architecture/phases/phase1-ai-failure-rate-protocol.md` (予定: 測定プロトコル文書)
- `cli/twl/tests/scripts/ac8_significance_test.py` (予定: binomial proportion test スクリプト)
- `cli/twl/tests/scripts/ac8_goldfiles/` (予定: 6 操作 × 2 経路の goldfiles)
- `cli/twl/tests/test_issue_1019_ac8_binomial.py` (TDD RED テスト 36 件)
- `cli/twl/tests/ac-test-mapping-1019.yaml` (AC→テストマッピング)

## テスト状態

現在 TDD RED フェーズ。全 36 件 FAIL（NotImplementedError）。
実装完了後に GREEN になる。

## 依存関係

前提: #1018 (state MCP 化) の AC1-AC4 達成が必要。