### PR TITLE
refactor(autopilot-launch): extract _check_label_fallback helper (#1004)

### DIFF
--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -204,6 +204,24 @@ fi
 
 # --- Status pre-check (AC5/6/7: fail-closed, cross-repo fallback, observability) ---
 _STATUS_GATE_LOG="${STATUS_GATE_LOG:-/tmp/refined-status-gate.log}"
+_check_label_fallback() {
+  local issue_num="$1"
+  local deny_log_token="$2"
+  local deny_msg="$3"
+  # Option 1: 事前 capture → 文字列検索（pipefail 下の SIGPIPE false-negative を回避 #960）
+  local labels has_label=0
+  labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null || true)
+  if printf '%s\n' "$labels" | grep -Fxq 'refined'; then
+    has_label=1
+  fi
+  if [[ "$has_label" -eq 1 ]]; then
+    echo "[$(date -Iseconds)] ALLOW_LABEL_FALLBACK issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
+    return 0
+  fi
+  echo "[$(date -Iseconds)] ${deny_log_token} issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
+  echo "$deny_msg" >&2
+  return 1
+}
 _check_refined_status() {
   local issue_num="$1"
   local bypass="${2:-0}"
@@ -231,38 +249,17 @@ _check_refined_status() {
   done
   if [[ -z "$status" && -z "$board_items" ]]; then
     # Board 取得失敗 → cross-repo fallback: refined label を確認
-    # Option 1: 事前 capture → 文字列検索（pipefail 下の SIGPIPE false-negative を回避 #960）
-    local labels has_label=0
-    labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null || true)
-    if printf '%s\n' "$labels" | grep -Fxq 'refined'; then
-      has_label=1
-    fi
-    if [[ "$has_label" -eq 1 ]]; then
-      echo "[$(date -Iseconds)] ALLOW_LABEL_FALLBACK issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
-      return 0
-    fi
-    echo "[$(date -Iseconds)] DENY_API_FAILURE issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
-    echo "Error: GitHub API 障害により Status を取得できませんでした (3 回リトライ後)。" >&2
-    echo "  対処: gh auth refresh -s project を実行してから再試行してください。" >&2
-    return 1
+    _check_label_fallback "$issue_num" "DENY_API_FAILURE" \
+      "Error: GitHub API 障害により Status を取得できませんでした (3 回リトライ後)。
+  対処: gh auth refresh -s project を実行してから再試行してください。"
+    return $?
   fi
   if [[ -z "$status" ]]; then
     # Issue が Board 未登録 → cross-repo fallback: refined label を確認
-    # Option 1: 事前 capture → 文字列検索（pipefail 下の SIGPIPE false-negative を回避 #960）
-    # 同一関数スコープで明示的に 0 で初期化（前ブロックの値を引き継がないよう保証）
-    local labels has_label=0
-    labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null || true)
-    if printf '%s\n' "$labels" | grep -Fxq 'refined'; then
-      has_label=1
-    fi
-    if [[ "$has_label" -eq 1 ]]; then
-      echo "[$(date -Iseconds)] ALLOW_LABEL_FALLBACK issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
-      return 0
-    fi
-    echo "[$(date -Iseconds)] DENY_NOT_ON_BOARD issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
-    echo "Error: Issue #${issue_num} は Project Board に登録されていません。" >&2
-    echo "  対処: Board に Issue を add してから再試行してください。" >&2
-    return 1
+    _check_label_fallback "$issue_num" "DENY_NOT_ON_BOARD" \
+      "Error: Issue #${issue_num} は Project Board に登録されていません。
+  対処: Board に Issue を add してから再試行してください。"
+    return $?
   fi
   case "$status" in
     "Refined"|"In Progress"|"Done")

