### PR TITLE
fix(catalog-integrity): bats test #10 を動的検出化 — pitfalls-catalog.md セクション数 hardcode 解消 (#1100)

### DIFF
--- a/plugins/twl/tests/bats/catalog-integrity.bats
+++ b/plugins/twl/tests/bats/catalog-integrity.bats
@@ -154,12 +154,17 @@ EOF
 # Group 3: Section number continuity (## N. format)
 # ===========================================================================
 
-@test "catalog-integrity: pitfalls-catalog has 14 consecutive sections §0-13" {
+@test "catalog-integrity: pitfalls-catalog has consecutive sections starting from §0" {
+  # 動的検出化: hardcoded section 数ではなく §0 起点契約と件数 ≥ 1 を assert する。
+  # pitfalls-catalog.md のセクション数変更（例: §0-15）に追従するためこの形式に移行。
+  # 背景: #1084 rework ブロッカー解消 / #1097 retrospective 参照。
   local pitfalls="${REPO_ROOT}/skills/su-observer/refs/pitfalls-catalog.md"
   [ -f "${pitfalls}" ]
   run bash "${SCRIPT}" --repo-root "${REPO_ROOT}" --check-sections "${pitfalls}"
   [ "${status}" -eq 0 ]
-  [[ "${output}" == *"sections:"*"pitfalls-catalog.md"*"14 sections §0-13"* ]]
+  # 動的 assertion: ファイル名 + section 件数 ≥ 1 + §0 起点
+  [[ "${output}" =~ sections:\ skills/su-observer/refs/pitfalls-catalog\.md\ \(([0-9]+)\ sections\ §0-[0-9]+\) ]]
+  [ "${BASH_REMATCH[1]}" -ge 1 ]
 }
 
 @test "catalog-integrity: --check-sections passes for all current ref files" {
@@ -182,6 +187,27 @@ EOF
   run bash "${SCRIPT}" --repo-root "${TMPDIR_TEST}" --check-sections "${fixture}"
   [ "${status}" -ne 0 ]
   [[ "${output}" == *"section gap"* ]]
+}
+
+@test "catalog-integrity: --check-sections §0-origin contract: §1-start catalog does not match §0 pattern" {
+  # AC3 regression: §0 起点契約の強制を確認する mock fixture テスト。
+  # §1 から始まる catalog は §0-origin assertion に一致しないことを検証する。
+  # test #12 (gap 検出) とは独立: gap なしで §1 起点という別条件をカバー。
+  local fixture="${TMPDIR_TEST}/non-zero-start.md"
+  cat > "${fixture}" <<'EOF'
+---
+type: reference
+---
+## 1. First Section
+content
+
+## 2. Second Section
+content
+EOF
+  run bash "${SCRIPT}" --repo-root "${TMPDIR_TEST}" --check-sections "${fixture}"
+  [ "${status}" -eq 0 ]
+  # §1 起点の出力は "§1-2" 形式になり、§0 起点パターンに一致しないことを確認
+  [[ ! "${output}" =~ \§0-[0-9]+ ]]
 }
 
 @test "catalog-integrity: --check-sections passes for file without numbered sections" {


### PR DESCRIPTION
## 概要

pitfalls-catalog.md のセクション数増加に追従するため、catalog-integrity.bats の test #10 を動的検出版に置換した。

**#1084 rework のブロッカー解消**: 本 PR merge 後、#1084 (★HUMAN GATE 規約) の rework が着手可能になる。

## 背景

- main 上で pitfalls-catalog.md は §0-15 (16 sections) なのに test #10 が `14 sections §0-13` を hardcoded → CI catalog-integrity job が RED
- PR #1097 (#1084 ★HUMAN GATE 規約実装試行) もこの test #10 で fail → CLOSED に至った（[retrospective](https://github.com/shuu5/twill/issues/1084#issuecomment-4339988679)）

## 変更内容

### catalog-integrity.bats

**test #10**: hardcoded 文字列マッチ → 動的正規表現 assert に置換
- `pitfalls-catalog has 14 consecutive sections §0-13` → `pitfalls-catalog has consecutive sections starting from §0`
- `== *"14 sections §0-13"*` → `=~ sections: skills/su-observer/refs/pitfalls-catalog\.md \(([0-9]+) sections §0-[0-9]+\)` + `BASH_REMATCH[1] -ge 1`
- コメントで動的検出化の意図と #1084/#1097 retrospective を参照

**新規 test (AC3)**: §0 起点契約の強制を確認する mock fixture テスト
- §1 起点 catalog に対して §0-origin assertion が一致しないことを確認

## AC チェックリスト

- [x] AC1: test #10 を動的検出版に置換（正規表現 + §0 起点 + N ≥ 1）
- [x] AC2: 他 catalog の動的化はスコープ外（test #11 で網羅済み）— 実装なし
- [x] AC3: §0 起点契約強制の mock fixture テスト追加
- [x] AC4: コメントで動的検出化の意図 + #1084/#1097 retrospective 参照を記載
- [x] AC5: #1084 rework のブロッカー解消を本 PR description に明記

## テスト結果

bats 実行: 25/25 PASS（修正前: not ok 10）

## 関連 Issue

Closes #1100
Unblocks #1084