### PR TITLE
fix(types) + docs(su-observer): workflow.can_spawn に reference 追加 + pitfalls-catalog §16 commit

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -287,3 +287,75 @@ issue_1089:
       note: |
         RED: ac1 / ac1b は実装前 fail（Hono 検出ロジック未実装）
         GREEN: ac5-negative は実装前後ともに PASS（import なしでは非検出）
+
+# --- Issue #1118 ---
+issue_1118:
+  issue: 1118
+  framework: pytest
+  test_file: "cli/twl/tests/test_issue_1118_workflow_can_spawn.py"
+  mappings:
+    - ac_index: 1
+      ac_text: "cli/twl/types.yaml の workflow.can_spawn に reference を追加 ([atomic, composite, specialist, script] → [atomic, composite, specialist, reference, script])"
+      test_name: "test_ac1_types_yaml_workflow_can_spawn_includes_reference"
+      status: RED
+      red_mechanism: "現在 types.yaml の workflow.can_spawn = [atomic, composite, specialist, script] で reference が欠落"
+
+    - ac_index: 1
+      ac_text: "workflow.can_spawn の順序が [atomic, composite, specialist, reference, script] であること"
+      test_name: "test_ac1_types_yaml_workflow_can_spawn_order"
+      status: RED
+      red_mechanism: "reference 欠落のため順序不一致で assert が fail"
+
+    - ac_index: 1
+      ac_text: "types.py の _FALLBACK_TYPE_RULES['workflow']['can_spawn'] に 'reference' が含まれること"
+      test_name: "test_ac1_fallback_type_rules_workflow_includes_reference"
+      status: RED
+      red_mechanism: "_FALLBACK_TYPE_RULES['workflow']['can_spawn'] = {'atomic', 'composite', 'specialist'} で reference も script も欠落"
+
+    - ac_index: 2
+      ac_text: "plugins/twl/ で twl --validate を実行すると Violations: 0 になること"
+      test_name: "test_ac2_validate_violations_zero"
+      status: RED
+      red_mechanism: "現在 4 violations が検出されている（workflow が reference を spawn できないとして違反）"
+
+    - ac_index: 2
+      ac_text: "twl --validate で他カテゴリの新規違反が発生していないこと"
+      test_name: "test_ac2_validate_no_new_violations_in_other_categories"
+      status: RED
+      red_mechanism: "violations > 0 のため Violations: 0 チェックが fail"
+
+    - ac_index: 3
+      ac_text: "test_v3_schema.py / test_promote.py / test_supervisor_type.py が引き続き pass すること"
+      test_name: "test_ac3_existing_pytest_suite_passes"
+      status: RED
+      red_mechanism: "types.yaml が不整合のため load_type_rules() が旧 can_spawn を返し間接的に fail するケースがある"
+
+    - ac_index: 4
+      ac_text: "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md に §16 セクションが存在すること"
+      test_name: "test_ac4_pitfalls_catalog_has_section_16"
+      status: RED
+      red_mechanism: "現在最後のセクションは §15。§16 が存在しないため regex match が fail"
+
+    - ac_index: 7
+      ac_text: "workflow-pr-merge の deps.yaml can_spawn が types.yaml 変更後と矛盾しないこと"
+      test_name: "test_ac7_workflow_pr_merge_can_spawn_consistent_with_types"
+      status: RED
+      red_mechanism: "types.yaml が reference を許可していないため整合性検証で fail"
+
+    - ac_index: 7
+      ac_text: "workflow-issue-lifecycle の deps.yaml can_spawn が types.yaml 変更後と矛盾しないこと"
+      test_name: "test_ac7_workflow_issue_lifecycle_can_spawn_consistent_with_types"
+      status: RED
+      red_mechanism: "types.yaml が reference を許可していないため整合性検証で fail"
+
+    - ac_index: 7
+      ac_text: "workflow-issue-refine の deps.yaml can_spawn が types.yaml 変更後と矛盾しないこと"
+      test_name: "test_ac7_workflow_issue_refine_can_spawn_consistent_with_types"
+      status: RED
+      red_mechanism: "types.yaml が reference を許可していないため整合性検証で fail"
+
+    - ac_index: 7
+      ac_text: "workflow-pr-merge が calls で reference を呼ぶなら can_spawn に reference が必要"
+      test_name: "test_ac7_workflow_pr_merge_can_spawn_includes_reference_when_calls_reference"
+      status: RED
+      red_mechanism: "workflow-pr-merge.can_spawn = [composite, atomic, script] で reference が calls にあるにもかかわらず can_spawn に reference がない"

