### PR TITLE
fix(chain-runner): #1041/#1042 follow-up — realpath macOS 互換 fallback

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -106,29 +106,52 @@ resolve_autopilot_dir() {
 # =====================================================================
 # Trace Event (Phase 3 / Layer 1 経験的監査)
 # =====================================================================
+# _resolve_path: 互換性のあるパス解決ヘルパー（issue-1041/1042 follow-up）
+# GNU realpath は --canonicalize-missing をサポートするが BSD realpath (macOS)
+# は非互換。下記 4 段 fallback で symlink 解決を試みる:
+#   Tier 1: GNU realpath --canonicalize-missing (Linux)
+#   Tier 2: greadlink -f (macOS coreutils via homebrew)
+#   Tier 3: python3 os.path.realpath (POSIX 互換)
+#   Tier 4: 失敗時は return 1（呼び出し元で安全側拒否）
+# stdout に解決済みパスを出力。成功は return 0、失敗は return 1。
+_resolve_path() {
+  local p="$1"
+  local resolved
+  if resolved=$(realpath --canonicalize-missing "$p" 2>/dev/null) && [[ -n "$resolved" ]]; then
+    echo "$resolved"; return 0
+  fi
+  if resolved=$(greadlink -f "$p" 2>/dev/null) && [[ -n "$resolved" ]]; then
+    echo "$resolved"; return 0
+  fi
+  if resolved=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$p" 2>/dev/null) && [[ -n "$resolved" ]]; then
+    echo "$resolved"; return 0
+  fi
+  return 1
+}
+
 # TWL_CHAIN_TRACE 環境変数が設定されている場合、step の start/end を
 # JSON Lines 形式で append する。設定がなければノーオペ（後方互換）。
 trace_event() {
   local step="$1" phase="$2" exit_code="${3:-}"
   [[ -z "${TWL_CHAIN_TRACE:-}" ]] && return 0
   local trace_file="$TWL_CHAIN_TRACE"
-  # パストラバーサル拒否
+  # パストラバーサル拒否（相対パスのみ意味あり、絶対パスは下記 _resolve_path で正規化される）
   case "$trace_file" in
     *..*) return 0 ;;
   esac
   # 絶対パス検証（issue-1015）: /tmp・TMPDIR・AUTOPILOT_DIR 配下のみ許可
   if [[ "$trace_file" = /* ]]; then
-    # symlink TOCTOU 対策（issue-1041）: realpath で symlink を解決してから検証
-    # 解決失敗時（realpath 利用不可など）は安全側に倒して書き込み拒否
+    # symlink TOCTOU 対策（issue-1041, macOS 互換: H1 follow-up）:
+    # _resolve_path で symlink を解決してから検証。解決失敗時は安全側に倒して書き込み拒否
     local resolved_trace
-    resolved_trace=$(realpath --canonicalize-missing "$trace_file" 2>/dev/null) || return 0
+    resolved_trace=$(_resolve_path "$trace_file") || return 0
     trace_file="$resolved_trace"
     local _ok=0
     [[ "$trace_file" == /tmp/* ]] && _ok=1
     if [[ "$_ok" -eq 0 && -n "${TMPDIR:-}" ]]; then
       # TMPDIR 自体が symlink である可能性に備えて resolve（macOS 互換性等）
       local _tmp_resolved
-      _tmp_resolved=$(realpath --canonicalize-missing "${TMPDIR%/}" 2>/dev/null) || _tmp_resolved="${TMPDIR%/}"
+      _tmp_resolved=$(_resolve_path "${TMPDIR%/}") || _tmp_resolved="${TMPDIR%/}"
       [[ "$trace_file" == "${_tmp_resolved}/"* ]] && _ok=1
     fi
     if [[ "$_ok" -eq 0 && -n "${AUTOPILOT_DIR:-}" ]]; then
@@ -136,7 +159,7 @@ trace_event() {
       [[ "$_ap" != /* ]] && _ap="${PWD}/${_ap}"
       # AUTOPILOT_DIR 自体が symlink を含む可能性に備えて resolve
       local _ap_resolved
-      _ap_resolved=$(realpath --canonicalize-missing "$_ap" 2>/dev/null) || _ap_resolved="$_ap"
+      _ap_resolved=$(_resolve_path "$_ap") || _ap_resolved="$_ap"
       # AUTOPILOT_DIR 信頼性検証（issue-1042）: 攻撃者が AUTOPILOT_DIR=/etc 等を設定して
       # ホワイトリストを拡張する攻撃を防ぐため、信頼できる親ディレクトリ
       # (/tmp・TMPDIR・$HOME) 配下の場合のみ AUTOPILOT_DIR ホワイトリストを適用する
@@ -144,12 +167,12 @@ trace_event() {
       [[ "$_ap_resolved" == /tmp/* ]] && _autopilot_trusted=1
       if [[ "$_autopilot_trusted" -eq 0 && -n "${TMPDIR:-}" ]]; then
         local _tmp_trust_resolved
-        _tmp_trust_resolved=$(realpath --canonicalize-missing "${TMPDIR%/}" 2>/dev/null) || _tmp_trust_resolved="${TMPDIR%/}"
+        _tmp_trust_resolved=$(_resolve_path "${TMPDIR%/}") || _tmp_trust_resolved="${TMPDIR%/}"
         [[ "$_ap_resolved" == "${_tmp_trust_resolved}/"* ]] && _autopilot_trusted=1
       fi
       if [[ "$_autopilot_trusted" -eq 0 && -n "${HOME:-}" ]]; then
         local _home_trust_resolved
-        _home_trust_resolved=$(realpath --canonicalize-missing "${HOME%/}" 2>/dev/null) || _home_trust_resolved="${HOME%/}"
+        _home_trust_resolved=$(_resolve_path "${HOME%/}") || _home_trust_resolved="${HOME%/}"
         [[ "$_ap_resolved" == "${_home_trust_resolved}/"* ]] && _autopilot_trusted=1
       fi
       if [[ "$_autopilot_trusted" -eq 1 ]]; then

--- a/plugins/twl/tests/unit/chain-runner-resolve-path/chain-runner-resolve-path.bats
+++ b/plugins/twl/tests/unit/chain-runner-resolve-path/chain-runner-resolve-path.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# chain-runner-resolve-path.bats
+# Requirement: chain-runner.sh の _resolve_path() ヘルパーが GNU/BSD/macOS で互換動作する
+# Spec: Wave S Quality Review H1 follow-up (#1041/#1042)
+# Coverage: --type=unit --coverage=portability
+#
+# 検証する仕様:
+#   1. _resolve_path() ヘルパーが定義されている (structural)
+#   2. GNU realpath / greadlink / python3 の 3 段 fallback が実装されている (structural)
+#   3. trace_event() が _resolve_path を使用している (structural)
+#   4. GNU realpath が利用不可でも python3 fallback で /tmp 配下の trace が作成される (functional)
+
+load '../../bats/helpers/common.bash'
+
+setup() {
+  common_setup
+
+  export WORKER_ISSUE_NUM=1041
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1 (structural): _resolve_path() ヘルパー関数が定義されている
+# ===========================================================================
+
+@test "resolve-path[structural]: chain-runner.sh に _resolve_path() ヘルパー関数が定義されている" {
+  grep -F '_resolve_path()' "$CR" || {
+    echo "FAIL: _resolve_path() 関数定義が chain-runner.sh に含まれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2 (structural): _resolve_path() に GNU realpath / greadlink / python3 の 3 段 fallback が含まれる
+# ===========================================================================
+
+@test "resolve-path[structural]: _resolve_path() に GNU realpath fallback (Tier 1) が含まれる" {
+  awk '/^_resolve_path\(\) \{/,/^\}$/' "$CR" | grep -F 'realpath --canonicalize-missing' || {
+    echo "FAIL: _resolve_path() に GNU realpath --canonicalize-missing が含まれていない" >&2
+    return 1
+  }
+}
+
+@test "resolve-path[structural]: _resolve_path() に greadlink fallback (Tier 2, macOS coreutils) が含まれる" {
+  awk '/^_resolve_path\(\) \{/,/^\}$/' "$CR" | grep -F 'greadlink -f' || {
+    echo "FAIL: _resolve_path() に greadlink -f が含まれていない" >&2
+    return 1
+  }
+}
+
+@test "resolve-path[structural]: _resolve_path() に python3 os.path.realpath fallback (Tier 3, POSIX) が含まれる" {
+  awk '/^_resolve_path\(\) \{/,/^\}$/' "$CR" | grep -F 'os.path.realpath' || {
+    echo "FAIL: _resolve_path() に python3 os.path.realpath fallback が含まれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3 (structural): trace_event() が _resolve_path を使用している
+# ===========================================================================
+
+@test "resolve-path[structural]: trace_event() が _resolve_path を使用している" {
+  awk '/^trace_event\(\) \{/,/^\}$/' "$CR" | grep -F '_resolve_path' || {
+    echo "FAIL: trace_event() が _resolve_path を使用していない（直接 realpath 呼び出しが残っている可能性）" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4 (functional): GNU realpath / greadlink が利用不可でも python3 fallback で動作する
+# Linux 上で macOS 環境を simulate するため、stub bin で realpath/greadlink を exit 1 にする
+# ===========================================================================
+
+@test "resolve-path[functional]: realpath/greadlink 不在でも python3 fallback で /tmp 配下の trace が作成される" {
+  # stub bin で realpath と greadlink を強制 fail
+  cat > "$STUB_BIN/realpath" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  cat > "$STUB_BIN/greadlink" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$STUB_BIN/realpath" "$STUB_BIN/greadlink"
+
+  local trace_path="/tmp/twl-test-h1-pyfallback-$$"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: realpath/greadlink fail 状態で python3 fallback が動作せず trace が作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5 (functional): すべての fallback が利用不可なら書き込み拒否（安全側）
+# ===========================================================================
+
+@test "resolve-path[functional]: realpath/greadlink/python3 すべて利用不可なら書き込みを拒否する" {
+  # stub で全部 fail
+  cat > "$STUB_BIN/realpath" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  cat > "$STUB_BIN/greadlink" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  cat > "$STUB_BIN/python3" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$STUB_BIN/realpath" "$STUB_BIN/greadlink" "$STUB_BIN/python3"
+
+  local trace_path="/tmp/twl-test-h1-allfail-$$"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  # python3 が fail すると chain-runner.sh の他処理が壊れる可能性（resolve-issue-num など）
+  # → 単に呼び出して trace_path に書き込まれないことを確認、exit code は問わない
+  bash "$CR" --trace "$trace_path" resolve-issue-num 2>/dev/null || true
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -f "$trace_path" 2>/dev/null || true
+
+  [[ "$file_created" -eq 0 ]] || {
+    echo "FAIL: 全 fallback fail 状態で trace が作成された（安全側拒否されていない）: $trace_path" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Wave S Quality Review (post-merge) で feature-dev:code-reviewer が confidence 85 で検出した H1 を修正。

## 背景

PR #1054 (#1041) / #1055 (#1042) で導入した `realpath --canonicalize-missing` は GNU 拡張。BSD realpath (macOS) 非互換のため、macOS では空文字列を返し `|| return 0` でサイレントに書き込みスキップされる。mac 開発者は test 不能になる。

## 修正

`_resolve_path()` ヘルパー関数を導入し、3 段 fallback で互換性確保:
- **Tier 1**: GNU `realpath --canonicalize-missing` (Linux)
- **Tier 2**: `greadlink -f` (macOS coreutils via homebrew)
- **Tier 3**: `python3 os.path.realpath` (POSIX 互換)
- **Tier 4**: 全失敗時 `return 1` → `trace_event` 側で安全側に倒して書き込み拒否

`trace_event()` 内の 4 箇所の realpath 呼び出しを `_resolve_path` に統一（MED M1 DRY 化を副産物として実現）。

## テスト

新規 bats `chain-runner-resolve-path.bats` 7 件:
- structural: `_resolve_path()` 関数定義 / 3 段 fallback 含有 / `trace_event` 利用
- functional: realpath/greadlink fail でも python3 fallback で動作
- functional: 全 fallback fail で安全側拒否

既存 regression: trace-symlink (4) + trace-abspath (8) + autopilot-dir-validate (4) = 16/16 pass。

合計 23/23 pass。

Wave S follow-up to #1041, #1042