### PR TITLE
feat(#1026): ADR-024 親 Epic Status auto-transition 実装 (AC1+AC2)

### DIFF
--- a/cli/twl/src/twl/autopilot/github.py
+++ b/cli/twl/src/twl/autopilot/github.py
@@ -5,6 +5,7 @@ Replaces: parse-issue-ac.sh, merge-gate-issues.sh, create-harness-issue.sh,
 
 CLI usage:
     python3 -m twl.autopilot.github extract-ac <issue-number> [owner/repo]
+    python3 -m twl.autopilot.github extract-parent-epic <issue-number> [owner/repo]
     python3 -m twl.autopilot.github resolve-project [owner]
     python3 -m twl.autopilot.github pr-findings <pr-number> [owner/repo]
 """
@@ -150,6 +151,48 @@ def _extract_ac_section(body: str) -> str:
             section_lines.append(line)
 
     return "\n".join(section_lines)
+
+
+# ---------------------------------------------------------------------------
+# Parent Epic extraction (Issue #1026 ADR-024 AC1)
+# ---------------------------------------------------------------------------
+
+# `Parent: #N` 規約は plugins/twl/commands/issue-create.md L51 で SSoT 定義済み。
+# 子 Issue body 内の `^[\s]*Parent:\s*#(\d+)` を抽出する。
+_PARENT_EPIC_RE = re.compile(r"(?:^|\n)\s*Parent:\s*#(\d+)", re.MULTILINE)
+
+
+def extract_parent_epic(issue_num: str, repo: str | None = None) -> int | None:
+    """Extract parent Epic issue number from a child Issue's body.
+
+    Parses the SSoT regulated `Parent: #N` line (issue-create.md L51).
+    Returns the parent number as int when found, None when not present.
+
+    Args:
+        issue_num: Child Issue number (integer string).
+        repo: Optional ``owner/repo`` string for cross-repo access.
+
+    Returns:
+        Parent Epic number as int, or None if no Parent line found in body.
+
+    Raises:
+        GitHubError: On invalid issue_num/repo or gh API failure.
+    """
+    _validate_issue_num(issue_num)
+    if repo:
+        _validate_repo(repo)
+
+    repo_flag = ["-R", repo] if repo else []
+
+    issue_data = _gh_json("issue", "view", issue_num, *repo_flag, "--json", "body,number")
+    body: str = issue_data.get("body") or ""
+    if not body:
+        return None
+
+    match = _PARENT_EPIC_RE.search(body)
+    if match is None:
+        return None
+    return int(match.group(1))
 
 
 # ---------------------------------------------------------------------------
@@ -413,7 +456,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args:
         print("Usage: python3 -m twl.autopilot.github <command> [args...]", file=sys.stderr)
-        print("Commands: extract-ac, resolve-project, pr-findings", file=sys.stderr)
+        print("Commands: extract-ac, extract-parent-epic, resolve-project, pr-findings", file=sys.stderr)
         return 1
 
     command = args[0]
@@ -429,6 +472,20 @@ def main(argv: list[str] | None = None) -> int:
             acs = extract_issue_ac(issue_num, repo)
             for i, ac in enumerate(acs, 1):
                 print(f"{i}. {ac}")
+            return 0
+
+        elif command == "extract-parent-epic":
+            # Issue #1026 ADR-024 AC1: 子 Issue body の `Parent: #N` から親 Epic 番号を抽出
+            # exit 0 = 親 Epic 番号 stdout 出力 / exit 2 = 親なし (caller が skip 判断) / exit 1 = エラー
+            if not rest:
+                print("Usage: extract-parent-epic <issue-number> [owner/repo]", file=sys.stderr)
+                return 1
+            issue_num = rest[0]
+            repo = rest[1] if len(rest) > 1 else None
+            parent = extract_parent_epic(issue_num, repo)
+            if parent is None:
+                return 2
+            print(str(parent))
             return 0
 
         elif command == "resolve-project":

--- a/cli/twl/tests/autopilot/test_github_parent_epic.py
+++ b/cli/twl/tests/autopilot/test_github_parent_epic.py
@@ -1,0 +1,143 @@
+"""Tests for extract_parent_epic in github.py (Issue #1026 ADR-024 AC1).
+
+Covers:
+  - extract_parent_epic returns parent number from `Parent: #N` line
+  - extract_parent_epic returns None when no Parent line
+  - extract_parent_epic raises GitHubError for invalid issue_num
+  - extract_parent_epic handles multiline body correctly
+  - CLI dispatch `extract-parent-epic` returns exit 0 (with number) or exit 2 (not found)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from twl.autopilot.github import (
+    GitHubError,
+    extract_parent_epic,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _gh_response(stdout: str, returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+# ---------------------------------------------------------------------------
+# extract_parent_epic
+# ---------------------------------------------------------------------------
+
+
+class TestExtractParentEpic:
+    def test_parent_found(self) -> None:
+        """Body contains `Parent: #42` → returns 42."""
+        body = "## 概要\n\nSome text.\n\n## Related\nParent: #42\n"
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            assert extract_parent_epic("999") == 42
+
+    def test_no_parent_line(self) -> None:
+        """Body without Parent line → returns None."""
+        body = "## 概要\n\nSome text.\n\n## Related\nRelated: #100\n"
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            assert extract_parent_epic("999") is None
+
+    def test_empty_body(self) -> None:
+        """Empty body → returns None (not error, since parent is optional)."""
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": "", "number": 999},
+        ):
+            assert extract_parent_epic("999") is None
+
+    def test_invalid_issue_num(self) -> None:
+        """Non-integer issue_num → raises GitHubError."""
+        with pytest.raises(GitHubError, match="Issue番号"):
+            extract_parent_epic("abc")
+
+    def test_parent_in_middle_of_body(self) -> None:
+        """Multiline body with Parent in middle → still extracts correctly."""
+        body = (
+            "# Title\n"
+            "\n"
+            "## Description\n"
+            "Long description...\n"
+            "\n"
+            "Parent: #555\n"
+            "\n"
+            "## Acceptance Criteria\n"
+            "- [ ] AC1\n"
+        )
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            assert extract_parent_epic("999") == 555
+
+    def test_parent_with_leading_whitespace(self) -> None:
+        """Body with `  Parent: #N` (leading whitespace) → still extracts."""
+        body = "Some text\n  Parent: #777\n"
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            assert extract_parent_epic("999") == 777
+
+    def test_invalid_repo(self) -> None:
+        """Invalid repo format → raises GitHubError."""
+        with pytest.raises(GitHubError, match="不正な owner/repo"):
+            extract_parent_epic("999", repo="invalid format")
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch: extract-parent-epic
+# ---------------------------------------------------------------------------
+
+
+class TestCLIExtractParentEpic:
+    def test_cli_parent_found(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI with parent found → prints number and exits 0."""
+        body = "Parent: #42\n"
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            exit_code = main(["extract-parent-epic", "999"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert captured.out.strip() == "42"
+
+    def test_cli_parent_not_found(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI with no parent → exits 2 (distinct exit code for not-found)."""
+        body = "No parent here\n"
+        with patch(
+            "twl.autopilot.github._gh_json",
+            return_value={"body": body, "number": 999},
+        ):
+            exit_code = main(["extract-parent-epic", "999"])
+        assert exit_code == 2
+
+    def test_cli_missing_args(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """CLI with no issue_num → exits 1 with usage message."""
+        exit_code = main(["extract-parent-epic"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "Usage" in captured.err
+
+    def test_cli_invalid_issue_num(self) -> None:
+        """CLI with invalid issue_num → exits 1 with error."""
+        exit_code = main(["extract-parent-epic", "abc"])
+        assert exit_code == 1

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2598,7 +2598,7 @@ scripts:
   autopilot-github:
     type: script
     path: ../../cli/twl/src/twl/autopilot/github.py
-    description: "GitHub API ラッパー（Issue AC抽出・PR findings・Project解決・Issue作成）（Python: python3 -m twl.autopilot.github）"
+    description: "GitHub API ラッパー（Issue AC抽出・親 Epic抽出・PR findings・Project解決・Issue作成）（Python: python3 -m twl.autopilot.github）"
 
   session-audit:
     type: script

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -354,6 +354,87 @@ step_worktree_create() {
   ok "worktree-create" "完了"
 }
 
+# --- _transition_parent_epic_if_refined: 親 Epic auto-transition (Issue #1026 ADR-024 AC1+AC2) ---
+# 子 Issue が "In Progress" に遷移した時、親 Epic が "Refined" なら "In Progress" に遷移する。
+# Idempotent: 親 Epic が既に "In Progress" / "Done" / 他の場合は no-op。
+# 失敗時は全エラーを skip 扱いで suppress（既存 step_board_status_update と同じ防御戦略）。
+#
+# Args:
+#   $1=child_issue_num: 子 Issue 番号
+#   $2=project_num:     gh project 番号
+#   $3=project_id:      gh project ID（item-edit 用）
+#   $4=owner:           project owner
+#   $5=repo_full:       親 Epic 追加用の owner/repo_name 形式
+#   $6=fields_json:     既に取得済みの gh project field-list JSON（再利用）
+_transition_parent_epic_if_refined() {
+  local child_issue_num="$1"
+  local project_num="$2"
+  local project_id="$3"
+  local owner="$4"
+  local repo_full="$5"
+  local fields_json="$6"
+
+  # Step 1: 親 Epic 番号を取得（Python parser で `Parent: #N` 抽出）
+  # H1 (Quality Review): local 宣言と代入を分離して bash の $? が local 自体で
+  # 上書きされる bug を回避
+  ensure_pythonpath || return 0
+  local parent_num exit_code
+  parent_num=$(python3 -m twl.autopilot.github extract-parent-epic "$child_issue_num" 2>/dev/null)
+  exit_code=$?
+  # exit 2 = parent なし、exit 1 = エラー → どちらも skip
+  if [[ "$exit_code" -ne 0 ]] || [[ -z "$parent_num" ]]; then
+    return 0
+  fi
+
+  # Step 2: 親 Epic を Project に追加（既存ならエラーにならない、空 id 返却の可能性あり）
+  gh project item-add "$project_num" --owner "$owner" \
+    --url "https://github.com/${repo_full}/issues/${parent_num}" --format json 2>/dev/null \
+    >/dev/null || true
+  # ↑ 戻り値の id は使わない。fallback を兼ねた item-list を信頼する
+
+  # Step 3: item-list を 1 回だけ呼んで items_json をキャッシュし、parent_item_id と
+  # parent_status を同一 JSON から抽出する（H4: API call 重複削減）
+  # H2: jq filter で .content.number の型不一致を吸収（API が string/number 両方返す可能性に対応）
+  local items_json parent_item_id parent_status
+  items_json=$(gh project item-list "$project_num" --owner "$owner" --format json --limit 200 2>/dev/null) || return 0
+  parent_item_id=$(echo "$items_json" | jq -r --arg n "$parent_num" \
+    '.items[] | select((.content.number | tostring) == $n and .content.type == "Issue") | .id' \
+    | head -n1)
+  parent_status=$(echo "$items_json" | jq -r --arg n "$parent_num" \
+    '.items[] | select((.content.number | tostring) == $n and .content.type == "Issue") | .status' \
+    | head -n1)
+
+  # H3: cross-repo / 親 Epic が project に存在しない場合の observability — skip ログを残す
+  if [[ -z "$parent_item_id" || "$parent_item_id" == "null" ]]; then
+    skip "epic-auto-transition" "親 Epic #${parent_num} が Project に見つからない (cross-repo の可能性)"
+    return 0
+  fi
+
+  # Step 4: Idempotent gating — Refined のみ遷移、それ以外は no-op
+  if [[ "$parent_status" != "Refined" ]]; then
+    skip "epic-auto-transition" "親 Epic #${parent_num} は ${parent_status:-unknown} — Refined でないため no-op (idempotent)"
+    return 0
+  fi
+
+  # Step 5: Status field / In Progress option の ID を fields_json から抽出
+  local status_field_id in_progress_option_id
+  status_field_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status") | .id')
+  in_progress_option_id=$(echo "$fields_json" | jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "In Progress") | .id')
+  if [[ -z "$status_field_id" || -z "$in_progress_option_id" ]]; then
+    skip "epic-auto-transition" "Status field / In Progress option ID 取得失敗"
+    return 0
+  fi
+
+  # Step 6: 親 Epic を In Progress に遷移
+  gh project item-edit --id "$parent_item_id" --project-id "$project_id" \
+    --field-id "$status_field_id" --single-select-option-id "$in_progress_option_id" 2>/dev/null || {
+    skip "epic-auto-transition" "親 Epic #${parent_num} の Status 更新失敗"
+    return 0
+  }
+
+  ok "epic-auto-transition" "親 Epic #${parent_num}: Refined → In Progress (子 #${child_issue_num} 起因)"
+}
+
 # --- board-status-update: Project Board Status 更新 ---
 step_board_status_update() {
   record_current_step "board-status-update"
@@ -418,6 +499,12 @@ step_board_status_update() {
   }
 
   ok "board-status-update" "Project Board Status → $target_status (#$issue_num)"
+
+  # Issue #1026 ADR-024 AC1+AC2: 子 Issue が "In Progress" に遷移した時、
+  # 親 Epic が "Refined" なら "In Progress" に自動遷移する
+  if [[ "$target_status" == "In Progress" ]]; then
+    _transition_parent_epic_if_refined "$issue_num" "$final_num" "$final_id" "$owner" "$repo" "$fields"
+  fi
 }
 
 # --- board-archive: Project Board アイテムをアーカイブ ---

--- a/plugins/twl/tests/bats/scripts/chain-runner-parent-epic-transition.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-parent-epic-transition.bats
@@ -1,0 +1,221 @@
+#!/usr/bin/env bats
+# chain-runner-parent-epic-transition.bats
+# Requirement: Issue #1026 ADR-024 AC1+AC2 — 子 Issue が "In Progress" に遷移した時、
+#              親 Epic が "Refined" なら "In Progress" に自動遷移する
+# Spec: ADR-024 dual-write 規約「子 Issue 実装着手で親 Epic 自動 In Progress 遷移」
+# Coverage: --type=integration --coverage=autopilot
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+
+  GH_LOG="$SANDBOX/gh-calls.log"
+  export GH_LOG
+  : > "$GH_LOG"
+
+  PYTHON_REAL=$(command -v python3)
+  export PYTHON_REAL
+}
+
+teardown() {
+  common_teardown
+}
+
+# python3 stub: extract-parent-epic と resolve-project をモック化
+# 他 (state read/write 等) は実体に委譲
+# Args: $1=parent_num (空文字列で extract-parent-epic exit 2)
+_setup_python_stub_full() {
+  local parent_num="${1:-}"
+
+  cat > "$STUB_BIN/python3" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"twl.autopilot.github extract-parent-epic"*)
+    if [[ -z "$parent_num" ]]; then
+      exit 2
+    fi
+    echo "$parent_num"
+    exit 0
+    ;;
+  *"twl.autopilot.github resolve-project"*)
+    cat <<'JSON'
+{"project_num":"99","project_id":"PVT_mock_proj","owner":"shuu5","repo_name":"twill","repo_fullname":"shuu5/twill"}
+JSON
+    exit 0
+    ;;
+  *)
+    exec "$PYTHON_REAL" "\$@"
+    ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/python3"
+}
+
+# gh stub: project list / item-add / field-list / item-list / item-edit / issue view を mock
+# Args: $1=parent_status ("Refined", "In Progress", "Done")
+_setup_gh_stub() {
+  local parent_status="${1:-Refined}"
+
+  cat > "$STUB_BIN/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh: \$*" >> "$GH_LOG"
+case "\$*" in
+  "project list --owner @me --limit 1")
+    echo '[]'
+    exit 0
+    ;;
+  "project item-add"*)
+    echo '{"id":"PVTI_mock_item_id"}'
+    exit 0
+    ;;
+  "project field-list"*)
+    cat <<'JSON'
+{
+  "fields": [
+    {
+      "name": "Status",
+      "id": "PVTSSF_mock_status_field",
+      "options": [
+        {"name":"Refined","id":"opt_refined"},
+        {"name":"In Progress","id":"opt_in_progress"},
+        {"name":"Done","id":"opt_done"}
+      ]
+    }
+  ]
+}
+JSON
+    exit 0
+    ;;
+  "project item-list"*)
+    cat <<JSON_EOF
+{
+  "items": [
+    {
+      "id": "PVTI_mock_item_id",
+      "content": {"number": 100, "type": "Issue"},
+      "status": "${parent_status}"
+    }
+  ]
+}
+JSON_EOF
+    exit 0
+    ;;
+  "issue view"*)
+    echo '{"body":"some body","number":1}'
+    exit 0
+    ;;
+  "project item-edit"*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+# ===========================================================================
+# AC1: 親 Epic Refined → In Progress 遷移
+# ===========================================================================
+
+@test "parent-epic-transition[RED]: 親 Epic が Refined の場合、In Progress に遷移する" {
+  _setup_python_stub_full "100"
+  _setup_gh_stub "Refined"
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  # 子 Issue 用 1 回 + 親 Epic 用 1 回 = 計 2 回の item-edit
+  local edit_count
+  edit_count=$(grep -c "project item-edit" "$GH_LOG" || true)
+  [[ "$edit_count" -ge 2 ]] || {
+    echo "FAIL: 親 Epic Refined→In Progress の item-edit が呼ばれていない (edit_count=$edit_count)" >&2
+    cat "$GH_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2: 親 Epic 既に In Progress → idempotent
+# ===========================================================================
+
+@test "parent-epic-transition[idempotent]: 親 Epic が In Progress なら item-edit が呼ばれない (idempotent)" {
+  _setup_python_stub_full "100"
+  _setup_gh_stub "In Progress"
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  local edit_count
+  edit_count=$(grep -c "project item-edit" "$GH_LOG" || true)
+  [[ "$edit_count" -eq 1 ]] || {
+    echo "FAIL: 親 Epic In Progress なのに item-edit が ${edit_count} 回呼ばれた (期待: 1 = 子のみ)" >&2
+    cat "$GH_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3 (regression): 親 Epic Done → 何もしない
+# ===========================================================================
+
+@test "parent-epic-transition[regression-done]: 親 Epic が Done なら item-edit が呼ばれない" {
+  _setup_python_stub_full "100"
+  _setup_gh_stub "Done"
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  local edit_count
+  edit_count=$(grep -c "project item-edit" "$GH_LOG" || true)
+  [[ "$edit_count" -eq 1 ]] || {
+    echo "FAIL: 親 Epic Done なのに item-edit が ${edit_count} 回呼ばれた (期待: 1)" >&2
+    cat "$GH_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: 子 Issue に Parent 行なし → hook 全体スキップ
+# ===========================================================================
+
+@test "parent-epic-transition[no-parent]: 子 Issue に Parent 行がない場合、親 Epic hook はスキップ" {
+  _setup_python_stub_full ""  # extract-parent-epic exit 2
+  _setup_gh_stub "Refined"
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  local edit_count
+  edit_count=$(grep -c "project item-edit" "$GH_LOG" || true)
+  [[ "$edit_count" -eq 1 ]] || {
+    echo "FAIL: Parent なしなのに親 Epic 用 item-edit が呼ばれた (edit_count=${edit_count})" >&2
+    cat "$GH_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5: target_status != "In Progress" → hook スキップ
+# ===========================================================================
+
+@test "parent-epic-transition[target-guard]: target_status='Done' では親 Epic hook がスキップされる" {
+  _setup_python_stub_full "100"
+  _setup_gh_stub "Refined"
+
+  run bash "$CR" board-status-update 9001 "Done"
+
+  assert_success
+  local edit_count
+  edit_count=$(grep -c "project item-edit" "$GH_LOG" || true)
+  [[ "$edit_count" -eq 1 ]] || {
+    echo "FAIL: target_status='Done' なのに親 Epic hook が動作した (edit_count=${edit_count})" >&2
+    cat "$GH_LOG" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1026 ADR-024 dual-write 規約の実装: 子 Issue が Refined → In Progress に遷移したタイミングで、親 Epic が Refined ならば In Progress に自動遷移する hook を新設。

## 設計（feature-dev フロー Phase 1-7 経由、Design B clean architecture 採用）

### Python parser 層 (`cli/twl/src/twl/autopilot/github.py`)
- `_PARENT_EPIC_RE = r"(?:^|\n)\s*Parent:\s*#(\d+)"`
- `extract_parent_epic(issue_num, repo) -> int | None`: 子 Issue body から親 Epic 番号を抽出
- `Parent: #N` 規約 (`plugins/twl/commands/issue-create.md` L51 SSoT) に基づく
- CLI dispatch `extract-parent-epic`: exit 0=found, **exit 2=not-found**, exit 1=error

### Bash hook 層 (`plugins/twl/scripts/chain-runner.sh`)
- `_transition_parent_epic_if_refined()` helper 関数を `step_board_status_update()` 直前に追加
- `step_board_status_update()` 末尾で `target_status == "In Progress"` 時のみ hook 呼び出し
- Idempotent: 親 Epic が既に `In Progress` / `Done` / 他 → no-op + skip ログ
- 失敗時はすべて skip 戦略（既存 step_board_status_update と同じ防御パターン）

## AC scope

| AC | 状態 |
|---|---|
| AC1: parent reference parser | ✅ 実装 |
| AC2: auto-transition hook | ✅ 実装 |
| AC3: AC checklist auto-update | 別 issue 化（子 → Epic AC mapping 規約が未確立、別 issue で規約設計が必要） |

## Quality Review (Phase 6) 修正済み HIGH

| # | finding | 修正 |
|---|---|---|
| H1 | `local var=$(...)` で bash `$?` 上書きバグ | local 宣言と代入を分離 |
| H2 | jq filter `.content.number == $n` 型不一致 | `tostring` 比較で型吸収 |
| H3 | cross-repo / 親 Epic 不在の observability 欠如 | skip ログ追加 |
| H4 | `gh project item-list` 2 重呼び出し | 1 回に統合し JSON キャッシュ |
| H5 | `bats load '../helpers/common.bash'` 規約不一致 | `.bash` 削除（既存規約整合） |
| H6 | `deps.yaml` autopilot-github description 未反映 | 「親 Epic抽出」追記 |

## テスト

- **pytest** (`cli/twl/tests/autopilot/test_github_parent_epic.py`) 11 件: parser 単体 + CLI dispatch
- **bats** (`plugins/twl/tests/bats/scripts/chain-runner-parent-epic-transition.bats`) 5 件: 親 Refined→遷移 / In Progress→no-op / Done→no-op / Parent なし / target_status='Done' guard

合計 **16/16 pass**。既存 chain-runner 28 件 + state 6 件も regression なし。

## Quality Gate

- `twl --validate`: OK 2661 / Violations 4（既存、増加なし）
- `twl --check`: All files exist (Missing 0)

Closes #1026 (AC1+AC2)