### PR TITLE
fix(#1022): budget-detect.sh 2軸判定 — cycle reset wall-clock を「残量」と誤認する bug を修正

### DIFF
--- a/.autopilot/ac-test-mapping-1022.yaml
+++ b/.autopilot/ac-test-mapping-1022.yaml
@@ -1,0 +1,36 @@
+mappings:
+  - ac_index: 1
+    ac_text: "budget-detect.sh で 2 軸独立判定を実装 (consumption-based + cycle-based): 軸1 (consumption): budget_remaining_min = cycle_total_min × (100 - pct%) / 100 ≤ BUDGET_THRESHOLD_REMAINING (default: 40分); 軸2 (cycle): cycle_reset_min ≤ BUDGET_THRESHOLD_CYCLE (default: 5分); 発火条件: 軸1 OR 軸2"
+    test_file: "plugins/twl/tests/bats/scripts/budget-detect-1022.bats"
+    test_names:
+      - "ac1: budget-detect.sh に BUDGET_THRESHOLD_REMAINING 変数が存在する（static grep）"
+      - "ac1: budget-detect.sh に BUDGET_THRESHOLD_CYCLE 変数が存在する（static grep）"
+      - "ac1: budget-detect.sh に consumption-based 残量計算 (remaining_min) が存在する（static grep）"
+      - "ac1: budget-detect.sh が bash -n を通過する（syntax check）"
+      - "ac4-extra: budget-detect.sh が BUDGET_THRESHOLD_CYCLE を cycle 軸判定に使用する（static grep）"
+      - "ac4-extra: budget-detect.sh の判定ロジックに 2 軸分の条件分岐が存在する（static grep）"
+
+  - ac_index: 2
+    ac_text: "monitor-channel-catalog.md [BUDGET-LOW] セクションで (YYm) の意味を明記 (cycle reset wall-clock であって残量ではない)"
+    test_file: "plugins/twl/tests/bats/scripts/budget-detect-docs-1022.bats"
+    test_names:
+      - "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに 'cycle reset' の言及が存在する"
+      - "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに 'wall-clock' または '残量ではない' の言及が存在する"
+      - "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに '(YYm)' の注記が存在する"
+
+  - ac_index: 3
+    ac_text: "SKILL.md 該当箇所を訂正 (「残量 15 分」と「reset まで 15 分」を区別)"
+    test_file: "plugins/twl/tests/bats/scripts/budget-detect-docs-1022.bats"
+    test_names:
+      - "ac3: SKILL.md に 'consumption-based' または '消費ベース' の記述が存在する"
+      - "ac3: SKILL.md に 'cycle-based' または 'cycle reset' と閾値の区別が存在する"
+      - "ac3: SKILL.md が '残量 15 分' ではなく 2 軸判定の正しい説明を含む"
+      - "ac3: SKILL.md に '(YYm) は cycle reset まで の時刻' または同等の訂正注記が存在する"
+
+  - ac_index: 4
+    ac_text: "bats で 3 ケースを検証: (1) 5h:9%(0h10m): remaining=273分(>40), cycle=10分(>5) → alert なし; (2) 5h:88%(2h00m): remaining=36分(≤40), cycle=120分(>5) → alert OK (軸1); (3) 5h:50%(0h03m): remaining=150分(>40), cycle=3分(≤5) → alert OK (軸2)"
+    test_file: "plugins/twl/tests/bats/scripts/budget-detect-1022.bats"
+    test_names:
+      - "ac4-case1: 5h:9%(0h10m) — 両軸不発で alert なし (exit 0)"
+      - "ac4-case2: 5h:88%(2h00m) — 軸1 consumption で alert あり (exit 1)"
+      - "ac4-case3: 5h:50%(0h03m) — 軸2 cycle で alert あり (exit 1)"

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -85,7 +85,7 @@ spawnable_by:
 | SU-2 | Layer 2（Escalate）の介入はユーザー確認が MUST |
 | SU-3 | Supervisor 自身が Issue の直接実装を行ってはならない（SHALL） |
 | SU-4 | 同時に supervise できる controller session は 5 を超えてはならない（SHALL） |
-| SU-5 | context 消費量 80% 到達時に知識外部化を開始しなければならない（SHALL）。検知手段: Claude Code の PreCompact hook（`su-precompact.sh`）が自動発火するため、hook stdout の `[PRE-COMPACT]` マーカーを観測すること。また status line の `[BUDGET-LOW]` シグナルも補助的に使用可。能動的な context 残量取得手段は現時点では未確立（#1020 追跡）。 |
+| SU-5 | context 消費量 80% 到達時に知識外部化を開始しなければならない（SHALL）。検知手段: Claude Code の PreCompact hook（`su-precompact.sh`）が自動発火するため、hook stdout の `[PRE-COMPACT]` マーカーを観測すること。また status line の `[BUDGET-LOW]` シグナルも補助的に使用可。能動的な context 残量取得手段は現時点では未確立（#1020 追跡）。`[BUDGET-LOW]` は 2 軸独立判定（consumption-based: token残量 ≤ 40分 / cycle-based: cycle reset wall-clock `(YYm)` ≤ 5分）で発火する。`(YYm)` は次の cycle reset までの wall-clock であり token 残量ではない（#1022）。詳細: `refs/monitor-channel-catalog.md` の `[BUDGET-LOW]` セクション参照。 |
 | SU-6a | Wave 完了時に結果収集と externalize-state を実行しなければならない（SHALL） |
 | SU-6b | context 逼迫時またはユーザー指示時に `/compact` をユーザーへ提案しなければならない（SHOULD） |
 | SU-7 | observed session への inject/send-keys は介入プロトコルに従う場合に許可（MAY） |

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -13,7 +13,7 @@ Wave 開始時に本カタログから Wave 種別に応じたチャネルを選
 | WORKERS | worker window 出現・消失 | 即時 | Auto |
 | PHASE-DONE | PHASE_COMPLETE 検知 | 即時 | Auto |
 | NON-TERMINAL | `>>> 実装完了:` 後の chain 不遷移 | 2分 | Confirm |
-| BUDGET-LOW | 5h rolling budget 残量 | 残り 15 分 or 90% 消費（設定可） | Auto |
+| BUDGET-LOW | 5h rolling budget 残量 | token残量 40分以下 or cycle reset まで 5分以下（設定可） | Auto |
 | BUDGET-ALERT | Monitor watcher が検知した budget threshold 超過 | threshold_percent (default 90%) | Auto |
 | PERMISSION-PROMPT | Worker window の permission prompt 出現（`1. Yes, proceed` 等） | 即時（thinking 中でも emit） | Confirm |
 | **PILOT-PHASE-COMPLETE** | Pilot 内部 chain の Phase/Issue 完了 signal | 即時 | Auto |
@@ -352,9 +352,22 @@ fi
 
 ## [BUDGET-LOW] — 5h rolling budget 残量検知
 
-**検知対象**: Claude Code の tmux status line から実フォーマット `5h:XX%(YYm)`（例: `5h:10%(4h21m)`）をパースし、閾値以下になった場合に停止シーケンスを自動実行する
+**検知対象**: Claude Code の tmux status line から実フォーマット `5h:XX%(YYm)`（例: `5h:10%(4h21m)`）をパースし、2 軸独立判定で閾値以下になった場合に停止シーケンスを自動実行する
 
-**閾値**: 残り `threshold_minutes`（default 15）分 または `threshold_percent`（default 90）% 消費（`.supervisor/budget-config.json` で override 可能）
+**フォーマット `5h:XX%(YYm)` の意味（重要）**:
+- `5h` — 5 時間単位の rolling budget cycle
+- `XX%` — **消費 token 比率**（使用した量、0〜100%）
+- `(YYm)` — **次の cycle reset までの wall-clock remaining**（cycle 残り時間）
+- ⚠️ `(YYm)` は token 残量ではない。`XX%` と独立した別軸（#1022）
+
+**2 軸独立判定（OR 発火）**:
+- **軸1 (consumption-based)**: token 残量 = `300 × (100 - XX%) / 100` ≤ `threshold_remaining_minutes`（default 40分）
+- **軸2 (cycle-based)**: cycle reset wall-clock `(YYm)` ≤ `threshold_cycle_minutes`（default 5分）
+- 設定: `.supervisor/budget-config.json` で `threshold_remaining_minutes` / `threshold_cycle_minutes` を override 可能
+
+**閾値デフォルト**:
+- `threshold_remaining_minutes` = 40（token 残量 40分以下で発火）
+- `threshold_cycle_minutes` = 5（cycle reset まで 5分以下で発火）
 
 **検知方法**: `tmux capture-pane -t "$PILOT_WINDOW" -p -S -1` で status line をキャプチャし正規表現でパース。取得不能の場合は `session-comm.sh capture` にフォールバック。それでも取得不能な場合は検知をスキップし stderr に警告。
 
@@ -363,9 +376,12 @@ fi
 **bash スニペット:**
 
 ```bash
-# BUDGET-LOW: status line から budget 残量をパース（実フォーマット: 5h:XX%(YYm)、例: 5h:10%(4h21m)）
-BUDGET_THRESHOLD_MIN=15  # デフォルト閾値（分）
-BUDGET_THRESHOLD_PCT=90  # デフォルト閾値（%消費）
+# BUDGET-LOW: status line から 2 軸 budget 判定（実フォーマット: 5h:XX%(YYm)）
+# 軸1 (consumption-based): token残量 = 300 × (100 - pct%) / 100 ≤ threshold_remaining_minutes
+# 軸2 (cycle-based): (YYm) = cycle reset wall-clock ≤ threshold_cycle_minutes
+# ※ (YYm) は cycle reset wall-clock であり token 残量ではない（#1022）
+BUDGET_THRESHOLD_REMAINING=40  # 軸1 デフォルト閾値（token 残量 分）
+BUDGET_THRESHOLD_CYCLE=5       # 軸2 デフォルト閾値（cycle reset wall-clock 分）
 
 get_budget_info() {
   local pilot_win="${1:-}"
@@ -384,31 +400,37 @@ get_budget_info() {
   fi
   if [[ -z "$pct" && -z "$raw" ]]; then
     echo "[BUDGET-LOW] WARN: budget 情報を取得できません。" >&2
-    echo "pct=-1 min=-1"
+    echo "pct=-1 cycle_min=-1 remaining_min=-1"
     return 0
   fi
-  local minutes=-1
+  local cycle_min=-1
   if [[ "$raw" =~ ^([0-9]+)h([0-9]+)m$ ]]; then
-    minutes=$(( ${BASH_REMATCH[1]} * 60 + ${BASH_REMATCH[2]} ))
+    cycle_min=$(( ${BASH_REMATCH[1]} * 60 + ${BASH_REMATCH[2]} ))
   elif [[ "$raw" =~ ^([0-9]+)h$ ]]; then
-    minutes=$(( ${BASH_REMATCH[1]} * 60 ))
+    cycle_min=$(( ${BASH_REMATCH[1]} * 60 ))
   elif [[ "$raw" =~ ^([0-9]+)m$ ]]; then
-    minutes=${BASH_REMATCH[1]}
+    cycle_min=${BASH_REMATCH[1]}
   fi
-  echo "pct=${pct:-0} min=${minutes}"
+  local remaining_min=-1
+  if [[ "${pct:-}" =~ ^[0-9]+$ ]]; then
+    remaining_min=$(( 300 * (100 - pct) / 100 ))
+  fi
+  echo "pct=${pct:-0} cycle_min=${cycle_min} remaining_min=${remaining_min}"
 }
 
 check_budget_low() {
   local pilot_win="${1:-}"
-  local threshold_min="${BUDGET_THRESHOLD_MIN}"
-  local threshold_pct="${BUDGET_THRESHOLD_PCT}"
-  local info pct minutes alert=false
+  local threshold_remaining="${BUDGET_THRESHOLD_REMAINING}"
+  local threshold_cycle="${BUDGET_THRESHOLD_CYCLE}"
+  local info pct cycle_min remaining_min alert=false
   info=$(get_budget_info "$pilot_win")
   eval "$info"
-  if [[ "$min" -ge 0 && "$min" -le "$threshold_min" ]]; then alert=true; fi
-  if [[ "$pct" =~ ^[0-9]+$ && "$pct" -ge "$threshold_pct" ]]; then alert=true; fi
+  # 軸1 (consumption-based): token 残量 ≤ threshold_remaining_minutes
+  if [[ "$remaining_min" -ge 0 && "$remaining_min" -le "$threshold_remaining" ]]; then alert=true; fi
+  # 軸2 (cycle-based): cycle reset wall-clock ≤ threshold_cycle_minutes
+  if [[ "$cycle_min" -ge 0 && "$cycle_min" -le "$threshold_cycle" ]]; then alert=true; fi
   if [[ "$alert" == "true" ]]; then
-    echo "[BUDGET-LOW] 5h budget 残り ${min}分 (${pct}% 消費)（閾値: ${threshold_min}分 or ${threshold_pct}%）。安全停止シーケンスを開始します。"
+    echo "[BUDGET-LOW] 5h budget: token残量 ${remaining_min}分 (${pct}% 消費), cycle reset まで ${cycle_min}分。安全停止シーケンスを開始します。"
     return 1
   fi
   return 0

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -424,7 +424,13 @@ check_budget_low() {
   local threshold_cycle="${BUDGET_THRESHOLD_CYCLE}"
   local info pct cycle_min remaining_min alert=false
   info=$(get_budget_info "$pilot_win")
-  eval "$info"
+  # eval を避け、パラメータ展開で個別抽出する（インジェクション回避）
+  pct="${info#*pct=}"; pct="${pct%% *}"
+  cycle_min="${info#*cycle_min=}"; cycle_min="${cycle_min%% *}"
+  remaining_min="${info#*remaining_min=}"; remaining_min="${remaining_min%% *}"
+  [[ "$pct" =~ ^-?[0-9]+$ ]] || pct=-1
+  [[ "$cycle_min" =~ ^-?[0-9]+$ ]] || cycle_min=-1
+  [[ "$remaining_min" =~ ^-?[0-9]+$ ]] || remaining_min=-1
   # 軸1 (consumption-based): token 残量 ≤ threshold_remaining_minutes
   if [[ "$remaining_min" -ge 0 && "$remaining_min" -le "$threshold_remaining" ]]; then alert=true; fi
   # 軸2 (cycle-based): cycle reset wall-clock ≤ threshold_cycle_minutes

--- a/plugins/twl/skills/su-observer/scripts/budget-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/budget-detect.sh
@@ -48,22 +48,18 @@ fi
 # 軸1 (consumption-based): 5h budget の token 残量 = 300 × (100 - pct%) / 100 が閾値以下
 # 軸2 (cycle-based): (YYm) = cycle reset までの wall-clock が閾値以下
 # ※ (YYm) は cycle reset wall-clock であり token 残量ではない（#1022）
-BUDGET_THRESHOLD_REMAINING=$(python3 -c "
-import json, sys
+_THRESHOLDS=$(python3 -c "
+import json
 try:
-  cfg = json.load(open('.supervisor/budget-config.json'))
-  print(cfg.get('threshold_remaining_minutes', 40))
-except:
-  print(40)
-" 2>/dev/null || echo "40")
-BUDGET_THRESHOLD_CYCLE=$(python3 -c "
-import json, sys
-try:
-  cfg = json.load(open('.supervisor/budget-config.json'))
-  print(cfg.get('threshold_cycle_minutes', 5))
-except:
-  print(5)
-" 2>/dev/null || echo "5")
+  with open('.supervisor/budget-config.json') as f:
+    cfg = json.load(f)
+  print(cfg.get('threshold_remaining_minutes', 40), cfg.get('threshold_cycle_minutes', 5))
+except Exception:
+  print(40, 5)
+" 2>/dev/null || echo "40 5")
+BUDGET_THRESHOLD_REMAINING="${_THRESHOLDS%% *}"
+BUDGET_THRESHOLD_CYCLE="${_THRESHOLDS##* }"
+unset _THRESHOLDS
 
 [[ ! "$BUDGET_THRESHOLD_REMAINING" =~ ^[0-9]+$ ]] && BUDGET_THRESHOLD_REMAINING=40
 [[ ! "$BUDGET_THRESHOLD_CYCLE" =~ ^[0-9]+$ ]] && BUDGET_THRESHOLD_CYCLE=5

--- a/plugins/twl/skills/su-observer/scripts/budget-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/budget-detect.sh
@@ -17,10 +17,10 @@ if [[ -z "$PILOT_WINDOW" ]]; then
 fi
 
 # status line から budget 残量を抽出（実フォーマット: 5h:XX%(YYm)）
-BUDGET_PCT=$(tmux capture-pane -t "$PILOT_WINDOW" -p -S -1 2>/dev/null \
-  | grep -oP '5h:\K[0-9]+(?=%)' | tail -1 || echo "")
-BUDGET_RAW=$(tmux capture-pane -t "$PILOT_WINDOW" -p -S -1 2>/dev/null \
-  | grep -oP '5h:[0-9]+%\(\K[^\)]+' | tail -1 || echo "")
+_PANE=$(tmux capture-pane -t "$PILOT_WINDOW" -p -S -1 2>/dev/null || echo "")
+BUDGET_PCT=$(echo "$_PANE" | grep -oP '5h:\K[0-9]+(?=%)' | tail -1 || echo "")
+BUDGET_RAW=$(echo "$_PANE" | grep -oP '5h:[0-9]+%\(\K[^\)]+' | tail -1 || echo "")
+unset _PANE
 
 # フォールバック: session-comm.sh capture による full pane 取得
 if [[ -z "$BUDGET_RAW" && -z "$BUDGET_PCT" ]]; then

--- a/plugins/twl/skills/su-observer/scripts/budget-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/budget-detect.sh
@@ -45,31 +45,45 @@ elif [[ "$BUDGET_RAW" =~ ^([0-9]+)m$ ]]; then
 fi
 
 # 閾値読み込み（.supervisor/budget-config.json または デフォルト値）
-BUDGET_THRESHOLD=$(python3 -c "
+# 軸1 (consumption-based): 5h budget の token 残量 = 300 × (100 - pct%) / 100 が閾値以下
+# 軸2 (cycle-based): (YYm) = cycle reset までの wall-clock が閾値以下
+# ※ (YYm) は cycle reset wall-clock であり token 残量ではない（#1022）
+BUDGET_THRESHOLD_REMAINING=$(python3 -c "
 import json, sys
 try:
   cfg = json.load(open('.supervisor/budget-config.json'))
-  print(cfg.get('threshold_minutes', 15))
+  print(cfg.get('threshold_remaining_minutes', 40))
 except:
-  print(15)
-" 2>/dev/null || echo "15")
-BUDGET_PCT_THRESHOLD=$(python3 -c "
+  print(40)
+" 2>/dev/null || echo "40")
+BUDGET_THRESHOLD_CYCLE=$(python3 -c "
 import json, sys
 try:
   cfg = json.load(open('.supervisor/budget-config.json'))
-  print(cfg.get('threshold_percent', 90))
+  print(cfg.get('threshold_cycle_minutes', 5))
 except:
-  print(90)
-" 2>/dev/null || echo "90")
+  print(5)
+" 2>/dev/null || echo "5")
 
-[[ ! "$BUDGET_THRESHOLD" =~ ^[0-9]+$ ]] && BUDGET_THRESHOLD=15
-[[ ! "$BUDGET_PCT_THRESHOLD" =~ ^[0-9]+$ ]] && BUDGET_PCT_THRESHOLD=90
+[[ ! "$BUDGET_THRESHOLD_REMAINING" =~ ^[0-9]+$ ]] && BUDGET_THRESHOLD_REMAINING=40
+[[ ! "$BUDGET_THRESHOLD_CYCLE" =~ ^[0-9]+$ ]] && BUDGET_THRESHOLD_CYCLE=5
+
+# 軸1: token 残量計算 = 300分 × (100 - 消費%) / 100
+BUDGET_REMAINING_MIN=-1
+if [[ -n "$BUDGET_PCT" && "$BUDGET_PCT" =~ ^[0-9]+$ ]]; then
+  BUDGET_REMAINING_MIN=$(( 300 * (100 - BUDGET_PCT) / 100 ))
+fi
+
+# 軸2: cycle reset wall-clock (BUDGET_RAW = YYm の値)
+BUDGET_CYCLE_MIN=$BUDGET_MIN
 
 BUDGET_ALERT=false
-if [[ $BUDGET_MIN -ge 0 && $BUDGET_MIN -le $BUDGET_THRESHOLD ]]; then
+# 軸1 (consumption-based): token 残量 ≤ threshold_remaining_minutes
+if [[ $BUDGET_REMAINING_MIN -ge 0 && $BUDGET_REMAINING_MIN -le $BUDGET_THRESHOLD_REMAINING ]]; then
   BUDGET_ALERT=true
 fi
-if [[ -n "$BUDGET_PCT" && "$BUDGET_PCT" =~ ^[0-9]+$ && $BUDGET_PCT -ge $BUDGET_PCT_THRESHOLD ]]; then
+# 軸2 (cycle-based): cycle reset wall-clock ≤ threshold_cycle_minutes
+if [[ $BUDGET_CYCLE_MIN -ge 0 && $BUDGET_CYCLE_MIN -le $BUDGET_THRESHOLD_CYCLE ]]; then
   BUDGET_ALERT=true
 fi
 
@@ -77,7 +91,7 @@ if [[ "$BUDGET_ALERT" != "true" ]]; then
   exit 0
 fi
 
-echo "[BUDGET-LOW] 5h budget 残り ${BUDGET_MIN:-?}分 (${BUDGET_PCT:-?}% 消費)。安全停止シーケンスを開始します。"
+echo "[BUDGET-LOW] 5h budget: token残量 ${BUDGET_REMAINING_MIN:-?}分 (${BUDGET_PCT:-?}% 消費), cycle reset まで ${BUDGET_CYCLE_MIN:-?}分。安全停止シーケンスを開始します。"
 
 # 1. orchestrator 停止（PID 数値バリデーション必須: kill 0 はプロセスグループ全体を対象とするため禁止）
 ORCH_PID=$(cat "${AUTOPILOT_DIR}/orchestrator.pid" 2>/dev/null || pgrep -f 'autopilot-orchestrator' | head -1 || echo "")

--- a/plugins/twl/tests/bats/scripts/budget-detect-1022.bats
+++ b/plugins/twl/tests/bats/scripts/budget-detect-1022.bats
@@ -102,13 +102,10 @@ teardown() {
 # フォーマット解釈:
 #   pct = 9 (消費率)
 #   cycle_raw = 0h10m → cycle_reset_min = 10分
-#   cycle_total_min = cycle_reset_min / (pct / 100) = 10 / 0.09 ≈ 111分
-#   remaining_min = cycle_total_min × (100 - 9) / 100 ≈ 101分
 #
-# 実際の計算（整数演算）:
-#   cycle_reset_min = 10
-#   budget_remaining_min = (10 * (100 - 9)) / 9 = (10 * 91) / 9 = 910 / 9 = 101分 (>40)
-#   cycle_reset_min = 10 (>5)
+# 実装の計算式（budget-detect.sh: BUDGET_REMAINING_MIN = 300 * (100 - pct) / 100）:
+#   budget_remaining_min = 300 * (100 - 9) / 100 = 300 * 91 / 100 = 273分 (>40)
+#   cycle_reset_min = 10分 (>5)
 #   → 両軸不発 → alert なし
 #
 # RED 理由: 現在の実装は BUDGET_MIN (= cycle_reset_min = 10) と BUDGET_THRESHOLD (= 15) を比較し、

--- a/plugins/twl/tests/bats/scripts/budget-detect-1022.bats
+++ b/plugins/twl/tests/bats/scripts/budget-detect-1022.bats
@@ -1,0 +1,297 @@
+#!/usr/bin/env bats
+# budget-detect-1022.bats - Issue #1022 AC1/AC4 TDD RED フェーズ
+#
+# Issue #1022: tech-debt(observer): budget-detect.sh が cycle reset wall-clock を「残量」と誤認
+#
+# このファイルは実装前（RED）状態で全テストが fail することを意図している。
+# 実装完了後（GREEN）は全テストが PASS すること。
+#
+# AC1: budget-detect.sh で 2 軸独立判定を実装 (consumption-based + cycle-based)
+#   - 軸1 (consumption): budget_remaining_min = cycle_total_min × (100 - pct%) / 100 ≤ BUDGET_THRESHOLD_REMAINING (default: 40分)
+#   - 軸2 (cycle): cycle_reset_min ≤ BUDGET_THRESHOLD_CYCLE (default: 5分)
+#   - 発火条件: 軸1 OR 軸2
+#
+# AC4: bats で以下3ケースを検証:
+#   入力              remaining       cycle       期待          発火軸
+#   5h:9%(0h10m)      273分 (>40)     10分 (>5)   alert なし    両軸不発
+#   5h:88%(2h00m)     36分 (≤40)      120分 (>5)  alert OK      軸1 (consumption)
+#   5h:50%(0h03m)     150分 (>40)     3分 (≤5)    alert OK      軸2 (cycle)
+
+load '../helpers/common'
+
+BUDGET_DETECT_SCRIPT=""
+
+setup() {
+  common_setup
+  BUDGET_DETECT_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/budget-detect.sh"
+
+  # tmux をスタブ化（budget-detect.sh は tmux capture-pane を呼ぶ）
+  # スタブは FAKE_STATUS_LINE 環境変数から status line を返す
+  stub_command "tmux" '
+args=("$@")
+if [[ "${args[0]}" == "capture-pane" ]]; then
+  echo "${FAKE_STATUS_LINE:-}"
+elif [[ "${args[0]}" == "list-windows" ]]; then
+  echo ""
+elif [[ "${args[0]}" == "send-keys" ]]; then
+  exit 0
+else
+  exit 0
+fi
+'
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: 2 軸独立判定の実装チェック（static grep）
+#
+# RED 理由: 現在の実装は BUDGET_THRESHOLD (cycle_reset_min との比較) のみで
+#           BUDGET_THRESHOLD_REMAINING / BUDGET_THRESHOLD_CYCLE による
+#           consumption-based + cycle-based の 2 軸判定が存在しない。
+# ===========================================================================
+
+@test "ac1: budget-detect.sh に BUDGET_THRESHOLD_REMAINING 変数が存在する（static grep）" {
+  # RED: 現在の実装に BUDGET_THRESHOLD_REMAINING が存在しないため fail する
+  # PASS 条件（実装後）: 2 軸判定の consumption 軸閾値変数が存在する
+  run grep -E 'BUDGET_THRESHOLD_REMAINING' "$BUDGET_DETECT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: BUDGET_THRESHOLD_REMAINING が budget-detect.sh に存在しない"
+    echo "現在の実装（閾値変数）:"
+    grep -E 'BUDGET_THRESHOLD' "$BUDGET_DETECT_SCRIPT" || true
+    return 1
+  }
+}
+
+@test "ac1: budget-detect.sh に BUDGET_THRESHOLD_CYCLE 変数が存在する（static grep）" {
+  # RED: 現在の実装に BUDGET_THRESHOLD_CYCLE が存在しないため fail する
+  # PASS 条件（実装後）: 2 軸判定の cycle 軸閾値変数が存在する
+  run grep -E 'BUDGET_THRESHOLD_CYCLE' "$BUDGET_DETECT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: BUDGET_THRESHOLD_CYCLE が budget-detect.sh に存在しない"
+    echo "現在の実装（閾値変数）:"
+    grep -E 'BUDGET_THRESHOLD' "$BUDGET_DETECT_SCRIPT" || true
+    return 1
+  }
+}
+
+@test "ac1: budget-detect.sh に consumption-based 残量計算 (remaining_min) が存在する（static grep）" {
+  # RED: 現在の実装は BUDGET_RAW (= cycle_reset_min) をそのまま閾値比較しており
+  #      cycle_total × (100 - pct%) / 100 の計算が存在しないため fail する
+  # PASS 条件（実装後）: 残量計算式 (100 - pct) * cycle_total / 100 などの式が存在する
+  run grep -E '(remaining|REMAINING).*pct|pct.*(remaining|REMAINING)|\(\s*100\s*-\s*.*PCT\s*\)|budget_remaining' "$BUDGET_DETECT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: consumption-based 残量計算が budget-detect.sh に存在しない"
+    echo "現在の判定ロジック部分:"
+    grep -n -A2 'BUDGET_ALERT' "$BUDGET_DETECT_SCRIPT" || true
+    return 1
+  }
+}
+
+@test "ac1: budget-detect.sh が bash -n を通過する（syntax check）" {
+  # 実装前後ともに syntax は通過すべき
+  run bash -n "$BUDGET_DETECT_SCRIPT"
+  assert_success
+}
+
+# ===========================================================================
+# AC4 ケース1: 5h:9%(0h10m) → alert なし（両軸不発）
+#
+# フォーマット解釈:
+#   pct = 9 (消費率)
+#   cycle_raw = 0h10m → cycle_reset_min = 10分
+#   cycle_total_min = cycle_reset_min / (pct / 100) = 10 / 0.09 ≈ 111分
+#   remaining_min = cycle_total_min × (100 - 9) / 100 ≈ 101分
+#
+# 実際の計算（整数演算）:
+#   cycle_reset_min = 10
+#   budget_remaining_min = (10 * (100 - 9)) / 9 = (10 * 91) / 9 = 910 / 9 = 101分 (>40)
+#   cycle_reset_min = 10 (>5)
+#   → 両軸不発 → alert なし
+#
+# RED 理由: 現在の実装は BUDGET_MIN (= cycle_reset_min = 10) と BUDGET_THRESHOLD (= 15) を比較し、
+#           10 <= 15 で alert=true になる（偽陽性）。実装後は alert なし。
+# ===========================================================================
+
+@test "ac4-case1: 5h:9%(0h10m) — 両軸不発で alert なし (exit 0)" {
+  # RED: 現在の実装は cycle_reset_min=10 <= BUDGET_THRESHOLD=15 で誤って alert になる
+  # PASS 条件（実装後）:
+  #   軸1 remaining=101分 > 40分 → 不発
+  #   軸2 cycle_reset=10分 > 5分 → 不発
+  #   → exit 0（alert なし）
+
+  local status_line="Claude [max] 5h:9%(0h10m) 7d:20%(5d14h)"
+  export FAKE_STATUS_LINE="$status_line"
+  export PILOT_WINDOW="fake-window"
+  export AUTOPILOT_DIR="$SANDBOX/.autopilot"
+
+  # budget-detect.sh を sandbox の scripts/ にコピーして実行
+  cp "$BUDGET_DETECT_SCRIPT" "$SANDBOX/budget-detect.sh"
+  chmod +x "$SANDBOX/budget-detect.sh"
+
+  # 閾値デフォルト値で実行（BUDGET_THRESHOLD_REMAINING=40, BUDGET_THRESHOLD_CYCLE=5）
+  run env \
+    PILOT_WINDOW="fake-window" \
+    AUTOPILOT_DIR="$SANDBOX/.autopilot" \
+    FAKE_STATUS_LINE="$status_line" \
+    PATH="$STUB_BIN:$PATH" \
+    bash "$SANDBOX/budget-detect.sh"
+
+  echo "--- exit status: $status ---"
+  echo "--- stdout: $output ---"
+
+  # 期待: exit 0（alert なし）
+  # RED: 現在の実装は exit 1（偽陽性 alert）
+  [ "$status" -eq 0 ] || {
+    echo "FAIL: 5h:9%(0h10m) で誤った alert が発火した（偽陽性）"
+    echo "現在の実装は cycle_reset_min=10 を残量と誤認して閾値以下と判断している"
+    echo "実装後は consumption-based 残量計算で alert なしになるべき"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4 ケース2: 5h:88%(2h00m) → alert OK（軸1 consumption-based）
+#
+# フォーマット解釈:
+#   pct = 88 (消費率)
+#   cycle_raw = 2h00m → cycle_reset_min = 120分
+#   budget_remaining_min = (120 * (100 - 88)) / 88 = (120 * 12) / 88 = 1440 / 88 = 16分
+#   cycle_reset_min = 120分 (>5)
+#
+# 軸1: remaining=16分 ≤ 40分 → 発火
+# 軸2: cycle_reset=120分 > 5分 → 不発
+# → 軸1 で alert あり → exit 1
+#
+# RED 理由: 現在の実装は BUDGET_MIN (= cycle_reset_min = 120) と BUDGET_THRESHOLD (= 15) を比較し、
+#           120 > 15 → alert=false になる。また PCT=88 < threshold_percent=90 → alert=false。
+#           → 合計: exit 0（偽陰性）。実装後は exit 1（consumption-based で発火）。
+# ===========================================================================
+
+@test "ac4-case2: 5h:88%(2h00m) — 軸1 consumption で alert あり (exit 1)" {
+  # RED: 現在の実装は cycle_reset_min=120 > BUDGET_THRESHOLD=15 で alert=false（偽陰性）
+  # PASS 条件（実装後）:
+  #   軸1 remaining=16分 ≤ 40分 → 発火 → exit 1
+
+  local status_line="Claude [max] 5h:88%(2h00m) 7d:20%(5d14h)"
+  export FAKE_STATUS_LINE="$status_line"
+
+  cp "$BUDGET_DETECT_SCRIPT" "$SANDBOX/budget-detect.sh"
+  chmod +x "$SANDBOX/budget-detect.sh"
+
+  run env \
+    PILOT_WINDOW="fake-window" \
+    AUTOPILOT_DIR="$SANDBOX/.autopilot" \
+    FAKE_STATUS_LINE="$status_line" \
+    PATH="$STUB_BIN:$PATH" \
+    bash "$SANDBOX/budget-detect.sh"
+
+  echo "--- exit status: $status ---"
+  echo "--- stdout: $output ---"
+
+  # 期待: exit 1（consumption-based alert）
+  # RED: 現在の実装は exit 0（偽陰性）
+  [ "$status" -eq 1 ] || {
+    echo "FAIL: 5h:88%(2h00m) で consumption-based alert が発火しなかった（偽陰性）"
+    echo "軸1: remaining = (120 * 12) / 88 = 16分 ≤ 40分 → alert 必須"
+    echo "現在の実装は cycle_reset_min=120 を残量として扱い、閾値15分超でスキップしている"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4 ケース3: 5h:50%(0h03m) → alert OK（軸2 cycle-based）
+#
+# フォーマット解釈:
+#   pct = 50 (消費率)
+#   cycle_raw = 0h03m → cycle_reset_min = 3分
+#   budget_remaining_min = (3 * (100 - 50)) / 50 = (3 * 50) / 50 = 3分
+#   ※ 実際は remaining も計算するが軸2 が先に発火
+#   cycle_reset_min = 3分 (≤5)
+#
+# 軸1: remaining=3分 ≤ 40分 → 発火（軸1 でも発火するがケース趣旨は軸2）
+# 軸2: cycle_reset=3分 ≤ 5分 → 発火
+# → OR 発火 → exit 1
+#
+# RED 理由: 現在の実装は BUDGET_MIN (= cycle_reset_min = 3) と BUDGET_THRESHOLD (= 15) を比較し、
+#           3 <= 15 → alert=true（偶然 PASS してしまう可能性あり）。
+#           しかし BUDGET_THRESHOLD_CYCLE が存在しないため、軸2 判定として正式に認識されない。
+#           正しい実装では BUDGET_THRESHOLD_CYCLE=5 との比較で発火する。
+#           （現在の実装は偶然 PASS するが、閾値の意味が間違っている）
+# ===========================================================================
+
+@test "ac4-case3: 5h:50%(0h03m) — 軸2 cycle で alert あり (exit 1)" {
+  # この ケースは現状の実装でも偶然 exit 1 になる可能性があるが、
+  # BUDGET_THRESHOLD_CYCLE が存在しないため「正しい理由で」発火していない。
+  # 実装後は軸2 (cycle_reset=3分 ≤ BUDGET_THRESHOLD_CYCLE=5分) で正式発火する。
+
+  local status_line="Claude [max] 5h:50%(0h03m) 7d:20%(5d14h)"
+
+  cp "$BUDGET_DETECT_SCRIPT" "$SANDBOX/budget-detect.sh"
+  chmod +x "$SANDBOX/budget-detect.sh"
+
+  run env \
+    PILOT_WINDOW="fake-window" \
+    AUTOPILOT_DIR="$SANDBOX/.autopilot" \
+    FAKE_STATUS_LINE="$status_line" \
+    BUDGET_THRESHOLD_CYCLE="5" \
+    PATH="$STUB_BIN:$PATH" \
+    bash "$SANDBOX/budget-detect.sh"
+
+  echo "--- exit status: $status ---"
+  echo "--- stdout: $output ---"
+
+  # 期待: exit 1（cycle-based alert）
+  [ "$status" -eq 1 ] || {
+    echo "FAIL: 5h:50%(0h03m) で cycle-based alert が発火しなかった"
+    echo "軸2: cycle_reset=3分 ≤ BUDGET_THRESHOLD_CYCLE=5分 → alert 必須"
+    return 1
+  }
+
+  # stdout に BUDGET-LOW マーカーが含まれること
+  echo "$output" | grep -q '\[BUDGET-LOW\]' || {
+    echo "FAIL: stdout に [BUDGET-LOW] マーカーが含まれない"
+    echo "output: $output"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4 追加: 正しい軸2 判定の意味チェック（BUDGET_THRESHOLD_CYCLE 参照を確認）
+#
+# RED 理由: 現在の実装は BUDGET_THRESHOLD (cycle_reset との比較) を使用しており
+#           BUDGET_THRESHOLD_CYCLE という名前の変数による cycle 軸判定が存在しない。
+# ===========================================================================
+
+@test "ac4-extra: budget-detect.sh が BUDGET_THRESHOLD_CYCLE を cycle 軸判定に使用する（static grep）" {
+  # RED: 現在の実装には BUDGET_THRESHOLD_CYCLE を参照する行が存在しない
+  # PASS 条件（実装後）: cycle_reset_min と BUDGET_THRESHOLD_CYCLE の比較ロジックが存在する
+  run grep -E 'BUDGET_THRESHOLD_CYCLE' "$BUDGET_DETECT_SCRIPT"
+  [ "${#lines[@]}" -gt 0 ] || {
+    echo "FAIL: BUDGET_THRESHOLD_CYCLE を使用した cycle 軸判定が budget-detect.sh に存在しない"
+    echo "現在の実装（閾値比較部分）:"
+    grep -n -A1 'BUDGET_THRESHOLD\|BUDGET_ALERT' "$BUDGET_DETECT_SCRIPT" || true
+    return 1
+  }
+}
+
+@test "ac4-extra: budget-detect.sh の判定ロジックに 2 軸分の条件分岐が存在する（static grep）" {
+  # RED: 現在の実装は 2 条件分岐（BUDGET_MIN と BUDGET_PCT）だが
+  #      BUDGET_THRESHOLD_REMAINING / BUDGET_THRESHOLD_CYCLE の 2 軸ではない
+  # PASS 条件（実装後）: consumption 軸と cycle 軸の 2 条件が BUDGET_ALERT=true を設定する
+  local threshold_cycle_count
+  threshold_cycle_count=$(grep -c 'BUDGET_THRESHOLD_CYCLE' "$BUDGET_DETECT_SCRIPT" 2>/dev/null | tail -1 || echo "0")
+  [[ "$threshold_cycle_count" =~ ^[0-9]+$ ]] || threshold_cycle_count=0
+  local threshold_remaining_count
+  threshold_remaining_count=$(grep -c 'BUDGET_THRESHOLD_REMAINING' "$BUDGET_DETECT_SCRIPT" 2>/dev/null | tail -1 || echo "0")
+  [[ "$threshold_remaining_count" =~ ^[0-9]+$ ]] || threshold_remaining_count=0
+
+  [ "$threshold_cycle_count" -ge 1 ] && [ "$threshold_remaining_count" -ge 1 ] || {
+    echo "FAIL: 2 軸判定の閾値変数が不完全"
+    echo "  BUDGET_THRESHOLD_CYCLE 参照数: ${threshold_cycle_count} (期待: >= 1)"
+    echo "  BUDGET_THRESHOLD_REMAINING 参照数: ${threshold_remaining_count} (期待: >= 1)"
+    return 1
+  }
+}

--- a/plugins/twl/tests/bats/scripts/budget-detect-docs-1022.bats
+++ b/plugins/twl/tests/bats/scripts/budget-detect-docs-1022.bats
@@ -1,0 +1,172 @@
+#!/usr/bin/env bats
+# budget-detect-docs-1022.bats - Issue #1022 AC2/AC3 TDD RED フェーズ
+#
+# Issue #1022: tech-debt(observer): budget-detect.sh が cycle reset wall-clock を「残量」と誤認
+#
+# このファイルは実装前（RED）状態で全テストが fail することを意図している。
+# 実装完了後（GREEN）は全テストが PASS すること。
+#
+# AC2: monitor-channel-catalog.md [BUDGET-LOW] セクションで (YYm) の意味を明記
+#      (cycle reset wall-clock であって残量ではない)
+#
+# AC3: SKILL.md 該当箇所を訂正 (「残量 15 分」と「reset まで 15 分」を区別)
+
+load '../helpers/common'
+
+CATALOG_MD=""
+SKILL_MD=""
+
+setup() {
+  common_setup
+  CATALOG_MD="$REPO_ROOT/skills/su-observer/refs/monitor-channel-catalog.md"
+  SKILL_MD="$REPO_ROOT/skills/su-observer/SKILL.md"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC2: monitor-channel-catalog.md の [BUDGET-LOW] セクションで (YYm) の意味を明記
+#
+# 仕様: `5h:XX%(YYm)` の `(YYm)` は cycle reset まで の wall-clock であり、
+#       budget 残量ではないことを明記する必要がある。
+#
+# RED 理由: 現在の catalog には [BUDGET-LOW] セクションで「(YYm) の意味」が
+#           明記されていない。"cycle reset" / "wall-clock" の言及が不足している。
+# ===========================================================================
+
+@test "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに 'cycle reset' の言及が存在する" {
+  # RED: 現在の [BUDGET-LOW] セクションには "(YYm) の意味" として
+  #      "cycle reset" という語が存在しないため fail する
+  # PASS 条件（実装後）: [BUDGET-LOW] セクションまたはその近傍に "cycle reset" が含まれる
+
+  # [BUDGET-LOW] セクションを抽出（次の ## セクションまで）
+  local budget_low_section
+  budget_low_section=$(sed -n '/^\#\# \[BUDGET-LOW\]/,/^\#\# /p' "$CATALOG_MD" 2>/dev/null || true)
+
+  echo "--- [BUDGET-LOW] セクション（先頭 30 行）---"
+  echo "$budget_low_section" | head -30
+
+  echo "$budget_low_section" | grep -qE 'cycle.reset|cycle reset|サイクルリセット' || {
+    echo "FAIL: [BUDGET-LOW] セクションに 'cycle reset' の説明が存在しない"
+    echo "現在の [BUDGET-LOW] セクション冒頭:"
+    echo "$budget_low_section" | head -10
+    return 1
+  }
+}
+
+@test "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに 'wall-clock' または '残量ではない' の言及が存在する" {
+  # RED: 現在の [BUDGET-LOW] セクションには "(YYm) が残量ではない" という
+  #      訂正注記が存在しないため fail する
+  # PASS 条件（実装後）: (YYm) が wall-clock / cycle reset であり残量ではないことを明記
+
+  local budget_low_section
+  budget_low_section=$(sed -n '/^\#\# \[BUDGET-LOW\]/,/^\#\# /p' "$CATALOG_MD" 2>/dev/null || true)
+
+  echo "--- [BUDGET-LOW] セクション（wall-clock 確認）---"
+  echo "$budget_low_section" | head -40
+
+  echo "$budget_low_section" | grep -qE 'wall.clock|wall_clock|残量ではない|残量でない|残量.*誤|誤.*残量|cycle reset' || {
+    echo "FAIL: [BUDGET-LOW] セクションに '(YYm) は wall-clock (cycle reset 時刻) であり残量ではない' の旨が記載されていない"
+    echo "現在の記述（閾値説明付近）:"
+    echo "$budget_low_section" | grep -A3 -B3 'threshold\|閾値\|YYm\|残り' || true
+    return 1
+  }
+}
+
+@test "ac2: monitor-channel-catalog.md [BUDGET-LOW] セクションに '(YYm)' の注記が存在する" {
+  # RED: 現在の [BUDGET-LOW] セクションには (YYm) の semantics 注記が存在しない
+  # PASS 条件（実装後）: (YYm) の意味（cycle reset wall-clock）を注記する行が存在する
+
+  local budget_low_section
+  budget_low_section=$(sed -n '/^\#\# \[BUDGET-LOW\]/,/^\#\# /p' "$CATALOG_MD" 2>/dev/null || true)
+
+  # "(YYm)" という文字列 + その意味説明（cycle / reset / wall-clock / 注意）が含まれること
+  echo "$budget_low_section" | grep -qE '\(YYm\).*cycle|\(YYm\).*reset|\(YYm\).*wall|YYm.*注|注.*YYm|cycle.*YYm|reset.*YYm' || {
+    echo "FAIL: [BUDGET-LOW] セクションに (YYm) の semantics 注記が存在しない"
+    echo "期待: '(YYm) は cycle reset までの wall-clock であり budget 残量ではない' などの注記"
+    echo "現在の (YYm) 関連行:"
+    echo "$budget_low_section" | grep -E 'YYm' || echo "(なし)"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: SKILL.md 該当箇所を訂正 (「残量 15 分」と「reset まで 15 分」を区別)
+#
+# 現在の SKILL.md / budget-detect.sh の問題:
+#   - BUDGET_THRESHOLD=15 が「cycle_reset_min (= YYm の値) ≤ 15分」として使われており
+#     「budget 残量」の閾値と混在している
+#   - SKILL.md の SU-5 や budget 関連記述で「残量 ≤ 閾値」と記述されているが
+#     実際は「cycle reset まで ≤ 閾値」になっていた
+#
+# RED 理由: SKILL.md の budget 関連記述に「cycle reset wall-clock」と「残量」の
+#           明確な区別が存在しない。
+# ===========================================================================
+
+@test "ac3: SKILL.md に 'consumption-based' または '消費ベース' の記述が存在する" {
+  # RED: 現在の SKILL.md には 2 軸判定（consumption-based / cycle-based）の
+  #      説明が存在しないため fail する
+  # PASS 条件（実装後）: 2 軸独立判定の説明が SKILL.md に追記されている
+
+  echo "--- SKILL.md budget 関連行 ---"
+  grep -n -E 'budget|BUDGET|残量|reset|cycle' "$SKILL_MD" | head -20
+
+  grep -qE 'consumption.based|消費ベース|consumption_based|軸1.*consumption|consumption.*軸1' "$SKILL_MD" || {
+    echo "FAIL: SKILL.md に 'consumption-based' 判定軸の記述が存在しない"
+    echo "実装後は 2 軸判定（consumption-based + cycle-based）の説明を含むべき"
+    echo "現在の budget 関連記述:"
+    grep -n -E 'budget|BUDGET|残量' "$SKILL_MD" | head -10 || echo "(なし)"
+    return 1
+  }
+}
+
+@test "ac3: SKILL.md に 'cycle-based' または 'cycle reset' と閾値の区別が存在する" {
+  # RED: 現在の SKILL.md には cycle reset wall-clock 閾値の説明が存在しない
+  # PASS 条件（実装後）: BUDGET_THRESHOLD_CYCLE など cycle reset 軸の説明が存在する
+
+  grep -qE 'cycle.based|cycle_based|THRESHOLD_CYCLE|cycle.*reset.*閾値|閾値.*cycle.*reset|reset.*まで.*閾値' "$SKILL_MD" || {
+    echo "FAIL: SKILL.md に 'cycle-based' 判定軸（cycle reset 閾値）の記述が存在しない"
+    echo "現在の budget/cycle 関連行:"
+    grep -n -E 'cycle|reset|THRESHOLD' "$SKILL_MD" | head -10 || echo "(なし)"
+    return 1
+  }
+}
+
+@test "ac3: SKILL.md が '残量 15 分' ではなく 2 軸判定の正しい説明を含む" {
+  # RED: 現在の SKILL.md には旧仕様の「残量 15 分」相当の記述があり
+  #      「(YYm) は cycle reset wall-clock」という訂正がない
+  # PASS 条件（実装後）: 2 軸判定の正しい説明（残量軸 + cycle reset 軸）が存在する
+
+  # 「残量 15 分」という旧仕様記述が残っていないこと、または訂正が存在すること
+  local old_description_count
+  old_description_count=$(grep -cE '残り\s*15\s*分|残量\s*(≤|<=|以下)\s*15' "$SKILL_MD" 2>/dev/null | tail -1 || echo "0")
+  # grep -c が "0\n0" 形式で返す場合を防ぐために tail -1 を使用
+  [[ "$old_description_count" =~ ^[0-9]+$ ]] || old_description_count=0
+
+  local new_description_count
+  new_description_count=$(grep -cE '(THRESHOLD_REMAINING|THRESHOLD_CYCLE|2\s*軸|consumption.based|cycle.based)' "$SKILL_MD" 2>/dev/null | tail -1 || echo "0")
+  [[ "$new_description_count" =~ ^[0-9]+$ ]] || new_description_count=0
+
+  echo "旧記述（'残り 15 分' 系）の件数: $old_description_count"
+  echo "新記述（2 軸判定）の件数: $new_description_count"
+
+  [ "$new_description_count" -ge 1 ] || {
+    echo "FAIL: SKILL.md に 2 軸判定の説明が存在しない"
+    echo "期待: BUDGET_THRESHOLD_REMAINING (default: 40分) / BUDGET_THRESHOLD_CYCLE (default: 5分) の説明"
+    return 1
+  }
+}
+
+@test "ac3: SKILL.md に '(YYm) は cycle reset まで の時刻' または同等の訂正注記が存在する" {
+  # RED: 現在の SKILL.md には (YYm) の意味（cycle reset wall-clock）の注記がない
+  # PASS 条件（実装後）: (YYm) の semantics が正しく説明されている
+
+  grep -qE '\(YYm\).*cycle|\(YYm\).*reset|cycle.*\(YYm\)|reset.*\(YYm\)' "$SKILL_MD" || {
+    echo "FAIL: SKILL.md に '(YYm) = cycle reset wall-clock' の注記が存在しない"
+    echo "現在の (YYm) 関連行:"
+    grep -n -E 'YYm' "$SKILL_MD" || echo "(なし)"
+    return 1
+  }
+}


### PR DESCRIPTION
## 概要

Issue #1022 の修正。budget-detect.sh の `(YYm)` 解釈誤りを修正し、2軸独立判定を実装。

## 問題

`5h:XX%(YYm)` の `(YYm)` は「次の cycle reset までの wall-clock」であり、「token 残量」ではない。旧実装は `(YYm)` を残量と誤認して閾値比較していたため偽陽性・偽陰性が発生していた。

## 修正内容

### budget-detect.sh (AC1)
- 旧: cycle_reset_min (YYm) ≤ BUDGET_THRESHOLD (15分) で alert
- 新: 2軸独立判定 (OR 発火)
  - 軸1 (consumption-based): token残量 = 300 × (100 - pct%) / 100 ≤ BUDGET_THRESHOLD_REMAINING (default: 40分)
  - 軸2 (cycle-based): cycle_reset_min ≤ BUDGET_THRESHOLD_CYCLE (default: 5分)

### monitor-channel-catalog.md (AC2)
- `(YYm)` は cycle reset wall-clock であり token 残量ではない旨を明記
- 2軸判定の説明と bash スニペットを更新

### SKILL.md (AC3)
- SU-5 の `[BUDGET-LOW]` 説明に 2軸判定と `(YYm)` の正しい意味を追記

## テスト (AC4)

bats 3ケース全 PASS:
| 入力 | token残量 | cycle reset | 期待 | 結果 |
|------|-----------|-------------|------|------|
| `5h:9%(0h10m)` | 273分 (>40) | 10分 (>5) | alert なし | ✅ exit 0 |
| `5h:88%(2h00m)` | 36分 (≤40) | 120分 (>5) | alert OK (軸1) | ✅ exit 1 |
| `5h:50%(0h03m)` | 150分 (>40) | 3分 (≤5) | alert OK (軸2) | ✅ exit 1 |

Closes #1022