--- a/cli/twl/src/twl/core/types.py
+++ b/cli/twl/src/twl/core/types.py
@@ -25,7 +25,7 @@ _FALLBACK_TOKEN_THRESHOLDS: Dict[str, Tuple[int, int]] = {
 
 _FALLBACK_TYPE_RULES = {
     'controller':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference'}, 'spawnable_by': {'user', 'launcher'}},
-    'workflow':    {'section': 'skills',   'can_spawn': {'atomic', 'composite', 'specialist'},  'spawnable_by': {'controller', 'user'}},
+    'workflow':    {'section': 'skills',   'can_spawn': {'atomic', 'composite', 'specialist', 'reference', 'script'},  'spawnable_by': {'controller', 'user'}},
     'atomic':      {'section': 'commands', 'can_spawn': {'reference', 'script'},                  'spawnable_by': {'workflow', 'controller', 'supervisor'}},
     'composite':   {'section': 'commands', 'can_spawn': {'specialist', 'script'},               'spawnable_by': {'workflow', 'controller'}},
     'specialist':  {'section': 'agents',   'can_spawn': set(),                                  'spawnable_by': {'workflow', 'composite', 'controller', 'supervisor'}},

--- a/cli/twl/src/twl/core/types.py
+++ b/cli/twl/src/twl/core/types.py
@@ -29,7 +29,7 @@ _FALLBACK_TYPE_RULES = {
     'atomic':      {'section': 'commands', 'can_spawn': {'reference', 'script'},                  'spawnable_by': {'workflow', 'controller', 'supervisor'}},
     'composite':   {'section': 'commands', 'can_spawn': {'specialist', 'script'},               'spawnable_by': {'workflow', 'controller'}},
     'specialist':  {'section': 'agents',   'can_spawn': set(),                                  'spawnable_by': {'workflow', 'composite', 'controller', 'supervisor'}},
-    'reference':   {'section': 'skills',   'can_spawn': set(),                                  'spawnable_by': {'controller', 'atomic', 'supervisor', 'agents.skills', 'all'}},
+    'reference':   {'section': 'skills',   'can_spawn': set(),                                  'spawnable_by': {'controller', 'atomic', 'composite', 'workflow', 'supervisor', 'agents.skills', 'all'}},
     'script':      {'section': 'scripts',  'can_spawn': {'script'},                              'spawnable_by': {'atomic', 'composite', 'script'}},
     'supervisor':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference', 'script'}, 'spawnable_by': {'user'}},
 }

--- a/cli/twl/tests/test_issue_1118_workflow_can_spawn.py
+++ b/cli/twl/tests/test_issue_1118_workflow_can_spawn.py
@@ -1,0 +1,297 @@
+"""Tests for Issue #1118: workflow.can_spawn に reference を追加する tech-debt 修正。
+
+TDD RED phase -- すべてのテストは実装前に FAIL する。
+実装完了後に GREEN になることを期待する。
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# パス定数
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parents[3]
+CLI_TWL = REPO_ROOT / "cli" / "twl"
+PLUGINS_TWL = REPO_ROOT / "plugins" / "twl"
+
+TYPES_YAML = CLI_TWL / "types.yaml"
+DEPS_YAML = PLUGINS_TWL / "deps.yaml"
+PITFALLS_CATALOG = PLUGINS_TWL / "skills" / "su-observer" / "refs" / "pitfalls-catalog.md"
+
+
+# ---------------------------------------------------------------------------
+# AC-1: types.yaml の workflow.can_spawn に reference が存在すること
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_types_yaml_workflow_can_spawn_includes_reference():
+    """AC-1: cli/twl/types.yaml の workflow.can_spawn に 'reference' が含まれること。
+
+    RED: 現在は can_spawn: [atomic, composite, specialist, script] で reference が欠落。
+    """
+    assert TYPES_YAML.exists(), f"types.yaml が存在しない: {TYPES_YAML}"
+    data = yaml.safe_load(TYPES_YAML.read_text(encoding="utf-8"))
+    can_spawn = data["types"]["workflow"]["can_spawn"]
+    assert "reference" in can_spawn, (
+        f"workflow.can_spawn に 'reference' が存在しない。現在の値: {can_spawn}"
+    )
+
+
+def test_ac1_types_yaml_workflow_can_spawn_order():
+    """AC-1 補足: can_spawn の順序が [atomic, composite, specialist, reference, script] であること。
+
+    RED: reference が欠落しているため順序検証も fail する。
+    """
+    assert TYPES_YAML.exists(), f"types.yaml が存在しない: {TYPES_YAML}"
+    data = yaml.safe_load(TYPES_YAML.read_text(encoding="utf-8"))
+    can_spawn = data["types"]["workflow"]["can_spawn"]
+    expected = ["atomic", "composite", "specialist", "reference", "script"]
+    assert can_spawn == expected, (
+        f"workflow.can_spawn の順序が期待と異なる。期待: {expected}, 実際: {can_spawn}"
+    )
+
+
+def test_ac1_fallback_type_rules_workflow_includes_reference():
+    """AC-1 補足: types.py の _FALLBACK_TYPE_RULES['workflow']['can_spawn'] に 'reference' が含まれること。
+
+    RED: 現在 {'atomic', 'composite', 'specialist'} で reference も script も欠落。
+    """
+    import sys
+    src_path = CLI_TWL / "src"
+    sys.path.insert(0, str(src_path))
+    try:
+        # モジュールキャッシュをリセットして最新の状態を読み込む
+        for mod_name in list(sys.modules.keys()):
+            if mod_name.startswith("twl"):
+                del sys.modules[mod_name]
+        from twl.core.types import _FALLBACK_TYPE_RULES
+        can_spawn = _FALLBACK_TYPE_RULES["workflow"]["can_spawn"]
+        assert "reference" in can_spawn, (
+            f"_FALLBACK_TYPE_RULES['workflow']['can_spawn'] に 'reference' が存在しない。現在の値: {can_spawn}"
+        )
+    finally:
+        sys.path.remove(str(src_path))
+
+
+# ---------------------------------------------------------------------------
+# AC-2: plugins/twl/ で twl --validate を実行すると violations が 0 になること
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_validate_violations_zero():
+    """AC-2: plugins/twl/ ディレクトリで twl --validate を実行したとき Violations: 0 が出力されること。
+
+    RED: 現在 4 violations が検出されている状態（workflow が reference を spawn できないとして違反）。
+    """
+    result = subprocess.run(
+        ["python3", "-m", "twl", "--validate"],
+        cwd=PLUGINS_TWL,
+        capture_output=True,
+        text=True,
+        env={**__import__("os").environ, "TWL_LOOM_ROOT": str(CLI_TWL)},
+    )
+    output = result.stdout + result.stderr
+    assert "Violations: 0" in output, (
+        f"twl --validate が Violations: 0 を出力しなかった。\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+def test_ac2_validate_no_new_violations_in_other_categories():
+    """AC-2 補足: twl --validate で workflow.can_spawn 関連以外の新規違反が発生していないこと。
+
+    RED: AC-1 実装後の回帰を検出するテスト。現時点では violations > 0 のため fail。
+    """
+    result = subprocess.run(
+        ["python3", "-m", "twl", "--validate"],
+        cwd=PLUGINS_TWL,
+        capture_output=True,
+        text=True,
+        env={**__import__("os").environ, "TWL_LOOM_ROOT": str(CLI_TWL)},
+    )
+    output = result.stdout + result.stderr
+    # Violations: 0 であれば新規違反なし
+    assert "Violations: 0" in output, (
+        f"twl --validate に violations が残っている。\n出力:\n{output}"
+    )
+    # ERROR レベルの非 violation メッセージが含まれていないこと
+    error_lines = [line for line in output.splitlines() if "ERROR" in line and "Violations" not in line]
+    assert not error_lines, (
+        f"validate 出力に予期しない ERROR が含まれている:\n" + "\n".join(error_lines)
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: types.yaml 変更が既存テストを破壊しないこと（smoke test）
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_existing_pytest_suite_passes():
+    """AC-3: 既存の pytest スイート (test_v3_schema.py, test_promote.py, test_supervisor_type.py) が pass すること。
+
+    RED: AC-1 実装前の状態では types.yaml が不整合のため、これらのテストが参照する
+    load_type_rules() が旧 can_spawn を返し、間接的に fail するケースがある。
+    実装後に GREEN になることを期待する。
+
+    注意: このテストは subprocess で既存テストを実行する smoke runner。
+    既存テスト自体は変更しない。
+    """
+    target_tests = [
+        "tests/test_v3_schema.py",
+        "tests/test_promote.py",
+        "tests/test_supervisor_type.py",
+    ]
+    result = subprocess.run(
+        ["python3", "-m", "pytest", "--tb=short", "-q"] + target_tests,
+        cwd=CLI_TWL,
+        capture_output=True,
+        text=True,
+        env={**__import__("os").environ, "TWL_LOOM_ROOT": str(CLI_TWL)},
+    )
+    assert result.returncode == 0, (
+        f"既存テストが fail した。\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: pitfalls-catalog.md に §16 が存在すること
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_pitfalls_catalog_has_section_16():
+    """AC-4: plugins/twl/skills/su-observer/refs/pitfalls-catalog.md に §16 セクションが存在すること。
+
+    RED: 現在最後のセクションは §15 であり、§16 は存在しない。
+    """
+    assert PITFALLS_CATALOG.exists(), f"pitfalls-catalog.md が存在しない: {PITFALLS_CATALOG}"
+    content = PITFALLS_CATALOG.read_text(encoding="utf-8")
+    # "## 16." または "## §16" の形式を許容
+    pattern = re.compile(r"^## (?:§?16[.\s])", re.MULTILINE)
+    assert pattern.search(content), (
+        "pitfalls-catalog.md に §16 セクション (## 16. ... または ## §16 ...) が存在しない。"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC-7: workflow-pr-merge / workflow-issue-lifecycle / workflow-issue-refine の
+#        deps.yaml can_spawn が types.yaml 変更後と矛盾しないこと
+# ---------------------------------------------------------------------------
+
+
+def _load_deps_yaml() -> dict:
+    assert DEPS_YAML.exists(), f"deps.yaml が存在しない: {DEPS_YAML}"
+    return yaml.safe_load(DEPS_YAML.read_text(encoding="utf-8"))
+
+
+def _load_types_yaml_workflow_can_spawn() -> list:
+    assert TYPES_YAML.exists(), f"types.yaml が存在しない: {TYPES_YAML}"
+    data = yaml.safe_load(TYPES_YAML.read_text(encoding="utf-8"))
+    return data["types"]["workflow"]["can_spawn"]
+
+
+def test_ac7_workflow_pr_merge_can_spawn_consistent_with_types():
+    """AC-7: workflow-pr-merge の deps.yaml can_spawn が types.yaml の workflow.can_spawn のサブセットであること。
+
+    RED: workflow-pr-merge.can_spawn = [composite, atomic, script] で reference を呼んでいる
+    (calls に reference: pr-merge-domain-rules / pr-merge-chain-steps) にもかかわらず
+    can_spawn に reference がない矛盾がある。types.yaml 修正後は can_spawn を
+    [composite, atomic, script, reference] または [composite, atomic, reference, script] に
+    更新すれば整合する。現時点では types.yaml が reference を許可していないため fail。
+    """
+    deps = _load_deps_yaml()
+    allowed_by_types = set(_load_types_yaml_workflow_can_spawn())
+
+    workflow_entry = deps["skills"]["workflow-pr-merge"]
+    entry_can_spawn = set(workflow_entry.get("can_spawn", []))
+
+    # deps.yaml の can_spawn が types.yaml で許可された型のみを含むこと
+    disallowed = entry_can_spawn - allowed_by_types
+    assert not disallowed, (
+        f"workflow-pr-merge.can_spawn に types.yaml で許可されていない型が含まれている: {disallowed}"
+    )
+
+    # calls に reference を含む場合、can_spawn に reference が含まれていること
+    calls = workflow_entry.get("calls", [])
+    has_reference_call = any("reference" in call for call in calls)
+    if has_reference_call:
+        assert "reference" in entry_can_spawn, (
+            "workflow-pr-merge は calls に reference を持つが、can_spawn に reference が含まれていない。"
+        )
+
+
+def test_ac7_workflow_issue_lifecycle_can_spawn_consistent_with_types():
+    """AC-7: workflow-issue-lifecycle の deps.yaml can_spawn が types.yaml の workflow.can_spawn のサブセットであること。
+
+    RED: 現在 types.yaml が reference を許可していないため、整合性検証で fail する可能性がある。
+    実装後（types.yaml に reference 追加）に GREEN になることを期待する。
+    """
+    deps = _load_deps_yaml()
+    allowed_by_types = set(_load_types_yaml_workflow_can_spawn())
+
+    workflow_entry = deps["skills"]["workflow-issue-lifecycle"]
+    entry_can_spawn = set(workflow_entry.get("can_spawn", []))
+
+    disallowed = entry_can_spawn - allowed_by_types
+    assert not disallowed, (
+        f"workflow-issue-lifecycle.can_spawn に types.yaml で許可されていない型が含まれている: {disallowed}"
+    )
+
+    calls = workflow_entry.get("calls", [])
+    has_reference_call = any("reference" in call for call in calls)
+    if has_reference_call:
+        assert "reference" in entry_can_spawn, (
+            "workflow-issue-lifecycle は calls に reference を持つが、can_spawn に reference が含まれていない。"
+        )
+
+
+def test_ac7_workflow_issue_refine_can_spawn_consistent_with_types():
+    """AC-7: workflow-issue-refine の deps.yaml can_spawn が types.yaml の workflow.can_spawn のサブセットであること。
+
+    RED: 現在 types.yaml が reference を許可していないため、整合性検証で fail する可能性がある。
+    実装後（types.yaml に reference 追加）に GREEN になることを期待する。
+    """
+    deps = _load_deps_yaml()
+    allowed_by_types = set(_load_types_yaml_workflow_can_spawn())
+
+    workflow_entry = deps["skills"]["workflow-issue-refine"]
+    entry_can_spawn = set(workflow_entry.get("can_spawn", []))
+
+    disallowed = entry_can_spawn - allowed_by_types
+    assert not disallowed, (
+        f"workflow-issue-refine.can_spawn に types.yaml で許可されていない型が含まれている: {disallowed}"
+    )
+
+    calls = workflow_entry.get("calls", [])
+    has_reference_call = any("reference" in call for call in calls)
+    if has_reference_call:
+        assert "reference" in entry_can_spawn, (
+            "workflow-issue-refine は calls に reference を持つが、can_spawn に reference が含まれていない。"
+        )
+
+
+def test_ac7_workflow_pr_merge_can_spawn_includes_reference_when_calls_reference():
+    """AC-7 補足: workflow-pr-merge が calls で reference を呼ぶなら can_spawn に reference が必要。
+
+    RED: 現在 workflow-pr-merge.can_spawn = [composite, atomic, script] で
+    reference が calls に含まれているにもかかわらず can_spawn に reference がない。
+    types.yaml に reference を追加し、deps.yaml の workflow-pr-merge.can_spawn も
+    更新すれば GREEN になる。
+    """
+    deps = _load_deps_yaml()
+    workflow_entry = deps["skills"]["workflow-pr-merge"]
+    calls = workflow_entry.get("calls", [])
+    entry_can_spawn = set(workflow_entry.get("can_spawn", []))
+
+    reference_calls = [call for call in calls if "reference" in call]
+    assert reference_calls, (
+        "テスト前提: workflow-pr-merge の calls に reference エントリが存在すること（前提確認用）"
+    )
+    assert "reference" in entry_can_spawn, (
+        f"workflow-pr-merge は {reference_calls} を calls するが can_spawn に reference がない。"
+    )

--- a/cli/twl/types.yaml
+++ b/cli/twl/types.yaml
@@ -13,7 +13,7 @@ types:
 
   workflow:
     section: skills
-    can_spawn: [atomic, composite, specialist, script]
+    can_spawn: [atomic, composite, specialist, reference, script]
     spawnable_by: [controller, user]
     token_target:
       warning: 1200

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -458,7 +458,7 @@ skills:
     path: skills/workflow-pr-merge/SKILL.md
     effort: medium
     spawnable_by: [controller]
-    can_spawn: [composite, atomic, script]
+    can_spawn: [composite, atomic, reference, script]
     calls:
       - composite: e2e-screening
         step: "6"
@@ -600,7 +600,7 @@ skills:
     path: skills/workflow-issue-lifecycle/SKILL.md
     effort: medium
     spawnable_by: [controller, user]
-    can_spawn: [composite, atomic, specialist]
+    can_spawn: [composite, atomic, specialist, reference]
     calls:
       - atomic: issue-structure
       - composite: issue-spec-review
@@ -617,7 +617,7 @@ skills:
     path: skills/workflow-issue-refine/SKILL.md
     effort: medium
     spawnable_by: [controller, user]
-    can_spawn: [composite, atomic, specialist]
+    can_spawn: [composite, atomic, specialist, reference]
     # ADR-0010: workflow-issue-refine は独立 workflow として設計されており、
     # co-issue（thin orchestrator）と user の両方から直接呼び出し可能。
     # refined-label 付与権限（Layer D gate）はこの workflow が保持する。

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -496,3 +496,29 @@ co-explore 完遂（.explore/<N>/summary.md 生成）を検知
 - co-explore 完遂 → next-step spawn の 5 分タイムアウト規約は `refs/su-observer-wave-management.md` に定義。
 
 **参照**: Issue #1085, Wave U incident 1+3, doobidoo `observer-pitfall` tag
+
+---
+
+## 16. Step 0 MUST refs Read 省略 incident（2026-04-29 ipatho2）
+
+**事象**: observer が workflow 実行前の Step 0 MUST（`refs/refine-processing-flow.md` Read）を省略し、processing flow の全ステップを把握しないまま実装を進めた。
+
+### 根本要因
+
+refs ファイルが `~/.claude/plugins/twl/refs/` ではなく `main/plugins/twl/skills/workflow-issue-refine/refs/` 等 **worktree 配下の実ファイルパス** に配置されているため、Read 先を `claude/` 配下と誤解し、「ファイル不在」として Step 0 を実質スキップした。
+
+### 既知の落とし穴（MUST 確認）
+
+| # | 誤解 | 正しい動作 |
+|---|------|-----------|
+| 16.1 | `claude/plugins/twl/refs/*.md` を Read しようとする | refs は **worktree の `plugins/twl/` 配下**に存在。`main/plugins/twl/skills/<workflow-name>/refs/` が正規パス |
+| 16.2 | `refs/` ファイルが見つからないとスキップする | SKILL.md の Step 0 は **MUST**。不在の場合はパスを確認し直す（絶対パスで再 Read） |
+| 16.3 | Step 0 を "init 処理" と混同して後回しにする | Step 0 は最初の実装ステップより**前**に完了させる（MUST 順守） |
+
+### 対策（MUST）
+
+1. workflow SKILL.md に `Step 0: Read refs/xxx.md` が記載されていれば、**必ず絶対パスで Read** する
+2. 絶対パス解決: `$(git rev-parse --show-toplevel)/plugins/twl/skills/<workflow>/refs/<file>.md`
+3. Read 失敗時はパスを変えて再試行し、スキップしない
+
+**参照**: Issue #1118, doobidoo hash `e73fc1fe`, `observer-pitfall` tag


### PR DESCRIPTION
Closes #1118

## 変更内容

### fix(types): workflow.can_spawn に reference を追加 (AC-1, AC-2, AC-3)

- `cli/twl/types.yaml`: `workflow.can_spawn` に `reference` を追加
  - 変更前: `[atomic, composite, specialist, script]`
  - 変更後: `[atomic, composite, specialist, reference, script]`
- `cli/twl/src/twl/core/types.py`: `_FALLBACK_TYPE_RULES['workflow']['can_spawn']` に `reference` と `script` を同期追加（AC-3 副作用確認）
- `plugins/twl/deps.yaml`: `workflow-pr-merge`, `workflow-issue-lifecycle`, `workflow-issue-refine` の `can_spawn` に `reference` を追加（AC-7 semantic consistency）

### docs(su-observer): pitfalls-catalog §16 追加 (AC-4)

- `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md`: §16 追加
  - 「Step 0 MUST refs Read 省略 incident（2026-04-29 ipatho2）」
  - refs ファイルが worktree 配下に存在するが `claude/` 配下と誤解してスキップする pitfall と対策

### test: TDD RED → GREEN (AC-3)

- `cli/twl/tests/test_issue_1118_workflow_can_spawn.py`: AC 1-4, 7 に対応する 11 テスト
- 実装前 RED: 10 failed / 1 passed → 実装後 GREEN: 11 passed

## 効果

- `twl --validate`: Violations: 4 → **0** (4 件の `workflow→reference` edge 違反を解消) (AC-2)
- OK: 2603 → 2607 (AC-7 依存宣言整合性確保)
- `pre-bash-commit-validate.sh` hook の doc-only commit blocking 問題を解消

## AC 対応

- [x] AC-1: types.yaml workflow.can_spawn に reference 追加
- [x] AC-2: twl --validate で Violations: 0 確認
- [x] AC-3: 既存 pytest suite pass + _FALLBACK_TYPE_RULES 同期確認
- [x] AC-4: pitfalls-catalog §16 commit
- [x] AC-5: ADR 追記不要（内部規約変更のみ）
- [x] AC-6: push で cross-machine 永続化（merge 後 git pull で他ホストに反映）
- [x] AC-7: deps.yaml 個別エントリの can_spawn 整合性確認・修正

## 経緯

bypass 制約（Claude Code Bash tool が `TWL_SKIP_COMMIT_GATE=1` env prefix を strip）により `pitfalls-catalog §16` の commit が deps.yaml 既存違反で間接 block されていた。本 PR で types.yaml fix と docs を 1 commit にまとめ、同時に bypass 制約の経緯を記録。