### PR TITLE
fix(#1015): chain-runner.sh TWL_CHAIN_TRACE 絶対パス書き込みを拒否

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -86,3 +86,39 @@ issue_999:
       test_file: "plugins/twl/tests/unit/cleanup-session-json-archive/cleanup-session-json-archive.bats"
       test_name: "ac6-negative: in-progress Wave の cleanup → session.json は archive されない"
       status: GREEN
+
+# --- Issue #1015 ---
+issue_1015:
+  issue: 1015
+  framework: bats
+  mappings:
+    - ac_index: 1
+      ac_text: "TWL_CHAIN_TRACE に絶対パス（/ 始まり）を設定した場合、trace_event() はファイルを作成しない"
+      test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
+      test_name: "trace-abspath[security][RED]: 絶対パスの場合、trace ファイルが作成されない"
+      status: RED
+      red_mechanism: "現行実装は *..*) パターンのみブロック。絶対パスは通過し mkdir -p + append が実行される"
+    - ac_index: 1a
+      ac_text: "TWL_CHAIN_TRACE に絶対パス＋サブディレクトリを設定した場合も拒否される"
+      test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
+      test_name: "trace-abspath[security][RED]: 絶対パス＋サブディレクトリの場合も trace ファイルが作成されない"
+      status: RED
+      red_mechanism: "同上。mkdir -p でサブディレクトリごと作成されファイルが書き込まれる"
+    - ac_index: 1b
+      ac_text: "TWL_CHAIN_TRACE 環境変数で絶対パスを渡した場合も同様に拒否される"
+      test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
+      test_name: "trace-abspath[env-var][RED]: TWL_CHAIN_TRACE 環境変数で絶対パスを渡した場合も拒否される"
+      status: RED
+      red_mechanism: "同上。--trace フラグ経由か環境変数経由かで挙動に差はない"
+    - ac_index: 2
+      ac_text: "TWL_CHAIN_TRACE に相対パスを設定した場合、trace_event() はファイルを作成する（既存動作を維持）"
+      test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
+      test_name: "trace-relpath[regression]: 相対パスの場合、trace ファイルが作成される"
+      status: GREEN
+      note: "回帰テスト。修正前後ともに PASS であること"
+    - ac_index: 3
+      ac_text: "TWL_CHAIN_TRACE に *..*（パストラバーサル）を含む場合、trace_event() はファイルを作成しない（既存動作）"
+      test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
+      test_name: "trace-traversal[regression]: パストラバーサル（*..*）は引き続きブロックされる"
+      status: GREEN
+      note: "回帰テスト。既存の case *..*) 節の動作を維持"

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -116,6 +116,20 @@ trace_event() {
   case "$trace_file" in
     *..*) return 0 ;;
   esac
+  # 絶対パス検証（issue-1015）: /tmp・TMPDIR・AUTOPILOT_DIR 配下のみ許可
+  if [[ "$trace_file" = /* ]]; then
+    local _ok=0
+    [[ "$trace_file" == /tmp/* ]] && _ok=1
+    if [[ "$_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
+      [[ "$trace_file" == "${TMPDIR}/"* ]] && _ok=1
+    fi
+    if [[ "$_ok" -eq 0 && -n "${AUTOPILOT_DIR:-}" ]]; then
+      local _ap="${AUTOPILOT_DIR%/}"
+      [[ "$_ap" != /* ]] && _ap="${PWD}/${_ap}"
+      [[ "$trace_file" == "${_ap}/"* ]] && _ok=1
+    fi
+    [[ "$_ok" -eq 0 ]] && return 0
+  fi
   # 親ディレクトリ作成（失敗してもサイレント）
   mkdir -p "$(dirname "$trace_file")" 2>/dev/null || return 0
   local ts

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -121,7 +121,7 @@ trace_event() {
     local _ok=0
     [[ "$trace_file" == /tmp/* ]] && _ok=1
     if [[ "$_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
-      [[ "$trace_file" == "${TMPDIR}/"* ]] && _ok=1
+      [[ "$trace_file" == "${TMPDIR%/}/"* ]] && _ok=1
     fi
     if [[ "$_ok" -eq 0 && -n "${AUTOPILOT_DIR:-}" ]]; then
       local _ap="${AUTOPILOT_DIR%/}"

--- a/plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats
+++ b/plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats
@@ -126,6 +126,30 @@ teardown() {
 }
 
 # ===========================================================================
+# AC4b: TMPDIR 配下の絶対パスは許可される（回帰テスト — TMPDIR trailing slash 正規化）
+# WHEN TMPDIR が設定されており、TWL_CHAIN_TRACE がその配下の絶対パスを指す
+# THEN trace_event() はそのパスにファイルを作成する（TMPDIR%/ 正規化の回帰防止）
+# ===========================================================================
+
+@test "trace-tmpdir[regression]: TMPDIR 配下の絶対パスは trace ファイルが作成される" {
+  local tmpdir_base="${TMPDIR:-/tmp}"
+  local trace_path="${tmpdir_base%/}/twl-test-trace-1015-tmpdir-$$"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run env TMPDIR="${tmpdir_base}" bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: TMPDIR 配下の絶対パスに trace ファイルが作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
 # AC5: AUTOPILOT_DIR 配下の絶対パスは許可される（回帰テスト）
 # WHEN AUTOPILOT_DIR が設定されており、TWL_CHAIN_TRACE がその配下の絶対パスを指す
 # THEN trace_event() はそのパスにファイルを作成する（autopilot-launch.sh との互換性）

--- a/plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats
+++ b/plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# chain-runner-trace-abspath.bats
+# Requirement: TWL_CHAIN_TRACE 絶対パス書き込み拒否（issue-1015）
+# Spec: PR #1013 / issue body description
+# Coverage: --type=unit --coverage=security
+#
+# 検証する仕様:
+#   1. TWL_CHAIN_TRACE に /tmp・TMPDIR・AUTOPILOT_DIR 以外の絶対パスを設定した場合、
+#      trace_event() はファイルを作成しない（ホワイトリスト外絶対パス拒否）
+#   2. TWL_CHAIN_TRACE に相対パスを設定した場合、trace_event() はファイルを作成する（回帰）
+#   3. TWL_CHAIN_TRACE に *..*（パストラバーサル）を含む場合、ファイルを作成しない（既存動作・回帰）
+#   4. /tmp 配下の絶対パスは引き続き許可される（回帰）
+#   5. AUTOPILOT_DIR 配下の絶対パスは引き続き許可される（回帰）
+#
+# NOTE: テスト 1（AC1）は実装前 RED 状態。
+#       修正（/tmp と AUTOPILOT_DIR のホワイトリスト方式）後に GREEN になる。
+#       evil path として $HOME 配下を使用する — /tmp は許可リストに含まれるため。
+#
+# 環境変数:
+#   WORKER_ISSUE_NUM=1015 — resolve_issue_num の Priority 0 による issue 番号固定
+#                           git branch / AUTOPILOT_DIR を参照せず動作する
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  export WORKER_ISSUE_NUM=1015
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: ホワイトリスト外の絶対パスは拒否される（RED: 修正前は FAIL）
+# WHEN TWL_CHAIN_TRACE に /tmp・TMPDIR・AUTOPILOT_DIR 以外の絶対パスを設定する
+# THEN trace_event() はそのパスにファイルを作成しない
+# Spec: issue-1015 ホワイトリスト方式
+# NOTE: evil path は $HOME 配下を使用する — /tmp は許可リストに含まれる
+# ===========================================================================
+
+@test "trace-abspath[security][RED]: ホワイトリスト外絶対パス（HOME）は trace ファイルが作成されない" {
+  local _home="${HOME:-/root}"
+  local evil_path="${_home}/twl-test-trace-1015-abspath-$$"
+  rm -f "$evil_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$evil_path" resolve-issue-num
+
+  local file_existed=0
+  [[ -f "$evil_path" ]] && file_existed=1
+  rm -f "$evil_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_existed" -eq 0 ]] || {
+    echo "FAIL: ホワイトリスト外の絶対パスに trace ファイルが書き込まれた（セキュリティ脆弱性）: $evil_path" >&2
+    return 1
+  }
+}
+
+@test "trace-abspath[security][RED]: HOME 配下サブディレクトリの場合も trace ファイルが作成されない" {
+  local _home="${HOME:-/root}"
+  local evil_dir="${_home}/twl-test-trace-1015-subdir-$$"
+  local evil_path="${evil_dir}/trace.jsonl"
+  rm -rf "$evil_dir" 2>/dev/null || true
+
+  run bash "$CR" --trace "$evil_path" resolve-issue-num
+
+  local file_existed=0
+  [[ -f "$evil_path" ]] && file_existed=1
+  rm -rf "$evil_dir" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_existed" -eq 0 ]] || {
+    echo "FAIL: ホワイトリスト外絶対パス（サブディレクトリ）に trace ファイルが書き込まれた: $evil_path" >&2
+    return 1
+  }
+}
+
+@test "trace-abspath[env-var][RED]: TWL_CHAIN_TRACE 環境変数でホワイトリスト外絶対パスを渡した場合も拒否される" {
+  local _home="${HOME:-/root}"
+  local evil_path="${_home}/twl-test-trace-1015-envvar-$$"
+  rm -f "$evil_path" 2>/dev/null || true
+
+  run env TWL_CHAIN_TRACE="$evil_path" bash "$CR" resolve-issue-num
+
+  local file_existed=0
+  [[ -f "$evil_path" ]] && file_existed=1
+  rm -f "$evil_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_existed" -eq 0 ]] || {
+    echo "FAIL: TWL_CHAIN_TRACE 環境変数でホワイトリスト外絶対パスが書き込まれた: $evil_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: /tmp 配下の絶対パスは許可される（回帰テスト）
+# WHEN TWL_CHAIN_TRACE に /tmp 配下の絶対パスを設定する
+# THEN trace_event() はそのパスにファイルを作成する（既存テストとの互換性）
+# ===========================================================================
+
+@test "trace-tmp[regression]: /tmp 配下の絶対パスは trace ファイルが作成される" {
+  local trace_path="/tmp/twl-test-trace-1015-allowed-$$"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: /tmp 配下の絶対パスに trace ファイルが作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5: AUTOPILOT_DIR 配下の絶対パスは許可される（回帰テスト）
+# WHEN AUTOPILOT_DIR が設定されており、TWL_CHAIN_TRACE がその配下の絶対パスを指す
+# THEN trace_event() はそのパスにファイルを作成する（autopilot-launch.sh との互換性）
+# ===========================================================================
+
+@test "trace-autopilot-dir[regression]: AUTOPILOT_DIR 配下の絶対パスは trace ファイルが作成される" {
+  # AUTOPILOT_DIR は common_setup が $SANDBOX/.autopilot に設定済み
+  local trace_dir="${AUTOPILOT_DIR}/trace/test-session"
+  local trace_path="${trace_dir}/issue-1015.jsonl"
+  mkdir -p "$trace_dir"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: AUTOPILOT_DIR 配下の絶対パスに trace ファイルが作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2: 相対パスは引き続き許可される（回帰テスト）
+# WHEN TWL_CHAIN_TRACE に相対パスを設定して chain-runner を実行する
+# THEN trace_event() はそのパスにファイルを作成する（既存動作を維持）
+# ===========================================================================
+
+@test "trace-relpath[regression]: 相対パスの場合、trace ファイルが作成される" {
+  local trace_rel="twl-trace-output-$$.jsonl"
+  local expected_file="$SANDBOX/$trace_rel"
+
+  run bash -c "cd '$SANDBOX' && bash '$CR' --trace '$trace_rel' resolve-issue-num"
+
+  assert_success
+  [[ -f "$expected_file" ]] || {
+    echo "FAIL: 相対パスに trace ファイルが作成されなかった: $expected_file" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: *..*（パストラバーサル）は引き続きブロックされる（回帰テスト）
+# WHEN TWL_CHAIN_TRACE に *..*（../ を含むパス）を設定する
+# THEN trace_event() はファイルを作成しない（既存の case *..*) 節）
+# ===========================================================================
+
+@test "trace-traversal[regression]: パストラバーサル（*..*）は引き続きブロックされる" {
+  local traversal_path="test/../../../twl-evil-trace-1015-test"
+
+  run bash "$CR" --trace "$traversal_path" resolve-issue-num
+
+  assert_success
+  [[ ! -f "$traversal_path" ]] || {
+    echo "FAIL: パストラバーサルパスに trace ファイルが作成された: $traversal_path" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1015 で報告された `TWL_CHAIN_TRACE` パストラバーサル脆弱性の修正。

`trace_event()` の絶対パス検証を追加し、許可リスト外のパス（例: `/etc/cron.d/evil`）への書き込みをブロックする。

## 変更内容

### `scripts/chain-runner.sh`

`trace_event()` に絶対パスホワイトリスト検証を追加:
- `/tmp/*` および `${TMPDIR}/*`: 許可（既存テスト・workflow-scenario との互換性維持）
- `${AUTOPILOT_DIR}/*`: 許可（`autopilot-launch.sh` 経由の trace path との互換性）
- その他の絶対パス: サイレント拒否 (`return 0`)

### `tests/unit/chain-runner-trace-abspath/`

TDD RED→GREEN テスト（7件）を追加:
- **RED→GREEN (3件)**: `$HOME` 配下へのホワイトリスト外絶対パス書き込みが拒否されること
- **回帰 (4件)**: `/tmp`・`AUTOPILOT_DIR`・相対パス・`*..*` の各動作が維持されること

## テスト結果

```
1..7
ok 1 trace-abspath[security][RED]: ホワイトリスト外絶対パス（HOME）は trace ファイルが作成されない
ok 2 trace-abspath[security][RED]: HOME 配下サブディレクトリの場合も trace ファイルが作成されない
ok 3 trace-abspath[env-var][RED]: TWL_CHAIN_TRACE 環境変数でホワイトリスト外絶対パスを渡した場合も拒否される
ok 4 trace-tmp[regression]: /tmp 配下の絶対パスは trace ファイルが作成される
ok 5 trace-autopilot-dir[regression]: AUTOPILOT_DIR 配下の絶対パスは trace ファイルが作成される
ok 6 trace-relpath[regression]: 相対パスの場合、trace ファイルが作成される
ok 7 trace-traversal[regression]: パストラバーサル（*..*）は引き続きブロックされる
```

Closes #1015