### PR TITLE
fix(orchestrator): #1028 follow-up — cross-device mv + macOS stat fallback

### DIFF
--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -1029,7 +1029,11 @@ generate_phase_report() {
     # AC2: 既存 phase-N-results.json が古い場合 (>5 分前) は自動 archive
     if [[ -f "$_results_file" ]]; then
       local _file_mtime _now _file_age
-      _file_mtime=$(stat -c '%Y' "$_results_file" 2>/dev/null || echo 0)
+      # M4 (#1028 follow-up): GNU stat (-c '%Y') / BSD stat (-f '%m') 互換
+      # macOS では GNU stat が利用不可なため fallback で対応
+      _file_mtime=$(stat -c '%Y' "$_results_file" 2>/dev/null \
+        || stat -f '%m' "$_results_file" 2>/dev/null \
+        || echo 0)
       _now=$(date +%s 2>/dev/null || echo 0)
       _file_age=$(( _now - _file_mtime ))
       if (( _file_age > 300 )); then
@@ -1041,9 +1045,16 @@ generate_phase_report() {
       fi
     fi
     # AC1: atomic write (tmp file → rename)
+    # M3 (#1028 follow-up): mv が EXDEV (cross-device, AUTOPILOT_DIR が cross-device
+    # symlink の場合) で失敗するケースに cp + rm fallback で対応
     local _tmp_file="${_results_file}.tmp.$$"
     if printf '%s\n' "$_report_json" > "$_tmp_file" 2>/dev/null; then
-      mv -f "$_tmp_file" "$_results_file" 2>/dev/null || rm -f "$_tmp_file" 2>/dev/null
+      if ! mv -f "$_tmp_file" "$_results_file" 2>/dev/null; then
+        # mv 失敗（EXDEV など）→ cp で書き込み試行
+        cp "$_tmp_file" "$_results_file" 2>/dev/null || true
+      fi
+      # tmp file の cleanup（mv 成功時は既に削除済み、cp fallback 時はここで削除）
+      rm -f "$_tmp_file" 2>/dev/null || true
     fi
   fi
 }

--- a/plugins/twl/tests/unit/orchestrator-phase-results/orchestrator-phase-results.bats
+++ b/plugins/twl/tests/unit/orchestrator-phase-results/orchestrator-phase-results.bats
@@ -182,3 +182,61 @@ EOF
   fi
   grep -F '"signal": "PHASE_COMPLETE"' "$results_file" || return 1
 }
+
+# ===========================================================================
+# M3 (#1028 follow-up): cross-device mv EXDEV fallback
+# AUTOPILOT_DIR が cross-device symlink の場合 mv -f が EXDEV で失敗する。
+# cp フォールバックが実装されていることを structural に確認する。
+# ===========================================================================
+
+@test "phase-results[M3 structural]: phase-N-results.json 書き込みに cp fallback が含まれる" {
+  awk '/^generate_phase_report\(\) \{/,/^\}$/' "$ORCHESTRATOR_SH" | grep -F 'cp "$_tmp_file"' || {
+    echo "FAIL: generate_phase_report() に cp fallback (EXDEV 対策) が含まれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# M4 (#1028 follow-up): stat -c '%Y' / -f '%m' GNU/BSD fallback
+# macOS (BSD stat) では -c '%Y' が利用不可。GNU/BSD 互換の fallback が
+# 実装されていることを structural に確認する。
+# ===========================================================================
+
+@test "phase-results[M4 structural]: stat に GNU (-c %Y) と BSD (-f %m) の fallback chain が含まれる" {
+  awk '/^generate_phase_report\(\) \{/,/^\}$/' "$ORCHESTRATOR_SH" | grep -F "stat -c '%Y'" || {
+    echo "FAIL: generate_phase_report() に GNU stat (-c %Y) が含まれていない" >&2
+    return 1
+  }
+  awk '/^generate_phase_report\(\) \{/,/^\}$/' "$ORCHESTRATOR_SH" | grep -F "stat -f '%m'" || {
+    echo "FAIL: generate_phase_report() に BSD stat (-f %m) fallback が含まれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# M3 functional: mv stub fail で cp fallback が動作することを確認
+# ===========================================================================
+
+@test "phase-results[M3 functional]: mv が失敗しても cp fallback で phase-N-results.json が作成される" {
+  _stub_state_read "9001:done"
+
+  # generate_phase_report 内の mv を fail させる stub
+  # ただし archive ロジックでも mv を使用するため、fresh ファイル状態に限定
+  cat > "$STUB_BIN/mv" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$STUB_BIN/mv"
+
+  generate_phase_report 6 9001 > /dev/null
+
+  local results_file="$AUTOPILOT_DIR/phase-6-results.json"
+  [[ -f "$results_file" ]] || {
+    echo "FAIL: mv 失敗時に cp fallback で phase-6-results.json が作成されなかった" >&2
+    return 1
+  }
+  grep -F '"signal": "PHASE_COMPLETE"' "$results_file" || {
+    echo "FAIL: cp fallback で書き込まれた phase-6-results.json の内容が壊れている" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Wave S Quality Review (post-merge) で feature-dev:code-reviewer が検出した M3 / M4 を統合修正。

## M3: cross-device mv EXDEV fallback (confidence 80)

AUTOPILOT_DIR が cross-device symlink の場合、`mv -f` が EXDEV で失敗し phase-N-results.json が更新されないリスクがあった。`2>/dev/null` で抑制されるためサイレントに書き込み失敗となる。

**修正**: `mv` 失敗時に `cp` フォールバックを追加。tmp file の cleanup も追加。

## M4: stat macOS 非互換 (confidence 80)

macOS (BSD stat) では `stat -c '%Y'` が利用不可。現状 `_file_mtime=0` となり、stale archive が誤動作（常に archive されてしまう）。

**修正**: `stat -c '%Y'` (GNU) → `stat -f '%m'` (BSD) → `echo 0` の fallback chain。

## テスト

`orchestrator-phase-results.bats` に 3 件追加 (5 → 8):
- M3 structural: cp fallback 含有確認
- M4 structural: GNU/BSD stat fallback chain 含有確認
- M3 functional: `mv` stub fail でも cp fallback で書き込み成功

合計 8/8 pass。

Wave S follow-up to #1028