### PR TITLE
fix(#1029): cld-observe-any に Claude 4.x thinking indicator を追加

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -133,36 +133,31 @@ issue_1029:
       ac_text: "既知 thinking indicator 10+ 件を catalog に追加（Sautéed, Burrowing, Cerebrating, Spinning, Beboppin', Thundering, Baked, Cooked, Crunched, Churned 等）"
       test_name: "AC1: thinking indicator 'Burrowing' あり → STAGNATE emit なし（偽陽性防止）"
       scenario: 14
-      status: RED
-      red_mechanism: "LLM_INDICATORS に 'Burrowing' が未収録。現実装では thinking guard をすり抜けて STAGNATE が emit される。"
+      status: GREEN
 
     - ac_index: 1
       ac_text: "既知 thinking indicator 10+ 件を catalog に追加（Sautéed, Burrowing, Cerebrating, Spinning, Beboppin', Thundering, Baked, Cooked, Crunched, Churned 等）"
       test_name: "AC1: thinking indicator 'Sautéed / Cerebrating / Thundering' あり → STAGNATE emit なし"
       scenario: 15
-      status: RED
-      red_mechanism: "LLM_INDICATORS に 'Sautéed' および 'Thundering' が未収録。現実装では STAGNATE が emit される。"
+      status: GREEN
 
     - ac_index: 2
       ac_text: "一般化 regex を実装し新 indicator にロバスト（`^[*•·✻✽✶✢✻] [A-Z][a-z]+(ed|ing|in')…?` 相当の一般化パターン）"
       test_name: "AC2: 未知 indicator 'Fizzing… (1s)'（一般化 regex 対象） → STAGNATE emit なし"
       scenario: 16
-      status: RED
-      red_mechanism: "完全未知の indicator 'Fizzing' が LLM_INDICATORS に含まれない。一般化 regex 実装後に PASS に変わる。"
+      status: GREEN
 
     - ac_index: 2
       ac_text: "一般化 regex を実装し新 indicator にロバスト（`^[*•·✻✽✶✢✻] [A-Z][a-z]+(ed|ing|in')…?` 相当の一般化パターン）"
       test_name: "AC2: indicator suffix \"in'\" を持つ 'Beboppin'' → STAGNATE emit なし（一般化 regex で検出）"
       scenario: 17
-      status: RED
-      red_mechanism: "'Beboppin'' の -in' suffix が LLM_INDICATORS の固定リストに未収録。一般化 regex で検出できるようになると PASS。"
+      status: GREEN
 
     - ac_index: 3
       ac_text: "bats で偽陽性 case（Burrowing… 等 thinking indicator あり）→ STAGNATE emit なし、本物の stall（出力なし 10 分）→ STAGNATE emit ありを検証"
       test_name: "AC3: 偽陽性ケース — 'Burrowing…' indicator あり → STAGNATE emit なし"
       scenario: 18
-      status: RED
-      red_mechanism: "'Burrowing' が LLM_INDICATORS に未収録のため偽陽性発生。AC1 実装後に PASS に変わる。"
+      status: GREEN
 
     - ac_index: 3
       ac_text: "bats で偽陽性 case（Burrowing… 等 thinking indicator あり）→ STAGNATE emit なし、本物の stall（出力なし 10 分）→ STAGNATE emit ありを検証"

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -122,3 +122,58 @@ issue_1015:
       test_name: "trace-traversal[regression]: パストラバーサル（*..*）は引き続きブロックされる"
       status: GREEN
       note: "回帰テスト。既存の case *..*) 節の動作を維持"
+
+# --- Issue #1029 ---
+issue_1029:
+  issue: 1029
+  framework: bats
+  test_file: "plugins/session/tests/cld-observe-any.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "既知 thinking indicator 10+ 件を catalog に追加（Sautéed, Burrowing, Cerebrating, Spinning, Beboppin', Thundering, Baked, Cooked, Crunched, Churned 等）"
+      test_name: "AC1: thinking indicator 'Burrowing' あり → STAGNATE emit なし（偽陽性防止）"
+      scenario: 14
+      status: RED
+      red_mechanism: "LLM_INDICATORS に 'Burrowing' が未収録。現実装では thinking guard をすり抜けて STAGNATE が emit される。"
+
+    - ac_index: 1
+      ac_text: "既知 thinking indicator 10+ 件を catalog に追加（Sautéed, Burrowing, Cerebrating, Spinning, Beboppin', Thundering, Baked, Cooked, Crunched, Churned 等）"
+      test_name: "AC1: thinking indicator 'Sautéed / Cerebrating / Thundering' あり → STAGNATE emit なし"
+      scenario: 15
+      status: RED
+      red_mechanism: "LLM_INDICATORS に 'Sautéed' および 'Thundering' が未収録。現実装では STAGNATE が emit される。"
+
+    - ac_index: 2
+      ac_text: "一般化 regex を実装し新 indicator にロバスト（`^[*•·✻✽✶✢✻] [A-Z][a-z]+(ed|ing|in')…?` 相当の一般化パターン）"
+      test_name: "AC2: 未知 indicator 'Fizzing… (1s)'（一般化 regex 対象） → STAGNATE emit なし"
+      scenario: 16
+      status: RED
+      red_mechanism: "完全未知の indicator 'Fizzing' が LLM_INDICATORS に含まれない。一般化 regex 実装後に PASS に変わる。"
+
+    - ac_index: 2
+      ac_text: "一般化 regex を実装し新 indicator にロバスト（`^[*•·✻✽✶✢✻] [A-Z][a-z]+(ed|ing|in')…?` 相当の一般化パターン）"
+      test_name: "AC2: indicator suffix \"in'\" を持つ 'Beboppin'' → STAGNATE emit なし（一般化 regex で検出）"
+      scenario: 17
+      status: RED
+      red_mechanism: "'Beboppin'' の -in' suffix が LLM_INDICATORS の固定リストに未収録。一般化 regex で検出できるようになると PASS。"
+
+    - ac_index: 3
+      ac_text: "bats で偽陽性 case（Burrowing… 等 thinking indicator あり）→ STAGNATE emit なし、本物の stall（出力なし 10 分）→ STAGNATE emit ありを検証"
+      test_name: "AC3: 偽陽性ケース — 'Burrowing…' indicator あり → STAGNATE emit なし"
+      scenario: 18
+      status: RED
+      red_mechanism: "'Burrowing' が LLM_INDICATORS に未収録のため偽陽性発生。AC1 実装後に PASS に変わる。"
+
+    - ac_index: 3
+      ac_text: "bats で偽陽性 case（Burrowing… 等 thinking indicator あり）→ STAGNATE emit なし、本物の stall（出力なし 10 分）→ STAGNATE emit ありを検証"
+      test_name: "AC3: 本物の stall — indicator なし + log 古い → STAGNATE emit あり"
+      scenario: 19
+      status: GREEN
+      note: "現実装で PASS する仕様確認テスト。AC1/AC2 実装後も regression しないことを保証する。"
+
+    - ac_index: 4
+      ac_text: "PR merged + main HEAD 更新（機械検証対象外）"
+      test_name: null
+      scenario: null
+      status: SKIPPED
+      note: "機械検証対象外のため、テスト生成をスキップ。"

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -10,6 +10,8 @@ else
 fi
 
 # LLM 思考 indicator 定数リスト（Claude Code UI 変更時はここを更新）
+# AC1: Claude Code 4.x 追加 indicator
+# AC2: 一般化 regex "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \([0-9])" で未知 indicator をカバー
 LLM_INDICATORS=(
     "Thinking"
     "Brewing"
@@ -26,6 +28,19 @@ LLM_INDICATORS=(
     "Running .* agents"
     "[0-9]+ tool uses"
     "thinking with max effort"
+    "Saut.*ed"
+    "Burrowing"
+    "Cerebrating"
+    "Spinning"
+    "Beboppin"
+    "Thundering"
+    "Baked"
+    "Cooked"
+    "Crunched"
+    "Churned"
+    "Skedaddling"
+    "Orchestrating"
+    "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \\([0-9])"
 )
 
 # --- デフォルト値 ---

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -625,3 +625,296 @@ MOCKEOF
     # thinking 中でも PERMISSION-PROMPT は emit される
     echo "$output" | grep -q "PERMISSION-PROMPT"
 }
+
+# ---------------------------------------------------------------------------
+# Scenario 14: AC1 — 既知 thinking indicator "Burrowing" あり → STAGNATE emit なし
+#   現実装の LLM_INDICATORS に "Burrowing" が含まれていないため、
+#   thinking guard が機能せず STAGNATE が emit される → RED（実装後 PASS）
+# ---------------------------------------------------------------------------
+@test "AC1: thinking indicator 'Burrowing' あり → STAGNATE emit なし（偽陽性防止）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-burrowing-win"
+
+# "Burrowing" は Claude Code が thinking 中に表示する indicator
+capture="Burrowing… (3s)
+Analyzing the codebase structure..."
+export capture
+
+# log ファイルを stagnate 閾値より古い mtime で作成（5s 閾値に対して 30s 前）
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '30 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-30S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+# stagnate-sec 5 で即時評価（log は 30s 前 → stagnate 超過）
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 5 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    # "Burrowing" は thinking 中の indicator なので STAGNATE は emit されない（RED: 現実装では emit される）
+    ! echo "$output" | grep -q "STAGNATE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 15: AC1 — 複数の未収録 indicator（Sautéed, Cerebrating, Thundering）
+#   各 indicator あり + stagnate 超過 → STAGNATE emit なしを assert
+#   現実装ではカタログ未収録のため thinking guard をすり抜けて STAGNATE emit される → RED
+# ---------------------------------------------------------------------------
+@test "AC1: thinking indicator 'Sautéed / Cerebrating / Thundering' あり → STAGNATE emit なし" {
+    # Sautéed のテスト
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-sauted-win"
+
+capture="Sautéed… (2s)
+Processing input tokens..."
+export capture
+
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '30 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-30S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 5 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    ! echo "$output" | grep -q "STAGNATE"
+
+    # Thundering のテスト
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-thundering-win"
+
+capture="Thundering… (4s)
+Working on the task..."
+export capture
+
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '30 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-30S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 5 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    ! echo "$output" | grep -q "STAGNATE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 16: AC2 — 完全未知の indicator（"Fizzing… (1s)"）でも STAGNATE emit なし
+#   一般化 regex `^[*•·✻✽✶✢✻] [A-Z][a-z]+(ed|ing|in')` で未知 indicator を汎用検出する実装後 PASS
+#   現実装（固定リスト）では "Fizzing" を検出できないため STAGNATE emit される → RED
+# ---------------------------------------------------------------------------
+@test "AC2: 未知 indicator 'Fizzing… (1s)'（一般化 regex 対象） → STAGNATE emit なし" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-fizzing-win"
+
+# "Fizzing" は LLM_INDICATORS に存在しない完全未知の indicator
+# 一般化 regex `^[A-Z][a-z]+(ed|ing|in')…` にマッチするパターン
+capture="Fizzing… (1s)
+Evaluating options..."
+export capture
+
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '30 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-30S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 5 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    # 未知の indicator でも thinking guard が機能し STAGNATE は emit されない（RED: 現実装では emit される）
+    ! echo "$output" | grep -q "STAGNATE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 17: AC2 — indicator suffix pattern "in'" （Beboppin'）も一般化検出対象
+#   "Beboppin'… (5s)" は `[A-Z][a-z]+in'` パターン → 実装後は thinking guard が機能するはず
+#   現実装では "Beboppin'" が LLM_INDICATORS に含まれないため STAGNATE emit される → RED
+# ---------------------------------------------------------------------------
+@test "AC2: indicator suffix \"in'\" を持つ 'Beboppin\\'' → STAGNATE emit なし（一般化 regex で検出）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-beboppin-win"
+
+# "Beboppin'" は Claude Code の thinking indicator（-in' suffix パターン）
+capture="Beboppin'… (5s)
+Generating code changes..."
+export capture
+
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '30 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-30S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 5 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    ! echo "$output" | grep -q "STAGNATE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 18: AC3 — 偽陽性ケース: "Burrowing…" indicator あり → STAGNATE emit なし
+#   Scenario 14 と同一趣旨だが AC3 の「偽陽性 case 検証」として明示的に配置
+#   現実装で "Burrowing" が未収録なため STAGNATE emit される → RED
+# ---------------------------------------------------------------------------
+@test "AC3: 偽陽性ケース — 'Burrowing…' indicator あり → STAGNATE emit なし" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-ac3-fp-win"
+
+capture="Burrowing… (7s)
+Reading source files..."
+export capture
+
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-60S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 30 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    # Burrowing indicator が存在する → LLM は思考中 → STAGNATE は emit されない（RED: 現実装では emit される）
+    ! echo "$output" | grep -q "STAGNATE"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 19: AC3 — 本物の stall: indicator なし + 出力なし（stagnate 超過）→ STAGNATE emit あり
+#   これは現実装でも PASS する（STAGNATE emit が機能している確認テスト）
+#   ただし、AC1/AC2 実装後も regression しないことを保証する
+# ---------------------------------------------------------------------------
+@test "AC3: 本物の stall — indicator なし + log 古い → STAGNATE emit あり" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+win="ap-ac3-stall-win"
+
+# indicator なし、出力なし（stall 状態）
+capture="Last output 10 minutes ago."
+export capture
+
+# log ファイルを stagnate-sec（10s）より十分古い mtime で作成
+logfile="$TMPD/${win}.log"
+touch -t "$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || date -v-60S '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')" "$logfile" 2>/dev/null || touch "$logfile"
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" --once \
+    --log-dir "$TMPD" \
+    --stagnate-sec 10 2>/dev/null
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    # indicator なし + stagnate 超過 → STAGNATE は emit される（これは AC1/AC2 実装後も保持される仕様）
+    echo "$output" | grep -q "STAGNATE"
+}


### PR DESCRIPTION
## 概要

Issue #1029 の修正。`cld-observe-any` の thinking indicator catalog が Claude Code 4.x 系の indicator を網羅していないため、LLM thinking 中の pane を `[STAGNATE]` として誤判定していた。

## 変更内容

### AC1: 既知 indicator を catalog に追加
`LLM_INDICATORS` に Claude Code 4.x 系の 12 件を追加:
- `Saut.*ed` (Sautéed 対応)
- `Burrowing`, `Cerebrating`, `Spinning`, `Beboppin`, `Thundering`
- `Baked`, `Cooked`, `Crunched`, `Churned`, `Skedaddling`, `Orchestrating`

### AC2: 一般化 regex を追加
`[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \([0-9])` パターンで未知の indicator も自動検出。

### テスト
- bats Scenarios 14-20 を追加（RED→GREEN 確認済み）
- AC3: 偽陽性テスト (Burrowing → STAGNATE emit なし) + 本物の stall テスト

## テスト結果
- AC1-AC3 全 6 件 GREEN
- 既存テスト (Scenarios 1-14) に regression なし

Closes #1029