### PR TITLE
fix(session-comm): #1048 follow-up — TOCTOU race window 縮小

### DIFF
--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -15,10 +15,27 @@ set -euo pipefail
 # テスト時のみ SESSION_COMM_SCRIPT_DIR を許可（_TEST_MODE ガード必須）
 # Issue #1048: 信頼境界として「実在ディレクトリ」かつ「session-state.sh を含む」
 # ことを追加検証し、攻撃者による任意パス上書きを拒否する
+# M2 (#1048 follow-up): realpath で symlink を解決して実 path に固定し、
+# check と use の間に symlink 差し替えされる TOCTOU race window を縮小する
 if [[ -n "${_TEST_MODE:-}" ]] && [[ -n "${SESSION_COMM_SCRIPT_DIR:-}" ]] \
     && [[ -d "$SESSION_COMM_SCRIPT_DIR" ]] \
     && [[ -f "$SESSION_COMM_SCRIPT_DIR/session-state.sh" ]]; then
-    SCRIPT_DIR="$SESSION_COMM_SCRIPT_DIR"
+    _resolved_state=""
+    if command -v realpath >/dev/null 2>&1; then
+      _resolved_state=$(realpath "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+    fi
+    if [[ -z "$_resolved_state" ]] && command -v greadlink >/dev/null 2>&1; then
+      _resolved_state=$(greadlink -f "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+    fi
+    if [[ -z "$_resolved_state" ]] && command -v python3 >/dev/null 2>&1; then
+      _resolved_state=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+    fi
+    if [[ -n "$_resolved_state" && -f "$_resolved_state" ]]; then
+      SCRIPT_DIR=$(dirname "$_resolved_state")
+    else
+      SCRIPT_DIR="$SESSION_COMM_SCRIPT_DIR"
+    fi
+    unset _resolved_state
 else
     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 fi

--- a/plugins/session/tests/session-comm-script-dir-validate.bats
+++ b/plugins/session/tests/session-comm-script-dir-validate.bats
@@ -133,3 +133,71 @@ STUB
         return 1
     }
 }
+
+# ===========================================================================
+# M2 (#1048 follow-up): TOCTOU race window 縮小のための realpath 解決
+# SESSION_COMM_SCRIPT_DIR が symlink を経由する場合でも、実 path に解決して
+# SCRIPT_DIR に固定することで check と use の間の race window を縮小する。
+# ===========================================================================
+
+@test "session-comm-script-dir[M2 structural]: realpath fallback chain (realpath / greadlink / python3) が含まれる" {
+    grep -F 'command -v realpath' "$SCRIPT" || {
+        echo "FAIL: SCRIPT_DIR 設定ブロックに realpath fallback が含まれていない" >&2
+        return 1
+    }
+    grep -F 'command -v greadlink' "$SCRIPT" || {
+        echo "FAIL: SCRIPT_DIR 設定ブロックに greadlink fallback が含まれていない" >&2
+        return 1
+    }
+    grep -F 'os.path.realpath' "$SCRIPT" || {
+        echo "FAIL: SCRIPT_DIR 設定ブロックに python3 os.path.realpath fallback が含まれていない" >&2
+        return 1
+    }
+}
+
+@test "session-comm-script-dir[M2 functional]: SESSION_COMM_SCRIPT_DIR が symlink でも SCRIPT_DIR は実 path になる" {
+    local real_dir="$SANDBOX/real_scripts"
+    local symlink_dir="$SANDBOX/symlink_scripts"
+    mkdir -p "$real_dir"
+    cat > "$real_dir/session-state.sh" <<'STUB'
+#!/bin/bash
+echo "real-mock"
+STUB
+    chmod +x "$real_dir/session-state.sh"
+    ln -s "$real_dir" "$symlink_dir"
+
+    # session-comm.sh の SCRIPT_DIR 設定ブロックを subshell で再実行（前回 #1048 と同じ pattern）
+    local result
+    result=$(SCRIPT_PATH="$SCRIPT" TM=1 CD="$symlink_dir" bash -c '
+        BASH_SOURCE=("$SCRIPT_PATH")
+        _TEST_MODE="$TM"
+        SESSION_COMM_SCRIPT_DIR="$CD"
+        if [[ -n "${_TEST_MODE:-}" ]] && [[ -n "${SESSION_COMM_SCRIPT_DIR:-}" ]] \
+            && [[ -d "$SESSION_COMM_SCRIPT_DIR" ]] \
+            && [[ -f "$SESSION_COMM_SCRIPT_DIR/session-state.sh" ]]; then
+            _resolved_state=""
+            if command -v realpath >/dev/null 2>&1; then
+              _resolved_state=$(realpath "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+            fi
+            if [[ -z "$_resolved_state" ]] && command -v greadlink >/dev/null 2>&1; then
+              _resolved_state=$(greadlink -f "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+            fi
+            if [[ -z "$_resolved_state" ]] && command -v python3 >/dev/null 2>&1; then
+              _resolved_state=$(python3 -c "import os, sys; print(os.path.realpath(sys.argv[1]))" "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
+            fi
+            if [[ -n "$_resolved_state" && -f "$_resolved_state" ]]; then
+              SCRIPT_DIR=$(dirname "$_resolved_state")
+            else
+              SCRIPT_DIR="$SESSION_COMM_SCRIPT_DIR"
+            fi
+        else
+            SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        fi
+        echo "$SCRIPT_DIR"
+    ')
+
+    [[ "$result" == "$real_dir" ]] || {
+        echo "FAIL: SESSION_COMM_SCRIPT_DIR が symlink ($symlink_dir) の場合、SCRIPT_DIR が実 path ($real_dir) ではなく $result になった" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## 概要

Wave S Quality Review (post-merge) で feature-dev:code-reviewer が confidence 80 で検出した M2 を修正。

## 背景

PR #1056 (#1048) で SCRIPT_DIR 上書き条件に `[[ -d ]]` と `[[ -f session-state.sh ]]` の追加検証を入れたが、check と `SCRIPT_DIR=` 代入の間に symlink を差し替える TOCTOU race window が原理上残存していた。

## 修正

realpath fallback chain (`realpath` / `greadlink -f` / `python3 os.path.realpath`) で `session-state.sh` の symlink を解決し、実 path の dirname を SCRIPT_DIR に固定。check と use の間に symlink 差し替え攻撃を緩和（race window 縮小）。

## テスト

`session-comm-script-dir-validate.bats` に 2 件追加 (5 → 7):
- M2 structural: realpath/greadlink/python3 fallback chain 含有確認
- M2 functional: SESSION_COMM_SCRIPT_DIR が symlink でも SCRIPT_DIR は実 path

合計 7/7 pass。既存 `session-comm.test.sh` 9/9 regression pass。

Wave S follow-up to #1048