### PR TITLE
fix(#1041): chain-runner.sh trace_event symlink TOCTOU 対策

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -118,15 +118,26 @@ trace_event() {
   esac
   # 絶対パス検証（issue-1015）: /tmp・TMPDIR・AUTOPILOT_DIR 配下のみ許可
   if [[ "$trace_file" = /* ]]; then
+    # symlink TOCTOU 対策（issue-1041）: realpath で symlink を解決してから検証
+    # 解決失敗時（realpath 利用不可など）は安全側に倒して書き込み拒否
+    local resolved_trace
+    resolved_trace=$(realpath --canonicalize-missing "$trace_file" 2>/dev/null) || return 0
+    trace_file="$resolved_trace"
     local _ok=0
     [[ "$trace_file" == /tmp/* ]] && _ok=1
     if [[ "$_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
-      [[ "$trace_file" == "${TMPDIR%/}/"* ]] && _ok=1
+      # TMPDIR 自体が symlink である可能性に備えて resolve（macOS 互換性等）
+      local _tmp_resolved
+      _tmp_resolved=$(realpath --canonicalize-missing "${TMPDIR%/}" 2>/dev/null) || _tmp_resolved="${TMPDIR%/}"
+      [[ "$trace_file" == "${_tmp_resolved}/"* ]] && _ok=1
     fi
     if [[ "$_ok" -eq 0 && -n "${AUTOPILOT_DIR:-}" ]]; then
       local _ap="${AUTOPILOT_DIR%/}"
       [[ "$_ap" != /* ]] && _ap="${PWD}/${_ap}"
-      [[ "$trace_file" == "${_ap}/"* ]] && _ok=1
+      # AUTOPILOT_DIR 自体が symlink を含む可能性に備えて resolve
+      local _ap_resolved
+      _ap_resolved=$(realpath --canonicalize-missing "$_ap" 2>/dev/null) || _ap_resolved="$_ap"
+      [[ "$trace_file" == "${_ap_resolved}/"* ]] && _ok=1
     fi
     [[ "$_ok" -eq 0 ]] && return 0
   fi

--- a/plugins/twl/tests/unit/chain-runner-trace-symlink/chain-runner-trace-symlink.bats
+++ b/plugins/twl/tests/unit/chain-runner-trace-symlink/chain-runner-trace-symlink.bats
@@ -1,0 +1,135 @@
+#!/usr/bin/env bats
+# chain-runner-trace-symlink.bats
+# Requirement: TWL_CHAIN_TRACE symlink TOCTOU 攻撃の拒否（issue-1041）
+# Spec: issue-1041 / depends on issue-1015 修正
+# Coverage: --type=unit --coverage=security
+#
+# 検証する仕様:
+#   1. /tmp 配下の symlink がホワイトリスト外の path を指す場合、書き込みを拒否する
+#   2. AUTOPILOT_DIR 配下の symlink がホワイトリスト外の path を指す場合、書き込みを拒否する
+#   3. /tmp 配下の通常ファイルは引き続き許可される（regression）
+#   4. AUTOPILOT_DIR 配下の通常ファイルは引き続き許可される（regression）
+#
+# NOTE: AC1, AC2 は実装前 RED 状態。
+#       trace_event() に realpath --canonicalize-missing による symlink 解決を追加すれば GREEN になる。
+#
+# 環境変数:
+#   WORKER_ISSUE_NUM=1041 — resolve_issue_num の Priority 0 による issue 番号固定
+
+load '../../bats/helpers/common.bash'
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  export WORKER_ISSUE_NUM=1041
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: /tmp 配下の symlink で外部 path を指す場合、書き込みを拒否する（TOCTOU 対策）
+# WHEN /tmp/legit-trace.jsonl が $HOME/twl-evil-trace を指す symlink である
+# THEN trace_event() は $HOME/twl-evil-trace に書き込まない
+# Spec: issue-1041 symlink TOCTOU 対策
+# ===========================================================================
+
+@test "trace-symlink[security][RED]: /tmp 配下の symlink が HOME 配下の victim を指すと書き込まれない" {
+  local _home="${HOME:-/root}"
+  local victim="${_home}/twl-test-trace-1041-symlink-victim-$$"
+  local symlink_path="/tmp/twl-test-trace-1041-symlink-$$"
+  rm -f "$victim" "$symlink_path" 2>/dev/null || true
+  ln -sf "$victim" "$symlink_path"
+
+  run bash "$CR" --trace "$symlink_path" resolve-issue-num
+
+  local victim_existed=0
+  [[ -f "$victim" ]] && victim_existed=1
+  rm -f "$victim" "$symlink_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$victim_existed" -eq 0 ]] || {
+    echo "FAIL: symlink を通じて HOME 配下の victim ファイルに trace ファイルが書き込まれた（TOCTOU）: $victim" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2: AUTOPILOT_DIR 配下の symlink が外部 path を指す場合、書き込みを拒否する
+# WHEN AUTOPILOT_DIR 配下の symlink が $HOME 配下の victim を指す
+# THEN trace_event() は victim に書き込まない
+# ===========================================================================
+
+@test "trace-symlink[security][RED]: AUTOPILOT_DIR 配下の symlink が HOME 配下の victim を指すと書き込まれない" {
+  local _home="${HOME:-/root}"
+  local victim="${_home}/twl-test-trace-1041-autopilot-symlink-victim-$$"
+  local symlink_dir="${AUTOPILOT_DIR}/trace"
+  local symlink_path="${symlink_dir}/sym-trace-$$.jsonl"
+  mkdir -p "$symlink_dir"
+  rm -f "$victim" "$symlink_path" 2>/dev/null || true
+  ln -sf "$victim" "$symlink_path"
+
+  run bash "$CR" --trace "$symlink_path" resolve-issue-num
+
+  local victim_existed=0
+  [[ -f "$victim" ]] && victim_existed=1
+  rm -f "$victim" "$symlink_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$victim_existed" -eq 0 ]] || {
+    echo "FAIL: AUTOPILOT_DIR 配下の symlink を通じて HOME 配下の victim ファイルに書き込まれた: $victim" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: /tmp 配下の通常ファイル（symlink でない）は引き続き許可される（regression）
+# ===========================================================================
+
+@test "trace-symlink[regression]: /tmp 配下の通常ファイルは引き続き trace ファイルが作成される" {
+  local trace_path="/tmp/twl-test-trace-1041-regular-$$"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: /tmp 配下の通常パスに trace ファイルが作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: AUTOPILOT_DIR 配下の通常ファイル（symlink でない）は引き続き許可される（regression）
+# ===========================================================================
+
+@test "trace-symlink[regression]: AUTOPILOT_DIR 配下の通常ファイルは引き続き trace ファイルが作成される" {
+  local trace_dir="${AUTOPILOT_DIR}/trace"
+  local trace_path="${trace_dir}/regular-trace-$$.jsonl"
+  mkdir -p "$trace_dir"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: AUTOPILOT_DIR 配下の通常パスに trace ファイルが作成されなかった: $trace_path" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1041 修正: `trace_event()` の TWL_CHAIN_TRACE 絶対パスホワイトリスト検証が文字列マッチングのため symlink TOCTOU で迂回できる脆弱性を修正。

## 背景

PR #1040 (#1015) で /tmp・TMPDIR・AUTOPILOT_DIR 配下のみ許可するホワイトリスト方式を実装したが、文字列マッチングのため symlink で偽装可能だった:

```bash
ln -s /etc/cron.d/evil /tmp/legit-trace.jsonl
TWL_CHAIN_TRACE=/tmp/legit-trace.jsonl chain-runner.sh
# → /tmp/legit-trace.jsonl は /tmp/* ホワイトリストを通過し /etc/cron.d/evil に書き込まれる
```

## 修正

`realpath --canonicalize-missing` で `trace_file`・`TMPDIR`・`AUTOPILOT_DIR` を解決してからホワイトリスト検証を実施。realpath 失敗時は安全側に倒して書き込み拒否。

## テスト

- 新規 bats: `chain-runner-trace-symlink.bats` 4 件
  - AC1: /tmp 配下の symlink が HOME 配下を指すと拒否（RED→GREEN）
  - AC2: AUTOPILOT_DIR 配下の symlink が HOME 配下を指すと拒否（RED→GREEN）
  - AC3: /tmp 配下の通常ファイル regression
  - AC4: AUTOPILOT_DIR 配下の通常ファイル regression
- 既存 regression: `chain-runner-trace-abspath.bats` 8 件 pass

合計 12/12 pass。

Closes #1041