### PR TITLE
fix(chain-runner): #1042 follow-up — AUTOPILOT_DIR 構造的バリデーション追加

### DIFF
--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -175,6 +175,18 @@ trace_event() {
         _home_trust_resolved=$(_resolve_path "${HOME%/}") || _home_trust_resolved="${HOME%/}"
         [[ "$_ap_resolved" == "${_home_trust_resolved}/"* ]] && _autopilot_trusted=1
       fi
+      # H2 (#1042 follow-up): AUTOPILOT_DIR 構造検証
+      # 攻撃者が AUTOPILOT_DIR=$HOME/twl-evil 等を設定して書き込み許可を拡張する攻撃を
+      # 防ぐため、basename が ".autopilot" のディレクトリのみ信頼する。
+      # resolve_autopilot_dir() の挙動（env var 優先、未設定時は ${main_wt}/.autopilot）と
+      # 整合する正規パターンに限定する。
+      if [[ "$_autopilot_trusted" -eq 1 ]]; then
+        local _ap_basename
+        _ap_basename=$(basename "$_ap_resolved")
+        if [[ "$_ap_basename" != ".autopilot" ]]; then
+          _autopilot_trusted=0
+        fi
+      fi
       if [[ "$_autopilot_trusted" -eq 1 ]]; then
         [[ "$trace_file" == "${_ap_resolved}/"* ]] && _ok=1
       fi

--- a/plugins/twl/tests/unit/chain-runner-autopilot-dir-structural/chain-runner-autopilot-dir-structural.bats
+++ b/plugins/twl/tests/unit/chain-runner-autopilot-dir-structural/chain-runner-autopilot-dir-structural.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# chain-runner-autopilot-dir-structural.bats
+# Requirement: AUTOPILOT_DIR の basename 検証で $HOME/twl-evil 攻撃を防ぐ（issue-1042 H2 follow-up）
+# Spec: Wave S Quality Review H2 — basename != ".autopilot" のディレクトリは信頼しない
+# Coverage: --type=unit --coverage=security
+#
+# 検証する仕様:
+#   1. AUTOPILOT_DIR=$HOME/twl-evil（basename != .autopilot）で書き込み拒否
+#   2. AUTOPILOT_DIR=$HOME/foo/bar/something（深い path、basename != .autopilot）で書き込み拒否
+#   3. AUTOPILOT_DIR=/tmp/twl-evil（basename != .autopilot）で書き込み拒否
+#   4. AUTOPILOT_DIR=$HOME/<sub>/.autopilot（basename = .autopilot）で書き込み許可（regression）
+#   5. AUTOPILOT_DIR=/tmp/<sub>/.autopilot（basename = .autopilot）で書き込み許可（regression）
+
+load '../../bats/helpers/common.bash'
+
+setup() {
+  common_setup
+
+  export WORKER_ISSUE_NUM=1042
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1 (security): AUTOPILOT_DIR=$HOME/twl-evil で書き込み拒否（H2 主目的）
+# 攻撃者が AUTOPILOT_DIR=$HOME/twl-evil を設定して書き込み許可ディレクトリを
+# 拡張しようとするのを basename != ".autopilot" で防ぐ
+# ===========================================================================
+
+@test "autopilot-dir-structural[security][RED]: AUTOPILOT_DIR=\$HOME/twl-evil（basename != .autopilot）で書き込み拒否" {
+  local _home="${HOME:-/root}"
+  local evil_autopilot="${_home}/twl-evil-h2-$$"
+  local evil_trace="${evil_autopilot}/trace.jsonl"
+  mkdir -p "$evil_autopilot"
+  rm -f "$evil_trace" 2>/dev/null || true
+
+  run env AUTOPILOT_DIR="$evil_autopilot" bash "$CR" --trace "$evil_trace" resolve-issue-num
+
+  local file_existed=0
+  [[ -f "$evil_trace" ]] && file_existed=1
+  rm -rf "$evil_autopilot" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_existed" -eq 0 ]] || {
+    echo "FAIL: AUTOPILOT_DIR=\$HOME/twl-evil（basename != .autopilot）でホワイトリスト経由で書き込めた: $evil_trace" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2 (security): AUTOPILOT_DIR=$HOME/foo/bar/something（深い path で basename != .autopilot）も拒否
+# ===========================================================================
+
+@test "autopilot-dir-structural[security][RED]: AUTOPILOT_DIR=\$HOME/foo/bar/baz（深い path、basename != .autopilot）で書き込み拒否" {
+  local _home="${HOME:-/root}"
+  local evil_autopilot="${_home}/twl-evil-deep-$$/foo/bar/baz"
+  local evil_trace="${evil_autopilot}/trace.jsonl"
+  mkdir -p "$evil_autopilot"
+  rm -f "$evil_trace" 2>/dev/null || true
+
+  run env AUTOPILOT_DIR="$evil_autopilot" bash "$CR" --trace "$evil_trace" resolve-issue-num
+
+  local file_existed=0
+  [[ -f "$evil_trace" ]] && file_existed=1
+  rm -rf "${_home}/twl-evil-deep-$$" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_existed" -eq 0 ]] || {
+    echo "FAIL: 深い path で basename != .autopilot でも書き込めた: $evil_trace" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3 (security): AUTOPILOT_DIR=/tmp/twl-evil（basename != .autopilot）で書き込み拒否
+# /tmp 配下でも basename 検証は適用される
+# ===========================================================================
+
+@test "autopilot-dir-structural[security][RED]: AUTOPILOT_DIR=/tmp/twl-evil（basename != .autopilot）で書き込み拒否" {
+  local evil_autopilot="/tmp/twl-evil-h2-tmp-$$"
+  local evil_trace="${evil_autopilot}/trace.jsonl"
+  mkdir -p "$evil_autopilot"
+  rm -f "$evil_trace" 2>/dev/null || true
+
+  run env AUTOPILOT_DIR="$evil_autopilot" bash "$CR" --trace "$evil_trace" resolve-issue-num
+
+  local file_existed=0
+  # /tmp 配下なので絶対パス検証 (issue-1015) で trace_file が /tmp/* なら _ok=1 になる。
+  # しかし AUTOPILOT_DIR ホワイトリストは別経路で適用されるため、/tmp 配下の trace は
+  # AUTOPILOT_DIR 経路ではなく /tmp ホワイトリスト経路で許可される。
+  # 本テストは「AUTOPILOT_DIR ホワイトリストが basename 検証で無効化される」ことを確認するため、
+  # AUTOPILOT_DIR が /tmp 配下のサブパス（/tmp 直下ではない）で trace_file もそのサブパス配下にする
+  [[ -f "$evil_trace" ]] && file_existed=1
+  rm -rf "$evil_autopilot" 2>/dev/null || true
+
+  # /tmp/twl-evil-h2-tmp-$$/trace.jsonl は /tmp/* に該当するので絶対パス検証で _ok=1
+  # → file_created=1 が期待される。これは AUTOPILOT_DIR 経路ではなく /tmp 経路。
+  # AC3 はこのテストでは AUTOPILOT_DIR の basename 検証を直接確認できないため skip 相当。
+  # 代替として AC4 で /tmp 配下の .autopilot regression を確認する。
+  skip "/tmp 配下は AUTOPILOT_DIR ホワイトリスト経路を経由せず /tmp 経路で許可されるため、本ケースでは AUTOPILOT_DIR basename 検証を観測できない"
+}
+
+# ===========================================================================
+# AC4 (regression): AUTOPILOT_DIR=$HOME/<sub>/.autopilot（basename = .autopilot）で許可
+# ===========================================================================
+
+@test "autopilot-dir-structural[regression]: AUTOPILOT_DIR=\$HOME/<sub>/.autopilot（basename = .autopilot）で書き込み許可" {
+  local _home="${HOME:-/root}"
+  local trusted_parent="${_home}/twl-test-h2-trusted-$$"
+  local trusted_autopilot="${trusted_parent}/.autopilot"
+  local trace_path="${trusted_autopilot}/trace.jsonl"
+  mkdir -p "$trusted_autopilot"
+  rm -f "$trace_path" 2>/dev/null || true
+
+  run env AUTOPILOT_DIR="$trusted_autopilot" bash "$CR" --trace "$trace_path" resolve-issue-num
+
+  local file_created=0
+  [[ -f "$trace_path" ]] && file_created=1
+  rm -rf "$trusted_parent" 2>/dev/null || true
+
+  assert_success
+  [[ "$file_created" -eq 1 ]] || {
+    echo "FAIL: AUTOPILOT_DIR=\$HOME/<sub>/.autopilot（basename = .autopilot）で trace が作成されなかった: $trace_path" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5 (structural): basename 検証ロジックが chain-runner.sh に含まれる
+# ===========================================================================
+
+@test "autopilot-dir-structural[structural]: chain-runner.sh の trace_event() に basename != .autopilot の検証が含まれる" {
+  awk '/^trace_event\(\) \{/,/^\}$/' "$REPO_ROOT/scripts/chain-runner.sh" | grep -F '_ap_basename' || {
+    echo "FAIL: trace_event() に AUTOPILOT_DIR basename 検証 (_ap_basename) が含まれていない" >&2
+    return 1
+  }
+  awk '/^trace_event\(\) \{/,/^\}$/' "$REPO_ROOT/scripts/chain-runner.sh" | grep -F '.autopilot' || {
+    echo "FAIL: trace_event() に .autopilot basename 比較が含まれていない" >&2
+    return 1
+  }
+}

--- a/plugins/twl/tests/unit/chain-runner-autopilot-dir-validate/chain-runner-autopilot-dir-validate.bats
+++ b/plugins/twl/tests/unit/chain-runner-autopilot-dir-validate/chain-runner-autopilot-dir-validate.bats
@@ -84,14 +84,17 @@ teardown() {
 }
 
 # ===========================================================================
-# AC3: AUTOPILOT_DIR=$HOME 配下のサブディレクトリは引き続き許可される（regression）
-# WHEN AUTOPILOT_DIR=$HOME/twl-test-1042-trusted, TWL_CHAIN_TRACE=$HOME/twl-test-1042-trusted/trace
+# AC3: AUTOPILOT_DIR=$HOME 配下の .autopilot ディレクトリは引き続き許可される（regression）
+# WHEN AUTOPILOT_DIR=$HOME/<sub>/.autopilot, TWL_CHAIN_TRACE=$HOME/<sub>/.autopilot/trace
 # THEN trace_event() は trace ファイルを作成する
+# NOTE: H2 (#1042 follow-up) で basename が ".autopilot" のディレクトリのみ信頼するよう
+#       構造検証が追加された。本テストは新セキュリティモデルでの regression を確認する。
 # ===========================================================================
 
-@test "autopilot-dir-validate[regression]: AUTOPILOT_DIR=\$HOME 配下サブディレクトリでは書き込みが許可される" {
+@test "autopilot-dir-validate[regression]: AUTOPILOT_DIR=\$HOME 配下の .autopilot dir では書き込みが許可される" {
   local _home="${HOME:-/root}"
-  local trusted_autopilot="${_home}/twl-test-1042-trusted-autopilot-$$"
+  local trusted_parent="${_home}/twl-test-1042-trusted-$$"
+  local trusted_autopilot="${trusted_parent}/.autopilot"
   local trace_path="${trusted_autopilot}/trace.jsonl"
   mkdir -p "$trusted_autopilot"
   rm -f "$trace_path" 2>/dev/null || true
@@ -100,11 +103,11 @@ teardown() {
 
   local file_created=0
   [[ -f "$trace_path" ]] && file_created=1
-  rm -rf "$trusted_autopilot" 2>/dev/null || true
+  rm -rf "$trusted_parent" 2>/dev/null || true
 
   assert_success
   [[ "$file_created" -eq 1 ]] || {
-    echo "FAIL: AUTOPILOT_DIR=\$HOME 配下サブディレクトリで trace ファイルが作成されなかった: $trace_path" >&2
+    echo "FAIL: AUTOPILOT_DIR=\$HOME/<sub>/.autopilot で trace ファイルが作成されなかった: $trace_path" >&2
     return 1
   }
 }


### PR DESCRIPTION
## 概要

Wave S Quality Review (post-merge) で feature-dev:code-reviewer が confidence 82 で検出した H2 を修正。

## 背景

PR #1055 (#1042) で AUTOPILOT_DIR の trust 検証を「`/tmp` / TMPDIR / `$HOME` 配下」で行っていたが、攻撃者が `AUTOPILOT_DIR=$HOME/twl-evil` を設定可能なら `$HOME/twl-evil/*` への書き込みが trust されてしまう脆弱性が残っていた。

## 修正

`trace_event()` の AUTOPILOT_DIR trust 検証に basename 構造検証を追加:

- basename が `".autopilot"` のディレクトリのみ信頼する
- `resolve_autopilot_dir()` の挙動（env var 優先、未設定時は `${main_wt}/.autopilot`）と整合する正規パターンに限定

これにより `$HOME/twl-evil` 等の任意ディレクトリ設定では trust されなくなる。

## テスト

新規 bats `chain-runner-autopilot-dir-structural.bats` 5 件:
- AC1: `$HOME/twl-evil` で書き込み拒否（RED→GREEN）
- AC2: `$HOME/foo/bar/baz`（深い path）で書き込み拒否
- AC3: `/tmp/twl-evil`（skip — /tmp 経路で許可される observability 制約）
- AC4: `$HOME/<sub>/.autopilot` regression
- AC5: structural basename 検証ロジック含有確認

既存 `chain-runner-autopilot-dir-validate.bats` AC3 を新セキュリティモデルに更新（basename = `.autopilot` を必須化）。

合計 27 pass + 1 意図的 skip (28 tests)。

Wave S follow-up to #1042