### PR TITLE
feat(mcp): autopilot 系 tool 12 個を tools.py に追加 (#1114)

### DIFF
--- a/cli/twl/src/twl/autopilot/worktree.py
+++ b/cli/twl/src/twl/autopilot/worktree.py
@@ -447,6 +447,63 @@ class WorktreeManager:
                         pass
             print(f"{branch}\t{path}\t{state}".rstrip())
 
+    def delete(self, branch_name: str) -> None:
+        """Delete a worktree and its local branch.
+
+        Mirrors worktree-delete.sh:30-100 logic (CWD guard excluded — handler layer).
+
+        Raises:
+            WorktreeArgError: On invalid branch name.
+            WorktreeError: On deletion failure.
+        """
+        if not branch_name or ".." in branch_name or branch_name.startswith("/"):
+            raise WorktreeArgError(f"不正なブランチ名: {branch_name!r}")
+
+        git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
+        worktree_path = project_dir / "worktrees" / branch_name
+
+        if not worktree_path.exists():
+            raise WorktreeError(f"worktree が存在しません: {worktree_path}")
+
+        # Run teardown hook before removal
+        run_teardown_hook(worktree_path)
+
+        # git worktree remove --force
+        result = subprocess.run(
+            ["git", "--git-dir", str(_resolve_git_dir(project_dir, git_common_dir)),
+             "worktree", "remove", str(worktree_path), "--force"],
+            capture_output=True, text=True,
+        )
+        if result.returncode != 0:
+            # Fallback: manual removal
+            import shutil
+            try:
+                shutil.rmtree(str(worktree_path))
+            except OSError as e:
+                raise WorktreeError(
+                    f"worktree 削除に失敗しました: {result.stderr}\n{e}"
+                )
+
+        # Delete local branch
+        branch_result = subprocess.run(
+            ["git", "--git-dir", str(_resolve_git_dir(project_dir, git_common_dir)),
+             "branch", "-D", branch_name],
+            capture_output=True, text=True,
+        )
+        if branch_result.returncode != 0:
+            # Non-fatal: branch may already be deleted or not exist locally
+            pass
+
+    def list_porcelain(self) -> list[dict]:
+        """Return worktrees as list of dicts (read-only).
+
+        Returns:
+            List of {"branch": str, "path": str} for worktrees under worktrees/.
+        """
+        git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
+        entries = self._list_worktrees(project_dir, git_common_dir)
+        return [{"branch": branch, "path": str(path)} for branch, path in entries]
+
     def cd(self, branch_query: str) -> None:
         """Print the path of a worktree matching branch_query to stdout."""
         git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)

--- a/cli/twl/src/twl/autopilot/worktree.py
+++ b/cli/twl/src/twl/autopilot/worktree.py
@@ -456,8 +456,9 @@ class WorktreeManager:
             WorktreeArgError: On invalid branch name.
             WorktreeError: On deletion failure.
         """
-        if not branch_name or ".." in branch_name or branch_name.startswith("/"):
+        if not branch_name:
             raise WorktreeArgError(f"不正なブランチ名: {branch_name!r}")
+        validate_branch_name(branch_name)
 
         git_common_dir, project_dir = _resolve_git_common_dir(self.repo_path)
         worktree_path = project_dir / "worktrees" / branch_name
@@ -466,7 +467,7 @@ class WorktreeManager:
             raise WorktreeError(f"worktree が存在しません: {worktree_path}")
 
         # Run teardown hook before removal
-        run_teardown_hook(worktree_path)
+        WorktreeManager.run_teardown_hook(worktree_path)
 
         # git worktree remove --force
         result = subprocess.run(

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -200,7 +200,9 @@ def twl_mergegate_run_handler(
             return {"ok": True, "message": "merge completed", "exit_code": 0}
         except SystemExit as e:
             code = int(e.code) if e.code is not None else 0
-            return {"ok": code == 0, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
+            if code == 0:
+                return {"ok": True, "message": "merge completed (exit 0)", "exit_code": 0}
+            return {"ok": False, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
         except MergeGateError as e:
             return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
 

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1,9 +1,12 @@
-"""twl MCP tool definitions (Phase 0 PoC).
+"""twl MCP tool definitions (Phase 0 PoC + autopilot Phase 2).
 
-Exposes twl_validate / twl_audit / twl_check as FastMCP tools.
+Exposes twl_validate / twl_audit / twl_check / twl_state_read / twl_state_write
++ 12 autopilot tools as FastMCP tools.
 Handler functions (_handler suffix) are pure Python for in-process testing.
 """
+import concurrent.futures
 import json
+import os
 from pathlib import Path
 
 
