### PR TITLE
feat(observer): 並列 spawn 自律判断 rule を機械化（pitfalls §11.3 update）

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2666,6 +2666,11 @@ scripts:
     description: "Issue/PR body + 全 comments 取得ヘルパー（gh_read_issue_full / gh_read_pr_full 関数: content-reading は body + comments 必須ポリシーを実装）"
 
   # observer window 存在確認共通ライブラリ (#948 Phase AA 2026-04-24)
+  observer-parallel-check:
+    type: script
+    path: scripts/lib/observer-parallel-check.sh
+    description: "観察的並列 spawn 可否判定ライブラリ（source 専用）: _check_parallel_spawn_eligibility() で 3 必須条件 + 3 precondition を AND 評価（§11.3 update, Issue #1116）。exit 0=≤4並列OK / exit 1=≤2並列degrade / exit 2=spawn禁止。env var injection で全条件 override 可"
+
   observer-window-check:
     type: script
     path: scripts/lib/observer-window-check.sh

--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# observer-parallel-check.sh: 並列 spawn 可否判定ライブラリ（source 専用）
+#
+# 背景（Issue #1116, pitfalls-catalog.md §11.3）:
+#   observer が自律的に複数 controller を並列 spawn する際の条件判定を機械化する。
+#   SKILL.md 文書のみでは observer LLM が「読まずに通過」するため、
+#   spawn-controller.sh に統合して機械的 enforcement を実現する。
+#
+# 使用方法:
+#   source "$(dirname "$0")/../scripts/lib/observer-parallel-check.sh"
+#   _check_parallel_spawn_eligibility && echo "≤4 並列 OK" || echo "spawn 不可"
+#
+# exit コード:
+#   0: 全条件 PASS → ≤ 4 並列 OK
+#   1: precondition 1つでも false → ≤ 2 並列 degrade（stderr に欠落 precondition）
+#   2: 必須条件 1つでも false → spawn 完全禁止（stderr に欠落必須条件）
+#
+# env var injection（テスト・override 用）:
+#   OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS     - atomicity 保証用タイムスタンプ（秒）
+#   OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE - "true"/"false"（必須条件1）
+#   OBSERVER_PARALLEL_CHECK_MODE            - permission mode（必須条件2）
+#   OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT - eligible controller 数（必須条件3）
+#   OBSERVER_PARALLEL_CHECK_MONITOR_CLD     - "true"/"false"（precondition4）
+#   OBSERVER_PARALLEL_CHECK_STATES          - controller states（space-separated）（precondition5）
+#   OBSERVER_PARALLEL_CHECK_BUDGET_MIN      - budget 残量（分）（precondition6）
+#   OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD - 閾値（分、default 150）
+#
+# NOTE: set -euo pipefail は意図的に省略（source 専用ライブラリ）
+
+# ---------------------------------------------------------------------------
+# check_controller_heartbeat_alive: controller の heartbeat が生存しているか確認
+#
+# 引数:
+#   $1: snapshot_ts（秒）
+#
+# 出力:
+#   "true" または "false"（stdout）
+#
+# 実装根拠（su-observer-supervise-channels.md L60-89）:
+#   observer 自身の heartbeat 更新（writer=observer）は判定対象から除外する（§15.3）。
+#   .supervisor/events/heartbeat-* ファイルの mtime を確認する。
+# ---------------------------------------------------------------------------
+check_controller_heartbeat_alive() {
+  local snapshot_ts="${1:-$(date +%s)}"
+  local supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+  local events_dir="${supervisor_dir}/events"
+  local max_age=300  # 5分
+
+  local found_alive=false
+  if [[ -d "$events_dir" ]]; then
+    while IFS= read -r -d '' hb_file; do
+      # observer 自身の heartbeat は除外（writer=observer）
+      local writer
+      writer=$(jq -r '.writer // "pilot"' "$hb_file" 2>/dev/null || echo "pilot")
+      if [[ "$writer" == "observer" ]]; then
+        continue
+      fi
+
+      # mtime チェック: snapshot_ts から max_age 秒以内に更新されていれば alive
+      local mtime
+      mtime=$(stat -c '%Y' "$hb_file" 2>/dev/null || echo "0")
+      if (( snapshot_ts - mtime <= max_age )); then
+        found_alive=true
+        break
+      fi
+    done < <(find "$events_dir" -name "heartbeat-*" -type f -print0 2>/dev/null)
+  fi
+
+  echo "$found_alive"
+}
+
+# ---------------------------------------------------------------------------
+# check_observer_mode: observer の permission mode を取得
+#
+# 出力:
+#   "auto", "bypass", "default", "plan", etc.（stdout）
+#
+# 判定方法（§11.3 必須条件2）:
+#   .supervisor/session.json の mode field を参照。
+#   field 不在時は --permission-mode flag の grep でフォールバック。
+# ---------------------------------------------------------------------------
+check_observer_mode() {
+  local supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+  local session_file="${supervisor_dir}/session.json"
+
+  # .supervisor/session.json の mode field を優先
+  if [[ -f "$session_file" ]]; then
+    local mode
+    mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+    if [[ -n "$mode" ]]; then
+      echo "$mode"
+      return
+    fi
+  fi
+
+  # フォールバック: プロセス引数から --permission-mode を grep
+  local mode_from_ps
+  mode_from_ps=$(ps aux 2>/dev/null | grep 'cld\b' | grep -oP '(?:--permission-mode\s+)\K\S+' | head -1 || echo "")
+  if [[ -n "$mode_from_ps" ]]; then
+    echo "$mode_from_ps"
+    return
+  fi
+
+  echo "unknown"
+}
+
+# ---------------------------------------------------------------------------
+# count_eligible_controllers: eligible な controller 数を返す
+#
+# 引数:
+#   $1: snapshot_ts（秒）
+#
+# 出力:
+#   controller 数（stdout）
+#
+# 実装根拠（§11.3 必須条件3）:
+#   tmux list-windows で (ap-|wt-co-).* パターンの window を count。
+#   直近 30 秒以内に spawn された controller は false positive 回避のため除外。
+# ---------------------------------------------------------------------------
+count_eligible_controllers() {
+  local snapshot_ts="${1:-$(date +%s)}"
+  local recent_threshold=30
+
+  local count=0
+  while IFS= read -r window_name; do
+    [[ -z "$window_name" ]] && continue
+    # (ap-|wt-co-) パターンのみ対象
+    if [[ ! "$window_name" =~ ^(ap-|wt-co-) ]]; then
+      continue
+    fi
+    # 直近 30 秒以内 spawn の window を除外（LLM_INDICATORS 未 emit による false positive 回避）
+    # window の pane-start-time で判定
+    local start_time
+    start_time=$(tmux display-message -t "$window_name" -p '#{pane_start_time}' 2>/dev/null || echo "0")
+    if (( snapshot_ts - start_time < recent_threshold )); then
+      continue
+    fi
+    (( count++ )) || true
+  done < <(tmux list-windows -a -F '#{window_name}' 2>/dev/null || echo "")
+
+  echo "$count"
+}
+
+# ---------------------------------------------------------------------------
+# check_monitor_cld_observe_alive: Monitor tool と cld-observe-any が起動しているか確認
+#
+# 出力:
+#   "true" または "false"（stdout）
+#
+# 実装根拠（§4.1, precondition4）:
+#   プロセスリストから cld-observe-any の存在を確認する。
+# ---------------------------------------------------------------------------
+check_monitor_cld_observe_alive() {
+  # cld-observe-any プロセスの存在確認
+  if pgrep -f "cld-observe-any" >/dev/null 2>&1; then
+    echo "true"
+  else
+    echo "false"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# get_controller_states: eligible controller の状態を返す
+#
+# 引数:
+#   $1: snapshot_ts（秒）
+#
+# 出力:
+#   space-separated list of states（S-2/S-3/S-4 等）（stdout）
+#
+# 実装根拠（precondition5）:
+#   cld-observe-any --once --pattern で各 controller の状態を取得する。
+# ---------------------------------------------------------------------------
+get_controller_states() {
+  local snapshot_ts="${1:-$(date +%s)}"
+  local cld_observe_any="${CLD_OBSERVE_ANY:-$(dirname "$0")/../../../../plugins/session/scripts/cld-observe-any}"
+
+  local states=()
+  while IFS= read -r window_name; do
+    [[ -z "$window_name" ]] && continue
+    if [[ ! "$window_name" =~ ^(ap-|wt-co-) ]]; then
+      continue
+    fi
+
+    # session-state.sh で状態取得
+    local state
+    state=$(bash "${SESSION_STATE_SH:-scripts/session-state.sh}" state "$window_name" 2>/dev/null || echo "S-0")
+    states+=("$state")
+  done < <(tmux list-windows -a -F '#{window_name}' 2>/dev/null || echo "")
+
+  echo "${states[*]:-}"
+}
+
+# ---------------------------------------------------------------------------
+# get_budget_minutes_remaining: budget 残量（分）を返す
+#
+# 出力:
+#   残量分数（stdout）。取得不能時は -1
+#
+# 実装根拠（precondition6）:
+#   cld-observe-any の get_budget_minutes() ロジックに準拠。
+#   Pilot window の pane から budget 情報を抽出する。
+# ---------------------------------------------------------------------------
+get_budget_minutes_remaining() {
+  local pilot_window="${PILOT_WINDOW:-}"
+
+  if [[ -z "$pilot_window" ]]; then
+    # supervisor/session.json から Pilot window を推定
+    local session_file="${SUPERVISOR_DIR:-.supervisor}/session.json"
+    if [[ -f "$session_file" ]]; then
+      pilot_window=$(jq -r '.pilot_window // empty' "$session_file" 2>/dev/null || echo "")
+    fi
+  fi
+
+  if [[ -z "$pilot_window" ]]; then
+    echo "-1"
+    return
+  fi
+
+  # budget 情報抽出（budget-detect.sh パターン準拠）
+  local pane_content
+  pane_content=$(tmux capture-pane -t "$pilot_window" -p -S -1 2>/dev/null || echo "")
+
+  local budget_pct budget_raw
+  budget_pct=$(echo "$pane_content" | grep -oP '5h:\K[0-9]+(?=%)' | tail -1 || echo "")
+  budget_raw=$(echo "$pane_content" | grep -oP '5h:[0-9]+%\(\K[^\)]+' | tail -1 || echo "")
+
+  if [[ -n "$budget_pct" && "$budget_pct" =~ ^[0-9]+$ ]]; then
+    # 5h budget から残量計算: 300分 × (100 - 消費%) / 100
+    echo $(( 300 * (100 - budget_pct) / 100 ))
+  elif [[ -n "$budget_raw" ]]; then
+    # 時間形式をパース
+    if [[ "$budget_raw" =~ ^([0-9]+)h([0-9]+)m$ ]]; then
+      echo $(( ${BASH_REMATCH[1]} * 60 + ${BASH_REMATCH[2]} ))
+    elif [[ "$budget_raw" =~ ^([0-9]+)h$ ]]; then
+      echo $(( ${BASH_REMATCH[1]} * 60 ))
+    elif [[ "$budget_raw" =~ ^([0-9]+)m$ ]]; then
+      echo "${BASH_REMATCH[1]}"
+    else
+      echo "-1"
+    fi
+  else
+    echo "-1"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# get_parallel_spawn_min_remaining_minutes: 並列 spawn 許可の budget 閾値（分）を返す
+#
+# 出力:
+#   閾値分数（stdout）。default 150
+#
+# 実装根拠（precondition6）:
+#   .supervisor/budget-config.json の parallel_spawn_min_remaining_minutes を参照。
+#   既存 threshold_remaining_minutes(default 40) とは独立した新規 key。
+# ---------------------------------------------------------------------------
+get_parallel_spawn_min_remaining_minutes() {
+  local config_file="${SUPERVISOR_DIR:-.supervisor}/budget-config.json"
+  local default_threshold=150
+
+  if [[ -f "$config_file" ]]; then
+    local threshold
+    threshold=$(jq -r '.parallel_spawn_min_remaining_minutes // empty' "$config_file" 2>/dev/null || echo "")
+    if [[ -n "$threshold" && "$threshold" =~ ^[0-9]+$ ]]; then
+      echo "$threshold"
+      return
+    fi
+  fi
+
+  echo "$default_threshold"
+}
+
+# ---------------------------------------------------------------------------
+# _check_parallel_spawn_eligibility: 並列 spawn 可否を AND 評価する純関数
+#
+# 戻り値:
+#   0: 全条件 PASS → ≤ 4 並列 OK
+#   1: precondition 1つでも false → ≤ 2 並列 degrade（stderr に欠落 precondition）
+#   2: 必須条件 1つでも false → spawn 完全禁止（stderr に欠落必須条件）
+# ---------------------------------------------------------------------------
+_check_parallel_spawn_eligibility() {
+  local snapshot_ts="${OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS:-$(date +%s)}"
+
+  # --- 各条件の評価 ---
+  local heartbeat_alive="${OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE:-$(check_controller_heartbeat_alive "$snapshot_ts")}"
+  local mode="${OBSERVER_PARALLEL_CHECK_MODE:-$(check_observer_mode)}"
+  local controller_count="${OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT:-$(count_eligible_controllers "$snapshot_ts")}"
+  local monitor_cld_alive="${OBSERVER_PARALLEL_CHECK_MONITOR_CLD:-$(check_monitor_cld_observe_alive)}"
+  local controller_states="${OBSERVER_PARALLEL_CHECK_STATES:-$(get_controller_states "$snapshot_ts")}"
+  local budget_min="${OBSERVER_PARALLEL_CHECK_BUDGET_MIN:-$(get_budget_minutes_remaining)}"
+  local budget_threshold="${OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD:-$(get_parallel_spawn_min_remaining_minutes)}"
+
+  # --- 必須条件評価（3つ, causally decisive） ---
+  local missing_must=()
+
+  # 必須条件1: controller heartbeat alive (≤ 5min)
+  if [[ "$heartbeat_alive" != "true" ]]; then
+    missing_must+=("heartbeat_alive=false: controller の heartbeat が 5分以内に更新されていない（§11.1）")
+  fi
+
+  # 必須条件2: permission mode が bypass または auto
+  if [[ "$mode" != "bypass" && "$mode" != "auto" ]]; then
+    missing_must+=("mode=${mode}: bypass または auto mode が必要（Layer A-D 自律実行可能性）")
+  fi
+
+  # 必須条件3: SU-4 整合: controller_count + 1 <= 4
+  if (( controller_count + 1 > 4 )); then
+    missing_must+=("controller_count=${controller_count}: +1=$(( controller_count + 1 )) > 4（SU-4 ≤5 整合違反）")
+  fi
+
+  if [[ ${#missing_must[@]} -gt 0 ]]; then
+    echo "DENY: 必須条件不足 — spawn 完全禁止" >&2
+    for msg in "${missing_must[@]}"; do
+      echo "  - $msg" >&2
+    done
+    return 2
+  fi
+
+  # --- precondition 評価（3つ, derivative） ---
+  local missing_pre=()
+
+  # precondition4: Monitor + cld-observe-any 起動
+  if [[ "$monitor_cld_alive" != "true" ]]; then
+    missing_pre+=("monitor_cld_alive=false: Monitor tool + cld-observe-any が未起動（§4.1）")
+  fi
+
+  # precondition5: 全 eligible controller が S-2/S-3/S-4 のいずれか
+  if [[ -n "$controller_states" ]]; then
+    for state in $controller_states; do
+      if [[ "$state" != "S-2" && "$state" != "S-3" && "$state" != "S-4" && \
+            "$state" != "S-2 THINKING" && "$state" != "S-3 MENU-READY" && "$state" != "S-4 REVIEW-READY" ]]; then
+        # S-0/S-1/S-5 等の不正状態を検出
+        if [[ "$state" =~ ^S-[015] ]]; then
+          missing_pre+=("controller_states に ${state} が含まれる: S-2/S-3/S-4 以外は precondition 違反（§4.10）")
+          break
+        fi
+      fi
+    done
+  fi
+
+  # precondition6: budget 残量 >= 閾値
+  if [[ "$budget_min" != "-1" ]] && (( budget_min < budget_threshold )); then
+    missing_pre+=("budget_min=${budget_min} < threshold=${budget_threshold}: budget 不足（[BUDGET-LOW] 閾値とは独立）")
+  fi
+
+  if [[ ${#missing_pre[@]} -gt 0 ]]; then
+    echo "DEGRADE_TO_2: precondition 不足 — ≤ 2 並列に degrade" >&2
+    for msg in "${missing_pre[@]}"; do
+      echo "  - $msg" >&2
+    done
+    return 1
+  fi
+
+  return 0
+}

--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -47,17 +47,16 @@ check_controller_heartbeat_alive() {
   local max_age=300  # 5分
 
   local found_alive=false
+  local writer='' mtime=0
   if [[ -d "$events_dir" ]]; then
     while IFS= read -r -d '' hb_file; do
       # observer 自身の heartbeat は除外（writer=observer）
-      local writer
       writer=$(jq -r '.writer // "pilot"' "$hb_file" 2>/dev/null || echo "pilot")
       if [[ "$writer" == "observer" ]]; then
         continue
       fi
 
       # mtime チェック: snapshot_ts から max_age 秒以内に更新されていれば alive
-      local mtime
       mtime=$(stat -c '%Y' "$hb_file" 2>/dev/null || echo "0")
       if (( snapshot_ts - mtime <= max_age )); then
         found_alive=true
@@ -173,17 +172,15 @@ check_monitor_cld_observe_alive() {
 # ---------------------------------------------------------------------------
 get_controller_states() {
   local snapshot_ts="${1:-$(date +%s)}"
-  local cld_observe_any="${CLD_OBSERVE_ANY:-$(dirname "$0")/../../../../plugins/session/scripts/cld-observe-any}"
-
   local states=()
+  local state=''
   while IFS= read -r window_name; do
     [[ -z "$window_name" ]] && continue
     if [[ ! "$window_name" =~ ^(ap-|wt-co-) ]]; then
       continue
     fi
 
-    # session-state.sh で状態取得
-    local state
+    # session-state.sh で状態取得（SESSION_STATE_SH env var で override 可）
     state=$(bash "${SESSION_STATE_SH:-scripts/session-state.sh}" state "$window_name" 2>/dev/null || echo "S-0")
     states+=("$state")
   done < <(tmux list-windows -a -F '#{window_name}' 2>/dev/null || echo "")
@@ -326,6 +323,7 @@ _check_parallel_spawn_eligibility() {
 
   # precondition5: 全 eligible controller が S-2/S-3/S-4 のいずれか
   if [[ -n "$controller_states" ]]; then
+    local state=''
     for state in $controller_states; do
       if [[ "$state" != "S-2" && "$state" != "S-3" && "$state" != "S-4" && \
             "$state" != "S-2 THINKING" && "$state" != "S-3 MENU-READY" && "$state" != "S-4 REVIEW-READY" ]]; then

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -302,7 +302,7 @@ commit は行わず `.supervisor/pending-pitfall-append.diff` として保存。
 
 ## 11. Observer idle 中の session disconnect 対策（MUST）
 
-★HUMAN GATE — §11.3/§11.4 の段階化・ScheduleWakeup 判断はユーザー escalation が必要（session disconnect 回避の承認）
+★HUMAN GATE — §11.3 は機械チェック PASS 時は HUMAN GATE skip 可（`_check_parallel_spawn_eligibility()` exit 0）。機械チェック欠落時は依然 escalate。§11.4 ScheduleWakeup 判断はユーザー escalation が必要（session disconnect 回避の承認）
 
 ### 事象（2026-04-22 ipatho1 実例、doobidoo hash 5fc20a83）
 
@@ -343,9 +343,67 @@ done
 - doobidoo に task_state memory 保存
 - session 停止しても resume 可能な状態を確保
 
-**11.3 並列 spawn の段階化（SHOULD）**
+**11.3 並列 spawn の自律判断 rule（MUST/SHOULD — Issue #1116 update）**
 
-co-architect / co-issue の 3 並列 spawn より 1 つずつ serial 処理の方が session disconnect リスク小。2026-04-22 事例では 3 並列後の 24 分 idle で停止。直列なら各 10-15 分で完了し idle 期間短縮。
+**条件成立時 ≤ 4 並列 MUST、不成立時 ≤ 2 並列 SHOULD**（既存 §11 keyword 階層 MUST/SHOULD/MAY と整合）。
+判定は `scripts/lib/observer-parallel-check.sh` の `_check_parallel_spawn_eligibility()` を呼び出すことで機械化済み（`spawn-controller.sh` 統合済み）。
+
+### 並列 spawn 可否 flowchart（疑似コード）
+
+```
+spawn 前評価:
+  SNAPSHOT_TS=$(date +%s)  # atomicity 保証
+  # 直近 30 秒以内 spawn は判定対象から除外（LLM_INDICATORS 未 emit による false positive 回避）
+  eligible_controllers = exclude_recent_spawned(controllers, threshold=30s)
+
+  # 必須条件 (causally decisive — 3つ全て満たす場合のみ ≤ 4 並列許可)
+  must_1 = (controller_heartbeat_alive(SNAPSHOT_TS, exclude_observer_writer=true) within 5min)
+  must_2 = (mode in [bypass, auto])
+  must_3 = (count(eligible_controllers) + 1 <= 4)
+  if NOT (must_1 AND must_2 AND must_3): exit 2 + stderr "DENY: <欠落条件>"
+
+  # precondition (他章 MUST 再確認 — 3つ全て満たす場合のみ ≤ 4 許可、不足時は ≤ 2)
+  pre_4 = (Monitor + cld-observe-any 起動)
+  pre_5 = all(c.state in [S-2 THINKING, S-3 MENU-READY, S-4 REVIEW-READY] for c in eligible_controllers)
+  pre_6 = (budget_minutes_remaining >= ${parallel_spawn_min_remaining_minutes:-150})
+  if NOT (pre_4 AND pre_5 AND pre_6): exit 1 + stderr "DEGRADE_TO_2: <欠落 precondition>"
+
+  exit 0  # ≤ 4 並列 OK
+```
+
+### 必須条件の根拠（3つ、causally decisive）
+
+1. **§11.1 Monitor heartbeat alive (≤ 5min)** — controller の heartbeat のみ（observer 自身の writer_pid は §15.3 で除外）
+2. **bypass または auto mode** — Layer A-D 自律実行可能性。deny 連発による idle 化を防止
+3. **SU-4 ≤5 整合: controller_count + 1 ≤ 4** — observer は SU-4 計数に含めない（SKILL.md L89 順守）
+
+### Precondition（3つ）
+
+4. **§4.1 Monitor + cld-observe-any 同時起動** — pattern `(ap-|wt-co-).*`
+5. **既存 controller が S-2/S-3/S-4 のいずれか** — S-1 IDLE は §4.10 で cleanup 対象（#1117 で格上げ予定）
+6. **budget 残量 ≥ 150 分** — `.supervisor/budget-config.json` の `parallel_spawn_min_remaining_minutes`（default 150）。既存 `[BUDGET-LOW]` 閾値(40分)とは独立
+
+### 失敗時 degrade
+
+- 必須条件 1 つでも false → **spawn 完全禁止 (exit 2)**、stderr に欠落必須条件
+- precondition 1 つでも false → **≤ 2 並列 degrade (exit 1)**、stderr に欠落 precondition
+- 全条件 PASS → ≤ 4 並列許可 (exit 0)
+
+### 実証パターン（2026-04-29 ipatho2）
+
+本 Issue 起票セッションが 4 並列で正常運用した実績（§11.3 緩和の根拠）:
+
+1. **並列数**: 4 controller（#1111 refine + #1113 refine + #1114 refine + #1105 explore）+ 1 observer = 5 windows（SU-4 ≤5 内）
+2. **観測継続時間**: spawn から Wave 完了確認まで 3時間超、session disconnect なし
+3. **session disconnect**: なし（2026-04-22 の 3 並列 24分 idle 停止とは対照的）
+4. **Monitor heartbeat alive**: writer_pid != observer による除外済み、5min heartbeat で active state 維持確認
+5. **doobidoo hash（ローカル参照、cross-machine 不変ではない）**: `bce7a4b9`（post-MCP-restart 自律進行）/ `e4f97e77`（Round 2 完遂 + Plan A 一貫判断、4 並列実績）/ `39ade8bd`（本セッション補足）
+
+### 過去文脈（旧 §11.3 — 2026-04-22 事例の教訓）
+
+旧文言: 「co-architect / co-issue の 3 並列 spawn より 1 つずつ serial 処理の方が session disconnect リスク小。2026-04-22 事例では 3 並列後の 24 分 idle で停止。直列なら各 10-15 分で完了し idle 期間短縮。」
+
+この制約は §11.1 Monitor heartbeat が未実装だった当時の overly conservative な rule。heartbeat + 上記 precondition を満たせば 4 並列まで安全に運用可能であることを 2026-04-29 ipatho2 で実証した。
 
 **11.4 ScheduleWakeup / Cron の活用（MAY）**
 

--- a/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
@@ -81,3 +81,43 @@ proxy 対話の要点:
 - spawn 直後に `tmux pipe-pane -t <window> -o "cat >> /tmp/<ctrl>-<sess>.log"` でセットアップ
 - input-waiting 検知 → pipe-pane log を ANSI strip して質問を読む → `session-comm.sh inject` で応答
 - co-issue の specialist review は絶対にスキップしてはならない（SHALL）
+
+## spawn 前条件チェック (§11.3) — MUST
+
+**MUST**: controller を spawn する前に必ず `_check_parallel_spawn_eligibility()` を呼び出して並列 spawn 可否を機械判定すること（教訓: `feedback_skill_md_not_enough.md`）。
+
+`spawn-controller.sh` はこのチェックを冒頭で自動実行する。直接 `cld-spawn` を呼び出してはならない（MUST NOT）。
+
+### exit コードと対応アクション
+
+| exit code | 意味 | observer の対応 |
+|-----------|------|----------------|
+| 0 | 全条件 PASS | ≤ 4 並列で spawn 実行 |
+| 1 | precondition 欠落 | ≤ 2 並列に degrade して spawn（stderr の欠落 precondition を確認） |
+| 2 | 必須条件欠落 | spawn 完全禁止（stderr の欠落必須条件を確認し、条件充足後に retry） |
+
+### fallback 判断 tree
+
+```
+_check_parallel_spawn_eligibility
+├── exit 0 → spawn 実行（≤ 4 並列）
+├── exit 1 → degrade: 現在の並列数が ≤ 2 になるまで spawn を延期
+│             → 欠落 precondition を stderr で確認
+│             → 条件充足後に再判定
+└── exit 2 → spawn abort
+              → 欠落必須条件を stderr で確認
+              → Layer 2 Escalate（ユーザー確認）または条件充足後に retry
+              → 自律 retry path（将来実装予定、本 Issue は文書化まで）
+```
+
+### override（observer 判断による介入時のみ）
+
+```bash
+SKIP_PARALLEL_CHECK=1 spawn-controller.sh <skill> <prompt>
+```
+
+`SKIP_PARALLEL_CHECK=1` を設定した場合は intervention 記録 MUST:
+```bash
+# 必ず記録すること
+echo "SKIP_PARALLEL_CHECK=1 使用: <理由>" >> .supervisor/intervention-log.md
+```

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -52,7 +52,7 @@ elif [[ -f "$_PARALLEL_CHECK_LIB" ]]; then
   # shellcheck source=/dev/null
   source "$_PARALLEL_CHECK_LIB"
   _PARALLEL_CHECK_EXIT=0
-  _check_parallel_spawn_eligibility 2>&1 >&2 || _PARALLEL_CHECK_EXIT=$?
+  _check_parallel_spawn_eligibility || _PARALLEL_CHECK_EXIT=$?
   if [[ "$_PARALLEL_CHECK_EXIT" -eq 2 ]]; then
     echo "[spawn-controller] ERROR: 並列 spawn 禁止（必須条件欠落）— spawn を abort します" >&2
     exit 2

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -43,6 +43,25 @@ if [[ ! -x "$CLD_SPAWN" ]]; then
   exit 2
 fi
 
+# --- 並列 spawn 可否チェック（§11.3, Issue #1116）---
+# SKIP_PARALLEL_CHECK=1 で bypass 可（intervention 記録 MUST）
+_PARALLEL_CHECK_LIB="$TWILL_ROOT/plugins/twl/scripts/lib/observer-parallel-check.sh"
+if [[ "${SKIP_PARALLEL_CHECK:-0}" == "1" ]]; then
+  echo "[spawn-controller] WARN: SKIP_PARALLEL_CHECK=1 — §11.3 チェックをスキップ（intervention 記録 MUST）" >&2
+elif [[ -f "$_PARALLEL_CHECK_LIB" ]]; then
+  # shellcheck source=/dev/null
+  source "$_PARALLEL_CHECK_LIB"
+  _PARALLEL_CHECK_EXIT=0
+  _check_parallel_spawn_eligibility 2>&1 >&2 || _PARALLEL_CHECK_EXIT=$?
+  if [[ "$_PARALLEL_CHECK_EXIT" -eq 2 ]]; then
+    echo "[spawn-controller] ERROR: 並列 spawn 禁止（必須条件欠落）— spawn を abort します" >&2
+    exit 2
+  elif [[ "$_PARALLEL_CHECK_EXIT" -eq 1 ]]; then
+    echo "[spawn-controller] WARN: precondition 欠落 — ≤ 2 並列 degrade mode（spawn は続行）" >&2
+  fi
+fi
+# --- チェック終了 ---
+
 VALID_SKILLS=(co-explore co-issue co-architect co-autopilot co-project co-utility co-self-improve)
 
 usage() {

--- a/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
@@ -1,0 +1,635 @@
+#!/usr/bin/env bats
+# su-observer-parallel-check.bats - Issue #1116 AC5a/AC5b/AC6 RED テスト
+#
+# AC5a: observer-parallel-check.sh に _check_parallel_spawn_eligibility() 純関数を新規実装
+#       bats test を plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats に配置
+#       env var injection、8件以上のシナリオ
+# AC5b: observer-parallel-check.sh に 7 helper 関数の production 実装
+#       (check_controller_heartbeat_alive, check_observer_mode, count_eligible_controllers,
+#        check_monitor_cld_observe_alive, get_controller_states,
+#        get_budget_minutes_remaining, get_parallel_spawn_min_remaining_minutes)
+# AC6:  spawn-controller.sh 冒頭に _check_parallel_spawn_eligibility() 呼出を追加
+#       exit 2/1/0 それぞれの動作
+#
+# Coverage: unit (env var injection / exit コード仕様 / helper 関数定義確認)
+#
+# exit コード仕様:
+#   0: 全条件 PASS → ≤ 4 並列 OK
+#   1: precondition 1つでも false → ≤ 2 並列 degrade、stderr に欠落 precondition
+#   2: 必須条件 1つでも false → spawn 完全禁止、stderr に欠落必須条件
+
+load '../helpers/common'
+
+PARALLEL_CHECK_LIB=""
+SPAWN_CONTROLLER=""
+
+setup() {
+  common_setup
+  PARALLEL_CHECK_LIB="$REPO_ROOT/scripts/lib/observer-parallel-check.sh"
+  SPAWN_CONTROLLER="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC5a: observer-parallel-check.sh ファイル存在確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: observer-parallel-check.sh が共通ライブラリとして存在する
+# WHEN: plugins/twl/scripts/lib/observer-parallel-check.sh を参照する
+# THEN: ファイルが存在する
+# ---------------------------------------------------------------------------
+
+@test "AC5a: scripts/lib/observer-parallel-check.sh が存在する" {
+  # RED: 実装前は fail する（スクリプト未作成）
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: observer-parallel-check.sh に _check_parallel_spawn_eligibility() が定義されている
+# WHEN: observer-parallel-check.sh を source する
+# THEN: _check_parallel_spawn_eligibility 関数が定義されている
+# ---------------------------------------------------------------------------
+
+@test "AC5a: observer-parallel-check.sh に _check_parallel_spawn_eligibility() が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  grep -q '_check_parallel_spawn_eligibility' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に _check_parallel_spawn_eligibility() が定義されていない"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 全条件 PASS 時に exit 0 を返す（env var injection）
+# WHEN: 全必須条件 + 全 precondition を true に設定して呼び出す
+# THEN: exit 0（≤ 4 並列 OK）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: 全条件 PASS 時に exit 0 を返す（env var injection）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  # 全条件を PASS 状態に env var injection で設定
+  # 必須3条件: heartbeat_alive=true, mode=auto, controller_count=2(+1=3≤4)
+  # precondition3条件: monitor_cld_alive=true, states=S-2/S-3/S-4のみ, budget_min≥threshold
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: heartbeat_alive=false 時に exit 2 を返す（必須条件失敗）
+# WHEN: heartbeat_alive を false に設定
+# THEN: exit 2（spawn 完全禁止）、stderr に欠落必須条件
+# ---------------------------------------------------------------------------
+
+@test "AC5a: heartbeat_alive=false 時に exit 2 を返す（必須条件失敗）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 2 ]] \
+    || fail "exit コードは 2 であるべきだが $status だった（heartbeat_alive=false は必須条件失敗）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: mode=disabled 時に exit 2 を返す（必須条件失敗）
+# WHEN: mode を invalid な値（disabled）に設定
+# THEN: exit 2（spawn 完全禁止）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: mode=disabled 時に exit 2 を返す（必須条件失敗）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=disabled \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 2 ]] \
+    || fail "exit コードは 2 であるべきだが $status だった（mode=disabled は必須条件失敗）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count >= 4 時に exit 2 を返す（SU-4 上限超過）
+# WHEN: controller_count=4（+1=5>4）に設定
+# THEN: exit 2（spawn 完全禁止）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: controller_count=4（+1=5>4）時に exit 2 を返す（SU-4 上限超過）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=4 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 2 ]] \
+    || fail "exit コードは 2 であるべきだが $status だった（controller_count=4 は SU-4 上限超過）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: monitor_cld_alive=false 時に exit 1 を返す（precondition 失敗）
+# WHEN: monitor_cld_alive を false に設定（必須条件は全 PASS）
+# THEN: exit 1（≤ 2 並列 degrade）、stderr に欠落 precondition
+# ---------------------------------------------------------------------------
+
+@test "AC5a: monitor_cld_alive=false 時に exit 1 を返す（precondition 失敗）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=false \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 1 ]] \
+    || fail "exit コードは 1 であるべきだが $status だった（monitor_cld_alive=false は precondition 失敗）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: budget_min < budget_threshold 時に exit 1 を返す（precondition 失敗）
+# WHEN: budget_min=100, budget_threshold=150（不足）に設定
+# THEN: exit 1（≤ 2 並列 degrade）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: budget_min=100 < budget_threshold=150 時に exit 1 を返す（precondition 失敗）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=100 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 1 ]] \
+    || fail "exit コードは 1 であるべきだが $status だった（budget 不足は precondition 失敗）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller state に S-2/S-3/S-4 以外が含まれる時に exit 1 を返す
+# WHEN: states に S-0 を含む設定
+# THEN: exit 1（≤ 2 並列 degrade）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: states に S-0 が含まれる時に exit 1 を返す（precondition 失敗）" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-0 S-3' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 1 ]] \
+    || fail "exit コードは 1 であるべきだが $status だった（S-0 state は precondition 失敗）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 必須条件失敗は precondition 失敗より優先（exit 2）
+# WHEN: heartbeat_alive=false（必須）かつ monitor_cld_alive=false（precondition）
+# THEN: exit 2（必須条件失敗が優先）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: 必須条件失敗は precondition 失敗より優先して exit 2 を返す" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=false \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=100 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_failure
+  [[ "$status" -eq 2 ]] \
+    || fail "exit コードは 2 であるべきだが $status だった（必須条件失敗が precondition 失敗より優先されるべき）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: mode=bypass でも全条件 PASS 時に exit 0 を返す
+# WHEN: mode=bypass（bypass も valid）
+# THEN: exit 0（bypass も auto と同等に許可）
+# ---------------------------------------------------------------------------
+
+@test "AC5a: mode=bypass でも全条件 PASS 時に exit 0 を返す" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=bypass \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-2' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=180 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: 必須条件失敗時に stderr に欠落条件が出力される
+# WHEN: heartbeat_alive=false で呼び出す
+# THEN: stderr に heartbeat または必須条件に関するメッセージが出力される
+# ---------------------------------------------------------------------------
+
+@test "AC5a: 必須条件失敗時に stderr に欠落条件が出力される" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5a 未実装）"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3 S-4' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  # stderr（2>&1 でマージされた出力）に失敗条件のメッセージが含まれること
+  echo "$output" | grep -qiE 'heartbeat|必須|required|MUST|condition' \
+    || fail "heartbeat_alive 失敗時に stderr への欠落条件メッセージが出力されていない（出力: $output）"
+}
+
+# ===========================================================================
+# AC5b: 7 helper 関数の定義確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: 7 helper 関数が全て定義されている
+# WHEN: observer-parallel-check.sh の内容を確認する
+# THEN: 7つの helper 関数名が全て grep で発見できる
+# ---------------------------------------------------------------------------
+
+@test "AC5b: check_controller_heartbeat_alive 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'check_controller_heartbeat_alive' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に check_controller_heartbeat_alive() が定義されていない"
+}
+
+@test "AC5b: check_observer_mode 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'check_observer_mode' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に check_observer_mode() が定義されていない"
+}
+
+@test "AC5b: count_eligible_controllers 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'count_eligible_controllers' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に count_eligible_controllers() が定義されていない"
+}
+
+@test "AC5b: check_monitor_cld_observe_alive 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'check_monitor_cld_observe_alive' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に check_monitor_cld_observe_alive() が定義されていない"
+}
+
+@test "AC5b: get_controller_states 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'get_controller_states' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に get_controller_states() が定義されていない"
+}
+
+@test "AC5b: get_budget_minutes_remaining 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'get_budget_minutes_remaining' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に get_budget_minutes_remaining() が定義されていない"
+}
+
+@test "AC5b: get_parallel_spawn_min_remaining_minutes 関数が定義されている" {
+  # RED: 実装前は fail する
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない（前提条件 AC5b 未実装）"
+
+  grep -q 'get_parallel_spawn_min_remaining_minutes' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に get_parallel_spawn_min_remaining_minutes() が定義されていない"
+}
+
+# ===========================================================================
+# AC6: spawn-controller.sh の _check_parallel_spawn_eligibility() 呼出確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: spawn-controller.sh が _check_parallel_spawn_eligibility を呼び出す
+# WHEN: spawn-controller.sh の内容を確認する
+# THEN: _check_parallel_spawn_eligibility の呼び出しが冒頭付近に存在する
+# ---------------------------------------------------------------------------
+
+@test "AC6: spawn-controller.sh が _check_parallel_spawn_eligibility() を呼び出している" {
+  # RED: 実装前は fail する（spawn-controller.sh への呼出追加前）
+  [[ -f "$SPAWN_CONTROLLER" ]] \
+    || fail "spawn-controller.sh が存在しない: $SPAWN_CONTROLLER"
+
+  grep -q '_check_parallel_spawn_eligibility' "$SPAWN_CONTROLLER" \
+    || fail "spawn-controller.sh に _check_parallel_spawn_eligibility() の呼び出しが存在しない（AC6 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: spawn-controller.sh が observer-parallel-check.sh を source している
+# WHEN: spawn-controller.sh の内容を確認する
+# THEN: observer-parallel-check.sh を source する記述が存在する
+# ---------------------------------------------------------------------------
+
+@test "AC6: spawn-controller.sh が observer-parallel-check.sh を source している" {
+  # RED: 実装前は fail する
+  [[ -f "$SPAWN_CONTROLLER" ]] \
+    || fail "spawn-controller.sh が存在しない: $SPAWN_CONTROLLER"
+
+  grep -q 'observer-parallel-check' "$SPAWN_CONTROLLER" \
+    || fail "spawn-controller.sh に observer-parallel-check.sh の source 記述が存在しない（AC6 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: spawn-controller.sh が _check_parallel_spawn_eligibility exit 2 で abort する
+# WHEN: _check_parallel_spawn_eligibility が exit 2 を返す状態で spawn-controller.sh を呼び出す
+# THEN: spawn-controller.sh は早期終了し cld-spawn を呼び出さない
+# ---------------------------------------------------------------------------
+
+@test "AC6: _check_parallel_spawn_eligibility exit 2 時に spawn-controller.sh が abort する" {
+  # RED: 実装前は fail する
+  [[ -f "$SPAWN_CONTROLLER" ]] \
+    || fail "spawn-controller.sh が存在しない: $SPAWN_CONTROLLER"
+
+  # observer-parallel-check.sh stub: _check_parallel_spawn_eligibility が exit 2 を返す
+  local mock_lib="$SANDBOX/scripts/lib/observer-parallel-check.sh"
+  mkdir -p "$(dirname "$mock_lib")"
+  cat > "$mock_lib" <<'MOCK_LIB'
+#!/usr/bin/env bash
+check_controller_heartbeat_alive() { echo "false"; }
+check_observer_mode() { echo "auto"; }
+count_eligible_controllers() { echo "0"; }
+check_monitor_cld_observe_alive() { echo "true"; }
+get_controller_states() { echo ""; }
+get_budget_minutes_remaining() { echo "200"; }
+get_parallel_spawn_min_remaining_minutes() { echo "150"; }
+_check_parallel_spawn_eligibility() {
+  echo "ERROR: heartbeat_alive=false (必須条件失敗)" >&2
+  return 2
+}
+MOCK_LIB
+
+  # cld-spawn stub: 呼ばれたら log を残す
+  local cld_log="$SANDBOX/cld-spawn-called.log"
+  stub_command "cld-spawn" "echo 'called' >> '$cld_log'; exit 0"
+
+  # prompt file stub
+  local prompt_file="$SANDBOX/test-prompt.txt"
+  echo "test prompt content" > "$prompt_file"
+
+  run bash "$SPAWN_CONTROLLER" co-explore "$prompt_file"
+
+  # cld-spawn が呼ばれていないこと
+  [[ ! -f "$cld_log" ]] \
+    || fail "exit 2 時に cld-spawn が呼ばれてはならないが呼ばれた（AC6 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: spawn-controller.sh の _check_parallel_spawn_eligibility 呼出が bash -n で valid
+# WHEN: spawn-controller.sh を bash -n で構文チェックする
+# THEN: syntax error なし（exit 0）
+# ---------------------------------------------------------------------------
+
+@test "AC6: spawn-controller.sh が bash syntax として valid" {
+  # 既存テストとの重複を避けるため、AC6 実装後も syntax 確認
+  [[ -f "$SPAWN_CONTROLLER" ]] \
+    || fail "spawn-controller.sh が存在しない: $SPAWN_CONTROLLER"
+
+  run bash -n "$SPAWN_CONTROLLER"
+  assert_success
+}
+
+# ===========================================================================
+# AC7: deps.yaml に observer-parallel-check エントリ確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: deps.yaml に observer-parallel-check script エントリが存在する
+# WHEN: plugins/twl/deps.yaml を参照する
+# THEN: observer-parallel-check の type:script エントリが存在する
+# ---------------------------------------------------------------------------
+
+@test "AC7: deps.yaml に observer-parallel-check script エントリが存在する" {
+  # RED: 実装前は fail する（deps.yaml 更新前）
+  local deps_yaml
+  deps_yaml="$REPO_ROOT/deps.yaml"
+
+  [[ -f "$deps_yaml" ]] \
+    || fail "deps.yaml が存在しない: $deps_yaml"
+
+  grep -q 'observer-parallel-check' "$deps_yaml" \
+    || fail "deps.yaml に observer-parallel-check エントリが存在しない（AC7 未実装）"
+}
+
+# ===========================================================================
+# AC1/AC2/AC3: pitfalls-catalog.md §11.3 更新確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 に「条件成立時 ≤ 4 並列 MUST」が記載されている
+# WHEN: pitfalls-catalog.md §11.3 セクションを参照する
+# THEN: 4 並列 MUST の記述が存在する
+# ---------------------------------------------------------------------------
+
+@test "AC1: pitfalls-catalog.md §11.3 に '≤ 4 並列 MUST' または '4.*MUST' が記載されている" {
+  # RED: 実装前は fail する（pitfalls-catalog.md 未更新）
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  grep -qE '4.*MUST|MUST.*4|≤.*4.*MUST|4 並列.*MUST' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に '≤ 4 並列 MUST' 記述が存在しない（AC1 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 に判断 flowchart（疑似コード）が追加されている
+# WHEN: pitfalls-catalog.md §11.3 セクションを参照する
+# THEN: flowchart または pseudocode 相当の記述が存在する
+# ---------------------------------------------------------------------------
+
+@test "AC2: pitfalls-catalog.md §11.3 に flowchart/pseudocode が追加されている" {
+  # RED: 実装前は fail する（pitfalls-catalog.md 未更新）
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  # flowchart / pseudocode / 疑似コード / exit コード定義のいずれかが存在すること
+  grep -qiE 'flowchart|pseudocode|疑似コード|exit.*0|exit.*1|exit.*2|SNAPSHOT_TS|eligible_controller' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に flowchart/pseudocode 相当の記述が存在しない（AC2 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 末尾に 2026-04-29 ipatho2 の実証パターンが記載されている
+# WHEN: pitfalls-catalog.md §11.3 末尾セクションを参照する
+# THEN: 5行以上で doobidoo hash (bce7a4b9/e4f97e77/39ade8bd) を含む記述が存在する
+# ---------------------------------------------------------------------------
+
+@test "AC3: pitfalls-catalog.md §11.3 末尾に doobidoo hash (bce7a4b9) を含む実証パターンが記載されている" {
+  # RED: 実装前は fail する（pitfalls-catalog.md 未更新）
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  grep -q 'bce7a4b9' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に doobidoo hash 'bce7a4b9' が存在しない（AC3 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 末尾に doobidoo hash e4f97e77 が記載されている
+# ---------------------------------------------------------------------------
+
+@test "AC3: pitfalls-catalog.md §11.3 末尾に doobidoo hash (e4f97e77) が記載されている" {
+  # RED: 実装前は fail する
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  grep -q 'e4f97e77' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に doobidoo hash 'e4f97e77' が存在しない（AC3 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: su-observer-controller-spawn-playbook.md に「spawn 前条件チェック (§11.3)」セクションが存在する
+# WHEN: su-observer-controller-spawn-playbook.md を参照する
+# THEN: spawn 前条件チェック または _check_parallel_spawn_eligibility の記述が存在する
+# ---------------------------------------------------------------------------
+
+@test "AC4: su-observer-controller-spawn-playbook.md に spawn 前条件チェックセクションが存在する" {
+  # RED: 実装前は fail する（playbook 未更新）
+  local playbook
+  playbook="$REPO_ROOT/skills/su-observer/refs/su-observer-controller-spawn-playbook.md"
+
+  [[ -f "$playbook" ]] \
+    || fail "su-observer-controller-spawn-playbook.md が存在しない: $playbook"
+
+  grep -qiE 'spawn.*前.*条件|条件.*チェック.*spawn|_check_parallel_spawn_eligibility|11\.3' "$playbook" \
+    || fail "su-observer-controller-spawn-playbook.md に spawn 前条件チェックセクションが存在しない（AC4 未実装）"
+}


### PR DESCRIPTION
Closes #1116

## 概要

observer が複数 controller を自律的に並列 spawn する際の条件判定を機械化。
SKILL.md 文書のみに依存せず、`spawn-controller.sh` への check 統合で二段階 enforcement を実現。

## 変更ファイル

| ファイル | 種別 | 内容 |
|---------|------|------|
| `scripts/lib/observer-parallel-check.sh` | 新規 | `_check_parallel_spawn_eligibility()` 純関数（3必須+3precondition AND評価） |
| `tests/bats/scripts/su-observer-parallel-check.bats` | 新規 | 29テスト全PASS（env var injection） |
| `skills/su-observer/scripts/spawn-controller.sh` | 修正 | 冒頭に eligibility check 統合（exit 2/1/0 分岐） |
| `skills/su-observer/refs/pitfalls-catalog.md` | 修正 | §11.3 update（flowchart + 実証パターン + HUMAN GATE 段階緩和） |
| `skills/su-observer/refs/su-observer-controller-spawn-playbook.md` | 修正 | spawn 前条件チェックセクション追加 |
| `deps.yaml` | 修正 | observer-parallel-check script エントリ追加 |

## テスト

```
bats tests/bats/scripts/su-observer-parallel-check.bats
# 29/29 PASS
```

## AC 対応

- AC-1: pitfalls-catalog.md §11.3 update ✅
- AC-2: 判断 flowchart 追加 ✅
- AC-3: 実証パターン（doobidoo hash bce7a4b9/e4f97e77/39ade8bd）✅
- AC-4: spawn-playbook に spawn 前条件チェックセクション追加 ✅
- AC-5a: observer-parallel-check.sh 純関数実装 + bats test ✅
- AC-5b: 7 helper 関数実装 ✅
- AC-6: spawn-controller.sh への check 統合 ✅
- AC-7: deps.yaml エントリ追加 ✅