### PR TITLE
fix(observer): PreCompact hook が working-memory を auto 更新し su-compact 誘導を追加 (#1020)

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2627,7 +2627,7 @@ scripts:
   su-precompact:
     type: script
     path: scripts/su-precompact.sh
-    description: "PreCompact hook: .supervisor/ なければ exit 0、あれば working-memory.md を stdout に出力"
+    description: "PreCompact hook: .supervisor/ なければ exit 0、session.json から状態を取り出して working-memory.md を atomic write で更新し stdout に出力"
 
   su-postcompact:
     type: script

--- a/plugins/twl/scripts/su-postcompact.sh
+++ b/plugins/twl/scripts/su-postcompact.sh
@@ -43,6 +43,7 @@ echo "### 復帰手順（必須）"
 echo "1. 以下の Working Memory を読み、処理中タスクと次のステップを把握する"
 echo "2. project_session_state.md (auto memory) を確認して全体状態を復元する"
 echo "3. mcp__doobidoo__memory_search で関連記憶を取得する（query: 直近のタスク内容）"
+echo "4. **Long-term Memory 保存**: Skill(twl:su-compact) を実行して doobidoo への知識外部化を行うこと（SU-6a 準拠）"
 echo ""
 
 if [ -f "$SUPERVISOR_DIR/working-memory.md" ]; then

--- a/plugins/twl/scripts/su-precompact.sh
+++ b/plugins/twl/scripts/su-precompact.sh
@@ -50,7 +50,7 @@ else
             echo "timestamp: $(date -Iseconds)"
             echo ""
             echo "(session.json なし — 状態復元に project_session_state.md と doobidoo を使用すること)"
-        } > "${SUPERVISOR_DIR}/working-memory.md"
+        } > "${SUPERVISOR_DIR}/working-memory.md.tmp" && mv "${SUPERVISOR_DIR}/working-memory.md.tmp" "${SUPERVISOR_DIR}/working-memory.md"
     fi
 fi
 

--- a/plugins/twl/scripts/su-precompact.sh
+++ b/plugins/twl/scripts/su-precompact.sh
@@ -3,12 +3,62 @@ set -euo pipefail
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
 [ -d "$SUPERVISOR_DIR" ] || exit 0
 
+# session.json から現在状態を取り出して working-memory.md を更新する
+SESSION_JSON="${SUPERVISOR_DIR}/session.json"
+if [[ -f "$SESSION_JSON" ]]; then
+    SESSION_STATE=$(SESSION_JSON_PATH="$SESSION_JSON" python3 - <<'PYEOF'
+import json, os, sys
+path = os.environ.get("SESSION_JSON_PATH", "")
+try:
+    with open(path) as f:
+        d = json.load(f)
+    parts = []
+    for key in ("session_id", "claude_session_id", "status", "current_task", "current_wave",
+                "processing_issue", "next_step", "started_at", "observer_window"):
+        if key in d and d[key]:
+            parts.append(f"- {key}: {d[key]}")
+    print("\n".join(parts) if parts else "(session.json: no fields)")
+except Exception as e:
+    print(f"(session.json parse error: {e})", file=sys.stderr)
+    print("")
+PYEOF
+)
+    {
+        echo "# Working Memory — PreCompact Snapshot"
+        echo "timestamp: $(date -Iseconds)"
+        echo ""
+        echo "## Session State (from session.json)"
+        echo "$SESSION_STATE"
+        echo ""
+        if [[ -f "${SUPERVISOR_DIR}/working-memory.md" ]]; then
+            echo "## Previous Working Memory"
+            cat "${SUPERVISOR_DIR}/working-memory.md"
+        fi
+    } > "${SUPERVISOR_DIR}/working-memory.md.tmp" && mv "${SUPERVISOR_DIR}/working-memory.md.tmp" "${SUPERVISOR_DIR}/working-memory.md"
+else
+    # session.json なし: 既存 working-memory.md があればタイムスタンプを更新
+    if [[ -f "${SUPERVISOR_DIR}/working-memory.md" ]]; then
+        {
+            echo "# Working Memory — PreCompact Snapshot"
+            echo "timestamp: $(date -Iseconds)"
+            echo ""
+            cat "${SUPERVISOR_DIR}/working-memory.md"
+        } > "${SUPERVISOR_DIR}/working-memory.md.tmp" && mv "${SUPERVISOR_DIR}/working-memory.md.tmp" "${SUPERVISOR_DIR}/working-memory.md"
+    else
+        {
+            echo "# Working Memory — PreCompact Snapshot"
+            echo "timestamp: $(date -Iseconds)"
+            echo ""
+            echo "(session.json なし — 状態復元に project_session_state.md と doobidoo を使用すること)"
+        } > "${SUPERVISOR_DIR}/working-memory.md"
+    fi
+fi
+
 echo "## [PRE-COMPACT] Working Memory スナップショット"
 echo "timestamp: $(date -Iseconds)"
 echo ""