@@ -142,6 +145,394 @@ def twl_state_write_handler(
         return {"ok": False, "error": str(e), "error_type": "state_error", "exit_code": 1}
 
 
+# ---------------------------------------------------------------------------
+# Phase 2: Autopilot handlers (ADR-029 Decision 2, Hybrid Path 5 原則)
+# ---------------------------------------------------------------------------
+
+# --- Mergegate ---
+
+def _resolve_issue_from_labels(labels: list[dict]) -> str | None:
+    """Extract issue number from PR labels (autopilot label convention: 'issue-N')."""
+    import re
+    for lbl in labels:
+        name = lbl.get("name", "")
+        m = re.search(r"issue-(\d+)", name)
+        if m:
+            return m.group(1)
+    return None
+
+
+def twl_mergegate_run_handler(
+    pr_number: int,
+    autopilot_dir: str | None = None,
+    cwd: str | None = None,
+    timeout_sec: int = 600,
+) -> dict:
+    """autopilot.mergegate: invoke MergeGate.execute() with SystemExit catch + ThreadPoolExecutor timeout wrap (sys.exit(1)/sys.exit(2) recoverable). Note: handler timeout 600s; set MCP_CLIENT_TIMEOUT>=660s."""
+    import subprocess
+
+    def _inner() -> dict:
+        try:
+            r = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "number,headRefName,labels"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if r.returncode != 0:
+                return {"ok": False, "error": f"gh pr view failed: {r.stderr}", "error_type": "pr_resolve_error", "exit_code": 2}
+            data = json.loads(r.stdout)
+            branch = data["headRefName"]
+            issue = _resolve_issue_from_labels(data.get("labels", []))
+            if not issue:
+                return {"ok": False, "error": "issue label not found in PR labels", "error_type": "pr_resolve_error", "exit_code": 2}
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception) as e:
+            return {"ok": False, "error": str(e), "error_type": "pr_resolve_error", "exit_code": 2}
+
+        from twl.autopilot.mergegate import MergeGate, MergeGateError
+        ap_dir = Path(autopilot_dir).expanduser().resolve() if autopilot_dir else None
+        try:
+            mg = MergeGate(
+                pr_number=str(pr_number),
+                branch=branch,
+                issue=issue,
+                autopilot_dir=ap_dir,
+            )
+            mg.execute()
+            return {"ok": True, "message": "merge completed", "exit_code": 0}
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+            return {"ok": code == 0, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
+        except MergeGateError as e:
+            return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_mergegate_reject_handler(
+    pr_number: int,
+    reason: str,
+    autopilot_dir: str | None = None,
+    cwd: str | None = None,
+    timeout_sec: int = 300,
+) -> dict:
+    """autopilot.mergegate: invoke MergeGate.reject() with SystemExit catch + timeout wrap (300s)."""
+    import subprocess
+
+    def _inner() -> dict:
+        try:
+            r = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "number,headRefName,labels"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if r.returncode != 0:
+                return {"ok": False, "error": f"gh pr view failed: {r.stderr}", "error_type": "pr_resolve_error", "exit_code": 2}
+            data = json.loads(r.stdout)
+            branch = data["headRefName"]
+            issue = _resolve_issue_from_labels(data.get("labels", []))
+            if not issue:
+                return {"ok": False, "error": "issue label not found", "error_type": "pr_resolve_error", "exit_code": 2}
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception) as e:
+            return {"ok": False, "error": str(e), "error_type": "pr_resolve_error", "exit_code": 2}
+
+        from twl.autopilot.mergegate import MergeGate, MergeGateError
+        ap_dir = Path(autopilot_dir).expanduser().resolve() if autopilot_dir else None
+        try:
+            mg = MergeGate(
+                pr_number=str(pr_number),
+                branch=branch,
+                issue=issue,
+                finding_summary=reason,
+                autopilot_dir=ap_dir,
+            )
+            mg.reject()
+            return {"ok": True, "message": "rejected", "exit_code": 0}
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+            return {"ok": False, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
+        except MergeGateError as e:
+            return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_mergegate_reject_final_handler(
+    pr_number: int,
+    reason: str,
+    autopilot_dir: str | None = None,
+    cwd: str | None = None,
+    timeout_sec: int = 300,
+) -> dict:
+    """autopilot.mergegate: invoke MergeGate.reject_final() with SystemExit catch + timeout wrap (300s)."""
+    import subprocess
+
+    def _inner() -> dict:
+        try:
+            r = subprocess.run(
+                ["gh", "pr", "view", str(pr_number), "--json", "number,headRefName,labels"],
+                capture_output=True, text=True, timeout=30,
+            )
+            if r.returncode != 0:
+                return {"ok": False, "error": f"gh pr view failed: {r.stderr}", "error_type": "pr_resolve_error", "exit_code": 2}
+            data = json.loads(r.stdout)
+            branch = data["headRefName"]
+            issue = _resolve_issue_from_labels(data.get("labels", []))
+            if not issue:
+                return {"ok": False, "error": "issue label not found", "error_type": "pr_resolve_error", "exit_code": 2}
+        except (subprocess.TimeoutExpired, json.JSONDecodeError, Exception) as e:
+            return {"ok": False, "error": str(e), "error_type": "pr_resolve_error", "exit_code": 2}
+
+        from twl.autopilot.mergegate import MergeGate, MergeGateError
+        ap_dir = Path(autopilot_dir).expanduser().resolve() if autopilot_dir else None
+        try:
+            mg = MergeGate(
+                pr_number=str(pr_number),
+                branch=branch,
+                issue=issue,
+                finding_summary=reason,
+                autopilot_dir=ap_dir,
+            )
+            mg.reject_final()
+            return {"ok": True, "message": "final rejection completed", "exit_code": 0}
+        except SystemExit as e:
+            code = int(e.code) if e.code is not None else 0
+            return {"ok": False, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
+        except MergeGateError as e:
+            return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+# --- Orchestrator ---
+
+def twl_orchestrator_phase_review_handler(
+    phase: int,
+    plan_file: str,
+    session_file: str,
+    project_dir: str,
+    autopilot_dir: str,
+    repos_json: str = "",
+    timeout_sec: int = 1800,
+) -> dict:
+    """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
+    if not Path(plan_file).is_file():
+        return {"ok": False, "error": "plan_file not found", "error_type": "arg_error", "exit_code": 2}
+
+    def _inner() -> dict:
+        from twl.autopilot.orchestrator import PhaseOrchestrator
+        try:
+            orch = PhaseOrchestrator(
+                plan_file=plan_file,
+                phase=phase,
+                session_file=session_file,
+                project_dir=project_dir,
+                autopilot_dir=autopilot_dir,
+                repos_json=repos_json,
+            )
+            result_dict = orch.run()
+            return {"ok": True, "result": result_dict, "exit_code": 0}
+        except (FileNotFoundError, OSError) as e:
+            return {"ok": False, "error": f"tmux subprocess error: {e}", "error_type": "subprocess_error", "exit_code": 127}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_orchestrator_get_phase_issues_handler(
+    phase: int,
+    plan_file: str,
+) -> dict:
+    """autopilot.orchestrator: pure get_phase_issues() (read-only, no subprocess). plan_file existence check."""
+    if not Path(plan_file).is_file():
+        return {"ok": False, "error": "plan_file not found", "error_type": "arg_error", "exit_code": 2}
+    from twl.autopilot.orchestrator import get_phase_issues
+    try:
+        issues = get_phase_issues(phase=phase, plan_file=plan_file)
+        return {"ok": True, "result": issues, "exit_code": 0}
+    except Exception as e:
+        return {"ok": False, "error": str(e), "error_type": "orchestrator_error", "exit_code": 1}
+
+
+def twl_orchestrator_summary_handler(
+    autopilot_dir: str,
+) -> dict:
+    """autopilot.orchestrator: pure generate_summary() (read-only)."""
+    from twl.autopilot.orchestrator import generate_summary, OrchestratorError
+    try:
+        summary = generate_summary(autopilot_dir=autopilot_dir)
+        return {"ok": True, "result": summary, "exit_code": 0}
+    except OrchestratorError as e:
+        return {"ok": False, "error": str(e), "error_type": "orchestrator_error", "exit_code": 1}
+
+
+def twl_orchestrator_resolve_repos_handler(
+    repos_json: str,
+) -> dict:
+    """autopilot.orchestrator: pure resolve_repos_config() (read-only)."""
+    from twl.autopilot.orchestrator import resolve_repos_config
+    result = resolve_repos_config(repos_json=repos_json)
+    return {"ok": True, "result": result, "exit_code": 0}
+
+
+# --- Worktree ---
+
+def _check_invariant_b(cwd: str | None) -> dict | None:
+    """Return error dict if CWD is under worktrees/ (invariant B violation), else None."""
+    cwd_path = os.path.realpath(cwd if cwd is not None else os.getcwd())
+    if "/worktrees/" in cwd_path:
+        return {
+            "ok": False,
+            "error": "不変条件 B 違反: Worker (worktrees/ 配下) からの worktree/orchestrator 操作は禁止されています",
+            "error_type": "invariant_b_violation",
+            "exit_code": 1,
+        }
+    return None
+
+
+def twl_worktree_create_handler(
+    branch: str,
+    base: str = "main",
+    repo: str | None = None,
+    repo_path: str | None = None,
+    cwd: str | None = None,
+    timeout_sec: int = 300,
+) -> dict:
+    """autopilot.worktree: WorktreeManager.create() with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (300s)."""
+    violation = _check_invariant_b(cwd)
+    if violation:
+        return violation
+
+    def _inner() -> dict:
+        from twl.autopilot.worktree import WorktreeManager, WorktreeError, WorktreeArgError
+        try:
+            manager = WorktreeManager(repo_path=repo_path)
+            worktree_dir = manager.create(branch_name=branch, base_branch=base, repo=repo)
+            return {"ok": True, "message": f"worktree created: {worktree_dir}", "path": str(worktree_dir), "exit_code": 0}
+        except WorktreeArgError as e:
+            return {"ok": False, "error": str(e), "error_type": "arg_error", "exit_code": 2}
+        except WorktreeError as e:
+            return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+        except Exception as e:
+            return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_worktree_delete_handler(
+    branch: str,
+    repo_path: str | None = None,
+    cwd: str | None = None,
+    timeout_sec: int = 120,
+) -> dict:
+    """autopilot.worktree: WorktreeManager.delete() (新規追加 method) with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (120s)."""
+    violation = _check_invariant_b(cwd)
+    if violation:
+        return violation
+
+    def _inner() -> dict:
+        from twl.autopilot.worktree import WorktreeManager, WorktreeError, WorktreeArgError
+        try:
+            manager = WorktreeManager(repo_path=repo_path)
+            manager.delete(branch)
+            return {"ok": True, "message": f"worktree {branch} deleted", "exit_code": 0}
+        except WorktreeArgError as e:
+            return {"ok": False, "error": str(e), "error_type": "arg_error", "exit_code": 2}
+        except WorktreeError as e:
+            return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_worktree_list_handler(
+    repo_path: str | None = None,
+) -> dict:
+    """autopilot.worktree: WorktreeManager.list_porcelain() (新規追加 method) - read-only list[dict] return."""
+    from twl.autopilot.worktree import WorktreeManager, WorktreeError
+    try:
+        manager = WorktreeManager(repo_path=repo_path)
+        entries = manager.list_porcelain()
+        return {"ok": True, "result": entries, "exit_code": 0}
+    except WorktreeError as e:
+        return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+
+
+def twl_worktree_generate_branch_name_handler(
+    issue_number: str,
+    repo: str | None = None,
+    timeout_sec: int = 60,
+) -> dict:
+    """autopilot.worktree: pure generate_branch_name(issue_number: str, ...) with gh issue view subprocess (timeout 60s)."""
+    def _inner() -> dict:
+        from twl.autopilot.worktree import generate_branch_name, WorktreeArgError, WorktreeError
+        try:
+            branch = generate_branch_name(issue_number=issue_number, repo=repo)
+            return {"ok": True, "result": branch, "exit_code": 0}
+        except WorktreeArgError as e:
+            return {"ok": False, "error": str(e), "error_type": "arg_error", "exit_code": 2}
+        except WorktreeError as e:
+            return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+
+    if timeout_sec is None:
+        return _inner()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+        future = ex.submit(_inner)
+        try:
+            return future.result(timeout=timeout_sec)
+        except concurrent.futures.TimeoutError:
+            return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+
+def twl_worktree_validate_branch_name_handler(
+    branch: str,
+) -> dict:
+    """autopilot.worktree: pure validate_branch_name() (read-only, raises WorktreeArgError)."""
+    from twl.autopilot.worktree import validate_branch_name, WorktreeArgError
+    try:
+        validate_branch_name(branch)
+        return {"ok": True, "message": f"branch name valid: {branch}", "exit_code": 0}
+    except WorktreeArgError as e:
+        return {"ok": False, "error": str(e), "error_type": "arg_error", "exit_code": 2}
+
+
 # MCP tool registration — requires fastmcp (optional dep)
 try:
     from fastmcp import FastMCP as _FastMCP
@@ -202,6 +593,68 @@ try:
             ensure_ascii=False,
         )
 
+    # --- Autopilot Phase 2 tools ---
+
+    @mcp.tool()
+    def twl_mergegate_run(pr_number: int, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 600) -> str:
+        """autopilot.mergegate: invoke MergeGate.execute() with SystemExit catch + ThreadPoolExecutor timeout wrap (sys.exit(1)/sys.exit(2) recoverable). Note: handler timeout 600s; set MCP_CLIENT_TIMEOUT>=660s."""
+        return json.dumps(twl_mergegate_run_handler(pr_number=pr_number, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_mergegate_reject(pr_number: int, reason: str, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:
+        """autopilot.mergegate: invoke MergeGate.reject() with SystemExit catch + timeout wrap (300s)."""
+        return json.dumps(twl_mergegate_reject_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_mergegate_reject_final(pr_number: int, reason: str, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:
+        """autopilot.mergegate: invoke MergeGate.reject_final() with SystemExit catch + timeout wrap (300s)."""
+        return json.dumps(twl_mergegate_reject_final_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", timeout_sec: int = 1800) -> str:
+        """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
+        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_orchestrator_get_phase_issues(phase: int, plan_file: str) -> str:
+        """autopilot.orchestrator: pure get_phase_issues() (read-only, no subprocess). plan_file existence check."""
+        return json.dumps(twl_orchestrator_get_phase_issues_handler(phase=phase, plan_file=plan_file), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_orchestrator_summary(autopilot_dir: str) -> str:
+        """autopilot.orchestrator: pure generate_summary() (read-only)."""
+        return json.dumps(twl_orchestrator_summary_handler(autopilot_dir=autopilot_dir), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_orchestrator_resolve_repos(repos_json: str) -> str:
+        """autopilot.orchestrator: pure resolve_repos_config() (read-only)."""
+        return json.dumps(twl_orchestrator_resolve_repos_handler(repos_json=repos_json), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_worktree_create(branch: str, base: str = "main", repo: str | None = None, repo_path: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:
+        """autopilot.worktree: WorktreeManager.create() with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (300s)."""
+        return json.dumps(twl_worktree_create_handler(branch=branch, base=base, repo=repo, repo_path=repo_path, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_worktree_delete(branch: str, repo_path: str | None = None, cwd: str | None = None, timeout_sec: int = 120) -> str:
+        """autopilot.worktree: WorktreeManager.delete() (新規追加 method) with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (120s)."""
+        return json.dumps(twl_worktree_delete_handler(branch=branch, repo_path=repo_path, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_worktree_list(repo_path: str | None = None) -> str:
+        """autopilot.worktree: WorktreeManager.list_porcelain() (新規追加 method) - read-only list[dict] return."""
+        return json.dumps(twl_worktree_list_handler(repo_path=repo_path), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_worktree_generate_branch_name(issue_number: str, repo: str | None = None, timeout_sec: int = 60) -> str:
+        """autopilot.worktree: pure generate_branch_name(issue_number: str, ...) with gh issue view subprocess (timeout 60s)."""
+        return json.dumps(twl_worktree_generate_branch_name_handler(issue_number=issue_number, repo=repo, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
+    def twl_worktree_validate_branch_name(branch: str) -> str:
+        """autopilot.worktree: pure validate_branch_name() (read-only, raises WorktreeArgError)."""
+        return json.dumps(twl_worktree_validate_branch_name_handler(branch=branch), ensure_ascii=False)
+
 except ImportError:
     mcp = None  # type: ignore[assignment]
 
@@ -253,3 +706,51 @@ except ImportError:
             ),
             ensure_ascii=False,
         )
+
+    def twl_mergegate_run(pr_number: int, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 600) -> str:  # type: ignore[misc]
+        """autopilot.mergegate: invoke MergeGate.execute() with SystemExit catch + ThreadPoolExecutor timeout wrap (sys.exit(1)/sys.exit(2) recoverable). Note: handler timeout 600s; set MCP_CLIENT_TIMEOUT>=660s."""
+        return json.dumps(twl_mergegate_run_handler(pr_number=pr_number, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_mergegate_reject(pr_number: int, reason: str, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:  # type: ignore[misc]
+        """autopilot.mergegate: invoke MergeGate.reject() with SystemExit catch + timeout wrap (300s)."""
+        return json.dumps(twl_mergegate_reject_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_mergegate_reject_final(pr_number: int, reason: str, autopilot_dir: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:  # type: ignore[misc]
+        """autopilot.mergegate: invoke MergeGate.reject_final() with SystemExit catch + timeout wrap (300s)."""
+        return json.dumps(twl_mergegate_reject_final_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", timeout_sec: int = 1800) -> str:  # type: ignore[misc]
+        """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
+        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_orchestrator_get_phase_issues(phase: int, plan_file: str) -> str:  # type: ignore[misc]
+        """autopilot.orchestrator: pure get_phase_issues() (read-only, no subprocess). plan_file existence check."""
+        return json.dumps(twl_orchestrator_get_phase_issues_handler(phase=phase, plan_file=plan_file), ensure_ascii=False)
+
+    def twl_orchestrator_summary(autopilot_dir: str) -> str:  # type: ignore[misc]
+        """autopilot.orchestrator: pure generate_summary() (read-only)."""
+        return json.dumps(twl_orchestrator_summary_handler(autopilot_dir=autopilot_dir), ensure_ascii=False)
+
+    def twl_orchestrator_resolve_repos(repos_json: str) -> str:  # type: ignore[misc]
+        """autopilot.orchestrator: pure resolve_repos_config() (read-only)."""
+        return json.dumps(twl_orchestrator_resolve_repos_handler(repos_json=repos_json), ensure_ascii=False)
+
+    def twl_worktree_create(branch: str, base: str = "main", repo: str | None = None, repo_path: str | None = None, cwd: str | None = None, timeout_sec: int = 300) -> str:  # type: ignore[misc]
+        """autopilot.worktree: WorktreeManager.create() with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (300s)."""
+        return json.dumps(twl_worktree_create_handler(branch=branch, base=base, repo=repo, repo_path=repo_path, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_worktree_delete(branch: str, repo_path: str | None = None, cwd: str | None = None, timeout_sec: int = 120) -> str:  # type: ignore[misc]
+        """autopilot.worktree: WorktreeManager.delete() (新規追加 method) with CWD-based 不変条件 B role check (realpath 適用) + timeout wrap (120s)."""
+        return json.dumps(twl_worktree_delete_handler(branch=branch, repo_path=repo_path, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_worktree_list(repo_path: str | None = None) -> str:  # type: ignore[misc]
+        """autopilot.worktree: WorktreeManager.list_porcelain() (新規追加 method) - read-only list[dict] return."""
+        return json.dumps(twl_worktree_list_handler(repo_path=repo_path), ensure_ascii=False)
+
+    def twl_worktree_generate_branch_name(issue_number: str, repo: str | None = None, timeout_sec: int = 60) -> str:  # type: ignore[misc]
+        """autopilot.worktree: pure generate_branch_name(issue_number: str, ...) with gh issue view subprocess (timeout 60s)."""
+        return json.dumps(twl_worktree_generate_branch_name_handler(issue_number=issue_number, repo=repo, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_worktree_validate_branch_name(branch: str) -> str:  # type: ignore[misc]
+        """autopilot.worktree: pure validate_branch_name() (read-only, raises WorktreeArgError)."""
+        return json.dumps(twl_worktree_validate_branch_name_handler(branch=branch), ensure_ascii=False)

--- a/cli/twl/tests/ac-test-mapping.yaml
+++ b/cli/twl/tests/ac-test-mapping.yaml
@@ -1,46 +1,115 @@
 mappings:
-  - ac_index: 1
-    ac_text: "3 workflow とも mcp__twl__twl_audit で workflow_token_bloat <= 1200 tok 達成"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "共通-1"
+    ac_text: "12 tool が tools.py に存在すること (twl_mergegate_run, twl_mergegate_reject, twl_mergegate_reject_final, twl_orchestrator_phase_review, twl_orchestrator_get_phase_issues, twl_orchestrator_summary, twl_orchestrator_resolve_repos, twl_worktree_create, twl_worktree_delete, twl_worktree_list, twl_worktree_generate_branch_name, twl_worktree_validate_branch_name)"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc1TokenBloat::test_ac1_lifecycle_token_bloat_le_1200"
-      - "TestAc1TokenBloat::test_ac1_refine_token_bloat_le_1200"
-      - "TestAc1TokenBloat::test_ac1_pr_merge_token_bloat_le_1200"
+      - "TestCommon1TwelveToolsExist::test_common1_all_12_tools_present_in_module"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_mergegate_run_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_mergegate_reject_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_mergegate_reject_final_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_orchestrator_phase_review_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_orchestrator_get_phase_issues_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_orchestrator_summary_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_orchestrator_resolve_repos_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_worktree_create_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_worktree_delete_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_worktree_list_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_worktree_generate_branch_name_exists"
+      - "TestCommon1TwelveToolsExist::test_common1_twl_worktree_validate_branch_name_exists"
 
-  - ac_index: 2
-    ac_text: "twl check --deps-integrity PASS (chain.py / chain-steps.sh / deps.yaml.chains の整合維持)"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "共通-2"
+    ac_text: "12 個の handler 関数が tools.py に存在すること（twl_<name>_handler 命名）"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc2DepsIntegrity::test_ac2_deps_integrity_passes"
+      - "TestCommon2TwelveHandlersExist::test_common2_all_12_handlers_present"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_mergegate_run_handler_exists"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_orchestrator_phase_review_handler_exists"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_worktree_create_handler_exists"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_worktree_delete_handler_exists"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_worktree_list_handler_exists"
+      - "TestCommon2TwelveHandlersExist::test_common2_twl_worktree_validate_branch_name_handler_exists"
 
-  - ac_index: 3
-    ac_text: "twl check PASS (deps.yaml v3.0 構造整合)"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "共通-3"
+    ac_text: "MCP tool 登録 — @mcp.tool() + try/except ImportError gate 実装済み"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc3TwlCheck::test_ac3_twl_check_passes"
+      - "TestCommon3McpToolRegistration::test_common3_tools_module_importable"
+      - "TestCommon3McpToolRegistration::test_common3_12_tools_importable_from_tools_module"
 
-  - ac_index: 4
-    ac_text: "各 workflow の動作変更なし (smoke test 3 件: lifecycle / refine / pr-merge を最小入力で実行し STATE 遷移が完了することを確認)"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "共通-9"
+    ac_text: "action 系 tool (mergegate_run/reject/reject_final, orchestrator_phase_review, worktree_create/delete) に timeout_sec: int 引数が存在すること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc4SmokeTests::test_ac4_lifecycle_smoke_state_transition"
-      - "TestAc4SmokeTests::test_ac4_refine_smoke_state_transition"
-      - "TestAc4SmokeTests::test_ac4_pr_merge_smoke_state_transition"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_mergegate_run_handler_has_timeout_sec"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_mergegate_reject_handler_has_timeout_sec"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_mergegate_reject_final_handler_has_timeout_sec"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_orchestrator_phase_review_handler_has_timeout_sec"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_worktree_create_handler_has_timeout_sec"
+      - "TestCommon9TimeoutSecArgument::test_common9_twl_worktree_delete_handler_has_timeout_sec"
 
-  - ac_index: 5
-    ac_text: "split 先 (refs/ 配下の各 .md) が SKILL.md から正規 Read 経路で参照されることを確認 (grep で SKILL.md -> refs/ への参照を検証)"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "AC4-1"
+    ac_text: "twl_mergegate_run_handler が存在し dict を返すこと。SystemExit/timeout/pr_resolve エラーを適切なエラー envelope で返却すること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc5RefsReferences::test_ac5_lifecycle_skill_references_refs"
-      - "TestAc5RefsReferences::test_ac5_refine_skill_references_refs"
-      - "TestAc5RefsReferences::test_ac5_pr_merge_skill_references_refs"
-      - "TestAc5RefsReferences::test_ac5_refs_files_exist_for_each_workflow"
+      - "TestAC41MergegateHandlers::test_ac41_twl_mergegate_run_handler_returns_dict"
+      - "TestAC41MergegateHandlers::test_ac41_twl_mergegate_run_handler_system_exit_catch"
+      - "TestAC41MergegateHandlers::test_ac41_twl_mergegate_run_handler_pr_resolve_error"
+      - "TestAC41MergegateHandlers::test_ac41_twl_mergegate_run_handler_timeout"
 
-  - ac_index: 6
-    ac_text: "specialist review 3 種 PASS — worker-architecture を必須として含む (chain SSoT 境界 / refs 切り出し境界の妥当性確認) + worker-codex-reviewer + issue-critic または issue-feasibility"
-    test_file: "cli/twl/tests/test_issue_985_workflow_split.py"
+  - ac_index: "AC4-2"
+    ac_text: "twl_orchestrator_phase_review_handler が存在し dict を返すこと。plan_file 不在/tmux 不在時は適切なエラー envelope を返却すること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
     test_names:
-      - "TestAc6SpecialistReview::test_ac6_worker_architecture_review_completed"
-      - "TestAc6SpecialistReview::test_ac6_worker_codex_reviewer_completed"
-      - "TestAc6SpecialistReview::test_ac6_issue_critic_or_feasibility_completed"
-    note: "specialist review は PR レビューフローで実施。テストはプレースホルダー。"
+      - "TestAC42OrchestratorHandlers::test_ac42_twl_orchestrator_phase_review_handler_returns_dict"
+      - "TestAC42OrchestratorHandlers::test_ac42_twl_orchestrator_phase_review_handler_plan_file_missing"
+      - "TestAC42OrchestratorHandlers::test_ac42_twl_orchestrator_phase_review_handler_tmux_not_found"
+      - "TestAC42OrchestratorHandlers::test_ac42_orchestrator_run_result_json_serializable"
+
+  - ac_index: "AC4-3"
+    ac_text: "WorktreeManager.delete/list_porcelain が worktree.py に存在し、twl_worktree_generate_branch_name_handler の issue_number が str 型であること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestAC43WorktreeHandlers::test_ac43_workTreeManager_delete_method_exists"
+      - "TestAC43WorktreeHandlers::test_ac43_workTreeManager_list_porcelain_method_exists"
+      - "TestAC43WorktreeHandlers::test_ac43_workTreeManager_list_porcelain_returns_list_of_dict"
+      - "TestAC43WorktreeHandlers::test_ac43_twl_worktree_generate_branch_name_handler_issue_number_is_str"
+
+  - ac_index: "AC4-5"
+    ac_text: "不変条件 B CWD-based role check — worktrees/ 配下の CWD から worktree_create/delete を呼ぶと invariant_b_violation で拒否される。main/ CWD からは通常実行パスに入る"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestAC45InvariantBCwdCheck::test_ac45_worktree_create_from_worktrees_cwd_rejected"
+      - "TestAC45InvariantBCwdCheck::test_ac45_worktree_delete_from_worktrees_cwd_rejected"
+      - "TestAC45InvariantBCwdCheck::test_ac45_worktree_create_from_main_cwd_not_rejected"
+
+  - ac_index: "AC4-6"
+    ac_text: "twl_worktree_list_handler が list[dict] 構造を含む dict を返すこと。twl_worktree_validate_branch_name_handler が WorktreeArgError を catch して envelope を返すこと"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestAC46CriticalAssertions::test_ac46_twl_worktree_list_handler_returns_list_dict_structure"
+      - "TestAC46CriticalAssertions::test_ac46_twl_worktree_validate_branch_name_handler_catches_worktree_arg_error"
+
+  - ac_index: "AC4-12"
+    ac_text: "twl_orchestrator_get_phase_issues_handler も plan_file 不在で graceful return すること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestAC412PlanFileCheck::test_ac412_twl_orchestrator_get_phase_issues_handler_plan_file_missing"
+
+  - ac_index: "AC4-13"
+    ac_text: "twl_mergegate_run と twl_orchestrator_phase_review の docstring に MCP_CLIENT_TIMEOUT が含まれること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestAC413DocstringTimeoutNote::test_ac413_twl_mergegate_run_docstring_has_mcp_client_timeout"
+      - "TestAC413DocstringTimeoutNote::test_ac413_twl_orchestrator_phase_review_docstring_has_mcp_client_timeout"
+
+  - ac_index: "AC-naming-1"
+    ac_text: "tool 名が snake_case で twl_<module>_<action> 規則に準拠していること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestACNaming1ToolNameConvention::test_naming1_all_tools_follow_snake_case_convention"
+
+  - ac_index: "AC-naming-2"
+    ac_text: "12 tool それぞれの docstring 1 行目が非空であること"
+    test_file: "cli/twl/tests/test_issue_1114_autopilot_tools.py"
+    test_names:
+      - "TestACNaming2DocstringNonEmpty::test_naming2_all_tools_have_non_empty_docstring_first_line"

--- a/cli/twl/tests/test_issue_1114_autopilot_tools.py
+++ b/cli/twl/tests/test_issue_1114_autopilot_tools.py
@@ -1,0 +1,921 @@
+"""Tests for Issue #1114: feat(mcp): autopilot tool 12 本追加 (tools.py EPI).
+
+TDD RED フェーズ用テストスタブ。
+実装前は全テストが FAIL する（意図的 RED）。
+
+AC 一覧:
+  共通-1: 12 tool が tools.py に存在すること
+  共通-2: 12 handler 関数が tools.py に存在すること
+  共通-3: MCP tool 登録 (@mcp.tool() + try/except ImportError gate)
+  共通-6: pytest 全テスト PASS（既存テスト含む）
+  共通-9: action 系 tool に timeout_sec: int 引数が存在すること
+  AC4-1: mergegate 系 3 tool のハンドラ動作
+  AC4-2: orchestrator 系 4 tool のハンドラ動作
+  AC4-3: worktree 系 5 tool のハンドラ動作
+  AC4-5: 不変条件 B CWD-based role check
+  AC4-6: critical assertion 群
+  AC4-12: plan_file check
+  AC4-13: docstring に timeout 注記
+  AC-naming-1: tool 名が snake_case で twl_<module>_<action> 規則に準拠
+  AC-naming-2: 12 tool それぞれの docstring 1 行目が非空
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ターゲットモジュール
+TWL_DIR = Path(__file__).resolve().parent.parent
+
+# 期待する 12 tool 名
+EXPECTED_TOOL_NAMES = [
+    "twl_mergegate_run",
+    "twl_mergegate_reject",
+    "twl_mergegate_reject_final",
+    "twl_orchestrator_phase_review",
+    "twl_orchestrator_get_phase_issues",
+    "twl_orchestrator_summary",
+    "twl_orchestrator_resolve_repos",
+    "twl_worktree_create",
+    "twl_worktree_delete",
+    "twl_worktree_list",
+    "twl_worktree_generate_branch_name",
+    "twl_worktree_validate_branch_name",
+]
+
+# action 系 tool（timeout_sec 引数が必要）
+ACTION_TOOL_HANDLER_NAMES = [
+    "twl_mergegate_run_handler",
+    "twl_mergegate_reject_handler",
+    "twl_mergegate_reject_final_handler",
+    "twl_orchestrator_phase_review_handler",
+    "twl_worktree_create_handler",
+    "twl_worktree_delete_handler",
+]
+
+
+# ---------------------------------------------------------------------------
+# 共通-1: 12 tool が tools.py に存在すること
+# ---------------------------------------------------------------------------
+
+
+class TestCommon1TwelveToolsExist:
+    """共通-1: 12 tool が tools.py に存在すること.
+
+    実装前は各 tool 名が tools モジュールに存在しないため
+    AttributeError で FAIL する（意図的 RED）。
+    """
+
+    def test_common1_all_12_tools_present_in_module(self):
+        # AC: 12 tool が tools.py に定義されていること
+        # RED: 実装前は各 tool 関数が存在しないため FAIL する
+        from twl.mcp_server import tools
+        missing = [name for name in EXPECTED_TOOL_NAMES if not hasattr(tools, name)]
+        assert not missing, (
+            f"tools.py に以下の tool が存在しない (共通-1 未実装): {missing}"
+        )
+
+    def test_common1_twl_mergegate_run_exists(self):
+        # AC: twl_mergegate_run が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_mergegate_run"), (
+            "tools.py に twl_mergegate_run が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_mergegate_reject_exists(self):
+        # AC: twl_mergegate_reject が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_mergegate_reject"), (
+            "tools.py に twl_mergegate_reject が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_mergegate_reject_final_exists(self):
+        # AC: twl_mergegate_reject_final が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_mergegate_reject_final"), (
+            "tools.py に twl_mergegate_reject_final が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_orchestrator_phase_review_exists(self):
+        # AC: twl_orchestrator_phase_review が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_orchestrator_phase_review"), (
+            "tools.py に twl_orchestrator_phase_review が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_orchestrator_get_phase_issues_exists(self):
+        # AC: twl_orchestrator_get_phase_issues が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_orchestrator_get_phase_issues"), (
+            "tools.py に twl_orchestrator_get_phase_issues が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_orchestrator_summary_exists(self):
+        # AC: twl_orchestrator_summary が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_orchestrator_summary"), (
+            "tools.py に twl_orchestrator_summary が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_orchestrator_resolve_repos_exists(self):
+        # AC: twl_orchestrator_resolve_repos が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_orchestrator_resolve_repos"), (
+            "tools.py に twl_orchestrator_resolve_repos が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_worktree_create_exists(self):
+        # AC: twl_worktree_create が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_create"), (
+            "tools.py に twl_worktree_create が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_worktree_delete_exists(self):
+        # AC: twl_worktree_delete が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_delete"), (
+            "tools.py に twl_worktree_delete が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_worktree_list_exists(self):
+        # AC: twl_worktree_list が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_list"), (
+            "tools.py に twl_worktree_list が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_worktree_generate_branch_name_exists(self):
+        # AC: twl_worktree_generate_branch_name が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_generate_branch_name"), (
+            "tools.py に twl_worktree_generate_branch_name が存在しない (共通-1 未実装)"
+        )
+
+    def test_common1_twl_worktree_validate_branch_name_exists(self):
+        # AC: twl_worktree_validate_branch_name が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_validate_branch_name"), (
+            "tools.py に twl_worktree_validate_branch_name が存在しない (共通-1 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 共通-2: 12 handler 関数が tools.py に存在すること
+# ---------------------------------------------------------------------------
+
+
+class TestCommon2TwelveHandlersExist:
+    """共通-2: 12 個の handler 関数が tools.py に存在すること（twl_<name>_handler 命名）.
+
+    実装前は handler 関数が存在しないため AttributeError で FAIL する（意図的 RED）。
+    """
+
+    def test_common2_all_12_handlers_present(self):
+        # AC: 12 handler 関数が tools.py に twl_<name>_handler 命名で存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        expected_handlers = [name + "_handler" for name in EXPECTED_TOOL_NAMES]
+        missing = [h for h in expected_handlers if not hasattr(tools, h)]
+        assert not missing, (
+            f"tools.py に以下の handler が存在しない (共通-2 未実装): {missing}"
+        )
+
+    def test_common2_twl_mergegate_run_handler_exists(self):
+        # AC: twl_mergegate_run_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_mergegate_run_handler"), (
+            "tools.py に twl_mergegate_run_handler が存在しない (共通-2 未実装)"
+        )
+
+    def test_common2_twl_orchestrator_phase_review_handler_exists(self):
+        # AC: twl_orchestrator_phase_review_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_orchestrator_phase_review_handler"), (
+            "tools.py に twl_orchestrator_phase_review_handler が存在しない (共通-2 未実装)"
+        )
+
+    def test_common2_twl_worktree_create_handler_exists(self):
+        # AC: twl_worktree_create_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_create_handler"), (
+            "tools.py に twl_worktree_create_handler が存在しない (共通-2 未実装)"
+        )
+
+    def test_common2_twl_worktree_delete_handler_exists(self):
+        # AC: twl_worktree_delete_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_delete_handler"), (
+            "tools.py に twl_worktree_delete_handler が存在しない (共通-2 未実装)"
+        )
+
+    def test_common2_twl_worktree_list_handler_exists(self):
+        # AC: twl_worktree_list_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_list_handler"), (
+            "tools.py に twl_worktree_list_handler が存在しない (共通-2 未実装)"
+        )
+
+    def test_common2_twl_worktree_validate_branch_name_handler_exists(self):
+        # AC: twl_worktree_validate_branch_name_handler が tools.py に存在すること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        assert hasattr(tools, "twl_worktree_validate_branch_name_handler"), (
+            "tools.py に twl_worktree_validate_branch_name_handler が存在しない (共通-2 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 共通-3: MCP tool 登録 (@mcp.tool() + try/except ImportError gate)
+# ---------------------------------------------------------------------------
+
+
+class TestCommon3McpToolRegistration:
+    """共通-3: @mcp.tool() + try/except ImportError gate 実装済み.
+
+    実装前は 12 tool がモジュールに存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_common3_tools_module_importable(self):
+        # AC: tools.py が import 可能であること
+        # RED: 12 tool 未実装のため import に失敗する可能性あり
+        from twl.mcp_server import tools  # noqa: F401
+
+    def test_common3_12_tools_importable_from_tools_module(self):
+        # AC: 12 tool が tools モジュールから直接 import 可能であること
+        # RED: 実装前は存在しないため FAIL する
+        from twl.mcp_server import tools
+        for name in EXPECTED_TOOL_NAMES:
+            assert hasattr(tools, name), (
+                f"tools.twl.{name} が存在しない (共通-3 未実装)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 共通-9: action 系 tool に timeout_sec: int 引数が存在すること
+# ---------------------------------------------------------------------------
+
+
+class TestCommon9TimeoutSecArgument:
+    """共通-9: action 系 tool handler に timeout_sec: int 引数が存在すること.
+
+    実装前は handler 関数が存在しないため AttributeError で FAIL する（意図的 RED）。
+    """
+
+    def test_common9_twl_mergegate_run_handler_has_timeout_sec(self):
+        # AC: twl_mergegate_run_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_mergegate_run_handler", None)
+        assert handler is not None, "twl_mergegate_run_handler が存在しない (共通-9 未実装)"
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_mergegate_run_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+        param = sig.parameters["timeout_sec"]
+        assert param.annotation == int or str(param.annotation) == "int", (
+            "twl_mergegate_run_handler の timeout_sec が int 型でない (共通-9 未実装)"
+        )
+
+    def test_common9_twl_mergegate_reject_handler_has_timeout_sec(self):
+        # AC: twl_mergegate_reject_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_mergegate_reject_handler", None)
+        assert handler is not None, "twl_mergegate_reject_handler が存在しない (共通-9 未実装)"
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_mergegate_reject_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+
+    def test_common9_twl_mergegate_reject_final_handler_has_timeout_sec(self):
+        # AC: twl_mergegate_reject_final_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_mergegate_reject_final_handler", None)
+        assert handler is not None, "twl_mergegate_reject_final_handler が存在しない (共通-9 未実装)"
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_mergegate_reject_final_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+
+    def test_common9_twl_orchestrator_phase_review_handler_has_timeout_sec(self):
+        # AC: twl_orchestrator_phase_review_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_orchestrator_phase_review_handler", None)
+        assert handler is not None, (
+            "twl_orchestrator_phase_review_handler が存在しない (共通-9 未実装)"
+        )
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_orchestrator_phase_review_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+
+    def test_common9_twl_worktree_create_handler_has_timeout_sec(self):
+        # AC: twl_worktree_create_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_worktree_create_handler", None)
+        assert handler is not None, "twl_worktree_create_handler が存在しない (共通-9 未実装)"
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_worktree_create_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+
+    def test_common9_twl_worktree_delete_handler_has_timeout_sec(self):
+        # AC: twl_worktree_delete_handler の引数に timeout_sec: int が存在すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_worktree_delete_handler", None)
+        assert handler is not None, "twl_worktree_delete_handler が存在しない (共通-9 未実装)"
+        sig = inspect.signature(handler)
+        assert "timeout_sec" in sig.parameters, (
+            "twl_worktree_delete_handler に timeout_sec 引数が存在しない (共通-9 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-1: mergegate 系 3 tool のハンドラ動作
+# ---------------------------------------------------------------------------
+
+
+class TestAC41MergegateHandlers:
+    """AC4-1: mergegate 系 3 tool のハンドラ動作.
+
+    実装前は handler が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac41_twl_mergegate_run_handler_returns_dict(self):
+        # AC: twl_mergegate_run_handler が dict を返すこと
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_mergegate_run_handler
+        result = twl_mergegate_run_handler.__call__  # type: ignore
+        assert callable(twl_mergegate_run_handler), (
+            "twl_mergegate_run_handler が callable でない (AC4-1 未実装)"
+        )
+
+    def test_ac41_twl_mergegate_run_handler_system_exit_catch(self):
+        # AC: MergeGate.execute() が sys.exit(1) を raise する mock で
+        #     handler が {"ok": False, "error_type": "merge_exit_1", "exit_code": 1} を返すこと
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_mergegate_run_handler
+
+        mock_gh_output = json.dumps({
+            "number": 1,
+            "headRefName": "feat/1-test",
+            "labels": [{"name": "issue-1"}],
+        })
+        mock_run_result = MagicMock()
+        mock_run_result.returncode = 0
+        mock_run_result.stdout = mock_gh_output
+
+        with patch("subprocess.run", return_value=mock_run_result):
+            with patch(
+                "twl.autopilot.mergegate.MergeGate.execute",
+                side_effect=SystemExit(1),
+            ):
+                result = twl_mergegate_run_handler(
+                    pr_number=1,
+                    timeout_sec=60,
+                )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-1 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-1 未実装)"
+        assert result.get("error_type") == "merge_exit_1", (
+            f"error_type が 'merge_exit_1' でない: {result.get('error_type')} (AC4-1 未実装)"
+        )
+        assert result.get("exit_code") == 1, (
+            f"exit_code が 1 でない: {result.get('exit_code')} (AC4-1 未実装)"
+        )
+
+    def test_ac41_twl_mergegate_run_handler_pr_resolve_error(self):
+        # AC: pr_number resolve 失敗 (gh API mock fail) で
+        #     {"ok": False, "error_type": "pr_resolve_error", "exit_code": 2} 返却
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_mergegate_run_handler
+
+        with patch(
+            "subprocess.run",
+            side_effect=Exception("gh API failure mock"),
+        ):
+            result = twl_mergegate_run_handler(
+                pr_number=1,
+                timeout_sec=60,
+            )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-1 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-1 未実装)"
+        assert result.get("error_type") == "pr_resolve_error", (
+            f"error_type が 'pr_resolve_error' でない: {result.get('error_type')} (AC4-1 未実装)"
+        )
+        assert result.get("exit_code") == 2, (
+            f"exit_code が 2 でない: {result.get('exit_code')} (AC4-1 未実装)"
+        )
+
+    def test_ac41_twl_mergegate_run_handler_timeout(self):
+        # AC: timeout_sec=1 の long-running mock で
+        #     {"ok": False, "error_type": "timeout", "exit_code": 124} 返却
+        # RED: handler が存在しないため FAIL する
+        import time
+        from twl.mcp_server.tools import twl_mergegate_run_handler
+
+        mock_gh_output = json.dumps({
+            "number": 1,
+            "headRefName": "feat/1-test",
+            "labels": [{"name": "issue-1"}],
+        })
+        mock_run_result = MagicMock()
+        mock_run_result.returncode = 0
+        mock_run_result.stdout = mock_gh_output
+
+        def _slow_execute(*args, **kwargs):
+            time.sleep(5)
+
+        with patch("subprocess.run", return_value=mock_run_result):
+            with patch("twl.autopilot.mergegate.MergeGate.execute", side_effect=_slow_execute):
+                result = twl_mergegate_run_handler(
+                    pr_number=1,
+                    timeout_sec=1,
+                )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-1 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-1 未実装)"
+        assert result.get("error_type") == "timeout", (
+            f"error_type が 'timeout' でない: {result.get('error_type')} (AC4-1 未実装)"
+        )
+        assert result.get("exit_code") == 124, (
+            f"exit_code が 124 でない: {result.get('exit_code')} (AC4-1 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-2: orchestrator 系 4 tool のハンドラ動作
+# ---------------------------------------------------------------------------
+
+
+class TestAC42OrchestratorHandlers:
+    """AC4-2: orchestrator 系 4 tool のハンドラ動作.
+
+    実装前は handler が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac42_twl_orchestrator_phase_review_handler_returns_dict(self):
+        # AC: twl_orchestrator_phase_review_handler が存在し dict を返すこと
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_orchestrator_phase_review_handler
+        assert callable(twl_orchestrator_phase_review_handler), (
+            "twl_orchestrator_phase_review_handler が callable でない (AC4-2 未実装)"
+        )
+
+    def test_ac42_twl_orchestrator_phase_review_handler_plan_file_missing(self):
+        # AC: plan_file 不在で {"ok": False, "error_type": "arg_error", "exit_code": 2} 返却
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_orchestrator_phase_review_handler
+
+        result = twl_orchestrator_phase_review_handler(
+            phase=1,
+            plan_file="/nonexistent/plan.yaml",
+            session_file="/tmp/session.json",
+            project_dir="/tmp/proj",
+            autopilot_dir="/tmp/.autopilot",
+            timeout_sec=60,
+        )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-2 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-2 未実装)"
+        assert result.get("error_type") == "arg_error", (
+            f"error_type が 'arg_error' でない: {result.get('error_type')} (AC4-2 未実装)"
+        )
+        assert result.get("exit_code") == 2, (
+            f"exit_code が 2 でない: {result.get('exit_code')} (AC4-2 未実装)"
+        )
+
+    def test_ac42_twl_orchestrator_phase_review_handler_tmux_not_found(self):
+        # AC: tmux 不在環境 mock (FileNotFoundError raise) で
+        #     {"ok": False, "error_type": "subprocess_error", "exit_code": 127} 返却
+        # RED: handler が存在しないため FAIL する
+        import tempfile, os
+        from twl.mcp_server.tools import twl_orchestrator_phase_review_handler
+
+        # plan_file を実際に作成してから tmux 不在をテスト
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("phases:\n  - phase: 1\n    issues:\n      - 1\n")
+            tmp_plan = f.name
+        try:
+            with patch(
+                "twl.autopilot.orchestrator.PhaseOrchestrator.run",
+                side_effect=FileNotFoundError("tmux not found"),
+            ):
+                result = twl_orchestrator_phase_review_handler(
+                    phase=1,
+                    plan_file=tmp_plan,
+                    session_file="/tmp/session.json",
+                    project_dir="/tmp/proj",
+                    autopilot_dir="/tmp/.autopilot",
+                    timeout_sec=60,
+                )
+        finally:
+            os.unlink(tmp_plan)
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-2 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-2 未実装)"
+        assert result.get("error_type") == "subprocess_error", (
+            f"error_type が 'subprocess_error' でない: {result.get('error_type')} (AC4-2 未実装)"
+        )
+        assert result.get("exit_code") == 127, (
+            f"exit_code が 127 でない: {result.get('exit_code')} (AC4-2 未実装)"
+        )
+
+    def test_ac42_orchestrator_run_result_json_serializable(self):
+        # AC: PhaseOrchestrator.run() が dict 返却 → tool 登録側 json.dumps で str 化される
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_orchestrator_phase_review_handler", None)
+        assert handler is not None, (
+            "twl_orchestrator_phase_review_handler が存在しない (AC4-2 未実装)"
+        )
+        # handler の戻り値が json.dumps 可能であることを確認する
+        # ここでは plan_file 不在ケースで確認
+        result = handler(phase=1, plan_file="/nonexistent/plan.yaml", session_file="/tmp/s.json", project_dir="/tmp/proj", autopilot_dir="/tmp/.ap", timeout_sec=60)
+        # json.dumps で例外が出ないこと
+        json_str = json.dumps(result, ensure_ascii=False)
+        assert isinstance(json_str, str), (
+            "handler の戻り値が json.dumps できない (AC4-2 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-3: worktree 系 5 tool のハンドラ動作
+# ---------------------------------------------------------------------------
+
+
+class TestAC43WorktreeHandlers:
+    """AC4-3: worktree 系 5 tool のハンドラ動作.
+
+    実装前は WorktreeManager に delete/list_porcelain が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac43_workTreeManager_delete_method_exists(self):
+        # AC: WorktreeManager.delete method が worktree.py に存在すること
+        # RED: delete が未実装のため FAIL する
+        from twl.autopilot.worktree import WorktreeManager
+        assert hasattr(WorktreeManager, "delete"), (
+            "WorktreeManager に delete method が存在しない (AC4-3 未実装)"
+        )
+        assert callable(getattr(WorktreeManager, "delete")), (
+            "WorktreeManager.delete が callable でない (AC4-3 未実装)"
+        )
+
+    def test_ac43_workTreeManager_list_porcelain_method_exists(self):
+        # AC: WorktreeManager.list_porcelain method が worktree.py に存在すること
+        # RED: list_porcelain が未実装のため FAIL する
+        from twl.autopilot.worktree import WorktreeManager
+        assert hasattr(WorktreeManager, "list_porcelain"), (
+            "WorktreeManager に list_porcelain method が存在しない (AC4-3 未実装)"
+        )
+        assert callable(getattr(WorktreeManager, "list_porcelain")), (
+            "WorktreeManager.list_porcelain が callable でない (AC4-3 未実装)"
+        )
+
+    def test_ac43_workTreeManager_list_porcelain_returns_list_of_dict(self):
+        # AC: WorktreeManager.list_porcelain が list[dict] を返すこと
+        # RED: list_porcelain が未実装のため FAIL する
+        from twl.autopilot.worktree import WorktreeManager
+
+        mock_porcelain = (
+            "worktree /tmp/proj/main\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n\n"
+            "worktree /tmp/proj/worktrees/feat/123-test\n"
+            "HEAD def456\n"
+            "branch refs/heads/feat/123-test\n\n"
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = mock_porcelain
+            mock_run.return_value = mock_result
+            mgr = WorktreeManager()
+            result = mgr.list_porcelain()
+
+        assert isinstance(result, list), (
+            f"list_porcelain が list を返さない: {type(result)} (AC4-3 未実装)"
+        )
+        if result:
+            assert isinstance(result[0], dict), (
+                f"list_porcelain の要素が dict でない: {type(result[0])} (AC4-3 未実装)"
+            )
+
+    def test_ac43_twl_worktree_generate_branch_name_handler_issue_number_is_str(self):
+        # AC: twl_worktree_generate_branch_name_handler の引数 issue_number が str 型であること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server import tools
+        handler = getattr(tools, "twl_worktree_generate_branch_name_handler", None)
+        assert handler is not None, (
+            "twl_worktree_generate_branch_name_handler が存在しない (AC4-3 未実装)"
+        )
+        sig = inspect.signature(handler)
+        assert "issue_number" in sig.parameters, (
+            "twl_worktree_generate_branch_name_handler に issue_number 引数がない (AC4-3 未実装)"
+        )
+        param = sig.parameters["issue_number"]
+        assert param.annotation == str or str(param.annotation) == "str", (
+            f"issue_number の型が str でない: {param.annotation} (AC4-3 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-5: 不変条件 B CWD-based role check
+# ---------------------------------------------------------------------------
+
+
+class TestAC45InvariantBCwdCheck:
+    """AC4-5: 不変条件 B CWD-based role check.
+
+    CWD が worktrees/ 配下の場合 twl_worktree_create/delete_handler は
+    invariant_b_violation で拒否すること。
+    実装前は handler が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac45_worktree_create_from_worktrees_cwd_rejected(self):
+        # AC: CWD が /tmp/xxx/worktrees/feat-test/ (realpath 後も /worktrees/ 含む) 状態で
+        #     twl_worktree_create_handler 呼出 → {"ok": False, "error_type": "invariant_b_violation", "exit_code": 1}
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_worktree_create_handler
+
+        with patch("os.getcwd", return_value="/tmp/proj/worktrees/feat-test"):
+            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/worktrees/feat-test")):
+                result = twl_worktree_create_handler(
+                    branch="feat/999-test",
+                    timeout_sec=60,
+                )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-5 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-5 未実装)"
+        assert result.get("error_type") == "invariant_b_violation", (
+            f"error_type が 'invariant_b_violation' でない: {result.get('error_type')} (AC4-5 未実装)"
+        )
+        assert result.get("exit_code") == 1, (
+            f"exit_code が 1 でない: {result.get('exit_code')} (AC4-5 未実装)"
+        )
+
+    def test_ac45_worktree_delete_from_worktrees_cwd_rejected(self):
+        # AC: CWD が /tmp/xxx/worktrees/feat-test/ 状態で twl_worktree_delete_handler 呼出
+        #     → {"ok": False, "error_type": "invariant_b_violation", "exit_code": 1}
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_worktree_delete_handler
+
+        with patch("os.getcwd", return_value="/tmp/proj/worktrees/feat-test"):
+            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/worktrees/feat-test")):
+                result = twl_worktree_delete_handler(
+                    branch="feat/999-test",
+                    timeout_sec=60,
+                )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-5 未実装)"
+        assert result.get("ok") is False, "ok が False でない (AC4-5 未実装)"
+        assert result.get("error_type") == "invariant_b_violation", (
+            f"error_type が 'invariant_b_violation' でない: {result.get('error_type')} (AC4-5 未実装)"
+        )
+        assert result.get("exit_code") == 1, (
+            f"exit_code が 1 でない: {result.get('exit_code')} (AC4-5 未実装)"
+        )
+
+    def test_ac45_worktree_create_from_main_cwd_not_rejected(self):
+        # AC: CWD が /tmp/xxx/main/ 状態で twl_worktree_create_handler 呼出
+        #     → invariant_b_violation ではない（通常実行パスに入る）
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_worktree_create_handler
+
+        with patch("os.getcwd", return_value="/tmp/proj/main"):
+            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/main")):
+                # 通常実行パスで WorktreeManager.create が呼ばれる想定
+                # 実際の git コマンドは mock して create 自体はエラーになってよい
+                with patch(
+                    "twl.autopilot.worktree.WorktreeManager.create",
+                    side_effect=Exception("mock create failure"),
+                ):
+                    result = twl_worktree_create_handler(
+                        branch="feat/999-test",
+                        timeout_sec=60,
+                    )
+        assert isinstance(result, dict), "handler が dict を返さない (AC4-5 未実装)"
+        # invariant_b_violation ではないこと
+        assert result.get("error_type") != "invariant_b_violation", (
+            "main/ CWD でも invariant_b_violation が返された (AC4-5 実装誤り)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-6: critical assertion 群
+# ---------------------------------------------------------------------------
+
+
+class TestAC46CriticalAssertions:
+    """AC4-6: critical assertion 群.
+
+    実装前は handler が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac46_twl_worktree_list_handler_returns_list_dict_structure(self):
+        # AC: twl_worktree_list_handler が list[dict] 構造を含む dict を返すこと
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_worktree_list_handler
+
+        mock_porcelain = (
+            "worktree /tmp/proj/main\n"
+            "HEAD abc123\n"
+            "branch refs/heads/main\n\n"
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_result = MagicMock()
+            mock_result.returncode = 0
+            mock_result.stdout = mock_porcelain
+            mock_run.return_value = mock_result
+
+            result = twl_worktree_list_handler()
+
+        assert isinstance(result, dict), (
+            f"twl_worktree_list_handler が dict を返さない: {type(result)} (AC4-6 未実装)"
+        )
+        assert "worktrees" in result or "items" in result or "ok" in result, (
+            f"dict に worktrees/items/ok キーがない: {list(result.keys())} (AC4-6 未実装)"
+        )
+        # ok=True の場合 worktrees フィールドが list[dict] であること
+        if result.get("ok"):
+            worktrees = result.get("worktrees") or result.get("items") or []
+            assert isinstance(worktrees, list), (
+                f"worktrees が list でない: {type(worktrees)} (AC4-6 未実装)"
+            )
+
+    def test_ac46_twl_worktree_validate_branch_name_handler_catches_worktree_arg_error(self):
+        # AC: twl_worktree_validate_branch_name_handler が WorktreeArgError を catch して
+        #     envelope 返却すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_worktree_validate_branch_name_handler
+        from twl.autopilot.worktree import WorktreeArgError
+
+        # 不正なブランチ名でも handler が例外を上に投げず envelope を返すこと
+        result = twl_worktree_validate_branch_name_handler(branch="main")
+        assert isinstance(result, dict), (
+            f"handler が dict を返さない: {type(result)} (AC4-6 未実装)"
+        )
+        # "main" は予約語なので ok=False が期待される
+        assert result.get("ok") is False, (
+            "'main' ブランチで ok が False でない (AC4-6 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-12: plan_file check
+# ---------------------------------------------------------------------------
+
+
+class TestAC412PlanFileCheck:
+    """AC4-12: plan_file check.
+
+    実装前は handler が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_ac412_twl_orchestrator_get_phase_issues_handler_plan_file_missing(self):
+        # AC: twl_orchestrator_get_phase_issues_handler も plan_file 不在で graceful return すること
+        # RED: handler が存在しないため FAIL する
+        from twl.mcp_server.tools import twl_orchestrator_get_phase_issues_handler
+
+        result = twl_orchestrator_get_phase_issues_handler(
+            phase=1,
+            plan_file="/nonexistent/plan.yaml",
+        )
+        assert isinstance(result, dict), (
+            f"handler が dict を返さない: {type(result)} (AC4-12 未実装)"
+        )
+        assert result.get("ok") is False, "ok が False でない (AC4-12 未実装)"
+        # graceful return: 例外が上に漏れず dict が返ること自体が AC を満たす
+        assert "error_type" in result, (
+            f"error_type キーが result に存在しない: {list(result.keys())} (AC4-12 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4-13: docstring に timeout 注記
+# ---------------------------------------------------------------------------
+
+
+class TestAC413DocstringTimeoutNote:
+    """AC4-13: docstring に timeout 注記.
+
+    実装前は tool 関数が存在しないため AttributeError で FAIL する（意図的 RED）。
+    """
+
+    def test_ac413_twl_mergegate_run_docstring_has_mcp_client_timeout(self):
+        # AC: twl_mergegate_run の docstring に "MCP_CLIENT_TIMEOUT" が含まれること
+        # RED: tool が存在しないため FAIL する
+        from twl.mcp_server import tools
+        tool_fn = getattr(tools, "twl_mergegate_run", None)
+        assert tool_fn is not None, "twl_mergegate_run が存在しない (AC4-13 未実装)"
+        doc = tool_fn.__doc__ or ""
+        assert "MCP_CLIENT_TIMEOUT" in doc, (
+            "twl_mergegate_run の docstring に 'MCP_CLIENT_TIMEOUT' が含まれない (AC4-13 未実装)\n"
+            f"docstring: {doc!r}"
+        )
+
+    def test_ac413_twl_orchestrator_phase_review_docstring_has_mcp_client_timeout(self):
+        # AC: twl_orchestrator_phase_review の docstring に "MCP_CLIENT_TIMEOUT" が含まれること
+        # RED: tool が存在しないため FAIL する
+        from twl.mcp_server import tools
+        tool_fn = getattr(tools, "twl_orchestrator_phase_review", None)
+        assert tool_fn is not None, (
+            "twl_orchestrator_phase_review が存在しない (AC4-13 未実装)"
+        )
+        doc = tool_fn.__doc__ or ""
+        assert "MCP_CLIENT_TIMEOUT" in doc, (
+            "twl_orchestrator_phase_review の docstring に 'MCP_CLIENT_TIMEOUT' が含まれない (AC4-13 未実装)\n"
+            f"docstring: {doc!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-naming-1: tool 名が snake_case で twl_<module>_<action> 規則に準拠
+# ---------------------------------------------------------------------------
+
+
+class TestACNaming1ToolNameConvention:
+    """AC-naming-1: tool 名が snake_case で twl_<module>_<action> 規則に準拠していること.
+
+    実装前は tool が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_naming1_all_tools_follow_snake_case_convention(self):
+        # AC: 12 tool 名が全て snake_case かつ twl_<module>_<action> 形式であること
+        # RED: tool が存在しないため FAIL する
+        import re
+        from twl.mcp_server import tools
+
+        snake_case_re = re.compile(r"^twl_[a-z][a-z0-9]*(_[a-z][a-z0-9]*)+$")
+        invalid = []
+        for name in EXPECTED_TOOL_NAMES:
+            if not snake_case_re.match(name):
+                invalid.append(name)
+
+        assert not invalid, (
+            f"以下の tool 名が snake_case/twl_<module>_<action> 規則に準拠していない: {invalid} (AC-naming-1 未実装)"
+        )
+
+        # tool が実際に存在することも確認
+        missing = [name for name in EXPECTED_TOOL_NAMES if not hasattr(tools, name)]
+        assert not missing, (
+            f"tools.py に以下の tool が存在しない (AC-naming-1 未実装): {missing}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-naming-2: 12 tool それぞれの docstring 1 行目が非空
+# ---------------------------------------------------------------------------
+
+
+class TestACNaming2DocstringNonEmpty:
+    """AC-naming-2: 12 tool それぞれの docstring 1 行目が非空であること.
+
+    実装前は tool が存在しないため FAIL する（意図的 RED）。
+    """
+
+    def test_naming2_all_tools_have_non_empty_docstring_first_line(self):
+        # AC: 12 tool それぞれの docstring 1 行目が非空であること
+        # RED: tool が存在しないため FAIL する
+        from twl.mcp_server import tools
+
+        empty_doc_tools = []
+        missing_tools = []
+        for name in EXPECTED_TOOL_NAMES:
+            tool_fn = getattr(tools, name, None)
+            if tool_fn is None:
+                missing_tools.append(name)
+                continue
+            doc = tool_fn.__doc__ or ""
+            first_line = doc.strip().split("\n")[0].strip() if doc.strip() else ""
+            if not first_line:
+                empty_doc_tools.append(name)
+
+        assert not missing_tools, (
+            f"tools.py に以下の tool が存在しない (AC-naming-2 未実装): {missing_tools}"
+        )
+        assert not empty_doc_tools, (
+            f"以下の tool の docstring 1 行目が空: {empty_doc_tools} (AC-naming-2 未実装)"
+        )

--- a/cli/twl/tests/test_issue_1114_autopilot_tools.py
+++ b/cli/twl/tests/test_issue_1114_autopilot_tools.py
@@ -663,7 +663,7 @@ class TestAC45InvariantBCwdCheck:
         from twl.mcp_server.tools import twl_worktree_create_handler
 
         with patch("os.getcwd", return_value="/tmp/proj/worktrees/feat-test"):
-            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/worktrees/feat-test")):
+            with patch("os.path.realpath", return_value="/tmp/proj/worktrees/feat-test"):
                 result = twl_worktree_create_handler(
                     branch="feat/999-test",
                     timeout_sec=60,
@@ -684,7 +684,7 @@ class TestAC45InvariantBCwdCheck:
         from twl.mcp_server.tools import twl_worktree_delete_handler
 
         with patch("os.getcwd", return_value="/tmp/proj/worktrees/feat-test"):
-            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/worktrees/feat-test")):
+            with patch("os.path.realpath", return_value="/tmp/proj/worktrees/feat-test"):
                 result = twl_worktree_delete_handler(
                     branch="feat/999-test",
                     timeout_sec=60,
@@ -705,7 +705,7 @@ class TestAC45InvariantBCwdCheck:
         from twl.mcp_server.tools import twl_worktree_create_handler
 
         with patch("os.getcwd", return_value="/tmp/proj/main"):
-            with patch("pathlib.Path.resolve", return_value=Path("/tmp/proj/main")):
+            with patch("os.path.realpath", return_value="/tmp/proj/main"):
                 # 通常実行パスで WorktreeManager.create が呼ばれる想定
                 # 実際の git コマンドは mock して create 自体はエラーになってよい
                 with patch(


### PR DESCRIPTION
## 概要

Issue #1114: autopilot 系 MCP tool 12 個を tools.py に追加（統合 epic #1101 子 4）。

## 変更内容

### tools.py — 12 tool + handler 追加
- mergegate 系: `twl_mergegate_run`, `twl_mergegate_reject`, `twl_mergegate_reject_final`
- orchestrator 系: `twl_orchestrator_phase_review`, `twl_orchestrator_get_phase_issues`, `twl_orchestrator_summary`, `twl_orchestrator_resolve_repos`
- worktree 系: `twl_worktree_create`, `twl_worktree_delete`, `twl_worktree_list`, `twl_worktree_generate_branch_name`, `twl_worktree_validate_branch_name`

### worktree.py — 新規 method 追加
- `WorktreeManager.delete(branch_name)`: worktree 削除 + branch 削除
- `WorktreeManager.list_porcelain()`: list[dict] 形式で worktree 一覧返却

### 設計方針
- Hybrid Path 5 原則踏襲 (handler pure / json.dumps / try/except ImportError / 明示引数 / 1 ファイル集約)
- SystemExit catch + ThreadPoolExecutor timeout wrap (action 系 tool)
- CWD-based 不変条件 B role check (realpath 適用)
- plan_file existence check (orchestrator_phase_review / get_phase_issues)
- fastmcp あり/なし 両ブランチ対応

## テスト
- 50 test PASS (pytest tests/test_issue_1114_autopilot_tools.py)
- 既存テスト 1784 PASS

Closes #1114