### PR TITLE
fix(session): remove duplicate --wait SECONDS in session-comm.sh usage comment

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -172,3 +172,15 @@ issue_1029:
       scenario: null
       status: SKIPPED
       note: "機械検証対象外のため、テスト生成をスキップ。"
+
+# --- Issue #1066 ---
+issue_1066:
+  issue: 1066
+  framework: bats
+  mappings:
+    - ac_index: 1
+      ac_text: "session-comm.sh ファイルヘッダ usage の inject-file 行から重複した [--wait SECONDS] を削除する"
+      test_file: "plugins/session/tests/session-comm-usage-typo-1066.bats"
+      test_name: "session-comm-usage-typo[structural][RED]: ファイルヘッダ inject-file 行に --wait が重複しない"
+      status: RED
+      red_mechanism: "現行 line 8 に [--wait SECONDS] が2回含まれるため count=2 → FAIL"

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -182,5 +182,4 @@ issue_1066:
       ac_text: "session-comm.sh ファイルヘッダ usage の inject-file 行から重複した [--wait SECONDS] を削除する"
       test_file: "plugins/session/tests/session-comm-usage-typo-1066.bats"
       test_name: "session-comm-usage-typo[structural][RED]: ファイルヘッダ inject-file 行に --wait が重複しない"
-      status: RED
-      red_mechanism: "現行 line 8 に [--wait SECONDS] が2回含まれるため count=2 → FAIL"
+      status: GREEN

--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -113,3 +113,8 @@ tests:
     type: test
     path: tests/session-comm-script-dir-validate.bats
     description: "session-comm.sh SCRIPT_DIR 上書きリスク対策の検証（#1048: _TEST_MODE+SESSION_COMM_SCRIPT_DIR の二段検証 / session-state.sh 存在確認）"
+
+  session-comm-usage-typo-1066-test:
+    type: test
+    path: tests/session-comm-usage-typo-1066.bats
+    description: "session-comm.sh ファイルヘッダ usage の inject-file 行に --wait SECONDS 重複がないことを検証（#1066）"

--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -5,7 +5,7 @@
 # Usage:
 #   session-comm.sh capture <window> [--lines N] [--raw]
 #   session-comm.sh inject <window> <text> [--force] [--no-enter]
-#   session-comm.sh inject-file <window> <file> [--force] [--no-enter] [--wait SECONDS] [--wait SECONDS]
+#   session-comm.sh inject-file <window> <file> [--force] [--no-enter] [--wait SECONDS]
 #   session-comm.sh wait-ready <window> [--timeout N]
 #
 # Dependencies: session-state.sh (#277)

--- a/plugins/session/tests/session-comm-usage-typo-1066.bats
+++ b/plugins/session/tests/session-comm-usage-typo-1066.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# session-comm-usage-typo-1066.bats
+# Requirement: session-comm.sh のファイルヘッダ usage コメントに
+#   [--wait SECONDS] が重複記載されている typo を修正 (issue-1066)
+# Spec: issue-1066
+# Coverage: --type=structural
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
+}
+
+# ===========================================================================
+# AC1: ファイルヘッダ usage の inject-file 行に --wait SECONDS が1回のみ含まれる
+# ===========================================================================
+
+@test "session-comm-usage-typo[structural][RED]: ファイルヘッダ inject-file 行に --wait が重複しない" {
+    local inject_file_line
+    inject_file_line=$(grep 'inject-file.*--wait' "$SCRIPT" | head -1)
+
+    local count
+    count=$(echo "$inject_file_line" | grep -o '\-\-wait' | wc -l)
+    [[ "$count" -eq 1 ]] || {
+        echo "FAIL: inject-file usage 行に --wait が ${count} 回含まれている (expected: 1)" >&2
+        echo "  line: $inject_file_line" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## 概要

`plugins/session/scripts/session-comm.sh` の line 8 (ファイルヘッダの usage) にあったコピペ typo を修正。

```
#   session-comm.sh inject-file <window> <file> [--force] [--no-enter] [--wait SECONDS] [--wait SECONDS]
```

→ `[--wait SECONDS]` が2回記載されていたのを1回に修正。

`usage()` 関数 (line 33) は既に正しく1回のみの記載だった。

## 変更内容

- `plugins/session/scripts/session-comm.sh` — line 8 の重複削除
- `plugins/session/tests/session-comm-usage-typo-1066.bats` — 回帰テスト追加 (structural)
- `ac-test-mapping.yaml` — Issue #1066 マッピング追記

## 影響

ドキュメントのみ。動作への影響なし。

Closes #1066