-
-if [ -f "$SUPERVISOR_DIR/working-memory.md" ]; then
-  cat "$SUPERVISOR_DIR/working-memory.md"
-else
-  echo "(working-memory.md なし)"
+echo "以下の Working Memory を保存しました。Compaction 後は PostCompact hook の指示に従い復元すること。"
+echo ""
+if [[ -f "${SUPERVISOR_DIR}/working-memory.md" ]]; then
+    cat "${SUPERVISOR_DIR}/working-memory.md"
 fi

--- a/plugins/twl/scripts/su-precompact.sh
+++ b/plugins/twl/scripts/su-precompact.sh
@@ -22,7 +22,7 @@ except Exception as e:
     print(f"(session.json parse error: {e})", file=sys.stderr)
     print("")
 PYEOF
-)
+) || SESSION_STATE="(session.json 読み取り失敗)"
     {
         echo "# Working Memory — PreCompact Snapshot"
         echo "timestamp: $(date -Iseconds)"

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -85,7 +85,7 @@ spawnable_by:
 | SU-2 | Layer 2（Escalate）の介入はユーザー確認が MUST |
 | SU-3 | Supervisor 自身が Issue の直接実装を行ってはならない（SHALL） |
 | SU-4 | 同時に supervise できる controller session は 5 を超えてはならない（SHALL） |
-| SU-5 | context 消費量 80% 到達時に知識外部化を開始しなければならない（SHALL） |
+| SU-5 | context 消費量 80% 到達時に知識外部化を開始しなければならない（SHALL）。検知手段: Claude Code の PreCompact hook（`su-precompact.sh`）が自動発火するため、hook stdout の `[PRE-COMPACT]` マーカーを観測すること。また status line の `[BUDGET-LOW]` シグナルも補助的に使用可。能動的な context 残量取得手段は現時点では未確立（#1020 追跡）。 |
 | SU-6a | Wave 完了時に結果収集と externalize-state を実行しなければならない（SHALL） |
 | SU-6b | context 逼迫時またはユーザー指示時に `/compact` をユーザーへ提案しなければならない（SHOULD） |
 | SU-7 | observed session への inject/send-keys は介入プロトコルに従う場合に許可（MAY） |

--- a/plugins/twl/tests/bats/ac-test-mapping-1020.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1020.yaml
@@ -1,0 +1,37 @@
+mappings:
+  - ac_index: 1
+    ac_text: "su-precompact.sh が working-memory.md の auto 更新 (session.json から状態取り出し → ensure write) を実装する"
+    test_file: "plugins/twl/tests/bats/su-precompact-hook-1020.bats"
+    test_names:
+      - "ac1: su-precompact.sh が working-memory.md を write する（static grep）"
+      - "ac1: su-precompact.sh が session.json から状態を取り出す（static grep）"
+      - "ac1: su-precompact.sh が bash -n を通過する（syntax check）"
+
+  - ac_index: 2
+    ac_text: "su-postcompact.sh stdout に「Skill(twl:su-compact) を実行して Long-term Memory 保存」を明示誘導"
+    test_file: "plugins/twl/tests/bats/su-precompact-hook-1020.bats"
+    test_names:
+      - "ac2: su-postcompact.sh に 'Skill(twl:su-compact)' を明示する行が存在する（static grep）"
+      - "ac2: su-postcompact.sh 実行時に stdout に 'Skill(twl:su-compact)' が含まれる"
+
+  - ac_index: 3
+    ac_text: "su-observer/SKILL.md SU-5 セクションに context 残量検知手段が明示される (案 C 範囲、別 Issue 切り出しも可)"
+    test_file: "plugins/twl/tests/bats/su-precompact-hook-1020.bats"
+    test_names:
+      - "ac3: SKILL.md の SU-5 行に context 残量検知手段が記述されている（grep チェック）"
+
+  - ac_index: 4
+    ac_text: "bats 経路で auto_precompact trigger が動作確認 (working-memory.md 更新検証)"
+    test_file: "plugins/twl/tests/bats/su-precompact-hook-1020.bats"
+    test_names:
+      - "ac4: su-precompact.sh 実行後に working-memory.md が更新される（tempdir）"
+      - "ac4: su-precompact.sh 実行後の working-memory.md に session.json の情報が含まれる"
+      - "ac4: su-precompact.sh — .supervisor ディレクトリが存在しない場合は正常 exit 0"
+
+  - ac_index: 5
+    ac_text: "PR merged + main HEAD 更新 + working-memory.md auto-update が e2e で動作"
+    test_file: "plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats"
+    test_names:
+      - "ac5(e2e): PreCompact hook 実行後に working-memory.md が session 状態を反映して更新される"
+      - "ac5(e2e): PreCompact hook — session.json が存在しない場合でも working-memory.md を保持/生成する"
+      - "ac5(e2e): PreCompact hook 実行後に su-postcompact.sh が Skill(twl:su-compact) 誘導を出力する"

--- a/plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats
+++ b/plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# e2e/su-precompact-hook-1020-e2e.bats
+#
+# Issue #1020: tech-debt(observer): PreCompact hook が working-memory を退避せず cat のみ
+#
+# AC5: PR merged + main HEAD 更新 + working-memory.md auto-update が e2e で動作
+#
+# このテストは e2e レベルの動作確認を行う。
+# PreCompact hook (su-precompact.sh) が HookEvent として登録されており、
+# 実際に実行されたときに working-memory.md が更新されることを確認する。
+#
+# RED: 現在の実装は working-memory.md を write しないため fail する
+
+load '../helpers/common'
+
+PRECOMPACT_SCRIPT=""
+
+setup() {
+  common_setup
+
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${helpers_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  local repo_root
+  repo_root="$(cd "${tests_dir}/.." && pwd)"
+
+  PRECOMPACT_SCRIPT="${repo_root}/scripts/su-precompact.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC5: e2e — working-memory.md auto-update が動作すること
+#
+# PreCompact hook 経路の e2e 動作確認:
+#   1. .supervisor/session.json に現在の状態が存在する
+#   2. su-precompact.sh を HookEvent として実行
+#   3. working-memory.md が session.json の状態を反映した内容で更新される
+#
+# RED: 現在の実装は cat のみで write しないため fail する
+# ===========================================================================
+
+@test "ac5(e2e): PreCompact hook 実行後に working-memory.md が session 状態を反映して更新される" {
+  # RED: 現在の su-precompact.sh は working-memory.md を write しないため fail する
+  # PASS 条件（実装後）:
+  #   - working-memory.md が更新タイムスタンプ付きで書き込まれる
+  #   - 内容に session.json 由来の状態（session_id 等）が含まれる
+
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+
+  # e2e シナリオ: 実際のユースケースを模したセッション状態を用意
+  local test_session_id="e2e-session-1020"
+  local test_task="Issue #1020 PreCompact write 実装の検証"
+
+  cat > "${supervisor_dir}/session.json" <<SESSIONEOF
+{
+  "session_id": "${test_session_id}",
+  "claude_session_id": "e2e-claude-session-id",
+  "observer_window": "e2e-observer",
+  "status": "active",
+  "current_task": "${test_task}",
+  "started_at": "2026-04-28T00:00:00Z",
+  "wave": "Wave-Q",
+  "current_issue": 1020
+}
+SESSIONEOF
+
+  # 既存の working-memory.md がある場合のシナリオ（前回のコンテンツ）
+  cat > "${supervisor_dir}/working-memory.md" <<'WMEOF'
+# Working Memory (previous)
+
+## 前回の状態
+- Wave-P 完了済み
+- Issue #1019 merge 完了
+WMEOF
+
+  local before_mtime
+  before_mtime=$(stat -c '%Y' "${supervisor_dir}/working-memory.md" 2>/dev/null || echo "0")
+
+  # PreCompact hook を実行（HookEvent: PreCompact）
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$PRECOMPACT_SCRIPT"
+
+  echo "--- PreCompact stdout ---"
+  echo "$output"
+  echo "--- status: $status ---"
+
+  # 1. スクリプトが正常終了すること
+  assert_success
+
+  # 2. working-memory.md が存在すること
+  [ -f "${supervisor_dir}/working-memory.md" ] || {
+    echo "FAIL: working-memory.md が存在しない"
+    ls -la "$supervisor_dir"
+    return 1
+  }
+
+  local after_content
+  after_content=$(cat "${supervisor_dir}/working-memory.md")
+  echo "--- working-memory.md after PreCompact ---"
+  echo "$after_content"
+
+  # 3. working-memory.md の内容が更新されている（session 情報が含まれる）こと
+  # RED: 現在の実装は cat のみで write しないため、内容は前回のままか存在しない
+  echo "$after_content" | grep -qE "(${test_session_id}|current_task|Issue #1020|Wave-Q)" || {
+    echo "FAIL: working-memory.md に session.json の最新状態が反映されていない"
+    echo "期待: ${test_session_id} または current_task 等の session 情報"
+    echo "実際:"
+    echo "$after_content"
+    return 1
+  }
+}
+
+@test "ac5(e2e): PreCompact hook — session.json が存在しない場合でも working-memory.md を保持/生成する" {
+  # RED: 現在の実装は session.json を参照しないため、この動作保証が存在しない
+  # PASS 条件（実装後）:
+  #   session.json がなくても working-memory.md に最低限のスナップショット情報が書かれる
+
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+  # session.json は作成しない
+
+  # 既存の working-memory.md を用意
+  cat > "${supervisor_dir}/working-memory.md" <<'WMEOF'
+# Working Memory
+
+## タスク状態
+- Issue #1020 対応中
+WMEOF
+
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$PRECOMPACT_SCRIPT"
+
+  assert_success
+
+  # working-memory.md が引き続き存在すること（削除されないこと）
+  [ -f "${supervisor_dir}/working-memory.md" ] || {
+    echo "FAIL: working-memory.md が削除されてしまった"
+    return 1
+  }
+
+  local content
+  content=$(cat "${supervisor_dir}/working-memory.md")
+  [ -n "$content" ] || {
+    echo "FAIL: working-memory.md が空になってしまった"
+    return 1
+  }
+
+  # タイムスタンプ付きスナップショットが書き込まれていること
+  echo "$content" | grep -qE '(timestamp|PRE-COMPACT|[0-9]{4}-[0-9]{2}-[0-9]{2})' || {
+    echo "FAIL: working-memory.md にタイムスタンプ情報が含まれない（スナップショット未更新）"
+    echo "内容:"
+    echo "$content"
+    return 1
+  }
+}
+
+@test "ac5(e2e): PreCompact hook 実行後に su-postcompact.sh が Skill(twl:su-compact) 誘導を出力する" {
+  # RED: 現在の su-postcompact.sh に Skill(twl:su-compact) 誘導が存在しないため fail する
+  # PASS 条件（実装後）: postcompact stdout に Skill(twl:su-compact) 誘導が含まれる
+
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${helpers_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  local repo_root
+  repo_root="$(cd "${tests_dir}/.." && pwd)"
+
+  local postcompact_script="${repo_root}/scripts/su-postcompact.sh"
+
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+  cat > "${supervisor_dir}/working-memory.md" <<'WMEOF'
+# Working Memory (e2e test)
+
+## 状態
+- e2e テスト実行中
+WMEOF
+
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$postcompact_script"
+
+  echo "--- PostCompact stdout ---"
+  echo "$output"
+  echo "--- status: $status ---"
+
+  assert_success
+
+  # Skill(twl:su-compact) 誘導が含まれること
+  echo "$output" | grep -qF 'Skill(twl:su-compact)' || {
+    echo "FAIL: su-postcompact.sh の stdout に 'Skill(twl:su-compact)' の誘導が含まれない"
+    return 1
+  }
+}

--- a/plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats
+++ b/plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats
@@ -58,18 +58,19 @@ teardown() {
   local test_session_id="e2e-session-1020"
   local test_task="Issue #1020 PreCompact write 実装の検証"
 
-  cat > "${supervisor_dir}/session.json" <<SESSIONEOF
-{
-  "session_id": "${test_session_id}",
-  "claude_session_id": "e2e-claude-session-id",
-  "observer_window": "e2e-observer",
-  "status": "active",
-  "current_task": "${test_task}",
-  "started_at": "2026-04-28T00:00:00Z",
-  "wave": "Wave-Q",
-  "current_issue": 1020
-}
-SESSIONEOF
+  jq -n \
+    --arg sid "$test_session_id" \
+    --arg task "$test_task" \
+    '{
+      session_id: $sid,
+      claude_session_id: "e2e-claude-session-id",
+      observer_window: "e2e-observer",
+      status: "active",
+      current_task: $task,
+      started_at: "2026-04-28T00:00:00Z",
+      wave: "Wave-Q",
+      current_issue: 1020
+    }' > "${supervisor_dir}/session.json"
 
   # 既存の working-memory.md がある場合のシナリオ（前回のコンテンツ）
   cat > "${supervisor_dir}/working-memory.md" <<'WMEOF'

--- a/plugins/twl/tests/bats/su-precompact-hook-1020.bats
+++ b/plugins/twl/tests/bats/su-precompact-hook-1020.bats
@@ -97,7 +97,7 @@ teardown() {
   mkdir -p "$supervisor_dir"
   echo "test working memory content" > "${supervisor_dir}/working-memory.md"
 
-  run bash "$POSTCOMPACT_SCRIPT"
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$POSTCOMPACT_SCRIPT"
 
   echo "--- stdout ---"
   echo "$output"

--- a/plugins/twl/tests/bats/su-precompact-hook-1020.bats
+++ b/plugins/twl/tests/bats/su-precompact-hook-1020.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+# su-precompact-hook-1020.bats
+#
+# Issue #1020: tech-debt(observer): PreCompact hook が working-memory を退避せず cat のみ
+#              auto-compact 経路で su-compact が経由されない
+#
+# AC1: su-precompact.sh が working-memory.md の auto 更新（session.json から状態取り出し → ensure write）を実装する
+# AC2: su-postcompact.sh stdout に「Skill(twl:su-compact) を実行して Long-term Memory 保存」を明示誘導
+# AC3: su-observer/SKILL.md SU-5 セクションに context 残量検知手段が明示される（案 C 範囲）
+# AC4: bats 経路で auto_precompact trigger が動作確認（working-memory.md 更新検証）
+#
+# 全テストは現在の実装では FAIL（RED）状態であること
+
+load 'helpers/common'
+
+PRECOMPACT_SCRIPT=""
+POSTCOMPACT_SCRIPT=""
+SKILL_MD=""
+
+setup() {
+  common_setup
+
+  local helpers_dir
+  helpers_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir="$helpers_dir"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  REPO_ROOT_1020="$(cd "${tests_dir}/.." && pwd)"
+
+  PRECOMPACT_SCRIPT="${REPO_ROOT_1020}/scripts/su-precompact.sh"
+  POSTCOMPACT_SCRIPT="${REPO_ROOT_1020}/scripts/su-postcompact.sh"
+  SKILL_MD="${REPO_ROOT_1020}/skills/su-observer/SKILL.md"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: su-precompact.sh が working-memory.md の write を実装していること
+#
+# RED: 現在の実装は cat のみで working-memory.md を write しない
+# ===========================================================================
+
+@test "ac1: su-precompact.sh が working-memory.md を write する（static grep）" {
+  # RED: 現在の実装に write 操作が存在しないため fail する
+  # PASS 条件（実装後）: スクリプト内に working-memory.md への書き込みパターンが存在する
+  run grep -E '(tee|>\s*.*working-memory\.md|write.*working-memory|ensure.*write)' "$PRECOMPACT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: working-memory.md への write 操作が su-precompact.sh に存在しない"
+    echo "現在の実装:"
+    cat "$PRECOMPACT_SCRIPT"
+    return 1
+  }
+}
+
+@test "ac1: su-precompact.sh が session.json から状態を取り出す（static grep）" {
+  # RED: 現在の実装は session.json を参照しないため fail する
+  # PASS 条件（実装後）: スクリプト内に session.json 参照が存在する
+  run grep -E 'session\.json' "$PRECOMPACT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: session.json の参照が su-precompact.sh に存在しない"
+    echo "現在の実装:"
+    cat "$PRECOMPACT_SCRIPT"
+    return 1
+  }
+}
+
+@test "ac1: su-precompact.sh が bash -n を通過する（syntax check）" {
+  # 実装前後ともに syntax は通過すべき（実装後の回帰防止）
+  run bash -n "$PRECOMPACT_SCRIPT"
+  assert_success
+}
+
+# ===========================================================================
+# AC2: su-postcompact.sh の stdout に Skill(twl:su-compact) 誘導が含まれること
+#
+# RED: 現在の実装に「Skill(twl:su-compact)」文字列が存在しないため fail する
+# ===========================================================================
+
+@test "ac2: su-postcompact.sh に 'Skill(twl:su-compact)' を明示する行が存在する（static grep）" {
+  # RED: 現在の su-postcompact.sh に Skill(twl:su-compact) 誘導が存在しないため fail する
+  # PASS 条件（実装後）: スクリプト内に明示誘導行が存在する
+  run grep -F 'Skill(twl:su-compact)' "$POSTCOMPACT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: 'Skill(twl:su-compact)' を実行して Long-term Memory 保存の誘導が su-postcompact.sh に存在しない"
+    echo "現在の実装:"
+    cat "$POSTCOMPACT_SCRIPT"
+    return 1
+  }
+}
+
+@test "ac2: su-postcompact.sh 実行時に stdout に 'Skill(twl:su-compact)' が含まれる" {
+  # RED: 現在の実装には Skill(twl:su-compact) の出力がないため fail する
+  # テスト用の .supervisor ディレクトリをサンドボックスに作成
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+  echo "test working memory content" > "${supervisor_dir}/working-memory.md"
+
+  run bash "$POSTCOMPACT_SCRIPT"
+
+  echo "--- stdout ---"
+  echo "$output"
+  echo "--- status: $status ---"
+
+  echo "$output" | grep -qF 'Skill(twl:su-compact)' || {
+    echo "FAIL: stdout に 'Skill(twl:su-compact)' が含まれない"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: SKILL.md の SU-5 セクションに context 残量検知手段が明示されること
+#
+# RED: 現在の SKILL.md の SU-5 行には検知手段が記載されていないため fail する
+# ===========================================================================
+
+@test "ac3: SKILL.md の SU-5 行に context 残量検知手段が記述されている（grep チェック）" {
+  # RED: 現在の SU-5 行は「context 消費量 80% 到達時に知識外部化を開始しなければならない（SHALL）」のみで
+  #      「検知手段」の記述がないため fail する
+  # PASS 条件（実装後）: SU-5 の行または近傍に検知手段（hooks/budget/PreCompact/残量 等）の言及がある
+  local su5_context
+  su5_context=$(grep -A 3 'SU-5' "$SKILL_MD" || true)
+
+  echo "--- SU-5 context ---"
+  echo "$su5_context"
+
+  echo "$su5_context" | grep -qE '(PreCompact|hooks?|budget|残量|検知|detect|trigger)' || {
+    echo "FAIL: SU-5 セクションに context 残量検知手段の記述が存在しない"
+    echo "現在の SU-5:"
+    echo "$su5_context"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: auto_precompact trigger — working-memory.md 更新検証
+#      tempdir 使用、su-precompact.sh 実行後に working-memory.md が更新される
+#
+# RED: 現在の実装は cat のみで write しないため fail する
+# ===========================================================================
+
+@test "ac4: su-precompact.sh 実行後に working-memory.md が更新される（tempdir）" {
+  # RED: 現在の実装は working-memory.md を write しないため fail する
+  # PASS 条件（実装後）: su-precompact.sh 実行後に working-memory.md が存在し更新される
+
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+
+  # session.json を作成（session.json から状態取り出しができるように）
+  cat > "${supervisor_dir}/session.json" <<'SESSIONEOF'
+{
+  "session_id": "test-session-1020",
+  "claude_session_id": "test-claude-session-id",
+  "observer_window": "test-window",
+  "status": "active",
+  "current_task": "Issue #1020 implementation",
+  "started_at": "2026-04-28T00:00:00Z"
+}
+SESSIONEOF
+
+  # SUPERVISOR_DIR をサンドボックスの .supervisor に向ける
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$PRECOMPACT_SCRIPT"
+
+  echo "--- stdout ---"
+  echo "$output"
+  echo "--- status: $status ---"
+
+  # working-memory.md が存在することを確認
+  [ -f "${supervisor_dir}/working-memory.md" ] || {
+    echo "FAIL: su-precompact.sh 実行後に working-memory.md が作成/更新されていない"
+    echo "supervisor_dir 内容:"
+    ls -la "$supervisor_dir"
+    return 1
+  }
+
+  # working-memory.md の内容が空でないことを確認
+  local content
+  content=$(cat "${supervisor_dir}/working-memory.md")
+  [ -n "$content" ] || {
+    echo "FAIL: working-memory.md が空（内容が書き込まれていない）"
+    return 1
+  }
+}
+
+@test "ac4: su-precompact.sh 実行後の working-memory.md に session.json の情報が含まれる" {
+  # RED: 現在の実装は session.json を読まないため fail する
+  # PASS 条件（実装後）: working-memory.md に session.json の状態情報が反映されている
+
+  local supervisor_dir="${SANDBOX}/.supervisor"
+  mkdir -p "$supervisor_dir"
+
+  cat > "${supervisor_dir}/session.json" <<'SESSIONEOF'
+{
+  "session_id": "test-session-1020",
+  "claude_session_id": "test-claude-session-id",
+  "observer_window": "",
+  "status": "active",
+  "current_task": "Issue #1020 precompact implementation",
+  "started_at": "2026-04-28T00:00:00Z"
+}
+SESSIONEOF
+
+  run env SUPERVISOR_DIR="${supervisor_dir}" bash "$PRECOMPACT_SCRIPT"
+
+  [ -f "${supervisor_dir}/working-memory.md" ] || {
+    echo "FAIL: working-memory.md が存在しない"
+    return 1
+  }
+
+  # working-memory.md に session 情報（session_id または状態）が含まれることを確認
+  local content
+  content=$(cat "${supervisor_dir}/working-memory.md")
+  echo "--- working-memory.md ---"
+  echo "$content"
+
+  echo "$content" | grep -qE '(test-session-1020|session_id|current_task|Issue #1020)' || {
+    echo "FAIL: working-memory.md に session.json の情報が含まれていない"
+    echo "working-memory.md の内容:"
+    echo "$content"
+    return 1
+  }
+}
+
+@test "ac4: su-precompact.sh — .supervisor ディレクトリが存在しない場合は正常 exit 0" {
+  # .supervisor なしの場合は exit 0 で終了すること（既存動作の回帰防止）
+  run env SUPERVISOR_DIR="${SANDBOX}/nonexistent-supervisor" bash "$PRECOMPACT_SCRIPT"
+  assert_success
+}


### PR DESCRIPTION
## Summary

Fixes #1020

PreCompact hook が `working-memory.md` を退避せず cat のみだった問題を修正。auto-compact 経路でも su-compact に相当する状態保存が行われるようにする。

## Changes

### AC1: `su-precompact.sh` — working-memory.md auto 更新
- `session.json` から `session_id`, `current_task`, `status` 等の現在状態を取り出す
- `working-memory.md` に Session State + 旧 working-memory を書き込む（上書きではなく最新化）
- `session.json` 不在時も既存 `working-memory.md` にタイムスタンプを更新

### AC2: `su-postcompact.sh` — Skill(twl:su-compact) 誘導追加
- 復帰手順 step 4 として `Skill(twl:su-compact)` 実行を明示指示（SU-6a 準拠）

### AC3: `su-observer/SKILL.md` — SU-5 context 検知手段明記
- SU-5 行に PreCompact hook (`su-precompact.sh`) による自動発火と `[PRE-COMPACT]` マーカー観測を記載
- 能動的 context 残量取得手段は現時点未確立として #1020 追跡を明記

## Tests

- `plugins/twl/tests/bats/su-precompact-hook-1020.bats`: 9件 GREEN
- `plugins/twl/tests/bats/e2e/su-precompact-hook-1020-e2e.bats`: 3件 GREEN