### PR TITLE
feat(#1030): spawn-controller.sh に _setup_observer_panes を追加 — observer window 4 pane layout 自動化

### DIFF
--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -216,6 +216,67 @@ if [[ "$HAS_WINDOW_NAME" == "false" ]]; then
   WINDOW_NAME_ARG=(--window-name "wt-${SKILL_NORMALIZED}-$(date +%H%M%S)")
 fi
 
+# _setup_observer_panes: observer window を 4 pane layout に分割し watcher を起動する
+# 呼び出し: _setup_observer_panes <observer_window> [fallback_pane_base]
+#   observer_window: 対象の tmux window 名（未指定時は .supervisor/session.json から取得）
+#   fallback_pane_base: pane-base-index 取得失敗時のフォールバック値（default: 0）
+# レイアウト: 左 50% (observer) | 右上 1/3 (heartbeat) / 右中 1/3 (budget) / 右下 1/3 (cldobs)
+_setup_observer_panes() {
+  local observer_window="${1:-}"
+  local fallback_pane_base="${2:-0}"
+  local supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+
+  if [[ -z "$observer_window" ]]; then
+    local session_file="$supervisor_dir/session.json"
+    if [[ -f "$session_file" ]]; then
+      observer_window=$(python3 -c "import json; d=json.load(open('$session_file')); print(d.get('observer_window', ''))" 2>/dev/null || echo "")
+    fi
+  fi
+
+  if [[ -z "$observer_window" ]]; then
+    echo "[spawn-controller] WARN: observer_window が未検出 — pane split をスキップ" >&2
+    return 0
+  fi
+
+  # orphan watcher cleanup
+  pkill -f "heartbeat-watcher.sh" 2>/dev/null || true
+  pkill -f "budget-monitor-watcher.sh" 2>/dev/null || true
+  pkill -f "cld-observe-any" 2>/dev/null || true
+
+  # pane-base-index auto-detect（環境差異を吸収）
+  local base
+  base=$(tmux show-options -gv pane-base-index 2>/dev/null || echo "$fallback_pane_base")
+
+  local cwd
+  cwd="$(pwd)"
+  local heartbeat_script="$SCRIPT_DIR/heartbeat-watcher.sh"
+  local budget_script="$SCRIPT_DIR/budget-monitor-watcher.sh"
+  local cld_observe_any="$TWILL_ROOT/plugins/session/scripts/cld-observe-any"
+
+  # Step 1: horizontal split (左右) — 右カラムに heartbeat-watcher を起動
+  tmux split-window -h -d -l 50% -t "${observer_window}:1.${base}" -c "$cwd" "bash '$heartbeat_script'" || \
+    tmux split-window -h -d -l 50% -t "${observer_window}" -c "$cwd" "bash '$heartbeat_script'"
+
+  # Step 2: vertical split — 右カラムを上下分割して budget-monitor を起動
+  tmux split-window -v -d -l 67% -t "${observer_window}:1.$((base+1))" -c "$cwd" "bash '$budget_script'" || \
+    tmux split-window -v -d -t "${observer_window}:1.$((base+1))" -c "$cwd" "bash '$budget_script'"
+
+  # Step 3: vertical split — 下段をさらに分割して cld-observe-any を起動
+  tmux split-window -v -d -l 50% -t "${observer_window}:1.$((base+2))" -c "$cwd" "bash '$cld_observe_any'" || \
+    tmux split-window -v -d -t "${observer_window}:1.$((base+2))" -c "$cwd" "bash '$cld_observe_any'"
+
+  # pane 数を確認してログ出力
+  local pane_count
+  pane_count=$(tmux list-panes -t "$observer_window" 2>/dev/null | wc -l || echo "?")
+  echo "[spawn-controller] ✓ observer window ${observer_window}: ${pane_count} pane layout を設定 (pane-base-index=${base})"
+}
+
 # cld-spawn 呼び出し（extra args を first, prompt を last に配置する必要あり — cld-spawn の option parse は先に終わり、残りが PROMPT になる）
 # 空配列ガード: set -u 環境で "${arr[@]}" が unbound を起こすため ${arr[@]+...} 形式で保護
-exec "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT"
+# co-autopilot（非 --with-chain）は exec を避けて pane setup を後続実行する
+if [[ "$SKILL_NORMALIZED" == "co-autopilot" && "$WITH_CHAIN" == "false" ]]; then
+  "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT"
+  _setup_observer_panes
+else
+  exec "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT"
+fi

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -229,7 +229,12 @@ _setup_observer_panes() {
   if [[ -z "$observer_window" ]]; then
     local session_file="$supervisor_dir/session.json"
     if [[ -f "$session_file" ]]; then
-      observer_window=$(python3 -c "import json; d=json.load(open('$session_file')); print(d.get('observer_window', ''))" 2>/dev/null || echo "")
+      observer_window=$(python3 - "$session_file" <<'PYEOF' 2>/dev/null || echo ""
+import json, sys
+d = json.load(open(sys.argv[1]))
+print(d.get('observer_window', ''))
+PYEOF
+)
     fi
   fi
 
@@ -275,7 +280,8 @@ _setup_observer_panes() {
 # 空配列ガード: set -u 環境で "${arr[@]}" が unbound を起こすため ${arr[@]+...} 形式で保護
 # co-autopilot（非 --with-chain）は exec を避けて pane setup を後続実行する
 if [[ "$SKILL_NORMALIZED" == "co-autopilot" && "$WITH_CHAIN" == "false" ]]; then
-  "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT"
+  # cld-spawn は prompt inject 後すぐに 0 終了する。|| true で set -e を抑制し pane setup を必ず実行する
+  "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT" || true
   _setup_observer_panes
 else
   exec "$CLD_SPAWN" "${WINDOW_NAME_ARG[@]+"${WINDOW_NAME_ARG[@]}"}" "$@" "$FINAL_PROMPT"

--- a/plugins/twl/tests/bats/ac-test-mapping-1030.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1030.yaml
@@ -1,0 +1,49 @@
+mappings:
+  - ac_index: 1
+    ac_text: "spawn-controller.sh co-autopilot 後に observer window が 4 pane (左 1 + 右 3) layout になる"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac1: _setup_observer_panes が tmux split-window を 3 回実行して 4 pane layout を作る"
+  - ac_index: 1b
+    ac_text: "spawn-controller.sh co-autopilot 後に observer window が 4 pane (左 1 + 右 3) layout になる (list-panes 確認)"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac1: _setup_observer_panes 実行後 tmux list-panes で 4 pane が確認できる"
+  - ac_index: 2
+    ac_text: "pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac2: pane-base-index=0 環境で _setup_observer_panes が正常完了する"
+  - ac_index: 2b
+    ac_text: "pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect) — pane-base-index=1 path"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac2: pane-base-index=1 環境で _setup_observer_panes が正常完了する"
+  - ac_index: 2c
+    ac_text: "pane-base-index auto-detect のため tmux show-options -gv pane-base-index が呼ばれる"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac2: pane-base-index auto-detect のため tmux show-options -gv pane-base-index が呼ばれる"
+  - ac_index: 3
+    ac_text: "orphan watcher process が pkill -f で事前 cleanup される"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac3: _setup_observer_panes 実行前に pkill -f で orphan watcher が cleanup される"
+  - ac_index: 3b
+    ac_text: "orphan watcher process が pkill -f で事前 cleanup される (引数検証)"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac3: pkill -f の引数に watcher スクリプト名が含まれる"
+  - ac_index: 4
+    ac_text: "tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証 (pane-base-index 非一致で fallback 誤動作する経緯あり)"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac4: pane-base-index=0 環境で split-window -h（左右分割）が最初に呼ばれる"
+  - ac_index: 4b
+    ac_text: "tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証 — pane-base-index=1 fallback なし"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac4: pane-base-index=1 環境でも split-window -h の方向が正しい（fallback 誤動作なし）"
+  - ac_index: 4c
+    ac_text: "pane-base-index=0 と pane-base-index=1 で split-window 呼び出し回数が同一（3回）"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "ac4: pane-base-index=0 と pane-base-index=1 で split-window 呼び出し回数が同一（3回）"
+  - ac_index: 5
+    ac_text: "bats で 4 pane layout 検証 (AC1と同等 - テストファイル自体が検証)"
+    test_file: "plugins/twl/tests/bats/spawn-controller-pane-split.bats"
+    test_name: "（テストファイル spawn-controller-pane-split.bats 自体が AC5 を体現）"
+  - ac_index: 6
+    ac_text: "PR merged + main HEAD 更新（process AC）"
+    test_file: ""
+    test_name: "（プロセスAC — batsテスト不要）"

--- a/plugins/twl/tests/bats/spawn-controller-pane-split.bats
+++ b/plugins/twl/tests/bats/spawn-controller-pane-split.bats
@@ -1,0 +1,324 @@
+#!/usr/bin/env bats
+# spawn-controller-pane-split.bats
+# RED tests for Issue #1030: spawn-controller.sh + SKILL.md 起動 routine に
+# observer window pane split + watcher pane 内起動を自動化
+#
+# AC coverage:
+#   AC1 - spawn-controller.sh co-autopilot 後に observer window が 4 pane (左 1 + 右 3) layout になる
+#   AC2 - pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)
+#   AC3 - orphan watcher process が pkill -f で事前 cleanup される
+#   AC4 - tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証
+#
+# テスト設計:
+#   - tmux コマンドは STUB_BIN に mock して引数を記録する
+#   - pkill コマンドも stub する（実際のプロセス kill 禁止）
+#   - pane-base-index は tmux show-options -gv を stub して 0/1 を制御
+#   - spawn-controller.sh 内から呼ばれる _setup_observer_panes 関数をテスト対象とする
+#   - .supervisor/session.json に observer_window を書き込んで入力として使う
+#
+# RED: _setup_observer_panes 関数が spawn-controller.sh に未実装のため全テストが fail する
+
+load 'helpers/common'
+
+SPAWN_SCRIPT=""
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  SPAWN_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/spawn-controller.sh"
+
+  # .supervisor ディレクトリと session.json を SANDBOX に作成
+  mkdir -p "$SANDBOX/.supervisor"
+
+  # cld-spawn stub（実際の tmux spawn をスキップ）
+  stub_command "cld-spawn" 'echo "stub-cld-spawn: $*"; exit 0'
+
+  # pkill stub（実プロセスを kill しない）
+  cat > "$STUB_BIN/pkill" <<'PKILLSTUB'
+#!/usr/bin/env bash
+echo "pkill-stub: $*" >> "${PKILL_LOG:-/dev/null}"
+exit 0
+PKILLSTUB
+  chmod +x "$STUB_BIN/pkill"
+
+  export PKILL_LOG="$SANDBOX/pkill.log"
+  touch "$PKILL_LOG"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Helper: session.json を作成して observer_window を設定
+# ---------------------------------------------------------------------------
+_create_session_json_with_window() {
+  local observer_window="${1:-observer-test}"
+  python3 -c "
+import json, sys
+data = {
+  'session_id': 'test-session-1030',
+  'claude_session_id': 'test-claude-id',
+  'observer_window': '${observer_window}',
+  'status': 'active',
+  'started_at': '2026-04-28T00:00:00Z'
+}
+json.dump(data, open('${SANDBOX}/.supervisor/session.json', 'w'), indent=2)
+"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: _setup_observer_panes 関数を spawn-controller.sh から抽出して実行
+# STUB_BIN の tmux を使って引数を記録する
+# ---------------------------------------------------------------------------
+_run_setup_observer_panes() {
+  local pane_base_index="${1:-0}"
+  local observer_window="${2:-observer-test}"
+
+  _create_session_json_with_window "$observer_window"
+
+  # tmux stub: 引数を記録してサブコマンドごとに分岐
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+case "\${1:-}" in
+  show-options)
+    echo "${pane_base_index}"
+    ;;
+  split-window)
+    echo "split-window-stub: \$*"
+    exit 0
+    ;;
+  list-panes)
+    printf '%s\n' 0 1 2 3
+    ;;
+  select-pane)
+    exit 0
+    ;;
+  send-keys)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  # _setup_observer_panes 関数を spawn-controller.sh から抽出して実行
+  # 関数が未実装の場合、grep が空を返し eval した bash が関数呼び出しで exit 127 になる
+  run bash -c "
+set -euo pipefail
+export PATH='${STUB_BIN}:${PATH}'
+export SUPERVISOR_DIR='${SANDBOX}/.supervisor'
+export PKILL_LOG='${PKILL_LOG}'
+export SCRIPT_DIR='${REPO_ROOT}/skills/su-observer/scripts'
+export TWILL_ROOT='${REPO_ROOT}/../../../../..'
+
+# spawn-controller.sh から _setup_observer_panes 関数を抽出
+FUNC_DEF=\$(grep -A 9999 '^_setup_observer_panes()' '${SPAWN_SCRIPT}' 2>/dev/null \
+  | awk '/^_setup_observer_panes\(\)/{found=1} found{print} found && /^\}\$/{exit}')
+
+if [[ -z \"\$FUNC_DEF\" ]]; then
+  echo 'RED: _setup_observer_panes function not found in spawn-controller.sh' >&2
+  exit 1
+fi
+
+eval \"\$FUNC_DEF\"
+_setup_observer_panes '${observer_window}' '${pane_base_index}'
+"
+}
+
+# ===========================================================================
+# AC1: spawn-controller.sh co-autopilot 後に observer window が
+#      4 pane (左 1 + 右 3) layout になる
+#
+# RED: _setup_observer_panes 関数が未実装のため fail する
+# PASS 条件（実装後）:
+#   - tmux split-window が合計 3 回呼ばれる（1 pane → 4 pane になる分割）
+#   - split-window -h が 1 回 + split-window -v が 2 回
+# ===========================================================================
+
+@test "ac1: _setup_observer_panes が tmux split-window を 3 回実行して 4 pane layout を作る" {
+  # AC: spawn-controller.sh co-autopilot 後に observer window が 4 pane (左 1 + 右 3) layout になる
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  local split_count
+  split_count=$(grep -c "split-window" "$SANDBOX/tmux.log" 2>/dev/null || echo "0")
+  [ "$split_count" -eq 3 ] || {
+    echo "FAIL: split-window should be called 3 times, got ${split_count}"
+    echo "tmux.log:"
+    cat "$SANDBOX/tmux.log"
+    return 1
+  }
+}
+
+@test "ac1: _setup_observer_panes 実行後 tmux list-panes で 4 pane が確認できる" {
+  # AC: observer window が 4 pane (左 1 + 右 3) layout になる
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run grep "list-panes" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+# ===========================================================================
+# AC2: pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)
+#
+# RED: 実装前は fail する
+# PASS 条件（実装後）:
+#   - pane-base-index=0 でも pane-base-index=1 でも split が成功する
+#   - tmux show-options -gv pane-base-index が呼ばれて auto-detect される
+# ===========================================================================
+
+@test "ac2: pane-base-index=0 環境で _setup_observer_panes が正常完了する" {
+  # AC: pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run grep "show-options" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+@test "ac2: pane-base-index=1 環境で _setup_observer_panes が正常完了する" {
+  # AC: pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "1" "observer-test"
+
+  assert_success
+
+  local split_count
+  split_count=$(grep -c "split-window" "$SANDBOX/tmux.log" 2>/dev/null || echo "0")
+  [ "$split_count" -eq 3 ] || {
+    echo "FAIL: split-window should be called 3 times with pane-base-index=1, got ${split_count}"
+    return 1
+  }
+}
+
+@test "ac2: pane-base-index auto-detect のため tmux show-options -gv pane-base-index が呼ばれる" {
+  # AC: pane-base-index = 0 / 1 双方の環境で正しく動作 (auto-detect)
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run grep -F "show-options" "$SANDBOX/tmux.log"
+  assert_success
+
+  run grep "pane-base-index" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+# ===========================================================================
+# AC3: orphan watcher process が pkill -f で事前 cleanup される
+#
+# RED: 実装前は fail する
+# PASS 条件（実装後）:
+#   - _setup_observer_panes 実行前に pkill -f でwatcher プロセスを cleanup する
+#   - pkill.log に pkill -f <watcher-pattern> が記録される
+# ===========================================================================
+
+@test "ac3: _setup_observer_panes 実行前に pkill -f で orphan watcher が cleanup される" {
+  # AC: orphan watcher process が pkill -f で事前 cleanup される
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run cat "$PKILL_LOG"
+  assert_success
+  assert_output --partial "pkill-stub:"
+}
+
+@test "ac3: pkill -f の引数に watcher スクリプト名が含まれる" {
+  # AC: orphan watcher process が pkill -f で事前 cleanup される
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run grep "\-f" "$PKILL_LOG"
+  assert_success
+}
+
+# ===========================================================================
+# AC4: tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証
+#      (pane-base-index 非一致で fallback 誤動作する経緯あり)
+#
+# RED: 実装前は fail する
+# PASS 条件（実装後）:
+#   - pane-base-index=0 環境で split-window -h（水平分割 = 左右）が最初に呼ばれる
+#   - pane-base-index=1 環境でも同様に -h が最初の分割に使われる
+#   - pane-base-index の値に関わらず分割方向が一貫する
+# ===========================================================================
+
+@test "ac4: pane-base-index=0 環境で split-window -h（左右分割）が最初に呼ばれる" {
+  # AC: tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+
+  assert_success
+
+  run grep "split-window.*-h" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+@test "ac4: pane-base-index=1 環境でも split-window -h の方向が正しい（fallback 誤動作なし）" {
+  # AC: tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証
+  #     pane-base-index 非一致で fallback 誤動作する経緯あり
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "1" "observer-test"
+
+  assert_success
+
+  run grep "split-window.*-h" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+@test "ac4: pane-base-index=0 と pane-base-index=1 で split-window 呼び出し回数が同一（3回）" {
+  # AC: tmux split-window -h の方向 (左右 vs 上下) を環境ごとに検証
+  # RED: 実装前は fail する（関数不在）
+
+  _run_setup_observer_panes "0" "observer-test"
+  assert_success
+  local count0
+  count0=$(grep -c "split-window" "$SANDBOX/tmux.log" 2>/dev/null || echo "0")
+
+  rm -f "$SANDBOX/tmux.log"
+  touch "$SANDBOX/tmux.log"
+
+  _run_setup_observer_panes "1" "observer-test"
+  assert_success
+  local count1
+  count1=$(grep -c "split-window" "$SANDBOX/tmux.log" 2>/dev/null || echo "0")
+
+  [ "$count0" -eq "$count1" ] || {
+    echo "FAIL: split-window call count differs between pane-base-index=0 (${count0}) and pane-base-index=1 (${count1})"
+    return 1
+  }
+  [ "$count0" -eq 3 ] || {
+    echo "FAIL: expected 3 split-window calls, got ${count0}"
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1030 の実装。`spawn-controller.sh co-autopilot` 実行後に observer window を自動的に 4 pane layout に分割し、watcher プロセスを起動する。

## 変更内容

### spawn-controller.sh

- `_setup_observer_panes()` 関数を追加:
  - `.supervisor/session.json` から `observer_window` を auto-detect
  - `tmux show-options -gv pane-base-index` で環境差異を自動吸収（0/1 双方対応、AC2）
  - orphan watcher process を `pkill -f` で事前 cleanup（AC3）
  - `tmux split-window -h` で左右分割（左 50% = observer） + `-v × 2` で右カラムを 3 等分（AC1, AC4）
  - 右 3 pane に heartbeat-watcher / budget-monitor-watcher / cld-observe-any を起動
- `co-autopilot`（非 `--with-chain`）パスで `exec` を除去し、`cld-spawn` 後に `_setup_observer_panes` を呼び出す

### テスト

- `plugins/twl/tests/bats/spawn-controller-pane-split.bats`（10 テスト、AC1-4 カバー）
- `plugins/twl/tests/bats/ac-test-mapping-1030.yaml`

## 解決する問題

- tmux window kill の race condition（同名 window kill が新 Wave watcher を巻き添え）→ pane 化で回避
- watcher window 不可視問題 → observer window 内統合で即時確認可能
- 毎 Wave の手動 `tmux new-window × 3` → 自動化

Closes #1030