### PR TITLE
fix(mcp): merge-gate specialist 指摘修正 — tools.py / worktree.py follow-up (#1114)

### DIFF
--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -256,6 +256,8 @@ def twl_mergegate_reject_handler(
             return {"ok": True, "message": "rejected", "exit_code": 0}
         except SystemExit as e:
             code = int(e.code) if e.code is not None else 0
+            if code == 0:
+                return {"ok": True, "message": "rejected (exit 0)", "exit_code": 0}
             return {"ok": False, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
         except MergeGateError as e:
             return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
@@ -310,6 +312,8 @@ def twl_mergegate_reject_final_handler(
             return {"ok": True, "message": "final rejection completed", "exit_code": 0}
         except SystemExit as e:
             code = int(e.code) if e.code is not None else 0
+            if code == 0:
+                return {"ok": True, "message": "reject_final completed (exit 0)", "exit_code": 0}
             return {"ok": False, "error": f"merge_gate exit code {code}", "error_type": f"merge_exit_{code}", "exit_code": code}
         except MergeGateError as e:
             return {"ok": False, "error": str(e), "error_type": "merge_gate_error", "exit_code": 1}
@@ -333,9 +337,13 @@ def twl_orchestrator_phase_review_handler(
     project_dir: str,
     autopilot_dir: str,
     repos_json: str = "",
+    cwd: str | None = None,
     timeout_sec: int = 1800,
 ) -> dict:
-    """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
+    """autopilot.orchestrator: invoke PhaseOrchestrator.run() with CWD-based 不変条件 B role check + handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
+    violation = _check_invariant_b(cwd)
+    if violation:
+        return violation
     if not Path(plan_file).is_file():
         return {"ok": False, "error": "plan_file not found", "error_type": "arg_error", "exit_code": 2}
 
@@ -389,6 +397,8 @@ def twl_orchestrator_summary_handler(
         summary = generate_summary(autopilot_dir=autopilot_dir)
         return {"ok": True, "result": summary, "exit_code": 0}
     except OrchestratorError as e:
+        return {"ok": False, "error": str(e), "error_type": "orchestrator_error", "exit_code": 1}
+    except Exception as e:
         return {"ok": False, "error": str(e), "error_type": "orchestrator_error", "exit_code": 1}
 
 
@@ -472,6 +482,8 @@ def twl_worktree_delete_handler(
         except WorktreeArgError as e:
             return {"ok": False, "error": str(e), "error_type": "arg_error", "exit_code": 2}
         except WorktreeError as e:
+            return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
+        except Exception as e:
             return {"ok": False, "error": str(e), "error_type": "worktree_error", "exit_code": 1}
 
     if timeout_sec is None:
@@ -613,9 +625,9 @@ try:
         return json.dumps(twl_mergegate_reject_final_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
-    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", timeout_sec: int = 1800) -> str:
+    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", cwd: str | None = None, timeout_sec: int = 1800) -> str:
         """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
-        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, timeout_sec=timeout_sec), ensure_ascii=False)
+        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
     def twl_orchestrator_get_phase_issues(phase: int, plan_file: str) -> str:
@@ -721,9 +733,9 @@ except ImportError:
         """autopilot.mergegate: invoke MergeGate.reject_final() with SystemExit catch + timeout wrap (300s)."""
         return json.dumps(twl_mergegate_reject_final_handler(pr_number=pr_number, reason=reason, autopilot_dir=autopilot_dir, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
 
-    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", timeout_sec: int = 1800) -> str:  # type: ignore[misc]
+    def twl_orchestrator_phase_review(phase: int, plan_file: str, session_file: str, project_dir: str, autopilot_dir: str, repos_json: str = "", cwd: str | None = None, timeout_sec: int = 1800) -> str:  # type: ignore[misc]
         """autopilot.orchestrator: invoke PhaseOrchestrator.run() with handler-level timeout wrap (1800s wall-clock guard for tmux + state.py subprocess). Note: set MCP_CLIENT_TIMEOUT>=1860s. plan_file existence check + tmux FileNotFoundError catch."""
-        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, timeout_sec=timeout_sec), ensure_ascii=False)
+        return json.dumps(twl_orchestrator_phase_review_handler(phase=phase, plan_file=plan_file, session_file=session_file, project_dir=project_dir, autopilot_dir=autopilot_dir, repos_json=repos_json, cwd=cwd, timeout_sec=timeout_sec), ensure_ascii=False)
 
     def twl_orchestrator_get_phase_issues(phase: int, plan_file: str) -> str:  # type: ignore[misc]
         """autopilot.orchestrator: pure get_phase_issues() (read-only, no subprocess). plan_file existence check."""

--- a/cli/twl/tests/test_issue_1114_autopilot_tools.py
+++ b/cli/twl/tests/test_issue_1114_autopilot_tools.py
@@ -499,6 +499,7 @@ class TestAC42OrchestratorHandlers:
             session_file="/tmp/session.json",
             project_dir="/tmp/proj",
             autopilot_dir="/tmp/.autopilot",
+            cwd="/tmp/main",
             timeout_sec=60,
         )
         assert isinstance(result, dict), "handler が dict を返さない (AC4-2 未実装)"
@@ -532,6 +533,7 @@ class TestAC42OrchestratorHandlers:
                     session_file="/tmp/session.json",
                     project_dir="/tmp/proj",
                     autopilot_dir="/tmp/.autopilot",
+                    cwd="/tmp/main",
                     timeout_sec=60,
                 )
         finally:
@@ -755,14 +757,14 @@ class TestAC46CriticalAssertions:
         assert isinstance(result, dict), (
             f"twl_worktree_list_handler が dict を返さない: {type(result)} (AC4-6 未実装)"
         )
-        assert "worktrees" in result or "items" in result or "ok" in result, (
-            f"dict に worktrees/items/ok キーがない: {list(result.keys())} (AC4-6 未実装)"
+        assert "ok" in result, (
+            f"dict に ok キーがない: {list(result.keys())} (AC4-6 未実装)"
         )
-        # ok=True の場合 worktrees フィールドが list[dict] であること
+        # ok=True の場合 "result" フィールドが list[dict] であること
         if result.get("ok"):
-            worktrees = result.get("worktrees") or result.get("items") or []
-            assert isinstance(worktrees, list), (
-                f"worktrees が list でない: {type(worktrees)} (AC4-6 未実装)"
+            entries = result.get("result", [])
+            assert isinstance(entries, list), (
+                f"result フィールドが list でない: {type(entries)} (AC4-6 未実装)"
             )
 
     def test_ac46_twl_worktree_validate_branch_name_handler_catches_worktree_arg_error(self):


### PR DESCRIPTION
## 背景

PR #1127（Issue #1114）の squash merge 後、merge-gate specialist review で指摘された問題の follow-up 修正。

feature branch 上の commit `2ec66d45` (`fix: merge-gate specialist 指摘修正 (exception/invariant-B/test)`) は squash merge のタイミングにより main の squash 合流コミット `da5fee68` に取り込まれず、結果として 5 件の指摘修正が main に未反映のまま残っている（`git blame -L 593,600 cli/twl/src/twl/mcp_server/tools.py` で `da5fee68` が現状を所有していることから確認済）。

本 Issue で 2ec66d45 の差分 (`cli/twl/src/twl/mcp_server/tools.py` +14/-3, `cli/twl/tests/test_issue_1114_autopilot_tools.py` +2/-2) を main に再適用する。

> Issue タイトルの "tools.py / worktree.py follow-up" の **`worktree.py` は単体ファイルとして存在しない**（`cli/twl/src/twl/mcp_server/` 配下に worktree handler は tools.py 内に統合済 — `_check_invariant_b` ヘルパー L744、`twl_worktree_create_handler` L766、`twl_worktree_delete_handler` L793 が同一ファイル内）。便宜上タイトルは保持するが、変更対象は単一ファイル `tools.py` + テスト 1 ファイル。

## 修正内容

すべて単一ファイル `cli/twl/src/twl/mcp_server/tools.py` への局所修正と、`cli/twl/tests/test_issue_1114_autopilot_tools.py` への引数追加。

### M1: `twl_mergegate_reject_handler` SystemExit(0) 非対称解消（tools.py L595-597）

現状 `SystemExit` を全て `ok: False / error_type: merge_exit_{code}` で扱っているが、MergeGate 側で `code == 0` (正常終了) を区別したいケースが merge-gate specialist で指摘された。`code == 0` のときのみ `ok: True / message: "rejected (exit 0)"` を返す early-return を追加する。

### M2: `twl_mergegate_reject_final_handler` SystemExit(0) 非対称解消（tools.py L649-651）

M1 と同型の修正。`reject_final()` 経路でも `code == 0` を `ok: True / message: "reject_final completed (exit 0)"` で early-return する。

> **対称性の意味**: 両 handler の **構造**（`if code == 0` 早期 return → ok:True、それ以外 → 既存の `merge_exit_{code}`）を一致させることが「対称」の意図。message 文字列は handler 名を反映するため意図的に異なる（"rejected (exit 0)" vs "reject_final completed (exit 0)"）。

### M3: `twl_orchestrator_phase_review_handler` 不変条件 B CWD check 追加（tools.py L667-678）

handler シグネチャに `cwd: str | None = None` 引数を追加し、本体冒頭で `_check_invariant_b(cwd)` 呼び出し（既存ヘルパー L744）を追加する。これは worktree create/delete handler (L766, L800) と同じ不変条件 B プロトコルへ揃えるもの。違反時の戻り値契約は既存ヘルパーに従い `{ok: False, error_type: "invariant_b_violation", exit_code: 1}` となる。

### M4: MCP wrapper 二重 branch への `cwd` 引数伝搬（tools.py L954 / L1077）

tools.py には MCP wrapper が 2 箇所定義されている:

- **try branch** (`try: ... import FastMCP ...`) 配下: `def twl_orchestrator_phase_review(...)` 関数定義は **L954**、handler 呼び出し return 文が **L956**
- **except-ImportError branch** (`except ImportError: ...`) 配下の fallback: 関数定義は **L1077**、handler 呼び出し return 文が **L1079**

両 branch のシグネチャに `cwd: str | None = None` を追加し、handler 呼び出しに `cwd=cwd` を渡す。**片方のみの修正は不可**（FastMCP 不在環境で機能不全になるため）。

### M5: `twl_orchestrator_summary_handler` 汎用例外カバレッジ（tools.py L729-730）

現状 `OrchestratorError` のみキャッチしているが、`except Exception` を末尾に追加し、未知例外でも MCP プロセスがクラッシュせず `ok: False / error_type: orchestrator_error` を返すようにする。

### M6: `twl_worktree_delete_handler._inner()` 汎用例外カバレッジ（tools.py L803-813）

現状 `WorktreeArgError` / `WorktreeError` のみキャッチ。`except Exception` を末尾に追加し、未知例外で MCP プロセスをクラッシュさせない。

> 参考: `twl_worktree_create_handler._inner()` (L780) には既に `except Exception` 実装済。M6 は create/delete の非対称性を解消する。

### M7: phase_review handler テスト引数修正（test_issue_1114_autopilot_tools.py 内）

`TestAC42OrchestratorHandlers` 内の `phase_review_handler` 呼び出し 2 箇所に `cwd="/tmp/main"` を追加。位置:

- 呼び出し 1: テストメソッド `test_ac42_*_returns_dict` 系（メソッド定義 L483、handler 呼び出し開始 L496、引数行 L499 付近）
- 呼び出し 2: テストメソッド `test_ac42_*_tmux_not_found` 系（メソッド定義 L513、handler 呼び出し開始 L529、引数行 L533 付近）

M3 で `cwd` 引数を追加するためテスト側も整合させる必要がある。

## 受け入れ基準（AC）

各 AC は機械検証可能。検証コマンドを **inline で各 AC に併記**する。

- [ ] **AC1**: `twl_mergegate_reject_handler` の `except SystemExit` 節に `if code == 0:` early-return が存在する
  ```bash
  awk '/def twl_mergegate_reject_handler/,/^def /' cli/twl/src/twl/mcp_server/tools.py | grep -nE 'if code == 0:.*return.*"ok": True' && echo OK
  ```
- [ ] **AC2**: `twl_mergegate_reject_final_handler` の `except SystemExit` 節にも対称な `if code == 0:` early-return が存在する
  ```bash
  awk '/def twl_mergegate_reject_final_handler/,/^def /' cli/twl/src/twl/mcp_server/tools.py | grep -nE 'if code == 0:.*return.*"ok": True' && echo OK
  ```
- [ ] **AC3a**: `twl_orchestrator_phase_review_handler` のシグネチャに `cwd: str | None = None` 引数が存在し、本体冒頭で `_check_invariant_b(cwd)` を呼び出している
  ```bash
  awk '/def twl_orchestrator_phase_review_handler/,/^def /' cli/twl/src/twl/mcp_server/tools.py | grep -nE 'cwd: str \| None|_check_invariant_b\(cwd\)'
  # 期待: 両方ヒット
  ```
- [ ] **AC3b**: cwd を `/tmp/worktrees/test` 等 `/worktrees/` 配下にして handler を直接呼び出すと戻り値が `{ok: False, error_type: "invariant_b_violation", exit_code: 1}` になる
  ```bash
  python3 -c "from twl.mcp_server.tools import twl_orchestrator_phase_review_handler as h; r = h(phase=1, plan_file='/dev/null', session_file='/tmp/s', project_dir='/tmp/p', autopilot_dir='/tmp/a', cwd='/tmp/worktrees/test'); assert r.get('error_type') == 'invariant_b_violation' and r.get('exit_code') == 1, r; print('OK')"
  ```
- [ ] **AC4**: MCP wrapper の **try branch (L954 周辺)** と **except-ImportError branch (L1077 周辺)** の両方の `twl_orchestrator_phase_review` シグネチャに `cwd` が存在し、handler 呼び出しに `cwd=cwd` が渡されている
  ```bash
  # 両 branch の関数定義に cwd が現れることを確認（2 件ヒット必須）
  COUNT=$(grep -nE 'def twl_orchestrator_phase_review\(.*cwd' cli/twl/src/twl/mcp_server/tools.py | wc -l)
  test "$COUNT" -ge 2 && echo "OK ($COUNT branches)" || { echo "FAIL: only $COUNT branch(es) updated"; exit 1; }
  # handler 呼び出しに cwd=cwd が渡る箇所も 2 件ヒット必須
  CALL_COUNT=$(grep -nE 'twl_orchestrator_phase_review_handler\(.*cwd=cwd' cli/twl/src/twl/mcp_server/tools.py | wc -l)
  test "$CALL_COUNT" -ge 2 && echo "OK ($CALL_COUNT calls)" || { echo "FAIL: only $CALL_COUNT call(s)"; exit 1; }
  ```
- [ ] **AC5**: `twl_orchestrator_summary_handler` の最後の except 節として `except Exception` が存在する
  ```bash
  awk '/def twl_orchestrator_summary_handler/,/^def /' cli/twl/src/twl/mcp_server/tools.py | grep -nE 'except Exception' && echo OK
  ```
- [ ] **AC6**: `twl_worktree_delete_handler._inner()` の最後の except 節として `except Exception` が存在する
  ```bash
  awk '/def twl_worktree_delete_handler/,/^def /' cli/twl/src/twl/mcp_server/tools.py | grep -nE 'except Exception' && echo OK
  ```
- [ ] **AC7**: `cli/twl/tests/test_issue_1114_autopilot_tools.py` の `TestAC42OrchestratorHandlers` 内 `phase_review_handler` 呼び出し 2 箇所に `cwd="/tmp/main"` 引数が含まれている
  ```bash
  awk '/class TestAC42OrchestratorHandlers/,/^class /' cli/twl/tests/test_issue_1114_autopilot_tools.py | grep -nE 'cwd="/tmp/main"' | wc -l | awk '$1 >= 2 {print "OK"; exit 0} {print "FAIL: " $1; exit 1}'
  ```
- [ ] **AC8**: `pytest cli/twl/tests/test_issue_1114_autopilot_tools.py -v` の **failure 件数が main HEAD 時点の baseline と比べて増加していない**（テストファイル先頭に「TDD RED フェーズ用スタブ」コメントがあるため、PASS 数は同等以上、FAIL 数は同等以下を必須とする）
  ```bash
  # 実装者が PR description に baseline (main HEAD pytest 出力の summary) を貼り、PR PR PR HEAD の summary と比較する
  # 検証例: pytest --tb=no -q | tail -1 を main HEAD と PR HEAD で取得し、失敗件数が non-decreasing でないこと
  ```
- [ ] **AC9**: `pytest cli/twl/tests/` 全体（test_issue_1114_autopilot_tools.py 以外）で本 PR が **新規 failure を導入していない**（main HEAD で PASS していたテストが PR HEAD で FAIL に転じない）
  ```bash
  pytest cli/twl/tests/ --ignore=cli/twl/tests/test_issue_1114_autopilot_tools.py -q
  # 実装者は main HEAD の同コマンド結果と diff を取り、新規 failure 0 を確認する
  ```

## スコープ

| 種別 | パス | 変更行数（目安） |
|---|---|---|
| 編集 | `cli/twl/src/twl/mcp_server/tools.py` | +14 / -3 |
| 編集 | `cli/twl/tests/test_issue_1114_autopilot_tools.py` | +2 / -0 |

変更ファイル数: **2**。1 PR で完結する小粒（commit 2ec66d45 の差分そのまま再適用＋必要なら微修正）。

**スコープ外**:
- `tools_comm.py` の `time.sleep` blocking 問題（→ #1138）
- `tools_comm.py` の allow-list ハードコード（→ #1139）
- 他の MCP handler（`twl_orchestrator_summary_handler` 等）への不変条件 B 横展開（必要なら別 Issue 起票）
- `twl_worktree_create_handler._inner()` の `except Exception` 整理（既に L780 に実装済のため対象外）

## 技術メモ

### 参照

- 元 Issue（親 epic 子 4）: #1114（CLOSED）
- 元 PR: #1127（MERGED at `da5fee68`）
- 親 epic: #1101（mcp tools 拡充）
- 同期先 commit: `2ec66d45b4c6dcd1c99439a424835a9c20832a03`（feature branch 上、main に squash 合流から漏れた）

### コード位置（main 現状, refine 時点）

| 対象 | path | line |
|---|---|---|
| `twl_mergegate_reject_handler` (def) | `cli/twl/src/twl/mcp_server/tools.py` | 557 |
| `twl_mergegate_reject_final_handler` (def) | 同上 | 611 |
| `twl_orchestrator_phase_review_handler` (def) | 同上 | 667 |
| `twl_orchestrator_summary_handler` (def) | 同上 | 721 |
| `twl_worktree_delete_handler` (def) | 同上 | 793 |
| `_check_invariant_b` (既存ヘルパー) | 同上 | 744 |
| MCP wrapper `twl_orchestrator_phase_review` try branch (def 行 / return 行) | 同上 | 954 / 956 |
| MCP wrapper except-ImportError branch (def 行 / return 行) | 同上 | 1077 / 1079 |
| AC42 test method (`test_ac42_*_returns_dict`) | `cli/twl/tests/test_issue_1114_autopilot_tools.py` | 483 (def) / 496 (call open) / 499 (arg row) |
| AC42 test method (`test_ac42_*_tmux_not_found`) | 同上 | 513 (def) / 529 (call open) / 533 (arg row) |

### 検証コマンド全体実行（任意）

```bash
# AC1〜AC7 を一括チェック（exit code 集約）
bash -c '
set -e
awk "/def twl_mergegate_reject_handler/,/^def /" cli/twl/src/twl/mcp_server/tools.py | grep -qE "if code == 0:" || { echo "AC1 FAIL"; exit 1; }
awk "/def twl_mergegate_reject_final_handler/,/^def /" cli/twl/src/twl/mcp_server/tools.py | grep -qE "if code == 0:" || { echo "AC2 FAIL"; exit 1; }
awk "/def twl_orchestrator_phase_review_handler/,/^def /" cli/twl/src/twl/mcp_server/tools.py | grep -qE "_check_invariant_b\(cwd\)" || { echo "AC3a FAIL"; exit 1; }
test $(grep -cE "def twl_orchestrator_phase_review\(.*cwd" cli/twl/src/twl/mcp_server/tools.py) -ge 2 || { echo "AC4 def FAIL"; exit 1; }
test $(grep -cE "twl_orchestrator_phase_review_handler\(.*cwd=cwd" cli/twl/src/twl/mcp_server/tools.py) -ge 2 || { echo "AC4 call FAIL"; exit 1; }
awk "/def twl_orchestrator_summary_handler/,/^def /" cli/twl/src/twl/mcp_server/tools.py | grep -qE "except Exception" || { echo "AC5 FAIL"; exit 1; }
awk "/def twl_worktree_delete_handler/,/^def /" cli/twl/src/twl/mcp_server/tools.py | grep -qE "except Exception" || { echo "AC6 FAIL"; exit 1; }
test $(awk "/class TestAC42OrchestratorHandlers/,/^class /" cli/twl/tests/test_issue_1114_autopilot_tools.py | grep -cE "cwd=\"/tmp/main\"") -ge 2 || { echo "AC7 FAIL"; exit 1; }
echo "AC1-AC7: OK"
'
```

### 関連（context）

- #1138 — tech-debt: `tools_comm.py` blocking `time.sleep` in asyncio context
- #1139 — tech-debt: `tools_comm.py` `_is_known_receiver` hardcoded allow-list
- #1101 — epic: twl MCP server tools 拡充

## ラベル候補

- `scope/cli-twl` — 主変更箇所が `cli/twl/` 配下（5 軸ラベル: path-based scope）
- `ctx/autopilot` — autopilot mergegate / worktree / orchestrator 領域（`plugins/twl/architecture/domain/contexts/autopilot.md` ドメイン）
- `refined` — refine 適用後付与（co-issue 終了時に dual-write で付与）
