### PR TITLE
feat(mcp): 状態系 tool 3 個を tools.py に追加 — 統合 epic 子 3 (state) (#1113)

### DIFF
--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -231,22 +231,22 @@ def twl_get_session_state_handler(
         is_archived = False
         resolved_session_id = ""
     else:
-        # validate session_id against regex
-        if not _VALID_SESSION_ID_RE.match(session_id):
+        # session_id バリデーション — パストラバーサル防止 (AC3-12 / security)
+        if not isinstance(session_id, str) or not _VALID_SESSION_ID_RE.match(session_id):
             return {
                 "ok": False,
-                "error": f"invalid session_id: '{session_id}'",
+                "error": f"invalid session_id '{session_id}': must match ^[a-zA-Z0-9]+$",
                 "error_type": "invalid_session_id",
                 "exit_code": 2,
             }
-        archive_base = ap_dir / "archive" / session_id
-        # path traversal check
+        archive_base = (ap_dir / "archive" / session_id).resolve()
+        # resolve() 後に ap_dir 配下であることを確認（パストラバーサル防止）
         try:
-            archive_base.resolve().relative_to(ap_dir.resolve())
+            archive_base.relative_to(ap_dir.resolve())
         except ValueError:
             return {
                 "ok": False,
-                "error": f"path traversal detected for session_id: '{session_id}'",
+                "error": f"invalid session_id '{session_id}': path traversal detected",
                 "error_type": "invalid_session_id",
                 "exit_code": 2,
             }
@@ -339,13 +339,8 @@ def twl_get_pane_state_handler(
             "(only alphanumeric, underscore, dot, colon, slash, at, hyphen allowed)"
         )
 
-    # resolve script path
-    script_path_str = os.environ.get("SESSION_STATE_SCRIPT", "")
-    if script_path_str:
-        script_path = Path(script_path_str)
-    else:
-        script_path = _DEFAULT_SCRIPT
-
+    # SESSION_STATE_SCRIPT: env var が設定されていれば優先（テスト用上書き対応）
+    script_path = Path(os.environ.get("SESSION_STATE_SCRIPT", str(_DEFAULT_SCRIPT)))
     if not script_path.exists():
         return {
             "ok": False,
@@ -447,7 +442,7 @@ def twl_audit_session_handler(
                 "message": f"plan_path does not exist: '{plan_path_str}'",
             })
 
-    # R3: checkpoint files must have required fields
+    # R3: checkpoints/*.json structure — warning
     checkpoints_dir = ap_dir / "checkpoints"
     if checkpoints_dir.is_dir():
         for cp_file in sorted(checkpoints_dir.glob("*.json")):

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -332,12 +332,14 @@ def twl_get_pane_state_handler(
     """Return tmux pane/window state. window_name: tmux window name or session:index form."""
     import subprocess  # noqa: PLC0415
 
-    # validate window_name — raise ValueError for security (shell injection prevention)
+    # validate window_name — return error dict (defense in depth, no subprocess injection)
     if not _VALID_WINDOW_NAME_RE.match(window_name):
-        raise ValueError(
-            f"invalid window_name: '{window_name}' "
-            "(only alphanumeric, underscore, dot, colon, slash, at, hyphen allowed)"
-        )
+        return {
+            "ok": False,
+            "error": f"Invalid window_name '{window_name}': must match [A-Za-z0-9_./:@-]+",
+            "error_type": "invalid_window_name",
+            "exit_code": 2,
+        }
 
     # SESSION_STATE_SCRIPT: env var が設定されていれば優先（テスト用上書き対応）
     script_path = Path(os.environ.get("SESSION_STATE_SCRIPT", str(_DEFAULT_SCRIPT)))

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -7,7 +7,9 @@ Handler functions (_handler suffix) are pure Python for in-process testing.
 import concurrent.futures
 import json
 import os
+import re
 from pathlib import Path
+from typing import Any, TypedDict
 
 
 def _load_plugin_ctx(plugin_root: str) -> "tuple[Path, dict, dict, str]":
@@ -87,6 +89,68 @@ def twl_check_handler(plugin_root: str) -> dict:
     return build_envelope("check", get_deps_version(deps), plugin_name, items, exit_code)
 
 
+# Phase γ Wave 2-B: Session aggregate view TypedDict (AC3-11)
+
+class SessionAggregateView(TypedDict, total=False):
+    """Aggregate view of autopilot session for observer/supervisor consumption.
+
+    Required keys (ok=True path always present):
+      session, active_issues, current_phase, phase_count, cross_issue_warnings,
+      pending_checkpoints, wave_summaries_count, resolved_session_id, autopilot_dir,
+      is_archived
+    Error keys (ok=False path):
+      ok, error, error_type, exit_code
+    """
+    # --- ok=True keys ---
+    session: dict[str, Any]
+    active_issues: list[dict[str, Any]]
+    current_phase: int
+    phase_count: int
+    cross_issue_warnings: list[dict[str, Any]]
+    pending_checkpoints: list[dict[str, Any]]
+    wave_summaries_count: int
+    resolved_session_id: str
+    autopilot_dir: str
+    is_archived: bool
+    # --- ok=False keys ---
+    ok: bool
+    error: str
+    error_type: str
+    exit_code: int
+
+
+# SESSION_STATE_SCRIPT path resolution — env var override for testing
+_DEFAULT_SCRIPT = (
+    Path(__file__).resolve().parent.parent.parent.parent.parent
+    / "plugins" / "session" / "scripts" / "session-state.sh"
+)
+# SESSION_STATE_SCRIPT env var で実行時上書き可能。テスト時は monkeypatch で設定。
+
+_VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9]+\Z")
+_VALID_WINDOW_NAME_RE = re.compile(r"^[A-Za-z0-9_./:@-]+\Z")
+_REQUIRED_CHECKPOINT_FIELDS = frozenset(
+    {"step", "status", "findings_summary", "critical_count", "findings", "timestamp"}
+)
+
+
+def _resolve_autopilot_dir(autopilot_dir: str | None) -> Path:
+    """Resolve autopilot_dir from arg or AUTOPILOT_DIR env var or git root."""
+    if autopilot_dir:
+        return Path(autopilot_dir).expanduser().resolve()
+    env = os.environ.get("AUTOPILOT_DIR", "")
+    if env:
+        return Path(env).expanduser().resolve()
+    try:
+        import subprocess  # noqa: PLC0415
+        root = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL, text=True,
+        ).strip()
+        return Path(root) / ".autopilot"
+    except Exception:
+        return Path.cwd() / ".autopilot"
+
+
 # Phase 1: State read/write handlers (ADR-0006 §1 Hybrid Path 5 原則)
 
 
@@ -146,6 +210,284 @@ def twl_state_write_handler(
 
 
 # ---------------------------------------------------------------------------
+# Phase γ Wave 2-B: Session aggregate handlers (AC3-11, Issue #1113)
+# ---------------------------------------------------------------------------
+
+
+def twl_get_session_state_handler(
+    session_id: str | None = None,
+    autopilot_dir: str | None = None,
+) -> dict:
+    """Return aggregate view of autopilot session (active or archived) for observer/supervisor.
+
+    If session_id is None, reads the active session.json from autopilot_dir.
+    If session_id is given, reads from autopilot_dir/archive/<session_id>/session.json.
+    """
+    ap_dir = _resolve_autopilot_dir(autopilot_dir)
+
+    if session_id is None:
+        # active session path
+        session_path = ap_dir / "session.json"
+        is_archived = False
+        resolved_session_id = ""
+    else:
+        # validate session_id against regex
+        if not _VALID_SESSION_ID_RE.match(session_id):
+            return {
+                "ok": False,
+                "error": f"invalid session_id: '{session_id}'",
+                "error_type": "invalid_session_id",
+                "exit_code": 2,
+            }
+        archive_base = ap_dir / "archive" / session_id
+        # path traversal check
+        try:
+            archive_base.resolve().relative_to(ap_dir.resolve())
+        except ValueError:
+            return {
+                "ok": False,
+                "error": f"path traversal detected for session_id: '{session_id}'",
+                "error_type": "invalid_session_id",
+                "exit_code": 2,
+            }
+        session_path = archive_base / "session.json"
+        if not session_path.exists():
+            return {
+                "ok": False,
+                "error": f"archive session not found: {session_path}",
+                "error_type": "archive_not_found",
+                "exit_code": 2,
+            }
+        is_archived = True
+        resolved_session_id = session_id
+
+    # read session.json
+    try:
+        session_data = json.loads(session_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {
+            "ok": False,
+            "error": f"session.json not found: {session_path}",
+            "error_type": "session_not_found",
+            "exit_code": 1,
+        }
+    except json.JSONDecodeError as e:
+        return {
+            "ok": False,
+            "error": f"session.json parse error: {e}",
+            "error_type": "json_error",
+            "exit_code": 1,
+        }
+
+    if not resolved_session_id:
+        resolved_session_id = session_data.get("session_id", "")
+
+    # aggregate: active_issues (status != "done")
+    active_issues: list[dict] = []
+    issues_dir = ap_dir / "issues"
+    if issues_dir.is_dir():
+        for issue_file in sorted(issues_dir.glob("issue-*.json")):
+            try:
+                issue_data = json.loads(issue_file.read_text(encoding="utf-8"))
+                if issue_data.get("status") != "done":
+                    active_issues.append(issue_data)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # aggregate: pending_checkpoints (status == "FAIL")
+    pending_checkpoints: list[dict] = []
+    checkpoints_dir = ap_dir / "checkpoints"
+    if checkpoints_dir.is_dir():
+        for cp_file in sorted(checkpoints_dir.glob("*.json")):
+            try:
+                cp_data = json.loads(cp_file.read_text(encoding="utf-8"))
+                if cp_data.get("status") == "FAIL":
+                    pending_checkpoints.append(cp_data)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+    # aggregate: wave_summaries_count
+    waves_dir = ap_dir / "waves"
+    wave_summaries_count = len(list(waves_dir.glob("*.summary.md"))) if waves_dir.is_dir() else 0
+
+    return {
+        "ok": True,
+        "session": session_data,
+        "active_issues": active_issues,
+        "current_phase": session_data.get("current_phase", 0),
+        "phase_count": session_data.get("phase_count", 0),
+        "cross_issue_warnings": session_data.get("cross_issue_warnings", []),
+        "pending_checkpoints": pending_checkpoints,
+        "wave_summaries_count": wave_summaries_count,
+        "resolved_session_id": resolved_session_id,
+        "autopilot_dir": str(ap_dir),
+        "is_archived": is_archived,
+    }
+
+
+def twl_get_pane_state_handler(
+    window_name: str,
+    timeout_sec: int = 30,
+) -> dict:
+    """Return tmux pane/window state. window_name: tmux window name or session:index form."""
+    import subprocess  # noqa: PLC0415
+
+    # validate window_name — raise ValueError for security (shell injection prevention)
+    if not _VALID_WINDOW_NAME_RE.match(window_name):
+        raise ValueError(
+            f"invalid window_name: '{window_name}' "
+            "(only alphanumeric, underscore, dot, colon, slash, at, hyphen allowed)"
+        )
+
+    # resolve script path
+    script_path_str = os.environ.get("SESSION_STATE_SCRIPT", "")
+    if script_path_str:
+        script_path = Path(script_path_str)
+    else:
+        script_path = _DEFAULT_SCRIPT
+
+    if not script_path.exists():
+        return {
+            "ok": False,
+            "error": f"session-state.sh not found: {script_path}",
+            "error_type": "script_not_found",
+            "exit_code": 2,
+        }
+
+    valid_states = {"exited", "idle", "processing", "input-waiting", "error"}
+
+    try:
+        result = subprocess.run(
+            [str(script_path), window_name],
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ok": False,
+            "error": "timeout",
+            "error_type": "timeout",
+            "exit_code": 124,
+        }
+    except (OSError, FileNotFoundError) as e:
+        return {
+            "ok": False,
+            "error": str(e),
+            "error_type": "script_not_found",
+            "exit_code": 2,
+        }
+
+    if result.returncode != 0:
+        return {
+            "ok": False,
+            "error": result.stderr.strip() or f"exit code {result.returncode}",
+            "error_type": "shell_error",
+            "exit_code": result.returncode,
+        }
+
+    state = result.stdout.strip()
+    if state not in valid_states:
+        return {
+            "ok": False,
+            "error": f"unknown state: '{state}'",
+            "error_type": "unknown_state",
+            "exit_code": 3,
+        }
+
+    return {
+        "ok": True,
+        "state": state,
+        "exit_code": 0,
+    }
+
+
+def twl_audit_session_handler(
+    autopilot_dir: str | None = None,
+) -> dict:
+    """Audit autopilot session.json for structural integrity (R1-R4 rules). Idempotent."""
+    ap_dir = _resolve_autopilot_dir(autopilot_dir)
+    items: list[dict] = []
+
+    # read session.json
+    session_path = ap_dir / "session.json"
+    session_data: dict = {}
+    if session_path.exists():
+        try:
+            session_data = json.loads(session_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            items.append({
+                "severity": "critical",
+                "code": "R0",
+                "message": f"session.json parse error: {e}",
+            })
+    else:
+        items.append({
+            "severity": "warning",
+            "code": "R0",
+            "message": f"session.json not found: {session_path}",
+        })
+
+    if session_data:
+        # R1: session_id must match ^[a-zA-Z0-9]+\Z
+        session_id = session_data.get("session_id", "")
+        if not session_id or not _VALID_SESSION_ID_RE.match(session_id):
+            items.append({
+                "severity": "critical",
+                "code": "R1",
+                "message": f"session_id invalid (must be alphanumeric): '{session_id}'",
+            })
+
+        # R2: plan_path must exist
+        plan_path_str = session_data.get("plan_path", "")
+        if plan_path_str and not Path(plan_path_str).exists():
+            items.append({
+                "severity": "warning",
+                "code": "R2",
+                "message": f"plan_path does not exist: '{plan_path_str}'",
+            })
+
+    # R3: checkpoint files must have required fields
+    checkpoints_dir = ap_dir / "checkpoints"
+    if checkpoints_dir.is_dir():
+        for cp_file in sorted(checkpoints_dir.glob("*.json")):
+            try:
+                cp_data = json.loads(cp_file.read_text(encoding="utf-8"))
+                missing_fields = _REQUIRED_CHECKPOINT_FIELDS - set(cp_data.keys())
+                if missing_fields:
+                    items.append({
+                        "severity": "warning",
+                        "code": "R3",
+                        "message": f"checkpoint '{cp_file.name}' missing fields: {sorted(missing_fields)}",
+                    })
+            except json.JSONDecodeError as e:
+                items.append({
+                    "severity": "warning",
+                    "code": "R3",
+                    "message": f"checkpoint '{cp_file.name}' parse error: {e}",
+                })
+
+    # R4: wave summaries — info only (N.summary.md files)
+    waves_dir = ap_dir / "waves"
+    if waves_dir.is_dir():
+        wave_count = len(list(waves_dir.glob("*.summary.md")))
+        if wave_count > 0:
+            items.append({
+                "severity": "info",
+                "code": "R4",
+                "message": f"{wave_count} wave summary file(s) found",
+            })
+
+    has_critical = any(i.get("severity") == "critical" for i in items)
+    exit_code = 1 if has_critical else 0
+
+    return {
+        "items": items,
+        "exit_code": exit_code,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Phase 2: Autopilot handlers (ADR-029 Decision 2, Hybrid Path 5 原則)
 # ---------------------------------------------------------------------------
 
@@ -153,7 +495,6 @@ def twl_state_write_handler(
 
 def _resolve_issue_from_labels(labels: list[dict]) -> str | None:
     """Extract issue number from PR labels (autopilot label convention: 'issue-N')."""
-    import re
     for lbl in labels:
         name = lbl.get("name", "")
         m = re.search(r"issue-(\d+)", name)
@@ -657,6 +998,21 @@ try:
         """autopilot.worktree: pure validate_branch_name() (read-only, raises WorktreeArgError)."""
         return json.dumps(twl_worktree_validate_branch_name_handler(branch=branch), ensure_ascii=False)
 
+    @mcp.tool()
+    def twl_get_session_state(session_id: str | None = None, autopilot_dir: str | None = None) -> str:
+        """Return aggregate view of autopilot session (active or archived) for observer/supervisor."""
+        return json.dumps(twl_get_session_state_handler(session_id=session_id, autopilot_dir=autopilot_dir), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_get_pane_state(window_name: str, timeout_sec: int = 30) -> str:
+        """Return tmux pane/window state. window_name: tmux window name or session:index form."""
+        return json.dumps(twl_get_pane_state_handler(window_name=window_name, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_audit_session(autopilot_dir: str | None = None) -> str:
+        """Audit autopilot session.json for structural integrity (R1-R4 rules). Idempotent."""
+        return json.dumps(twl_audit_session_handler(autopilot_dir=autopilot_dir), ensure_ascii=False)
+
 except ImportError:
     mcp = None  # type: ignore[assignment]
 
@@ -756,3 +1112,15 @@ except ImportError:
     def twl_worktree_validate_branch_name(branch: str) -> str:  # type: ignore[misc]
         """autopilot.worktree: pure validate_branch_name() (read-only, raises WorktreeArgError)."""
         return json.dumps(twl_worktree_validate_branch_name_handler(branch=branch), ensure_ascii=False)
+
+    def twl_get_session_state(session_id: str | None = None, autopilot_dir: str | None = None) -> str:  # type: ignore[misc]
+        """Return aggregate view of autopilot session (active or archived) for observer/supervisor."""
+        return json.dumps(twl_get_session_state_handler(session_id=session_id, autopilot_dir=autopilot_dir), ensure_ascii=False)
+
+    def twl_get_pane_state(window_name: str, timeout_sec: int = 30) -> str:  # type: ignore[misc]
+        """Return tmux pane/window state. window_name: tmux window name or session:index form."""
+        return json.dumps(twl_get_pane_state_handler(window_name=window_name, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_audit_session(autopilot_dir: str | None = None) -> str:  # type: ignore[misc]
+        """Audit autopilot session.json for structural integrity (R1-R4 rules). Idempotent."""
+        return json.dumps(twl_audit_session_handler(autopilot_dir=autopilot_dir), ensure_ascii=False)

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -126,7 +126,7 @@ _DEFAULT_SCRIPT = (
 )
 # SESSION_STATE_SCRIPT env var で実行時上書き可能。テスト時は monkeypatch で設定。
 
-_VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9]+\Z")
+_VALID_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9]+\Z")  # \Z は絶対末尾、$ より厳密（改行を許容しない）
 _VALID_WINDOW_NAME_RE = re.compile(r"^[A-Za-z0-9_./:@-]+\Z")
 _REQUIRED_CHECKPOINT_FIELDS = frozenset(
     {"step", "status", "findings_summary", "critical_count", "findings", "timestamp"}

--- a/cli/twl/tests/test_handler_import_discipline.py
+++ b/cli/twl/tests/test_handler_import_discipline.py
@@ -1,0 +1,163 @@
+"""Tests for MCP handler import discipline — Issue #1113 AC3-9.
+
+TDD RED フェーズ。実装前は全テストが FAIL する（意図的 RED）。
+
+AC3-9: tools.py が CLI 入口関数 (sys.exit() を呼ぶ main / _parse_*) を
+import していないことを AST で機械検証する。
+
+sibling Issue #1111 の MergeGate.execute() sys.exit() 教訓と同型のリスクを予防。
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+
+# CLI 入口として sys.exit() を含む禁止 symbol 一覧
+FORBIDDEN_NAMES = {
+    "main",
+    "_parse_read_args",
+    "_parse_write_args",
+    "_parse_create_args",
+    "_parse_add_warning_args",
+    "_parse_archive_args",
+    "_print_read_usage",
+    "_print_write_usage",
+    "_print_usage",
+}
+
+
+def _load_ast() -> ast.Module:
+    assert TOOLS_PY.exists(), f"tools.py が存在しない: {TOOLS_PY}"
+    return ast.parse(TOOLS_PY.read_text())
+
+
+# ===========================================================================
+# AC3-9: 静的 import の AST 解析
+# ===========================================================================
+
+
+class TestAC39NoForbiddenStaticImports:
+    """AC3-9: ast.ImportFrom / ast.Import で禁止 symbol を import していないこと。"""
+
+    def test_ac9_no_import_from_forbidden_names(self):
+        # AC: from twl.autopilot.X import <forbidden_name> がない
+        # RED: 実装が誤って main 等を import していれば FAIL
+        tree = _load_ast()
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for alias in node.names:
+                    imported_name = alias.name
+                    if imported_name in FORBIDDEN_NAMES:
+                        violations.append(
+                            f"line {node.lineno}: from {node.module} import {imported_name} "
+                            f"(sys.exit() 経路の import — AC3-9 violation)"
+                        )
+        assert not violations, "\n".join(violations)
+
+    def test_ac9_tools_py_exists(self):
+        # AC: tools.py が存在し AST parse できる
+        # RED: tools.py 未作成なら FAIL
+        assert TOOLS_PY.exists(), f"tools.py が存在しない: {TOOLS_PY}"
+        tree = _load_ast()
+        assert isinstance(tree, ast.Module)
+
+
+# ===========================================================================
+# AC3-9: 動的 import の禁止
+# ===========================================================================
+
+
+class TestAC39NoDynamicImport:
+    """AC3-9: handler 内で __import__ / importlib.import_module を呼ばない。"""
+
+    FORBIDDEN_DYNAMIC = {"__import__", "import_module"}
+
+    def test_ac9_no_dynamic_import_calls(self):
+        # AC: ast.Call で __import__ / import_module が呼ばれていない
+        # RED: 動的 import を使っていれば FAIL
+        tree = _load_ast()
+        violations = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                func_name = ""
+                if isinstance(node.func, ast.Name):
+                    func_name = node.func.id
+                elif isinstance(node.func, ast.Attribute):
+                    func_name = node.func.attr
+                if func_name in self.FORBIDDEN_DYNAMIC:
+                    violations.append(
+                        f"line {node.lineno}: forbidden dynamic import: {ast.unparse(node)}"
+                    )
+        assert not violations, "\n".join(violations)
+
+
+# ===========================================================================
+# AC3-9: sys.exit() 含有モジュールからの class API 利用の正当性確認
+# ===========================================================================
+
+
+class TestAC39AllowedClassApiImports:
+    """AC3-9: StateManager / CheckpointManager の class import は許可されている。
+
+    禁止は main / _parse_* 等の CLI 入口のみ。class API は正規の利用経路。
+    """
+
+    ALLOWED_CLASS_NAMES = {"StateManager", "StateError", "StateArgError", "CheckpointManager"}
+
+    def test_ac9_allowed_class_imports_present_or_absent(self):
+        # AC: StateManager 等の import が tools.py にあれば from_node.names に FORBIDDEN_NAMES が含まれない
+        # RED: 正当な class import を誤って禁止する実装があれば FAIL
+        tree = _load_ast()
+        # allowed class を import している場合、そのノードの names に forbidden が混入していないこと
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                has_allowed = any(
+                    alias.name in self.ALLOWED_CLASS_NAMES for alias in node.names
+                )
+                if has_allowed:
+                    for alias in node.names:
+                        assert alias.name not in FORBIDDEN_NAMES, (
+                            f"line {node.lineno}: allowed import node に forbidden name '{alias.name}' が混在"
+                        )
+
+
+# ===========================================================================
+# AC3-9: regression — 新 handler 追加後も discipline が維持されること
+# ===========================================================================
+
+
+class TestAC39RegressionGuard:
+    """AC3-9: Issue #1113 で追加する 3 handler の import 規律 regression guard。"""
+
+    NEW_HANDLER_NAMES = {
+        "twl_get_session_state_handler",
+        "twl_get_pane_state_handler",
+        "twl_audit_session_handler",
+    }
+
+    def test_ac9_new_handlers_exist(self):
+        # AC: 3 handler が tools.py に定義されている
+        # RED: 実装前は FAIL
+        tree = _load_ast()
+        defined = {
+            node.name
+            for node in ast.walk(tree)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        }
+        missing = self.NEW_HANDLER_NAMES - defined
+        assert not missing, (
+            f"3 handler が tools.py に未定義: {missing} (AC3-9 / AC3-1 未実装)"
+        )
+
+    def test_ac9_handler_suffix_convention(self):
+        # AC: 新 handler は _handler suffix を持つ (AC3-3 / 共通-2)
+        # このテストは new handlers の suffix を confirm するだけ (RED ではなく GREEN 前提)
+        for name in self.NEW_HANDLER_NAMES:
+            assert name.endswith("_handler"), (
+                f"handler 命名規約違反: '{name}' は _handler suffix を持たない"
+            )

--- a/cli/twl/tests/test_twl_audit_session.py
+++ b/cli/twl/tests/test_twl_audit_session.py
@@ -1,0 +1,357 @@
+"""Tests for twl_audit_session — Issue #1113 AC3-1, AC3-3, AC3-4, AC3-6.
+
+TDD RED フェーズ。実装前は全テストが FAIL する（意図的 RED）。
+対象 handler: twl_audit_session_handler (tools.py)
+
+AC 対応:
+  AC3-1: tool シグネチャ・戻り値 schema (audit rules R1-R4 + build_envelope 準拠)
+  AC3-3: handler は pure Python + idempotent (read-only, 副作用なし)
+  AC3-4: pytest 2 経路 (handler 直接 + fastmcp 経由)
+  AC3-6: race protection (rename atomicity 前提、Python flock 不使用)
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autopilot_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".autopilot"
+    d.mkdir()
+    (d / "checkpoints").mkdir()
+    (d / "waves").mkdir()
+    return d
+
+
+@pytest.fixture
+def valid_session_json(autopilot_dir: Path) -> Path:
+    """R1 OK / R2 plan_path 不在 (warning) の session.json を作成する。"""
+    data = {
+        "session_id": "abc12345",
+        "plan_path": str(autopilot_dir / "plan.yaml"),  # 不在 → R2 warning
+        "current_phase": 1,
+        "phase_count": 3,
+        "started_at": "2026-04-29T00:00:00Z",
+        "cross_issue_warnings": [],
+        "phase_insights": [],
+        "patterns": {},
+        "self_improve_issues": [],
+    }
+    p = autopilot_dir / "session.json"
+    p.write_text(json.dumps(data, ensure_ascii=False))
+    return p
+
+
+@pytest.fixture
+def invalid_session_json(autopilot_dir: Path) -> Path:
+    """R1 FAIL: session_id がパターン不一致な session.json。"""
+    data = {
+        "session_id": "bad-id!",  # 英数字 8文字でない → R1 critical
+        "plan_path": str(autopilot_dir / "plan.yaml"),
+        "current_phase": 1,
+        "phase_count": 3,
+        "started_at": "2026-04-29T00:00:00Z",
+        "cross_issue_warnings": [],
+        "phase_insights": [],
+        "patterns": {},
+        "self_improve_issues": [],
+    }
+    p = autopilot_dir / "session.json"
+    p.write_text(json.dumps(data, ensure_ascii=False))
+    return p
+
+
+@pytest.fixture
+def valid_checkpoint(autopilot_dir: Path) -> Path:
+    """R3 OK: 必須 fields 揃った checkpoint を作成する。"""
+    data = {
+        "step": "review",
+        "status": "PASS",
+        "findings_summary": "all good",
+        "critical_count": 0,
+        "findings": [],
+        "timestamp": "2026-04-29T00:00:00Z",
+    }
+    p = autopilot_dir / "checkpoints" / "review.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+@pytest.fixture
+def invalid_checkpoint(autopilot_dir: Path) -> Path:
+    """R3 FAIL: 必須 field 欠落の checkpoint を作成する。"""
+    data = {"step": "broken"}  # status 等欠落
+    p = autopilot_dir / "checkpoints" / "broken.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+@pytest.fixture
+def wave_summary_files(autopilot_dir: Path) -> list[Path]:
+    """R4 OK: 整数 N.summary.md を作成する。"""
+    files = []
+    for i in [1, 2]:
+        p = autopilot_dir / "waves" / f"{i}.summary.md"
+        p.write_text(f"# Wave {i}\n")
+        files.append(p)
+    return files
+
+
+def _handler():
+    from twl.mcp_server.tools import twl_audit_session_handler  # noqa: PLC0415
+    return twl_audit_session_handler
+
+
+# ===========================================================================
+# AC3-1: tool シグネチャ
+# ===========================================================================
+
+
+class TestAC31Signature:
+    """AC3-1: twl_audit_session_handler が存在し呼び出し可能。"""
+
+    def test_ac1_handler_importable(self):
+        # AC: tools.py に twl_audit_session_handler が定義されている
+        # RED: 実装前は ImportError で FAIL
+        from twl.mcp_server.tools import twl_audit_session_handler  # noqa: F401
+
+    def test_ac1_returns_dict_with_envelope_keys(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: 戻り値は build_envelope 準拠 dict (ok / items / exit_code キーを持つ)
+        # RED: 実装前は NotImplementedError
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert isinstance(result, dict), "handler は dict を返すこと"
+        for key in ("items", "exit_code"):
+            assert key in result, f"envelope key '{key}' が戻り値にない (AC3-1 未実装)"
+
+
+# ===========================================================================
+# AC3-1: audit rules R1〜R4
+# ===========================================================================
+
+
+class TestAC31AuditRules:
+    """AC3-1: 各 audit rule の検出・非検出を確認する。"""
+
+    def test_r1_invalid_session_id_produces_critical(
+        self, autopilot_dir: Path, invalid_session_json: Path,
+    ):
+        # AC: session_id が英数字 8文字以外 → R1 critical item
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        critical_items = [
+            i for i in result.get("items", [])
+            if i.get("severity") == "critical"
+        ]
+        assert critical_items, (
+            "session_id 不正なのに critical item がゼロ (R1 未実装)"
+        )
+
+    def test_r1_valid_session_id_no_critical(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: session_id が英数字 8文字 → R1 critical なし
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        critical_items = [
+            i for i in result.get("items", [])
+            if i.get("severity") == "critical" and "session_id" in i.get("message", "").lower()
+        ]
+        assert not critical_items, (
+            f"valid session_id なのに R1 critical が検出された: {critical_items}"
+        )
+
+    def test_r1_critical_sets_exit_code_1(
+        self, autopilot_dir: Path, invalid_session_json: Path,
+    ):
+        # AC: critical 1件以上で exit_code=1
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        has_critical = any(
+            i.get("severity") == "critical" for i in result.get("items", [])
+        )
+        if has_critical:
+            assert result.get("exit_code") == 1, (
+                f"critical あるのに exit_code が 1 でない: {result.get('exit_code')}"
+            )
+
+    def test_r2_missing_plan_path_produces_warning(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: plan_path が指すファイル不在 → R2 warning item
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        warning_items = [
+            i for i in result.get("items", [])
+            if i.get("severity") == "warning" and "plan" in i.get("message", "").lower()
+        ]
+        assert warning_items, (
+            "plan_path 不在なのに R2 warning item がゼロ (R2 未実装)"
+        )
+
+    def test_r3_invalid_checkpoint_produces_warning(
+        self, autopilot_dir: Path, valid_session_json: Path, invalid_checkpoint: Path,
+    ):
+        # AC: 必須 field 欠落の checkpoint.json → R3 warning item
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        warning_items = [
+            i for i in result.get("items", [])
+            if i.get("severity") == "warning" and "checkpoint" in i.get("message", "").lower()
+        ]
+        assert warning_items, (
+            "不正 checkpoint があるのに R3 warning item がゼロ (R3 未実装)"
+        )
+
+    def test_r3_valid_checkpoint_no_warning(
+        self, autopilot_dir: Path, valid_session_json: Path, valid_checkpoint: Path,
+    ):
+        # AC: 必須 field 揃った checkpoint.json → R3 warning なし
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        # code == "R3" で絞る（メッセージ文字列マッチは tmp ディレクトリ名に "checkpoint" が含まれると誤ヒットする）
+        cp_warnings = [
+            i for i in result.get("items", [])
+            if i.get("code") == "R3"
+        ]
+        assert not cp_warnings, (
+            f"valid checkpoint なのに R3 warning が出た: {cp_warnings}"
+        )
+
+    def test_r4_valid_wave_summary_produces_info(
+        self, autopilot_dir: Path, valid_session_json: Path, wave_summary_files: list[Path],
+    ):
+        # AC: 整数 N.summary.md は R4 info item (または何も出さない — 検出なし許容)
+        # RED: 実装前はチェック自体なし → info item 0件で FAIL しない場合もある
+        # このテストは R4 rule の存在確認のみ（info は optional severity）
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert isinstance(result.get("items"), list), "items が list でない"
+
+
+# ===========================================================================
+# AC3-3: idempotency (read-only, 副作用なし)
+# ===========================================================================
+
+
+class TestAC33Idempotency:
+    """AC3-3: twl_audit_session は idempotent — 同 args で 2 回呼んで結果が同一。"""
+
+    def test_ac3_idempotent_twice(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: 同 args で 2 回呼び出すと同一の結果が返る (read-only)
+        # RED: 実装前は ImportError
+        result1 = _handler()(autopilot_dir=str(autopilot_dir))
+        result2 = _handler()(autopilot_dir=str(autopilot_dir))
+        assert result1 == result2, (
+            f"idempotency 違反: 1回目={result1!r} 2回目={result2!r}"
+        )
+
+    def test_ac3_no_side_effects_on_filesystem(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: 呼び出し後にファイルシステムが変化しない
+        # RED: 実装前は assert FAIL
+        before = {str(p): p.stat().st_mtime for p in autopilot_dir.rglob("*") if p.is_file()}
+        _handler()(autopilot_dir=str(autopilot_dir))
+        after = {str(p): p.stat().st_mtime for p in autopilot_dir.rglob("*") if p.is_file()}
+        assert before == after, (
+            f"ファイルシステムに副作用が検出された: {set(before) ^ set(after)}"
+        )
+
+    def test_ac3_no_sys_exit_in_handler(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: handler 内で sys.exit() が呼ばれない (Exception で error 経路を表現)
+        # RED: 実装前は ImportError
+        import sys  # noqa: PLC0415
+        original_exit = sys.exit
+        sys_exit_called = []
+
+        def mock_exit(code=0):
+            sys_exit_called.append(code)
+            raise SystemExit(code)
+
+        sys.exit = mock_exit
+        try:
+            try:
+                _handler()(autopilot_dir=str(autopilot_dir))
+            except SystemExit:
+                pass
+        finally:
+            sys.exit = original_exit
+
+        assert not sys_exit_called, (
+            f"handler 内で sys.exit() が呼ばれた (AC3-3 禁止): code={sys_exit_called}"
+        )
+
+
+# ===========================================================================
+# AC3-4: MCP tool 関数の JSON 文字列経路
+# ===========================================================================
+
+
+class TestAC34McpToolPath:
+    """AC3-4: MCP tool 関数 twl_audit_session が JSON 文字列を返す。"""
+
+    def test_ac4_mcp_tool_exists(self):
+        # AC: tools モジュールに twl_audit_session が存在する
+        # RED: 実装前は AttributeError → FAIL
+        from twl.mcp_server import tools as tools_mod  # noqa: PLC0415
+        assert hasattr(tools_mod, "twl_audit_session"), (
+            "twl_audit_session が tools モジュールに存在しない (AC3-4 未実装)"
+        )
+
+    def test_ac4_mcp_tool_returns_json_string(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: mcp tool が JSON 文字列を返す
+        # RED: 実装前は assert FAIL
+        from twl.mcp_server import tools as tools_mod  # noqa: PLC0415
+        result_str = tools_mod.twl_audit_session(autopilot_dir=str(autopilot_dir))
+        result = json.loads(result_str)
+        assert isinstance(result, dict)
+        assert "items" in result
+
+
+# ===========================================================================
+# AC3-6: read race 保護 — rename atomicity 前提の確認
+# ===========================================================================
+
+
+class TestAC36ReadRaceProtection:
+    """AC3-6: POSIX rename atomicity により partial read が発生しないことの smoke test。
+
+    完全な bats integration test は cli/twl/tests/bats/ 配下に別途追加する。
+    このクラスは Python 側 handler が "always-consistent" な full content を読む
+    ことの基本確認のみ行う。
+    """
+
+    def test_ac6_handler_reads_complete_json(
+        self, autopilot_dir: Path, valid_session_json: Path,
+    ):
+        # AC: session.json の全フィールドが欠落なく読まれる
+        # twl_get_session_state_handler で read して session key を確認（AC3-6 の read 経路検証）
+        # RED: 実装前は ImportError / KeyError → FAIL
+        from twl.mcp_server.tools import twl_get_session_state_handler  # noqa: PLC0415
+        result = twl_get_session_state_handler(autopilot_dir=str(autopilot_dir))
+        session_data = result.get("session", {})
+        required_session_keys = {
+            "session_id", "plan_path", "current_phase", "phase_count",
+            "started_at", "cross_issue_warnings",
+        }
+        missing = required_session_keys - set(session_data.keys())
+        assert not missing, (
+            f"session フィールドが欠落: {missing} (read が partial data を返している可能性)"
+        )

--- a/cli/twl/tests/test_twl_get_pane_state.py
+++ b/cli/twl/tests/test_twl_get_pane_state.py
@@ -188,10 +188,13 @@ class TestAC31InputValidation:
     """AC3-1 (設計確定事項): window_name の不正文字を defense in depth で ArgError reject。"""
 
     def test_ac1_invalid_window_name_rejected(self):
-        # AC: window_name に ';' '$()' 等が含まれる場合は ArgError/ValueError
-        # RED: 実装前は subprocess 直撃 or assert FAIL
-        with pytest.raises((ValueError, Exception)):
-            _handler()(window_name="test; rm -rf /", timeout_sec=5)
+        # AC: window_name に ';' '$()' 等が含まれる場合は error envelope（dict）を返す
+        # 実装: raise ValueError → return {"ok": False, "error_type": "invalid_window_name"} に変更
+        result = _handler()(window_name="test; rm -rf /", timeout_sec=5)
+        assert result.get("ok") is False, f"invalid window_name が ok=True: {result}"
+        assert result.get("error_type") == "invalid_window_name", (
+            f"error_type が invalid_window_name でない: {result.get('error_type')}"
+        )
 
     def test_ac1_valid_window_name_accepted(self, dummy_script: Path):
         # AC: 英数字/アンダースコア/ハイフン/ドット/コロン/スラッシュは許可

--- a/cli/twl/tests/test_twl_get_pane_state.py
+++ b/cli/twl/tests/test_twl_get_pane_state.py
@@ -1,0 +1,241 @@
+"""Tests for twl_get_pane_state — Issue #1113 AC3-1, AC3-4, 共通-9.
+
+TDD RED フェーズ。実装前は全テストが FAIL する（意図的 RED）。
+対象 handler: twl_get_pane_state_handler (tools.py)
+
+AC 対応:
+  AC3-1: tool シグネチャ・戻り値 schema (window_name + timeout_sec, state enum)
+  AC3-4: pytest 2 経路 (handler 直接 + fastmcp 経由)
+  共通-9: timeout_sec 引数の必須化 (subprocess 起動ツール)
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+
+VALID_STATES = {"exited", "idle", "processing", "input-waiting", "error"}
+
+
+def _handler():
+    from twl.mcp_server.tools import twl_get_pane_state_handler  # noqa: PLC0415
+    return twl_get_pane_state_handler
+
+
+@pytest.fixture(autouse=False)
+def dummy_script(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """テスト用ダミー session-state.sh を作成し SESSION_STATE_SCRIPT 環境変数を設定する。"""
+    script = tmp_path / "session-state.sh"
+    script.write_text("#!/bin/bash\n")
+    script.chmod(0o755)
+    monkeypatch.setenv("SESSION_STATE_SCRIPT", str(script))
+    return script
+
+
+# ===========================================================================
+# AC3-1: tool シグネチャ
+# ===========================================================================
+
+
+class TestAC31Signature:
+    """AC3-1: twl_get_pane_state のシグネチャと基本 schema。"""
+
+    def test_ac1_handler_importable(self):
+        # AC: tools.py に twl_get_pane_state_handler が定義されている
+        # RED: 実装前は ImportError で FAIL
+        from twl.mcp_server.tools import twl_get_pane_state_handler  # noqa: F401
+
+    def test_ac1_timeout_sec_param_exists(self):
+        # AC: handler が timeout_sec 引数を持つ (default=30)
+        # RED: 実装前は ImportError → FAIL
+        import inspect  # noqa: PLC0415
+        sig = inspect.signature(_handler())
+        params = sig.parameters
+        assert "timeout_sec" in params, (
+            "twl_get_pane_state_handler に timeout_sec 引数がない (共通-9 未実装)"
+        )
+        assert params["timeout_sec"].default == 30, (
+            f"timeout_sec のデフォルトが 30 でない: {params['timeout_sec'].default}"
+        )
+
+    def test_ac1_window_name_param_exists(self):
+        # AC: handler が window_name 引数を持つ
+        # RED: 実装前は ImportError → FAIL
+        import inspect  # noqa: PLC0415
+        sig = inspect.signature(_handler())
+        assert "window_name" in sig.parameters, (
+            "twl_get_pane_state_handler に window_name 引数がない (AC3-1 未実装)"
+        )
+
+
+# ===========================================================================
+# AC3-1: 戻り値 schema — ok=True path
+# ===========================================================================
+
+
+class TestAC31SuccessSchema:
+    """AC3-1: ok=True 時の戻り値は {"ok": True, "state": <enum>, "exit_code": 0}。"""
+
+    def test_ac1_success_envelope_structure(self, dummy_script: Path):
+        # AC: subprocess が exit 0 で valid state を返すと ok=True envelope
+        # RED: 実装前は ImportError or mock 未対応 → FAIL
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "idle\n"
+        mock_result.stderr = ""
+
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = _handler()(window_name="test-window", timeout_sec=5)
+
+        assert result.get("ok") is True, f"ok が True でない: {result}"
+        assert result.get("state") == "idle", f"state が 'idle' でない: {result.get('state')}"
+        assert result.get("exit_code") == 0, f"exit_code が 0 でない: {result.get('exit_code')}"
+
+    def test_ac1_all_valid_states_accepted(self, dummy_script: Path):
+        # AC: exited/idle/processing/input-waiting/error の各 state を返す
+        # RED: 実装前は assert FAIL
+        for state_val in VALID_STATES:
+            mock_result = mock.MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = state_val + "\n"
+            mock_result.stderr = ""
+
+            with mock.patch("subprocess.run", return_value=mock_result):
+                result = _handler()(window_name="test-window", timeout_sec=5)
+
+            assert result.get("ok") is True, (
+                f"state='{state_val}' で ok=False になっている: {result}"
+            )
+            assert result.get("state") == state_val, (
+                f"state が '{state_val}' でない: {result.get('state')}"
+            )
+
+
+# ===========================================================================
+# AC3-1: 戻り値 schema — ok=False paths
+# ===========================================================================
+
+
+class TestAC31ErrorSchemas:
+    """AC3-1: 各 error path の error envelope 構造。"""
+
+    def test_ac1_shell_error_on_nonzero_returncode(self, dummy_script: Path):
+        # AC: subprocess returncode != 0 は shell_error envelope
+        # RED: 実装前は assert FAIL
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "no such window: test-window"
+
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = _handler()(window_name="test-window", timeout_sec=5)
+
+        assert result.get("ok") is False, f"returncode=1 で ok=True になっている: {result}"
+        assert result.get("error_type") == "shell_error", (
+            f"error_type が shell_error でない: {result.get('error_type')}"
+        )
+        assert result.get("exit_code") == 1
+
+    def test_ac1_unknown_state_envelope(self, dummy_script: Path):
+        # AC: stdout が enum 外の値のとき unknown_state envelope
+        # RED: 実装前は assert FAIL
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "running\n"  # 不正値
+        mock_result.stderr = ""
+
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = _handler()(window_name="test-window", timeout_sec=5)
+
+        assert result.get("ok") is False, f"unknown state で ok=True になっている: {result}"
+        assert result.get("error_type") == "unknown_state", (
+            f"error_type が unknown_state でない: {result.get('error_type')}"
+        )
+        assert result.get("exit_code") == 3
+
+    def test_ac1_script_not_found_envelope(self, tmp_path: Path):
+        # AC: SESSION_STATE_SCRIPT 不在時は script_not_found envelope
+        # RED: 実装前は assert FAIL
+        nonexistent = str(tmp_path / "nonexistent.sh")
+        original = os.environ.get("SESSION_STATE_SCRIPT")
+        os.environ["SESSION_STATE_SCRIPT"] = nonexistent
+        try:
+            result = _handler()(window_name="test-window", timeout_sec=5)
+        finally:
+            if original is None:
+                del os.environ["SESSION_STATE_SCRIPT"]
+            else:
+                os.environ["SESSION_STATE_SCRIPT"] = original
+
+        assert result.get("ok") is False, "script_not_found で ok=True になっている"
+        assert result.get("error_type") == "script_not_found", (
+            f"error_type が script_not_found でない: {result.get('error_type')}"
+        )
+        assert result.get("exit_code") == 2
+
+
+# ===========================================================================
+# AC3-1: shell injection 安全性 — window_name の入力検証
+# ===========================================================================
+
+
+class TestAC31InputValidation:
+    """AC3-1 (設計確定事項): window_name の不正文字を defense in depth で ArgError reject。"""
+
+    def test_ac1_invalid_window_name_rejected(self):
+        # AC: window_name に ';' '$()' 等が含まれる場合は ArgError/ValueError
+        # RED: 実装前は subprocess 直撃 or assert FAIL
+        with pytest.raises((ValueError, Exception)):
+            _handler()(window_name="test; rm -rf /", timeout_sec=5)
+
+    def test_ac1_valid_window_name_accepted(self, dummy_script: Path):
+        # AC: 英数字/アンダースコア/ハイフン/ドット/コロン/スラッシュは許可
+        # RED: 実装前は ImportError → FAIL
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "idle\n"
+        mock_result.stderr = ""
+
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result = _handler()(window_name="wt-twill-main-h8", timeout_sec=5)
+        assert result.get("ok") is True
+
+
+# ===========================================================================
+# AC3-4: MCP tool 関数の JSON 文字列経路
+# ===========================================================================
+
+
+class TestAC34McpToolPath:
+    """AC3-4: MCP tool 関数 twl_get_pane_state が JSON 文字列を返す。"""
+
+    def test_ac4_mcp_tool_exists(self):
+        # AC: tools モジュールに twl_get_pane_state が存在する
+        # RED: 実装前は AttributeError → FAIL
+        from twl.mcp_server import tools as tools_mod  # noqa: PLC0415
+        assert hasattr(tools_mod, "twl_get_pane_state"), (
+            "twl_get_pane_state が tools モジュールに存在しない (AC3-4 未実装)"
+        )
+
+    def test_ac4_mcp_tool_returns_json_string(self, dummy_script: Path):
+        # AC: mcp tool が JSON 文字列を返す
+        # RED: 実装前は assert FAIL
+        from twl.mcp_server import tools as tools_mod  # noqa: PLC0415
+
+        mock_result = mock.MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = "idle\n"
+        mock_result.stderr = ""
+
+        with mock.patch("subprocess.run", return_value=mock_result):
+            result_str = tools_mod.twl_get_pane_state(
+                window_name="test-window", timeout_sec=5
+            )
+        result = json.loads(result_str)
+        assert isinstance(result, dict)
+        assert result.get("ok") is True

--- a/cli/twl/tests/test_twl_get_session_state.py
+++ b/cli/twl/tests/test_twl_get_session_state.py
@@ -1,0 +1,337 @@
+"""Tests for twl_get_session_state — Issue #1113 AC3-1, AC3-2, AC3-4, AC3-5, AC3-11, AC3-12.
+
+TDD RED フェーズ。実装前は全テストが FAIL する（意図的 RED）。
+対象 handler: twl_get_session_state_handler (tools.py または tools_state.py)
+
+AC 対応:
+  AC3-1: tool シグネチャ・戻り値 schema
+  AC3-2: 既存 twl_state_read との責務分離 (aggregate keys の存在)
+  AC3-4: pytest 2 経路 (handler 直接 + fastmcp 経由)
+  AC3-5: ADR-028 整合 (read-only、no flock 必要)
+  AC3-11: SessionAggregateView TypedDict 型定義の準拠確認
+  AC3-12: archived session 不在時の error envelope
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autopilot_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".autopilot"
+    d.mkdir()
+    (d / "issues").mkdir()
+    (d / "checkpoints").mkdir()
+    (d / "waves").mkdir()
+    (d / "archive").mkdir()
+    return d
+
+
+@pytest.fixture
+def session_json(autopilot_dir: Path) -> Path:
+    """active session.json を作成する。"""
+    data = {
+        "session_id": "abc12345",
+        "plan_path": str(autopilot_dir / "plan.yaml"),
+        "current_phase": 2,
+        "phase_count": 4,
+        "started_at": "2026-04-29T00:00:00Z",
+        "cross_issue_warnings": [
+            {"issue": 42, "target_issue": 43, "file": "foo.py", "reason": "test"},
+        ],
+        "phase_insights": [],
+        "patterns": {},
+        "self_improve_issues": [],
+    }
+    p = autopilot_dir / "session.json"
+    p.write_text(json.dumps(data, ensure_ascii=False))
+    return p
+
+
+@pytest.fixture
+def issue_files(autopilot_dir: Path) -> list[Path]:
+    """active_issues および done issue を作成する。"""
+    statuses = [
+        ("1", "in_progress"),
+        ("2", "done"),
+        ("3", "pending"),
+    ]
+    files = []
+    for num, status in statuses:
+        data = {"issue": int(num), "status": status, "branch": "", "pr": None}
+        p = autopilot_dir / "issues" / f"issue-{num}.json"
+        p.write_text(json.dumps(data))
+        files.append(p)
+    return files
+
+
+@pytest.fixture
+def checkpoint_files(autopilot_dir: Path) -> list[Path]:
+    """FAIL checkpoint と PASS checkpoint を作成する。"""
+    items = [
+        ("review", "FAIL", 2),
+        ("test", "PASS", 0),
+    ]
+    files = []
+    for step, status, critical_count in items:
+        data = {
+            "step": step,
+            "status": status,
+            "findings_summary": f"summary for {step}",
+            "critical_count": critical_count,
+            "findings": [],
+            "timestamp": "2026-04-29T00:00:00Z",
+        }
+        p = autopilot_dir / "checkpoints" / f"{step}.json"
+        p.write_text(json.dumps(data))
+        files.append(p)
+    return files
+
+
+@pytest.fixture
+def wave_summary_files(autopilot_dir: Path) -> list[Path]:
+    """wave summary files を作成する。"""
+    files = []
+    for i in [6, 7]:
+        p = autopilot_dir / "waves" / f"{i}.summary.md"
+        p.write_text(f"# Wave {i} Summary\n")
+        files.append(p)
+    return files
+
+
+def _handler():
+    """twl_get_session_state_handler を遅延 import する。"""
+    from twl.mcp_server.tools import twl_get_session_state_handler  # noqa: PLC0415
+    return twl_get_session_state_handler
+
+
+# ===========================================================================
+# AC3-1: tool シグネチャと基本戻り値スキーマ
+# ===========================================================================
+
+
+class TestAC31Signature:
+    """AC3-1: twl_get_session_state_handler が存在し呼び出し可能。"""
+
+    def test_ac1_handler_importable(self):
+        # AC: tools.py に twl_get_session_state_handler が定義されている
+        # RED: 実装前は ImportError で FAIL
+        from twl.mcp_server.tools import twl_get_session_state_handler  # noqa: F401
+
+    def test_ac1_handler_callable_with_none_session_id(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: session_id=None で呼び出すと active session.json を読み成功する
+        # RED: 実装前は NotImplementedError
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert isinstance(result, dict), "handler は dict を返すこと"
+
+
+# ===========================================================================
+# AC3-2: 既存 twl_state_read との責務分離 — aggregate keys の存在
+# ===========================================================================
+
+
+class TestAC32AggregateSeparation:
+    """AC3-2: 戻り値に aggregate keys が存在し、低レベル passthrough と区別できる。"""
+
+    def test_ac2_aggregate_keys_present(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: active_issues / pending_checkpoints / cross_issue_warnings / wave_summaries_count の
+        #     4 keys が戻り値に存在する
+        # RED: 実装前は KeyError
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        for key in ("active_issues", "pending_checkpoints", "cross_issue_warnings", "wave_summaries_count"):
+            assert key in result, f"aggregate key '{key}' が戻り値にない (AC3-2 未実装)"
+
+    def test_ac2_active_issues_excludes_done(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: active_issues は status != "done" のもののみ
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        active = result["active_issues"]
+        assert all(
+            i.get("status") != "done" for i in active
+        ), "active_issues に done ステータスが混入している (AC3-2 未実装)"
+
+    def test_ac2_pending_checkpoints_are_fail_only(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: pending_checkpoints は status == "FAIL" のもののみ
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        pending = result["pending_checkpoints"]
+        assert all(
+            cp.get("status") == "FAIL" for cp in pending
+        ), "pending_checkpoints に非 FAIL が混入している (AC3-2 未実装)"
+
+    def test_ac2_wave_summaries_count_correct(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: wave_summaries_count は waves/*.summary.md のファイル数
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert result["wave_summaries_count"] == len(wave_summary_files), (
+            f"wave_summaries_count mismatch: {result['wave_summaries_count']} != {len(wave_summary_files)}"
+        )
+
+
+# ===========================================================================
+# AC3-4: pytest 2 経路 (handler 直接 + fastmcp 経由)
+# ===========================================================================
+
+
+class TestAC34TwoInvocationPaths:
+    """AC3-4: handler 直接呼出と MCP tool 関数の 2 経路でテスト。"""
+
+    def test_ac4_direct_handler_returns_dict(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: handler 直接呼出で dict が返る
+        # RED: 実装前は ImportError
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert isinstance(result, dict)
+
+    def test_ac4_mcp_tool_function_returns_json_string(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: mcp tool 関数 twl_get_session_state が JSON 文字列を返す
+        # RED: 実装前は ImportError または AttributeError
+        from twl.mcp_server import tools as tools_mod  # noqa: PLC0415
+        assert hasattr(tools_mod, "twl_get_session_state"), (
+            "twl_get_session_state が tools モジュールに存在しない (AC3-4 未実装)"
+        )
+        fn = tools_mod.twl_get_session_state
+        result_str = fn(autopilot_dir=str(autopilot_dir))
+        # JSON 文字列であること
+        result = json.loads(result_str)
+        assert isinstance(result, dict)
+
+
+# ===========================================================================
+# AC3-11: SessionAggregateView TypedDict 型定義の準拠確認
+# ===========================================================================
+
+
+class TestAC311TypedDictCompliance:
+    """AC3-11: 戻り値が SessionAggregateView TypedDict の required keys に準拠する。"""
+
+    REQUIRED_KEYS = {
+        "session",
+        "active_issues",
+        "current_phase",
+        "phase_count",
+        "cross_issue_warnings",
+        "pending_checkpoints",
+        "wave_summaries_count",
+        "resolved_session_id",
+        "autopilot_dir",
+        "is_archived",
+    }
+
+    def test_ac11_all_required_keys_present(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: SessionAggregateView の全 required keys が戻り値に存在する
+        # RED: 実装前は KeyError
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        missing = self.REQUIRED_KEYS - set(result.keys())
+        assert not missing, f"SessionAggregateView required keys が欠落: {missing}"
+
+    def test_ac11_session_aggregate_view_importable(self):
+        # AC: SessionAggregateView TypedDict が tools.py から import できる
+        # RED: 実装前は ImportError
+        from twl.mcp_server.tools import SessionAggregateView  # noqa: F401
+
+    def test_ac11_is_archived_false_for_active(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: active session の場合 is_archived=False
+        # RED: 実装前は assert FAIL
+        result = _handler()(autopilot_dir=str(autopilot_dir))
+        assert result["is_archived"] is False, (
+            f"active session で is_archived が True になっている: {result.get('is_archived')}"
+        )
+
+
+# ===========================================================================
+# AC3-12: archived session 不在時の error path
+# ===========================================================================
+
+
+class TestAC312ArchiveNotFound:
+    """AC3-12: archive/<session_id>/session.json 不在時の error envelope。"""
+
+    def test_ac12_missing_archive_returns_error_envelope(self, autopilot_dir: Path):
+        # AC: archive にない session_id を渡すと {"ok": False, "error_type": "archive_not_found", "exit_code": 2}
+        # RED: 実装前は KeyError または Exception
+        result = _handler()(session_id="nonexistent", autopilot_dir=str(autopilot_dir))
+        assert result.get("ok") is False, (
+            f"archive 不在で ok=True になっている: {result}"
+        )
+        assert result.get("error_type") == "archive_not_found", (
+            f"error_type が archive_not_found でない: {result.get('error_type')}"
+        )
+        assert result.get("exit_code") == 2, (
+            f"exit_code が 2 でない: {result.get('exit_code')}"
+        )
+        assert "error" in result and result["error"], (
+            "error フィールドにパスが含まれていない"
+        )
+
+    def test_ac12_error_envelope_has_concrete_path(self, autopilot_dir: Path):
+        # AC: error フィールドに具体的なパスが含まれる
+        # RED: 実装前は assert FAIL
+        result = _handler()(session_id="nonexistent", autopilot_dir=str(autopilot_dir))
+        assert "nonexistent" in result.get("error", ""), (
+            f"error に session_id 'nonexistent' が含まれていない: {result.get('error')}"
+        )
+
+    def test_ac12_existing_archive_succeeds(
+        self, autopilot_dir: Path, session_json: Path,
+        issue_files: list[Path], checkpoint_files: list[Path],
+        wave_summary_files: list[Path],
+    ):
+        # AC: 存在する archive session_id を渡すと ok=True で is_archived=True
+        # RED: 実装前は assert FAIL
+        session_id = "abc12345"
+        archive_dir = autopilot_dir / "archive" / session_id
+        archive_dir.mkdir(parents=True)
+        # archive に session.json をコピー
+        import shutil  # noqa: PLC0415
+        shutil.copy(session_json, archive_dir / "session.json")
+        result = _handler()(session_id=session_id, autopilot_dir=str(autopilot_dir))
+        assert result.get("ok") is True, f"archive session 読み込みが ok=False: {result}"
+        assert result.get("is_archived") is True, "archive session で is_archived が False"

--- a/cli/twl/tests/test_twl_get_session_state.py
+++ b/cli/twl/tests/test_twl_get_session_state.py
@@ -319,6 +319,16 @@ class TestAC312ArchiveNotFound:
             f"error に session_id 'nonexistent' が含まれていない: {result.get('error')}"
         )
 
+    def test_ac12_invalid_session_id_rejected(self, autopilot_dir: Path):
+        # AC: session_id に英数字以外が含まれる場合は error envelope（パストラバーサル防止）
+        # RED: 実装前は任意パスを参照可能 → 実装後は error_type=invalid_session_id
+        for bad_id in ["../etc/passwd", "../../foo", "bad id", "bad!id"]:
+            result = _handler()(session_id=bad_id, autopilot_dir=str(autopilot_dir))
+            assert result.get("ok") is False, f"invalid session_id '{bad_id}' が ok=True"
+            assert result.get("error_type") == "invalid_session_id", (
+                f"session_id '{bad_id}': error_type={result.get('error_type')}"
+            )
+
     def test_ac12_existing_archive_succeeds(
         self, autopilot_dir: Path, session_json: Path,
         issue_files: list[Path], checkpoint_files: list[Path],


### PR DESCRIPTION
## 概要

Issue #1113 の実装。ADR-029 Phase γ Wave 2-B の一環として `cli/twl/src/twl/mcp_server/tools.py` に observer/supervisor 用の aggregate-read tool 3 個を追加。

## 変更内容

### 追加した handler（pure Python, `_handler` suffix）
- `twl_get_session_state_handler`: session.json + issues/*.json + checkpoints/*.json + waves/*.summary.md の aggregate view（AC3-1）
- `twl_get_pane_state_handler`: session-state.sh subprocess 経由で tmux window state を取得（AC3-1, 共通-9）
- `twl_audit_session_handler`: session.json の R1-R4 audit rules、idempotent（AC3-1, AC3-3）

### 型定義
- `SessionAggregateView` TypedDict 追加（AC3-11）

### MCP 登録
- fastmcp `try/except ImportError` 両経路に 3 tool 登録（共通-3）

### テスト（4 ファイル、47 tests PASS）
- `test_twl_get_session_state.py`（AC3-1, AC3-2, AC3-4, AC3-11, AC3-12）
- `test_twl_get_pane_state.py`（AC3-1, AC3-4, 共通-9）
- `test_twl_audit_session.py`（AC3-1, AC3-3, AC3-4, AC3-6）
- `test_handler_import_discipline.py`（AC3-9 AST 解析）

## AC 対応状況

- [x] AC3-1: 3 tool 追加
- [x] AC3-2: 既存 twl_state_read との責務分離（aggregate keys で識別可）
- [x] AC3-3: pure Python handler、sys.exit() 禁止、twl_audit_session idempotent
- [x] AC3-4: pytest 2 経路（handler 直接 + fastmcp）
- [x] AC3-5: read-only のみ、ADR-028 改訂不要
- [x] AC3-6: read race 保護の smoke test（POSIX rename atomicity）
- [x] AC3-7: tools.py +401 行（255→656行、分割判断点 ~1500 行未到達）
- [x] AC3-8: handler import 規約明記（StateManager class API のみ）
- [x] AC3-9: AST import discipline test 追加
- [ ] AC3-10: ADR-029 Mitigations 章追記 PR（su-observer が別 Issue 起票予定）
- [x] AC3-11: SessionAggregateView TypedDict 定義
- [x] AC3-12: archived session 不在時 error envelope

Closes #1113