### PR TITLE
test(#1016): RESOLVE_FAIL_COUNT 直接アサート test を workflow-pr-fix.bats に追加

### DIFF
--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
@@ -176,3 +176,122 @@ _init_issue_state() {
     --field current_step 2>/dev/null)
   [ "$step" = "warning-fix" ]
 }
+
+# ─── Issue #1016: AC3 RESOLVE_FAILED カウンター直接アサート ────────────────────
+# 既存 ac3 test は resolve_next_workflow exit 0 を proxy 検証していたが、
+# RESOLVE_FAIL_COUNT 変数自体への増加・リセット動作を直接 assert するケースを追加する。
+
+@test "ac3-direct: inject_next_workflow が resolve_next_workflow 失敗時に RESOLVE_FAIL_COUNT を increment する" {
+  # current_step=post-fix-verify (terminal step ではない) で resolve_next_workflow が失敗
+  # → inject_next_workflow が RESOLVE_FAIL_COUNT[$entry] を increment する経路を直接検証
+  local issue_num=9201
+  local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
+  git checkout -q -b "feat/${issue_num}-stub-fail-count-incr" 2>/dev/null || true
+  export AUTOPILOT_DIR="$autopilot_dir"
+  _init_issue_state "$issue_num" "$autopilot_dir"  # current_step=post-fix-verify
+
+  # cleanup_worker stub: inject-next-workflow.sh 先頭コメント「呼び出し元で定義」要件
+  cleanup_worker() { :; }
+
+  # inject_next_workflow を bats プロセスに source
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/scripts/lib/inject-next-workflow.sh"
+
+  # stagnate 検知を抑制（巨大閾値でカウンターのみ増やす）
+  export AUTOPILOT_STAGNATE_SEC=999999
+  # 連想配列を初期化（global scope, lib 側 declare -gA と同名）
+  RESOLVE_FAIL_COUNT=()
+  RESOLVE_FAIL_FIRST_TS=()
+  INJECT_TIMEOUT_COUNT=()
+  NUDGE_COUNTS=()
+
+  local entry="_default:${issue_num}"
+
+  # 1 回目: resolve_next_workflow 失敗 → RESOLVE_FAIL_COUNT[$entry] = 1
+  inject_next_workflow "$issue_num" "fake-window:0" || true
+
+  [ "${RESOLVE_FAIL_COUNT[$entry]:-0}" -eq 1 ] || {
+    echo "FAIL: 1 回目 inject_next_workflow 後 RESOLVE_FAIL_COUNT[$entry] = ${RESOLVE_FAIL_COUNT[$entry]:-0} (expected 1)" >&2
+    return 1
+  }
+
+  # 2 回目: 同じく失敗 → カウント 2
+  inject_next_workflow "$issue_num" "fake-window:0" || true
+
+  [ "${RESOLVE_FAIL_COUNT[$entry]:-0}" -eq 2 ] || {
+    echo "FAIL: 2 回目 inject_next_workflow 後 RESOLVE_FAIL_COUNT[$entry] = ${RESOLVE_FAIL_COUNT[$entry]:-0} (expected 2)" >&2
+    return 1
+  }
+
+  # 3 回目: カウント 3
+  inject_next_workflow "$issue_num" "fake-window:0" || true
+
+  [ "${RESOLVE_FAIL_COUNT[$entry]:-0}" -eq 3 ] || {
+    echo "FAIL: 3 回目 inject_next_workflow 後 RESOLVE_FAIL_COUNT[$entry] = ${RESOLVE_FAIL_COUNT[$entry]:-0} (expected 3)" >&2
+    return 1
+  }
+}
+
+@test "ac3-direct: inject_next_workflow が resolve_next_workflow 成功時に RESOLVE_FAIL_COUNT を 0 にリセットする" {
+  # current_step=warning-fix (terminal step) で resolve_next_workflow 成功
+  # → inject_next_workflow が RESOLVE_FAIL_COUNT[$entry] = 0 にリセットする経路を直接検証
+  local issue_num=9202
+  local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
+  git checkout -q -b "feat/${issue_num}-stub-fail-count-reset" 2>/dev/null || true
+  export AUTOPILOT_DIR="$autopilot_dir"
+
+  # current_step=warning-fix で初期化（resolve_next_workflow が /twl:workflow-pr-merge を返す）
+  mkdir -p "$autopilot_dir/issues"
+  python3 -m twl.autopilot.state write \
+    --autopilot-dir "$autopilot_dir" --type issue --issue "$issue_num" \
+    --role worker --init --set "status=running" 2>/dev/null
+  python3 -m twl.autopilot.state write \
+    --autopilot-dir "$autopilot_dir" --type issue --issue "$issue_num" \
+    --role worker --set "current_step=warning-fix" 2>/dev/null
+
+  cleanup_worker() { :; }
+
+  # shellcheck source=/dev/null
+  source "$PLUGIN_ROOT/scripts/lib/inject-next-workflow.sh"
+
+  export AUTOPILOT_STAGNATE_SEC=999999
+  # USE_SESSION_STATE=false で tmux capture-pane fallback。
+  # tmux モックなしでも prompt 検出失敗→return 1 までに RESOLVE_FAIL_COUNT のリセットは
+  # 実行されている（line 56-58、resolve 成功直後）
+  export USE_SESSION_STATE=false
+
+  RESOLVE_FAIL_COUNT=()
+  RESOLVE_FAIL_FIRST_TS=()
+  INJECT_TIMEOUT_COUNT=()
+  NUDGE_COUNTS=()
+
+  local entry="_default:${issue_num}"
+
+  # 事前にカウントを 5 に設定（リセット前条件）
+  RESOLVE_FAIL_COUNT[$entry]=5
+  RESOLVE_FAIL_FIRST_TS[$entry]=1000
+
+  # tmux send-keys が失敗してもリセット (line 56-58) は既に実行済み
+  # ただし sleep 2/4/8 の合計 14s が走るので bats の timeout 内に終わる必要あり
+  # → tmux モックを stub bin に配置して capture-pane で prompt を返し早期成功させる
+  # （inject_next_workflow が成功 path を辿る）
+  cat > "$WORKFLOW_STUB_BIN/tmux" <<'STUB_EOF'
+#!/usr/bin/env bash
+case "$1" in
+  capture-pane) echo "ready ❯ "; exit 0 ;;
+  send-keys) exit 0 ;;
+  display-message) echo "0 claude"; exit 0 ;;
+  has-session) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB_EOF
+  chmod +x "$WORKFLOW_STUB_BIN/tmux"
+
+  # inject_next_workflow 実行（resolve 成功 → RESOLVE_FAIL_COUNT[$entry]=0 にリセット）
+  inject_next_workflow "$issue_num" "fake-window:0" || true
+
+  [ "${RESOLVE_FAIL_COUNT[$entry]}" -eq 0 ] || {
+    echo "FAIL: resolve 成功後 RESOLVE_FAIL_COUNT[$entry] = ${RESOLVE_FAIL_COUNT[$entry]} (expected 0 — reset)" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1016 修正: 既存の `ac3` test は `resolve_next_workflow exit 0` を proxy として `RESOLVE_FAILED` カウンター非上昇を間接検証していたが、`autopilot-orchestrator.sh` の `RESOLVE_FAIL_COUNT` 変数への直接アサートは存在しなかった。本 PR で直接アサートを追加。

## 追加テスト

`workflow-pr-fix.bats` に 2 件追加:

### ac3-direct (increment)
- current_step=post-fix-verify (terminal step ではない) で `inject_next_workflow` を 3 回連続呼び出し
- `RESOLVE_FAIL_COUNT[$entry]` が 1 → 2 → 3 と直接 assert

### ac3-direct (reset)
- 事前に `RESOLVE_FAIL_COUNT[$entry]=5` を設定
- current_step=warning-fix (terminal step) で resolve 成功
- `RESOLVE_FAIL_COUNT[$entry]` が 0 にリセットされることを直接 assert

## 検証

bats 12/12 pass（既存 10 + 新規 2）。

Closes #1016