### PR TITLE
docs(deps): #1048 follow-up — session-comm-script-dir-validate.bats を deps.yaml に登録

### DIFF
--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -108,3 +108,8 @@ tests:
     type: test
     path: tests/cld-observe-any.bats
     description: "cld-observe-any の bats unit tests（多指標 AND 判定: LLM indicator false positive / MENU-READY / PANE-DEAD / BUDGET-LOW / PHASE-COMPLETE cmd-echo / event-dir スキーマ確認 / PERMISSION-PROMPT 4 ケース）"
+
+  session-comm-script-dir-validate-test:
+    type: test
+    path: tests/session-comm-script-dir-validate.bats
+    description: "session-comm.sh SCRIPT_DIR 上書きリスク対策の検証（#1048: _TEST_MODE+SESSION_COMM_SCRIPT_DIR の二段検証 / session-state.sh 存在確認）"


### PR DESCRIPTION
## 概要

PR #1056 (#1048) で追加した `plugins/session/tests/session-comm-script-dir-validate.bats` が `plugins/session/deps.yaml` の `tests:` セクションに未登録だった。

CLAUDE.md の編集フロー「コンポーネント編集 → deps.yaml 更新 → twl check → twl update-readme」違反の修正。

Wave S Quality Review (post-merge) で worker-prompt-reviewer が confidence 90 で検出 (H3)。

## 修正

`plugins/session/deps.yaml` の `tests:` セクションに `session-comm-script-dir-validate-test` を追加。

## 検証

- `twl --validate`: OK 42 / Violations 0
- `twl --check`: All files exist