--- a/plugins/twl/tests/bats/autopilot-launch-status-gate.bats
+++ b/plugins/twl/tests/bats/autopilot-launch-status-gate.bats
@@ -32,13 +32,17 @@ _run_status_gate() {
   local bypass="${2:-0}"
 
   # 関数定義を動的抽出（行番号ハードコード回避）
-  local func_def
+  # _check_label_fallback も抽出する（#1004: _check_refined_status から呼び出されるため）
+  local fallback_def func_def
+  fallback_def=$(sed -n '/^_check_label_fallback()/,/^}/p' "$SCRIPT")
   func_def=$(sed -n '/^_check_refined_status()/,/^}/p' "$SCRIPT")
 
   run bash -c "
 set -euo pipefail
 export PATH='${STUB_BIN}:/usr/bin:/bin'
 export _STATUS_GATE_LOG='${SANDBOX}/gate.log'
+
+${fallback_def}
 
 ${func_def}
 

--- a/plugins/twl/tests/bats/scripts/autopilot-launch-label-fallback-dry.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-launch-label-fallback-dry.bats
@@ -1,0 +1,176 @@
+#!/usr/bin/env bats
+# autopilot-launch-label-fallback-dry.bats
+#
+# Issue #1004: _check_refined_status の label fallback ブロック DRY 化
+# Board 取得失敗 path と Board 未登録 path の label fallback ロジックが
+# _check_label_fallback ヘルパーに集約されていることを検証する。
+#
+# AC1: _check_label_fallback 関数が autopilot-launch.sh に定義されていること
+# AC2: label fallback のインライン重複ロジックが解消されていること（2 → ≤ 1 箇所）
+# AC3: _check_label_fallback が DENY_API_FAILURE トークンで正しく動作すること
+# AC4: _check_label_fallback が DENY_NOT_ON_BOARD トークンで正しく動作すること
+#
+# RED: 全テストは _check_label_fallback 未抽出状態で fail する
+
+load '../helpers/common'
+
+SCRIPT=""
+
+# _run_label_fallback <issue_num> <deny_log_token> <deny_msg>
+# autopilot-launch.sh から _check_label_fallback を動的抽出して呼び出す
+_run_label_fallback() {
+  local issue_num="$1"
+  local deny_log_token="$2"
+  local deny_msg="$3"
+
+  local func_def
+  func_def=$(sed -n '/^_check_label_fallback()/,/^}/p' "$SCRIPT")
+
+  run bash -c "
+set -euo pipefail
+export PATH='${STUB_BIN}:/usr/bin:/bin'
+export _STATUS_GATE_LOG='${SANDBOX}/gate.log'
+
+${func_def}
+
+_check_label_fallback '${issue_num}' '${deny_log_token}' '${deny_msg}'
+"
+}
+
+setup() {
+  common_setup
+  SCRIPT="${REPO_ROOT}/scripts/autopilot-launch.sh"
+  : > "$SANDBOX/gate.log"
+  stub_command "git" 'echo "stub-git"'
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: _check_label_fallback 関数が autopilot-launch.sh に定義されていること
+# RED: 現在の実装には _check_label_fallback が存在しないため grep が失敗する
+# ===========================================================================
+
+@test "ac1: _check_label_fallback 関数が autopilot-launch.sh に定義されている" {
+  # RED: 関数定義がまだ存在しない
+  run grep -n '^_check_label_fallback()' "$SCRIPT"
+  assert_success
+}
+
+# ===========================================================================
+# AC2: label fallback インラインロジックの重複が解消されていること
+# RED: 現在は Board 取得失敗 path と Board 未登録 path の両方に
+#      labels=$(gh issue view ...) が存在する（count=2）
+# PASS 条件（実装後）: count が ≤ 1（helper 内に集約）
+# ===========================================================================
+
+@test "ac2: label fallback インライン取得ロジックが重複していない（2 箇所 → ≤ 1 箇所）" {
+  local inline_count
+  inline_count=$(grep -c 'labels=\$(gh issue view.*--json labels' "$SCRIPT" 2>/dev/null || echo "0")
+  # RED: 現在は 2 箇所存在するためこのチェックが fail する
+  [ "$inline_count" -le 1 ] || {
+    echo "FAIL: label fallback インライン重複が ${inline_count} 箇所あります（期待: ≤ 1）"
+    grep -n 'labels=\$(gh issue view.*--json labels' "$SCRIPT"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: _check_label_fallback が DENY_API_FAILURE トークンで正しく動作すること
+# ===========================================================================
+
+@test "ac3: _check_label_fallback — refined label なし → DENY_API_FAILURE をログに記録して return 1" {
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"issue view"*"--json labels"*)
+    echo ""
+    exit 0 ;;
+  *)
+    exit 1 ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  _run_label_fallback "1004" "DENY_API_FAILURE" "Error: API 障害"
+
+  # RED: 関数未定義のため exit 127、[ "$status" -eq 1 ] で fail する
+  # PASS 条件（実装後）: exit 1 で DENY
+  assert_failure
+  [ "$status" -eq 1 ]
+  run grep -F "DENY_API_FAILURE issue=#1004" "$SANDBOX/gate.log"
+  assert_success
+}
+
+@test "ac3: _check_label_fallback — refined label あり → ALLOW_LABEL_FALLBACK をログに記録して return 0" {
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"issue view"*"--json labels"*)
+    printf 'bug\nrefined\n'
+    exit 0 ;;
+  *)
+    exit 1 ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  _run_label_fallback "1004" "DENY_API_FAILURE" "Error: API 障害"
+
+  # RED: 関数未定義のため exit 127、assert_success が fail する
+  # PASS 条件（実装後）: exit 0 で ALLOW
+  assert_success
+  run grep -F "ALLOW_LABEL_FALLBACK issue=#1004" "$SANDBOX/gate.log"
+  assert_success
+}
+
+# ===========================================================================
+# AC4: _check_label_fallback が DENY_NOT_ON_BOARD トークンで正しく動作すること
+# ===========================================================================
+
+@test "ac4: _check_label_fallback — refined label なし → DENY_NOT_ON_BOARD をログに記録して return 1" {
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"issue view"*"--json labels"*)
+    echo ""
+    exit 0 ;;
+  *)
+    exit 1 ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  _run_label_fallback "1004" "DENY_NOT_ON_BOARD" "Error: Board 未登録"
+
+  # RED: 関数未定義のため exit 127、[ "$status" -eq 1 ] で fail する
+  # PASS 条件（実装後）: exit 1 で DENY
+  assert_failure
+  [ "$status" -eq 1 ]
+  run grep -F "DENY_NOT_ON_BOARD issue=#1004" "$SANDBOX/gate.log"
+  assert_success
+}
+
+@test "ac4: _check_label_fallback — refined label あり → ALLOW_LABEL_FALLBACK をログに記録して return 0" {
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"issue view"*"--json labels"*)
+    printf 'bug\nrefined\n'
+    exit 0 ;;
+  *)
+    exit 1 ;;
+esac
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  _run_label_fallback "1004" "DENY_NOT_ON_BOARD" "Error: Board 未登録"
+
+  # RED: 関数未定義のため exit 127、assert_success が fail する
+  # PASS 条件（実装後）: exit 0 で ALLOW
+  assert_success
+  run grep -F "ALLOW_LABEL_FALLBACK issue=#1004" "$SANDBOX/gate.log"
+  assert_success
+}


### PR DESCRIPTION
## 変更概要

Fixes #1004

`_check_refined_status` の Board 取得失敗 path（L232-248）と Board 未登録 path（L249-265）で
完全重複していた label fallback ロジックを `_check_label_fallback` ヘルパー関数として抽出。

## 変更点

- `autopilot-launch.sh`: `_check_label_fallback <issue_num> <deny_log_token> <deny_msg>` を追加
  - 両 path のインライン重複ロジックを関数呼び出しに置換
  - 差分（ログトークン・エラーメッセージ）は引数で渡す

## テスト

- 新規: `autopilot-launch-label-fallback-dry.bats`（6件）
  - AC1: 関数定義の存在確認
  - AC2: インライン重複解消確認
  - AC3/AC4: DENY_API_FAILURE / DENY_NOT_ON_BOARD トークン動作確認
- 既存: `autopilot-launch-status-gate.bats` の `_run_status_gate` ヘルパーに
  `_check_label_fallback` 抽出を追加（リグレッション対応）