### PR TITLE
test(workflow-pr-fix): #1016 follow-up — branch checkout を冪等化

### DIFF
--- a/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
+++ b/plugins/twl/tests/bats/workflow-scenarios/workflow-pr-fix.bats
@@ -60,7 +60,7 @@ _init_issue_state() {
   # RED: chain-runner.sh に record-current-step case が未定義のため exit 1
   local issue_num=9101
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-warning-fix-skip" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-warning-fix-skip" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"
 
@@ -77,7 +77,7 @@ _init_issue_state() {
   # RED: record-current-step case 未定義のため state 更新されない
   local issue_num=9102
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-warning-fix-hb" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-warning-fix-hb" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"
 
@@ -95,7 +95,7 @@ _init_issue_state() {
   # ここでは state を手動設定して resolve_next_workflow 単体を検証する。
   local issue_num=9103
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-resolve-nw" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-resolve-nw" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   mkdir -p "$autopilot_dir/issues"
   python3 -m twl.autopilot.state write \
@@ -116,7 +116,7 @@ _init_issue_state() {
   # 実際の orchestrator では RESOLVE_FAILED カウンターが増加する
   local issue_num=9104
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-resolve-fail" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-resolve-fail" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"
 
@@ -142,7 +142,7 @@ _init_issue_state() {
   # RED: record-current-step case 未定義のため両フィールドとも更新されない
   local issue_num=9105
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-ac5-skip" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-ac5-skip" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"
 
@@ -164,7 +164,7 @@ _init_issue_state() {
   # RED: record-current-step case 未定義のため state 更新されない
   local issue_num=9106
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-ac5-nonskip" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-ac5-nonskip" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"
 
@@ -186,7 +186,7 @@ _init_issue_state() {
   # → inject_next_workflow が RESOLVE_FAIL_COUNT[$entry] を increment する経路を直接検証
   local issue_num=9201
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-fail-count-incr" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-fail-count-incr" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
   _init_issue_state "$issue_num" "$autopilot_dir"  # current_step=post-fix-verify
 
@@ -237,7 +237,7 @@ _init_issue_state() {
   # → inject_next_workflow が RESOLVE_FAIL_COUNT[$entry] = 0 にリセットする経路を直接検証
   local issue_num=9202
   local autopilot_dir="$WORKFLOW_SANDBOX/.autopilot"
-  git checkout -q -b "feat/${issue_num}-stub-fail-count-reset" 2>/dev/null || true
+  git checkout -q -B "feat/${issue_num}-stub-fail-count-reset" 2>/dev/null || true
   export AUTOPILOT_DIR="$autopilot_dir"
 
   # current_step=warning-fix で初期化（resolve_next_workflow が /twl:workflow-pr-merge を返す）


### PR DESCRIPTION
## 概要

Wave S Quality Review (post-merge) で feature-dev:code-reviewer が confidence 80 で検出した L3 を defensive 改善として修正。

## 背景

`workflow-pr-fix.bats` の各 test で `git checkout -q -b "feat/${issue_num}-stub-..."` を実行している。

実際は `workflow-scenario-env` helper が test ごとに `WORKFLOW_SANDBOX` を `mktemp -d` で再生成するため独立 git repo になっており、branch 既存衝突は起きない構造。しかし helper が将来変更されたり、test を直接 sandbox 共有環境で動かす場合の冪等性を defensive に確保する。

## 修正

`git checkout -q -b` → `git checkout -q -B` (force re-create) を 8 箇所適用 (ac1/ac2/ac3/ac5/ac3-direct)。

## 検証

bats 12/12 pass。

Wave S follow-up to #1016