### PR TITLE
feat(#1070): ADR-024 Epic AC checklist auto-update — Closes-AC 規約 + Done 遷移時 auto-flip 実装

### DIFF
--- a/cli/twl/src/twl/autopilot/github.py
+++ b/cli/twl/src/twl/autopilot/github.py
@@ -6,6 +6,8 @@ Replaces: parse-issue-ac.sh, merge-gate-issues.sh, create-harness-issue.sh,
 CLI usage:
     python3 -m twl.autopilot.github extract-ac <issue-number> [owner/repo]
     python3 -m twl.autopilot.github extract-parent-epic <issue-number> [owner/repo]
+    python3 -m twl.autopilot.github extract-closes-ac <issue-number> [owner/repo]
+    python3 -m twl.autopilot.github update-epic-ac-checklist <issue-number> [owner/repo]
     python3 -m twl.autopilot.github resolve-project [owner]
     python3 -m twl.autopilot.github pr-findings <pr-number> [owner/repo]
 """
@@ -198,6 +200,188 @@ def extract_parent_epic(issue_num: str, repo: str | None = None) -> int | None:
     if match is None:
         return None
     return int(match.group(1))
+
+
+# ---------------------------------------------------------------------------
+# Closes-AC extraction + Epic AC checkbox auto-update (Issue #1070)
+# ---------------------------------------------------------------------------
+
+# `Closes-AC: #EPIC:ACN` 規約 (Issue #1070 AC1)。子 Issue body から複数行抽出。
+# Note: Code blocks (``` ... ``` / ~~~ ... ~~~) are stripped before regex match
+# to avoid false-matches on documentation examples (R2-H1 review fix).
+_CLOSES_AC_RE = re.compile(
+    r"(?:^|\n)\s*Closes-AC:\s*#(\d+):AC(\d+)", re.MULTILINE
+)
+_FENCED_CODE_BLOCK_RE = re.compile(
+    r"^(```|~~~).*?^(```|~~~)\s*$", re.MULTILINE | re.DOTALL
+)
+
+
+def _strip_fenced_code_blocks(text: str) -> str:
+    """Remove fenced code blocks (``` or ~~~) from markdown text.
+
+    Used to prevent false-matches when scanning for Closes-AC references —
+    a child Issue body may contain documentation examples inside code fences
+    that should NOT trigger Epic AC flips.
+    """
+    return _FENCED_CODE_BLOCK_RE.sub("", text)
+
+
+def _validate_positive_int(value: int, label: str) -> None:
+    if not isinstance(value, int) or value <= 0:
+        raise GitHubError(f"{label}は正の整数である必要があります: {value!r}")
+
+
+def _patch_checkbox_in_text(body: str, ac_num: int) -> tuple[str, bool]:
+    """Pure: flip ``- [ ] **AC{ac_num}**`` to ``- [x] **AC{ac_num}**``.
+
+    Strict format match: only ``- [ ] **AC{N}**`` lines are matched.
+    Bare ``- [ ] AC1`` (no bold) is intentionally NOT matched to minimize
+    false-positive flips on prose mentions.
+
+    Args:
+        body: Epic body markdown text.
+        ac_num: AC number to flip (1-based).
+
+    Returns:
+        Tuple of (patched_body, was_changed). ``was_changed`` is True iff
+        at least one ``- [ ]`` was flipped to ``- [x]`` for this AC.
+        Idempotent: already-checked boxes return (body, False).
+    """
+    pattern = re.compile(
+        rf"^(\s*-\s*)\[ \](\s*\*\*AC{ac_num}\*\*)", re.MULTILINE
+    )
+    new_body, count = pattern.subn(r"\1[x]\2", body)
+    return new_body, count > 0
+
+
+def extract_closes_ac(
+    issue_num: str, repo: str | None = None
+) -> list[tuple[int, int]]:
+    """Extract ``Closes-AC: #EPIC:ACN`` references from a child Issue body.
+
+    Returns the list of ``(epic_num, ac_num)`` tuples in document order.
+    Returns ``[]`` if no ``Closes-AC`` lines exist (NOT an error — the
+    convention is optional and will only apply forward-going).
+
+    Args:
+        issue_num: Child Issue number (integer string).
+        repo: Optional ``owner/repo`` string for cross-repo access.
+
+    Returns:
+        List of ``(epic_num, ac_num)`` tuples.
+
+    Raises:
+        GitHubError: On invalid issue_num/repo or gh API failure.
+    """
+    _validate_issue_num(issue_num)
+    if repo:
+        _validate_repo(repo)
+
+    repo_flag = ["-R", repo] if repo else []
+
+    issue_data = _gh_json("issue", "view", issue_num, *repo_flag, "--json", "body,number")
+    body: str = issue_data.get("body") or ""
+    if not body:
+        return []
+
+    # Strip fenced code blocks so doc examples like ```Closes-AC: #N:AC1``` are
+    # not mistaken for actual references (R2-H1 review fix).
+    sanitized = _strip_fenced_code_blocks(body)
+
+    return [
+        (int(epic), int(ac))
+        for epic, ac in _CLOSES_AC_RE.findall(sanitized)
+    ]
+
+
+def flip_epic_ac_checkbox(
+    epic_num: int, ac_num: int, repo: str | None = None
+) -> bool:
+    """Fetch Epic body, flip ``- [ ] **AC{ac_num}**`` checkbox, and persist via gh.
+
+    Args:
+        epic_num: Parent Epic Issue number.
+        ac_num: AC number to flip.
+        repo: Optional ``owner/repo`` string for cross-repo Epic access.
+
+    Returns:
+        ``True`` if an unchecked checkbox was flipped (gh issue edit was called).
+        ``False`` if already checked (idempotent skip — no API write) or if no
+        matching ``- [ ] **AC{N}**`` line exists in the Epic body (format deviation).
+
+    Raises:
+        GitHubError: On invalid input or gh API failure.
+
+    Note:
+        TOCTOU: this performs fetch → patch → edit without ``If-Match`` semantics.
+        If a parallel writer mutates the Epic body between fetch and edit, the
+        flip wins last-write. Acceptable for the autopilot single-Wave model;
+        concurrent flips on the same Epic are rare and self-converging
+        (re-running the hook is idempotent). Bulk-merge race is a known
+        limitation tracked separately.
+    """
+    _validate_positive_int(epic_num, "Epic番号")
+    _validate_positive_int(ac_num, "AC番号")
+    if repo:
+        _validate_repo(repo)
+
+    repo_flag = ["-R", repo] if repo else []
+
+    issue_data = _gh_json(
+        "issue", "view", str(epic_num), *repo_flag, "--json", "body,number"
+    )
+    body: str = issue_data.get("body") or ""
+
+    new_body, changed = _patch_checkbox_in_text(body, ac_num)
+    if not changed:
+        # Idempotent: skip the write (saves a gh API rate-hit)
+        return False
+
+    _gh("issue", "edit", str(epic_num), *repo_flag, "--body", new_body)
+    return True
+
+
+def update_epic_ac_checklist(
+    child_issue_num: str, repo: str | None = None
+) -> bool:
+    """Orchestrator: parse ``Closes-AC`` from child, flip each Epic AC checkbox.
+
+    For each ``(epic_num, ac_num)`` reference in the child Issue body, attempts
+    to flip the corresponding Epic body checkbox. Errors per-Epic are
+    suppressed (logged via stderr) so a transient failure on one Epic does
+    not block updates for others — this matches the AC1+AC2 chain-runner.sh
+    skip-on-error strategy.
+
+    Args:
+        child_issue_num: Child Issue number (integer string).
+        repo: Optional ``owner/repo`` string.
+
+    Returns:
+        ``True`` if at least one checkbox was flipped (newly checked).
+        ``False`` if no ``Closes-AC`` references found, or all flips were
+        idempotent (already checked).
+
+    Raises:
+        GitHubError: On invalid child_issue_num/repo or initial body fetch failure.
+    """
+    refs = extract_closes_ac(child_issue_num, repo)
+    if not refs:
+        return False
+
+    any_flipped = False
+    for epic_num, ac_num in refs:
+        try:
+            if flip_epic_ac_checkbox(epic_num, ac_num, repo):
+                any_flipped = True
+        except GitHubError as exc:
+            # Suppress per-Epic failure; mirrors chain-runner.sh skip-on-error.
+            print(
+                f"[update-epic-ac-checklist] WARN: Epic #{epic_num} AC{ac_num}"
+                f" 更新失敗 (継続): {exc}",
+                file=sys.stderr,
+            )
+    return any_flipped
 
 
 # ---------------------------------------------------------------------------
@@ -461,7 +645,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args:
         print("Usage: python3 -m twl.autopilot.github <command> [args...]", file=sys.stderr)
-        print("Commands: extract-ac, extract-parent-epic, resolve-project, pr-findings", file=sys.stderr)
+        print(
+            "Commands: extract-ac, extract-parent-epic, extract-closes-ac, "
+            "update-epic-ac-checklist, resolve-project, pr-findings",
+            file=sys.stderr,
+        )
         return 1
 
     command = args[0]
@@ -491,6 +679,35 @@ def main(argv: list[str] | None = None) -> int:
             if parent is None:
                 return 2
             print(str(parent))
+            return 0
+
+        elif command == "extract-closes-ac":
+            # Issue #1070 AC2: 子 Issue body の `Closes-AC: #EPIC:ACN` 全行を抽出
+            # exit 0 = 1 件以上見つかった (各 line stdout) / exit 2 = 0 件 / exit 1 = エラー
+            if not rest:
+                print("Usage: extract-closes-ac <issue-number> [owner/repo]", file=sys.stderr)
+                return 1
+            issue_num = rest[0]
+            repo = rest[1] if len(rest) > 1 else None
+            refs = extract_closes_ac(issue_num, repo)
+            if not refs:
+                return 2
+            for epic, ac in refs:
+                print(f"{epic}:{ac}")
+            return 0
+
+        elif command == "update-epic-ac-checklist":
+            # Issue #1070 AC3: 子 Issue の Closes-AC 全件で親 Epic body の
+            # `- [ ] **AC{N}**` を `- [x]` に flip し gh issue edit で persist。
+            # exit 0 = 1 件以上 flip 実行 / exit 2 = no-op (idempotent or no refs) / exit 1 = エラー
+            if not rest:
+                print("Usage: update-epic-ac-checklist <issue-number> [owner/repo]", file=sys.stderr)
+                return 1
+            issue_num = rest[0]
+            repo = rest[1] if len(rest) > 1 else None
+            flipped = update_epic_ac_checklist(issue_num, repo)
+            if not flipped:
+                return 2
             return 0
 
         elif command == "resolve-project":

--- a/cli/twl/tests/autopilot/test_github_closes_ac.py
+++ b/cli/twl/tests/autopilot/test_github_closes_ac.py
@@ -1,0 +1,444 @@
+"""Tests for Closes-AC parser + Epic AC checkbox flipper (Issue #1070).
+
+Covers:
+  - _patch_checkbox_in_text: pure function flipping `- [ ] **AC{N}**` to `- [x]`
+  - extract_closes_ac: parse `Closes-AC: #EPIC:ACN` lines from child Issue body
+  - flip_epic_ac_checkbox: I/O wrapper that fetches Epic body, patches, edits
+  - update_epic_ac_checklist: orchestrator + CLI dispatch
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from twl.autopilot.github import (
+    GitHubError,
+    _patch_checkbox_in_text,
+    extract_closes_ac,
+    flip_epic_ac_checkbox,
+    main,
+    update_epic_ac_checklist,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_issue_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[str, int], None]:
+    """Factory fixture: monkeypatch _gh_json with a fixed body."""
+
+    def _factory(body: str, number: int = 999) -> None:
+        monkeypatch.setattr(
+            "twl.autopilot.github._gh_json",
+            lambda *a, **kw: {"body": body, "number": number},
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def mock_gh_calls(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Capture _gh_json reads + _gh writes for assertion."""
+    calls: dict[str, Any] = {"json_reads": [], "edits": []}
+
+    def fake_gh_json(*args: str) -> dict[str, Any]:
+        calls["json_reads"].append(args)
+        body = calls.get("_next_body", "")
+        return {"body": body, "number": 999}
+
+    def fake_gh(*args: str, check: bool = True) -> Any:
+        calls["edits"].append((args, check))
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = ""
+        result.stderr = ""
+        return result
+
+    monkeypatch.setattr("twl.autopilot.github._gh_json", fake_gh_json)
+    monkeypatch.setattr("twl.autopilot.github._gh", fake_gh)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# _patch_checkbox_in_text — pure function, 8 tests
+# ---------------------------------------------------------------------------
+
+
+class TestPatchCheckboxInText:
+    """Pure regex-based body patcher. Strict match: `- [ ] **AC{N}**` only."""
+
+    def test_flips_unchecked_basic(self) -> None:
+        """Basic unchecked AC1 → checked."""
+        body = "- [ ] **AC1** (Phase 0): description\n"
+        patched, changed = _patch_checkbox_in_text(body, 1)
+        assert changed is True
+        assert "- [x] **AC1**" in patched
+        assert "- [ ] **AC1**" not in patched
+
+    def test_already_checked_idempotent(self) -> None:
+        """Already `[x]` → no change, returns same body."""
+        body = "- [x] **AC1** (Phase 0): description\n"
+        patched, changed = _patch_checkbox_in_text(body, 1)
+        assert changed is False
+        assert patched == body
+
+    def test_no_bold_not_matched(self) -> None:
+        """Strict format: bare `- [ ] AC1` (no bold) is NOT matched."""
+        body = "- [ ] AC1: description\n"
+        patched, changed = _patch_checkbox_in_text(body, 1)
+        assert changed is False
+        assert patched == body
+
+    def test_wrong_ac_number_unchanged(self) -> None:
+        """`- [ ] **AC2**` not flipped when patching AC1."""
+        body = "- [ ] **AC2** (Phase 0): description\n"
+        patched, changed = _patch_checkbox_in_text(body, 1)
+        assert changed is False
+        assert patched == body
+
+    def test_multiple_acs_only_target_flipped(self) -> None:
+        """When body has AC1 + AC2 + AC3, patching AC2 only flips AC2."""
+        body = (
+            "- [ ] **AC1** (Phase 0): first\n"
+            "- [ ] **AC2** (Phase 0): second\n"
+            "- [ ] **AC3** (Phase 0): third\n"
+        )
+        patched, changed = _patch_checkbox_in_text(body, 2)
+        assert changed is True
+        # AC2 is now [x]
+        assert "- [x] **AC2** (Phase 0): second" in patched
+        # AC1 and AC3 are unchanged
+        assert "- [ ] **AC1** (Phase 0): first" in patched
+        assert "- [ ] **AC3** (Phase 0): third" in patched
+
+    def test_with_leading_whitespace(self) -> None:
+        """Leading spaces/tabs preserved when flipping."""
+        body = "  - [ ] **AC5** (Phase 1): nested item\n"
+        patched, changed = _patch_checkbox_in_text(body, 5)
+        assert changed is True
+        assert "  - [x] **AC5** (Phase 1): nested item" in patched
+
+    def test_empty_body(self) -> None:
+        """Empty body → no change, no error."""
+        patched, changed = _patch_checkbox_in_text("", 1)
+        assert changed is False
+        assert patched == ""
+
+    def test_two_digit_ac_number(self) -> None:
+        """AC numbers > 9 (e.g., AC10) work correctly without AC1 false match."""
+        body = (
+            "- [ ] **AC1** (Phase 0): one\n"
+            "- [ ] **AC10** (Architecture): ten\n"
+        )
+        patched, changed = _patch_checkbox_in_text(body, 10)
+        assert changed is True
+        assert "- [x] **AC10** (Architecture): ten" in patched
+        # AC1 should remain unchecked — strict number match required
+        assert "- [ ] **AC1** (Phase 0): one" in patched
+
+
+# ---------------------------------------------------------------------------
+# extract_closes_ac — I/O via _gh_json, 6 tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractClosesAc:
+    def test_single_ref(self, mock_issue_body: Callable[[str, int], None]) -> None:
+        """One Closes-AC line → single tuple."""
+        mock_issue_body("Parent: #945\nCloses-AC: #945:AC8\n")
+        result = extract_closes_ac("999")
+        assert result == [(945, 8)]
+
+    def test_multi_ref(self, mock_issue_body: Callable[[str, int], None]) -> None:
+        """Multiple Closes-AC lines → multiple tuples in document order."""
+        body = (
+            "Parent: #945\n"
+            "Closes-AC: #945:AC6\n"
+            "Closes-AC: #945:AC7\n"
+        )
+        mock_issue_body(body)
+        result = extract_closes_ac("999")
+        assert result == [(945, 6), (945, 7)]
+
+    def test_no_refs_returns_empty(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """Body without Closes-AC → empty list (NOT exception)."""
+        mock_issue_body("Parent: #945\nRelated: #100\n")
+        assert extract_closes_ac("999") == []
+
+    def test_empty_body(self, mock_issue_body: Callable[[str, int], None]) -> None:
+        """Empty body → empty list."""
+        mock_issue_body("")
+        assert extract_closes_ac("999") == []
+
+    def test_invalid_issue_num_raises(self) -> None:
+        """Non-integer issue_num → GitHubError."""
+        with pytest.raises(GitHubError, match="Issue番号"):
+            extract_closes_ac("abc")
+
+    def test_invalid_repo_raises(self) -> None:
+        """Invalid repo format → GitHubError."""
+        with pytest.raises(GitHubError, match="不正な owner/repo"):
+            extract_closes_ac("999", repo="bad format")
+
+    def test_cross_epic_refs(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """Closes-AC across multiple Epics → all extracted."""
+        body = (
+            "Closes-AC: #945:AC8\n"
+            "Closes-AC: #1026:AC3\n"
+        )
+        mock_issue_body(body)
+        result = extract_closes_ac("999")
+        assert result == [(945, 8), (1026, 3)]
+
+    def test_fenced_code_block_ignored(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """``` ... ``` で囲まれた Closes-AC (例示) は抽出対象外 (R2-H1 fix)."""
+        body = (
+            "## 概要\n"
+            "下記は規約の例:\n"
+            "```\n"
+            "Closes-AC: #945:AC8\n"
+            "```\n"
+            "Parent: #1026\n"
+        )
+        mock_issue_body(body)
+        # Fenced block 内の Closes-AC は ignored
+        assert extract_closes_ac("999") == []
+
+    def test_fence_outside_block_still_matched(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """Fenced block の外にある Closes-AC は抽出対象."""
+        body = (
+            "## 概要\n"
+            "```python\n"
+            "x = 1  # not a Closes-AC\n"
+            "```\n"
+            "Closes-AC: #945:AC8\n"
+        )
+        mock_issue_body(body)
+        assert extract_closes_ac("999") == [(945, 8)]
+
+    def test_tilde_fence_also_stripped(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """~~~ ... ~~~ 形式の fence でも例示は ignored."""
+        body = (
+            "~~~\n"
+            "Closes-AC: #999:AC1\n"
+            "~~~\n"
+            "Closes-AC: #945:AC2\n"
+        )
+        mock_issue_body(body)
+        assert extract_closes_ac("999") == [(945, 2)]
+
+    def test_malformed_no_hash_ignored(
+        self, mock_issue_body: Callable[[str, int], None]
+    ) -> None:
+        """`Closes-AC: 945:AC8` (no `#`) → ignored, returns []."""
+        mock_issue_body("Closes-AC: 945:AC8\n")
+        assert extract_closes_ac("999") == []
+
+
+# ---------------------------------------------------------------------------
+# flip_epic_ac_checkbox — I/O wrapping pure patcher, 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestFlipEpicAcCheckbox:
+    def test_flip_calls_edit_when_changed(
+        self, mock_gh_calls: dict[str, Any]
+    ) -> None:
+        """When body has unchecked AC → gh issue edit called once with new body."""
+        mock_gh_calls["_next_body"] = "- [ ] **AC8** (Phase 1): foo\n"
+        result = flip_epic_ac_checkbox(945, 8)
+        assert result is True
+        # 1 read + 1 edit call expected
+        assert len(mock_gh_calls["json_reads"]) == 1
+        assert len(mock_gh_calls["edits"]) == 1
+        # The edit args should include `--body` with `[x]`
+        edit_args, _check = mock_gh_calls["edits"][0]
+        assert "issue" in edit_args
+        assert "edit" in edit_args
+        assert "945" in edit_args
+        assert "--body" in edit_args
+        body_idx = list(edit_args).index("--body")
+        new_body = edit_args[body_idx + 1]
+        assert "- [x] **AC8**" in new_body
+
+    def test_flip_skips_edit_when_already_checked(
+        self, mock_gh_calls: dict[str, Any]
+    ) -> None:
+        """Already `[x]` → no edit call (rate-hit savings)."""
+        mock_gh_calls["_next_body"] = "- [x] **AC8** (Phase 1): foo\n"
+        result = flip_epic_ac_checkbox(945, 8)
+        assert result is False
+        # Read happened, but no edit
+        assert len(mock_gh_calls["json_reads"]) == 1
+        assert len(mock_gh_calls["edits"]) == 0
+
+    def test_flip_returns_false_on_no_match(
+        self, mock_gh_calls: dict[str, Any]
+    ) -> None:
+        """Format-deviated body (`- [ ] AC8` no bold) → no edit, False."""
+        mock_gh_calls["_next_body"] = "- [ ] AC8: foo\n"
+        result = flip_epic_ac_checkbox(945, 8)
+        assert result is False
+        assert len(mock_gh_calls["edits"]) == 0
+
+    def test_invalid_epic_num_raises(self) -> None:
+        """Non-positive epic_num → GitHubError."""
+        with pytest.raises(GitHubError, match="Epic番号"):
+            flip_epic_ac_checkbox(0, 1)
+
+    def test_invalid_ac_num_raises(self) -> None:
+        """Non-positive ac_num → GitHubError."""
+        with pytest.raises(GitHubError, match="AC番号"):
+            flip_epic_ac_checkbox(945, 0)
+
+
+# ---------------------------------------------------------------------------
+# update_epic_ac_checklist — orchestrator, 3 tests
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateEpicAcChecklist:
+    def test_orchestrator_loops_multi_refs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Multiple Closes-AC → flip_epic_ac_checkbox called for each."""
+        # Stub extract_closes_ac to return 2 refs
+        monkeypatch.setattr(
+            "twl.autopilot.github.extract_closes_ac",
+            lambda issue, repo=None: [(945, 6), (945, 7)],
+        )
+        flip_calls: list[tuple[int, int]] = []
+        monkeypatch.setattr(
+            "twl.autopilot.github.flip_epic_ac_checkbox",
+            lambda epic, ac, repo=None: (flip_calls.append((epic, ac)) or True),
+        )
+        result = update_epic_ac_checklist("999")
+        assert result is True
+        assert flip_calls == [(945, 6), (945, 7)]
+
+    def test_orchestrator_returns_false_no_refs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No Closes-AC → no flip calls, returns False."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.extract_closes_ac",
+            lambda issue, repo=None: [],
+        )
+        result = update_epic_ac_checklist("999")
+        assert result is False
+
+    def test_orchestrator_returns_true_if_any_flipped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mixed: AC6 already checked, AC7 newly flipped → returns True."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.extract_closes_ac",
+            lambda issue, repo=None: [(945, 6), (945, 7)],
+        )
+
+        def fake_flip(epic: int, ac: int, repo: str | None = None) -> bool:
+            return ac == 7  # only AC7 newly flipped
+
+        monkeypatch.setattr(
+            "twl.autopilot.github.flip_epic_ac_checkbox", fake_flip
+        )
+        result = update_epic_ac_checklist("999")
+        assert result is True
+
+    def test_orchestrator_returns_false_if_all_idempotent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All flips return False (idempotent) → returns False."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.extract_closes_ac",
+            lambda issue, repo=None: [(945, 6), (945, 7)],
+        )
+        monkeypatch.setattr(
+            "twl.autopilot.github.flip_epic_ac_checkbox",
+            lambda epic, ac, repo=None: False,
+        )
+        result = update_epic_ac_checklist("999")
+        assert result is False
+
+    def test_orchestrator_suppresses_per_epic_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If one flip raises GitHubError, orchestrator continues with others."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.extract_closes_ac",
+            lambda issue, repo=None: [(945, 6), (1026, 1)],
+        )
+        flip_calls: list[tuple[int, int]] = []
+
+        def fake_flip(epic: int, ac: int, repo: str | None = None) -> bool:
+            flip_calls.append((epic, ac))
+            if epic == 945:
+                raise GitHubError("API failure")
+            return True
+
+        monkeypatch.setattr(
+            "twl.autopilot.github.flip_epic_ac_checkbox", fake_flip
+        )
+        # Should not raise; continue to second flip
+        result = update_epic_ac_checklist("999")
+        assert result is True
+        assert flip_calls == [(945, 6), (1026, 1)]
+
+
+# ---------------------------------------------------------------------------
+# CLI dispatch: update-epic-ac-checklist, 4 tests
+# ---------------------------------------------------------------------------
+
+
+class TestCLIUpdateEpicAcChecklist:
+    def test_cli_exit_0_on_flip(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """At least one flip occurred → exit 0."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.update_epic_ac_checklist",
+            lambda issue, repo=None: True,
+        )
+        exit_code = main(["update-epic-ac-checklist", "999"])
+        assert exit_code == 0
+
+    def test_cli_exit_2_on_no_change(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No flips occurred → exit 2 (idempotent skip signal)."""
+        monkeypatch.setattr(
+            "twl.autopilot.github.update_epic_ac_checklist",
+            lambda issue, repo=None: False,
+        )
+        exit_code = main(["update-epic-ac-checklist", "999"])
+        assert exit_code == 2
+
+    def test_cli_missing_args_exit_1(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Missing issue-num → exit 1 with usage."""
+        exit_code = main(["update-epic-ac-checklist"])
+        captured = capsys.readouterr()
+        assert exit_code == 1
+        assert "Usage" in captured.err
+
+    def test_cli_invalid_issue_num_exit_1(self) -> None:
+        """Invalid issue-num → exit 1."""
+        exit_code = main(["update-epic-ac-checklist", "abc"])
+        assert exit_code == 1

--- a/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
+++ b/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
@@ -86,6 +86,8 @@ Status gate は fail-closed を採用:
 - `plugins/twl/scripts/project-board-refined-migrate.sh` (新規、migration script)
 - `plugins/twl/skills/workflow-issue-refine/SKILL.md` (Step 6' に dual-write 追加)
 - `plugins/twl/commands/project-board-status-update.md` (target_status パラメータ化)
+- **#1026 (AC1+AC2) merged**: `cli/twl/src/twl/autopilot/github.py` `extract_parent_epic` + `plugins/twl/scripts/chain-runner.sh` `_transition_parent_epic_if_refined` (子 In Progress 遷移時に親 Epic Refined→In Progress を auto-fire)
+- **#1070 (AC checklist auto-update) merged**: `cli/twl/src/twl/autopilot/github.py` `extract_closes_ac` / `flip_epic_ac_checkbox` / `update_epic_ac_checklist` + `plugins/twl/scripts/chain-runner.sh` `_update_parent_epic_ac_checklist` (子 Done 遷移時に親 Epic body の `- [ ] **AC{N}**` を `Closes-AC: #EPIC:ACN` 規約に従って auto-flip)
 
 ## Phase B（別 Issue 起票予定）
 
@@ -95,3 +97,5 @@ Status gate は fail-closed を採用:
 - (c) su-observer による明示的 approval
 
 Phase B 内容: `pre-bash-refined-label-gate.sh` deprecate / 削除、label write 削除（Status のみ）、cache 導入。
+
+**Auto-update layer 完成 (Phase 1 範囲)**: 子 Issue → 親 Epic の Status auto-transition (#1026 AC1+AC2) と AC checklist auto-flip (#1070) の両方が autopilot 経路 (chain-runner.sh `step_board_status_update`) に組み込まれた。新規 Issue は `--parent #N` + `--closes-ac #EPIC:ACN` (issue-create.md) を指定することで dual-write 規約を full enforce できる。

--- a/plugins/twl/commands/issue-create.md
+++ b/plugins/twl/commands/issue-create.md
@@ -13,6 +13,7 @@ GitHub Issueを作成するatomicコマンド。
 ```
 /twl:issue-create "タイトル" "本文"
 /twl:issue-create "タイトル" "本文" --label enhancement --related #45 --parent #123
+/twl:issue-create "タイトル" "本文" --parent #945 --closes-ac #945:AC8
 ```
 
 ## 引数
@@ -24,6 +25,7 @@ GitHub Issueを作成するatomicコマンド。
 | --label | No | ラベル（複数指定可） |
 | --related #N | No | 関連Issue（本文末尾に `Related: #N` 追記） |
 | --parent #N | No | 親Issue（本文末尾に `Parent: #N` 追記） |
+| --closes-ac #EPIC:ACN | No | 親 Epic AC 紐付け（本文末尾に `Closes-AC: #EPIC:ACN` 追記、複数指定可）。Issue close 時に親 Epic body の `- [ ] **AC{N}**` を `- [x]` に auto-flip (Issue #1070) |
 | --repo owner/repo | No | 作成先リポジトリ（未指定時は現在のリポ） |
 
 ---
@@ -38,6 +40,7 @@ GitHub Issueを作成するatomicコマンド。
 - labels: --label に続く値（複数可）
 - related: --related に続く #N 値（複数可）
 - parent: --parent に続く #N 値
+- closes_ac: --closes-ac に続く #EPIC:ACN 値（複数可、Issue #1070）
 - repo: --repo に続く owner/repo 値（未指定時は空）
 
 タイトルと本文が両方指定されていることを確認。不足時は使用方法を表示。
@@ -49,7 +52,13 @@ IF --related が指定されている
 THEN 本文末尾に "\n\n---\nRelated: #N1, #N2" を追加
 IF --parent が指定されている
 THEN 本文末尾に "Parent: #N" を追加（Related と同じセクション内）
+IF --closes-ac が指定されている
+THEN 各 #EPIC:ACN について "Closes-AC: #EPIC:ACN" を行ごとに追加（Related/Parent と同セクション、複数 AC は複数行）
 ```
+
+`Closes-AC:` 規約 (Issue #1070) は Issue close 時に親 Epic body の `- [ ] **AC{N}**`
+を `- [x]` に auto-flip するための機械抽出 marker。`Parent: #N` と並列に配置する。
+複数 AC を満たす Issue は複数行で記述する (例: `Closes-AC: #945:AC6` + `Closes-AC: #945:AC7`)。
 
 ### 2.5 Format Guard（MUST）
 

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2598,7 +2598,7 @@ scripts:
   autopilot-github:
     type: script
     path: ../../cli/twl/src/twl/autopilot/github.py
-    description: "GitHub API ラッパー（Issue AC抽出・親 Epic抽出・PR findings・Project解決・Issue作成）（Python: python3 -m twl.autopilot.github）"
+    description: "GitHub API ラッパー（Issue AC抽出・親 Epic抽出・Closes-AC抽出・Epic AC checkbox auto-flip・PR findings・Project解決・Issue作成）（Python: python3 -m twl.autopilot.github）"
 
   session-audit:
     type: script

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -435,6 +435,38 @@ _transition_parent_epic_if_refined() {
   ok "epic-auto-transition" "親 Epic #${parent_num}: Refined → In Progress (子 #${child_issue_num} 起因)"
 }
 
+# --- _update_parent_epic_ac_checklist: 親 Epic AC checkbox auto-update (Issue #1070) ---
+# 子 Issue が "Done" に遷移した時、子 body の `Closes-AC: #EPIC:ACN` 全行に対し
+# 親 Epic body の `- [ ] **AC{N}**` を `- [x]` に flip する。
+# Idempotent: 既に [x] の場合は no-op (gh API write skip)。
+# 失敗時は全エラーを skip 扱いで suppress（既存 step_board_status_update と同じ防御戦略）。
+#
+# Args:
+#   $1=child_issue_num: 子 Issue 番号
+#   $2=repo_full:       owner/repo (cross-repo Epic 用、空なら現在 repo)
+_update_parent_epic_ac_checklist() {
+  local child_issue_num="$1"
+  local repo_full="${2:-}"
+
+  ensure_pythonpath || return 0
+  local exit_code
+  python3 -m twl.autopilot.github update-epic-ac-checklist \
+    "$child_issue_num" ${repo_full:+"$repo_full"} 2>/dev/null
+  exit_code=$?
+  case "$exit_code" in
+    0)
+      ok "epic-ac-checklist" "Epic AC チェックボックス更新 (子 #${child_issue_num})"
+      ;;
+    2)
+      skip "epic-ac-checklist" "Closes-AC なし or 全 AC 更新済み — no-op (子 #${child_issue_num})"
+      ;;
+    *)
+      skip "epic-ac-checklist" "Epic AC 更新失敗 — suppress (子 #${child_issue_num}, exit=${exit_code})"
+      ;;
+  esac
+  return 0
+}
+
 # --- board-status-update: Project Board Status 更新 ---
 step_board_status_update() {
   record_current_step "board-status-update"
@@ -504,6 +536,12 @@ step_board_status_update() {
   # 親 Epic が "Refined" なら "In Progress" に自動遷移する
   if [[ "$target_status" == "In Progress" ]]; then
     _transition_parent_epic_if_refined "$issue_num" "$final_num" "$final_id" "$owner" "$repo" "$fields"
+  fi
+
+  # Issue #1070: 子 Issue が "Done" に遷移した時、子の Closes-AC: #EPIC:ACN
+  # 全行について 親 Epic body の `- [ ] **AC{N}**` を `- [x]` に flip する
+  if [[ "$target_status" == "Done" ]]; then
+    _update_parent_epic_ac_checklist "$issue_num" "$repo"
   fi
 }
 

--- a/plugins/twl/tests/bats/scripts/chain-runner-epic-ac-checklist.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-epic-ac-checklist.bats
@@ -1,0 +1,273 @@
+#!/usr/bin/env bats
+# chain-runner-epic-ac-checklist.bats
+# Requirement: Issue #1070 — 子 Issue が "Done" に遷移した時、子 body の
+#              `Closes-AC: #EPIC:ACN` 全行について 親 Epic body の
+#              `- [ ] **AC{N}**` を `- [x]` に flip する。
+# Spec: ADR-024 dual-write 規約「AC checklist auto-update」
+# Coverage: --type=integration --coverage=autopilot
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  CR="$SANDBOX/scripts/chain-runner.sh"
+  export CR
+
+  GH_LOG="$SANDBOX/gh-calls.log"
+  export GH_LOG
+  : > "$GH_LOG"
+
+  PYTHON_REAL=$(command -v python3)
+  export PYTHON_REAL
+}
+
+teardown() {
+  common_teardown
+}
+
+# python3 stub: update-epic-ac-checklist と resolve-project をモック化
+# 他 (state read/write 等) は実体に委譲
+# Args: $1=ac_update_exit_code (0=flipped / 2=no-op / 1=error)
+_setup_python_stub_full() {
+  local ac_update_exit_code="${1:-0}"
+
+  cat > "$STUB_BIN/python3" <<EOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"twl.autopilot.github update-epic-ac-checklist"*)
+    exit ${ac_update_exit_code}
+    ;;
+  *"twl.autopilot.github extract-parent-epic"*)
+    # AC1+AC2 (#1026) hook が同じ step で発火するので minimal stub。
+    # parent なし扱い → AC1+AC2 hook はスキップ → AC3 hook のみテストできる
+    exit 2
+    ;;
+  *"twl.autopilot.github resolve-project"*)
+    cat <<'JSON'
+{"project_num":"99","project_id":"PVT_mock_proj","owner":"shuu5","repo_name":"twill","repo_fullname":"shuu5/twill"}
+JSON
+    exit 0
+    ;;
+  *)
+    exec "$PYTHON_REAL" "\$@"
+    ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/python3"
+}
+
+# gh stub: project list / item-add / field-list / item-edit を mock
+# bats 側は AC checklist update の "Python helper が呼ばれた回数" のみで判定するため、
+# AC checklist 更新の gh issue edit は Python stub 内で完結 (gh は呼ばれない)
+_setup_gh_stub() {
+  cat > "$STUB_BIN/gh" <<EOF
+#!/usr/bin/env bash
+echo "gh: \$*" >> "$GH_LOG"
+case "\$*" in
+  "project list --owner @me --limit 1")
+    echo '[]'
+    exit 0
+    ;;
+  "project item-add"*)
+    echo '{"id":"PVTI_mock_item_id"}'
+    exit 0
+    ;;
+  "project field-list"*)
+    cat <<'JSON'
+{
+  "fields": [
+    {
+      "name": "Status",
+      "id": "PVTSSF_mock_status_field",
+      "options": [
+        {"name":"Refined","id":"opt_refined"},
+        {"name":"In Progress","id":"opt_in_progress"},
+        {"name":"Done","id":"opt_done"}
+      ]
+    }
+  ]
+}
+JSON
+    exit 0
+    ;;
+  "project item-list"*)
+    echo '{"items":[]}'
+    exit 0
+    ;;
+  "issue view"*)
+    echo '{"body":"some body","number":1}'
+    exit 0
+    ;;
+  "project item-edit"*)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/gh"
+}
+
+# Capture python3 invocations (subset). $PY_LOG records what was called.
+_setup_python_stub_capture() {
+  local ac_update_exit_code="${1:-0}"
+  PY_LOG="$SANDBOX/python-calls.log"
+  export PY_LOG
+  : > "$PY_LOG"
+
+  cat > "$STUB_BIN/python3" <<EOF
+#!/usr/bin/env bash
+echo "py: \$*" >> "$PY_LOG"
+case "\$*" in
+  *"twl.autopilot.github update-epic-ac-checklist"*)
+    exit ${ac_update_exit_code}
+    ;;
+  *"twl.autopilot.github extract-parent-epic"*)
+    exit 2
+    ;;
+  *"twl.autopilot.github resolve-project"*)
+    cat <<'JSON'
+{"project_num":"99","project_id":"PVT_mock_proj","owner":"shuu5","repo_name":"twill","repo_fullname":"shuu5/twill"}
+JSON
+    exit 0
+    ;;
+  *)
+    exec "$PYTHON_REAL" "\$@"
+    ;;
+esac
+EOF
+  chmod +x "$STUB_BIN/python3"
+}
+
+# ===========================================================================
+# AC1: target_status="Done" + Closes-AC ある + flip 成功 → Python helper 呼ばれる
+# ===========================================================================
+
+@test "epic-ac-checklist[done-flip]: target_status='Done' で update-epic-ac-checklist が呼ばれ ok ログ" {
+  _setup_python_stub_capture 0
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "Done"
+
+  assert_success
+  # Python helper が呼ばれたことを確認
+  local py_count
+  py_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$py_count" -ge 1 ]] || {
+    echo "FAIL: update-epic-ac-checklist が呼ばれていない (py_count=$py_count)" >&2
+    cat "$PY_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2: target_status="Done" + Closes-AC なし → Python helper 呼ばれるが no-op (exit 2)
+# ===========================================================================
+
+@test "epic-ac-checklist[no-closes-ac]: Closes-AC なし (exit 2) で skip ログ + step は success" {
+  _setup_python_stub_capture 2
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "Done"
+
+  assert_success
+  # Python helper は呼ばれる (gating は Python 側)
+  local py_count
+  py_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$py_count" -ge 1 ]] || {
+    echo "FAIL: update-epic-ac-checklist が呼ばれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: target_status="In Progress" → AC checklist hook はスキップ (target guard)
+# ===========================================================================
+
+@test "epic-ac-checklist[target-guard-in-progress]: target_status='In Progress' では AC checklist hook が起動しない" {
+  _setup_python_stub_capture 0
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  # AC checklist hook は呼ばれてはならない
+  local py_count
+  py_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$py_count" -eq 0 ]] || {
+    echo "FAIL: target_status='In Progress' なのに update-epic-ac-checklist が呼ばれた (count=$py_count)" >&2
+    cat "$PY_LOG" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: target_status="Refined" でも AC checklist hook はスキップ
+# ===========================================================================
+
+@test "epic-ac-checklist[target-guard-refined]: target_status='Refined' でも AC checklist hook が起動しない" {
+  _setup_python_stub_capture 0
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "Refined"
+
+  assert_success
+  local py_count
+  py_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$py_count" -eq 0 ]] || {
+    echo "FAIL: target_status='Refined' で AC checklist hook が起動した" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5: Python helper が exit 1 (失敗) → step は success (suppress strategy)
+# ===========================================================================
+
+@test "epic-ac-checklist[suppress-failure]: Python helper exit 1 でも step は success (skip ログ)" {
+  _setup_python_stub_capture 1
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "Done"
+
+  # 失敗を suppress するため step は成功扱い
+  assert_success
+  # Python helper は呼ばれた
+  local py_count
+  py_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$py_count" -ge 1 ]] || {
+    echo "FAIL: update-epic-ac-checklist が呼ばれていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC6: AC1+AC2 hook (parent-epic-transition) と AC3 hook (epic-ac-checklist) は
+# 直交する — target_status="In Progress" では AC1+AC2 のみ起動
+# ===========================================================================
+
+@test "epic-ac-checklist[orthogonal]: 'In Progress' で AC1+AC2 hook が起動するが AC3 hook は起動しない" {
+  _setup_python_stub_capture 0
+  _setup_gh_stub
+
+  run bash "$CR" board-status-update 9001 "In Progress"
+
+  assert_success
+  # AC1+AC2 (extract-parent-epic) は呼ばれる
+  local parent_count
+  parent_count=$(grep -c "extract-parent-epic" "$PY_LOG" || true)
+  [[ "$parent_count" -ge 1 ]] || {
+    echo "FAIL: target_status='In Progress' で extract-parent-epic が呼ばれていない" >&2
+    cat "$PY_LOG" >&2
+    return 1
+  }
+  # AC3 (update-epic-ac-checklist) は呼ばれない
+  local ac_count
+  ac_count=$(grep -c "update-epic-ac-checklist" "$PY_LOG" || true)
+  [[ "$ac_count" -eq 0 ]] || {
+    echo "FAIL: target_status='In Progress' で update-epic-ac-checklist が呼ばれた" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1070 (ADR-024 dual-write 規約 — Epic AC checklist auto-update) を実装。
親 Issue #1026 (AC1+AC2 = Status auto-transition、PR #1068+#1069 で merged) の続編で、
当初 scope 外だった **AC3 = AC checklist auto-update** を別 Issue 化して扱う。

## 設計（feature-dev フロー Phase 1-7、Hybrid architecture 採用）

### 規約 (AC1)

子 Issue body 末尾に `Closes-AC: #EPIC:ACN` を追加（`Parent: #N` と対称）:

```
Parent: #945
Closes-AC: #945:AC6
Closes-AC: #945:AC7
```

`/twl:issue-create --closes-ac #945:AC6 --closes-ac #945:AC7` で自動追記。複数 AC は複数行で記述。

### Parser 層 (`cli/twl/src/twl/autopilot/github.py`)

| API | 役割 |
|---|---|
| `_CLOSES_AC_RE` | regex: `(?:^\|\n)\s*Closes-AC:\s*#(\d+):AC(\d+)` |
| `_strip_fenced_code_blocks(text)` | 例示用 ``` ... ``` / ~~~ ... ~~~ 内の Closes-AC を除外 (R2-H1 fix) |
| `_patch_checkbox_in_text(body, ac_num)` | 純粋関数。`(str, bool)` return で idempotent skip 時 API write 回避 |
| `extract_closes_ac(issue, repo)` | I/O wrapper、`list[tuple[int, int]]` を返す |
| `flip_epic_ac_checkbox(epic, ac, repo)` | Epic body fetch → patch → `gh issue edit --body` |
| `update_epic_ac_checklist(child, repo)` | orchestrator、per-Epic 失敗 suppress |

CLI dispatch: `extract-closes-ac` / `update-epic-ac-checklist` (3-way exit codes 0/2/1)。

### Hook 層 (`plugins/twl/scripts/chain-runner.sh`)

`step_board_status_update` 内に `_update_parent_epic_ac_checklist` helper を追加。
`target_status == "Done"` の時のみ発火（AC1+AC2 hook の `In Progress` と直交）。

```bash
if [[ "$target_status" == "In Progress" ]]; then
  _transition_parent_epic_if_refined ...   # 既存 (#1026)
fi
if [[ "$target_status" == "Done" ]]; then
  _update_parent_epic_ac_checklist "$issue_num" "$repo"   # NEW (#1070)
fi
```

`skip-on-error` 戦略を踏襲（既存 `_transition_parent_epic_if_refined` と同型）。

### Format Match Strict

`- [ ] **AC{N}**` のみ match (`#945` 等の現行 Epic 全形式と整合):

- bare `- [ ] AC1` (no bold) は match しない → 誤検出ゼロ
- AC10 vs AC1 の数字境界: regex `\*\*AC{N}\*\*` で安全 (test カバレッジあり)

## AC scope

| AC | 状態 |
|---|---|
| AC1: 規約定義 (issue-create.md / ADR-024) | ✅ 実装 |
| AC2: Parser 実装 (Python) | ✅ 実装 |
| AC3: Hook 実装 (Bash + Python helper) | ✅ 実装 |
| AC4: 統合テスト | ✅ 実装 |
| AC5: PR merge + main HEAD 更新 | 本 PR で達成予定 |

## Quality Review (Phase 6) 修正済み

| # | finding | 対応 |
|---|---|---|
| HIGH R2-H1 | code-fence (\`\`\`) 内の Closes-AC 例示が誤マッチ | `_strip_fenced_code_blocks` 追加 |
| HIGH R1-H1 | bash if/else 4 行が冗長 | `${var:+"$var"}` 1 行に簡素化 |
| MED R3-#4 | test_closes_ac.py 命名が `test_github_*` 規約に逸脱 | `test_github_closes_ac.py` に rename |
| MED R1-M1 | `_patch_checkbox_in_text` の WHAT コメント | docstring 内に統合し削除 |
| MED R2-M1 | TOCTOU race の制限が docstring に明記なし | docstring に Note: 明記 |

残課題は別 PR で対応:
- DRY: 3 関数 (`extract_issue_ac` / `extract_parent_epic` / `extract_closes_ac`) で `_validate_*` → `_gh_json("issue", "view", ...)` の 5 行が重複 → `_fetch_issue_body` helper 抽出
- `mock_issue_body` fixture を `conftest.py` に集約
- `_gh_json` の `json.JSONDecodeError` を `GitHubError` に変換
- chain-runner.sh `2>/dev/null` を `>>$CHAIN_LOG` 化（既存全体の suppress 戦略と一貫）

## テスト

### pytest (`cli/twl/tests/autopilot/test_github_closes_ac.py`)

33 件、全件 PASS:

| Class | 件数 | カバレッジ |
|---|---|---|
| `TestPatchCheckboxInText` | 8 | 純粋関数、AC10 vs AC1 境界、indent、idempotent |
| `TestExtractClosesAc` | 8 | single/multi/empty/cross-epic/code-fence/tilde-fence/malformed/invalid |
| `TestFlipEpicAcCheckbox` | 5 | flip / idempotent skip / no-match / invalid epic / invalid ac |
| `TestUpdateEpicAcChecklist` | 5 | multi-loop / no-refs / mixed / all-idempotent / per-epic-error suppress |
| `TestCLIUpdateEpicAcChecklist` | 4 | exit 0/2/1 + missing args |

### bats (`plugins/twl/tests/bats/scripts/chain-runner-epic-ac-checklist.bats`)

6 件、全件 PASS:

| test | 検証内容 |
|---|---|
| `[done-flip]` | `target_status='Done'` で `update-epic-ac-checklist` Python helper 発火 |
| `[no-closes-ac]` | exit 2 (Closes-AC なし) で skip ログ + step success |
| `[target-guard-in-progress]` | `target_status='In Progress'` では AC checklist hook 不発 |
| `[target-guard-refined]` | `target_status='Refined'` でも不発 |
| `[suppress-failure]` | Python helper exit 1 でも step success (suppress) |
| `[orthogonal]` | `In Progress` 時は AC1+AC2 のみ起動、AC3 hook 起動せず |

### Regression

- 既存 #1026 pytest 12 件 全件 PASS
- 既存 #1026 bats 5 件 全件 PASS
- 全 chain-runner bats 39 件 + 新 6 件 = **45/45 PASS**
- 全 github pytest 12 件 + 新 33 件 = **45/45 PASS**

## Quality Gate

- `twl --validate`: OK 2661 / Violations 4（既存、増加なし）
- `twl --check`: All files exist (Missing 0)
- AC1+AC2 (#1026) の mirror pattern を最大限保持

Closes #1070
