### PR TITLE
fix(su-observer): check_observer_mode の ps aux フォールバック撤去 + session-init.sh に mode 書込み追加 (#1134)

### DIFF
--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -76,13 +76,12 @@ check_controller_heartbeat_alive() {
 #
 # 判定方法（§11.3 必須条件2）:
 #   .supervisor/session.json の mode field を参照。
-#   field 不在時は --permission-mode flag の grep でフォールバック。
+#   field 不在または空文字の場合は "unknown" を返す（fail-closed）。
 # ---------------------------------------------------------------------------
 check_observer_mode() {
   local supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
   local session_file="${supervisor_dir}/session.json"
 
-  # .supervisor/session.json の mode field を優先
   if [[ -f "$session_file" ]]; then
     local mode
     mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
@@ -90,14 +89,6 @@ check_observer_mode() {
       echo "$mode"
       return
     fi
-  fi
-
-  # フォールバック: プロセス引数から --permission-mode を grep
-  local mode_from_ps
-  mode_from_ps=$(ps aux 2>/dev/null | grep 'cld\b' | grep -oP '(?:--permission-mode\s+)\K\S+' | head -1 || echo "")
-  if [[ -n "$mode_from_ps" ]]; then
-    echo "$mode_from_ps"
-    return
   fi
 
   echo "unknown"

--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -19,7 +19,8 @@ OBSERVER_WINDOW_NAME=$(tmux display-message -p '#W' 2>/dev/null || echo "")
 OBSERVER_MODE=""
 if [[ -r "/proc/$PPID/cmdline" ]]; then
   OBSERVER_MODE=$(tr '\0' ' ' < "/proc/$PPID/cmdline" \
-    | grep -oP '(?:--permission-mode\s+)\K\S+' || echo "")
+    | grep -oP '(?:--permission-mode )\K\S+' || echo "")
+  [[ -z "$OBSERVER_MODE" ]] && echo "[session-init] WARN: --permission-mode が $PPID の cmdline に見つかりません（mode は空文字で記録）" >&2 || true
 fi
 
 # session.json に書き込む

--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -15,23 +15,32 @@ CLAUDE_SESSION_ID_VAL=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/
   | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
 OBSERVER_WINDOW_NAME=$(tmux display-message -p '#W' 2>/dev/null || echo "")
 
+# 親プロセス (cld 本体) から --permission-mode を抽出（/proc/$PPID/cmdline 経由、self-pid ベース）
+OBSERVER_MODE=""
+if [[ -r "/proc/$PPID/cmdline" ]]; then
+  OBSERVER_MODE=$(tr '\0' ' ' < "/proc/$PPID/cmdline" \
+    | grep -oP '(?:--permission-mode\s+)\K\S+' || echo "")
+fi
+
 # session.json に書き込む
 python3 -c "
 import json, datetime, os, uuid
 supervisor_dir = os.environ.get('SUPERVISOR_DIR', '.supervisor')
 claude_session_id = os.environ.get('CLAUDE_SESSION_ID_VAL', '')
 observer_window = os.environ.get('OBSERVER_WINDOW_NAME', '')
+observer_mode = os.environ.get('OBSERVER_MODE', '')
 session_file = os.path.join(supervisor_dir, 'session.json')
 data = {
   'session_id': str(uuid.uuid4()),
   'claude_session_id': claude_session_id,
   'observer_window': observer_window,
+  'mode': observer_mode,
   'status': 'active',
   'started_at': datetime.datetime.utcnow().isoformat() + 'Z'
 }
 json.dump(data, open(session_file, 'w'), indent=2)
 print(f'[session-init] session.json 作成: {session_file}')
-" CLAUDE_SESSION_ID_VAL="$CLAUDE_SESSION_ID_VAL" OBSERVER_WINDOW_NAME="$OBSERVER_WINDOW_NAME"
+" CLAUDE_SESSION_ID_VAL="$CLAUDE_SESSION_ID_VAL" OBSERVER_WINDOW_NAME="$OBSERVER_WINDOW_NAME" OBSERVER_MODE="$OBSERVER_MODE"
 
 # audit on（CLAUDE_SESSION_ID_VAL を run-id として使用）
 if [[ -n "$CLAUDE_SESSION_ID_VAL" ]]; then

--- a/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
@@ -633,3 +633,158 @@ MOCK_LIB
   grep -qiE 'spawn.*前.*条件|条件.*チェック.*spawn|_check_parallel_spawn_eligibility|11\.3' "$playbook" \
     || fail "su-observer-controller-spawn-playbook.md に spawn 前条件チェックセクションが存在しない（AC4 未実装）"
 }
+
+# ===========================================================================
+# Issue #1134: check_observer_mode セクション
+# AC3/AC4/AC5/AC6/AC7/AC9/AC10/AC11
+# ===========================================================================
+# 共通前提:
+#   - OBSERVER_PARALLEL_CHECK_MODE は unset して実行（env バイパス防止）
+#   - SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor" を各テスト内で export
+#   - AC3 前提チェック: ps aux フォールバックブロック (L95-101) が削除済みであること
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario #1134-1: mode=auto 取得
+# GIVEN: .supervisor/session.json に {"mode":"auto"} が書かれている
+# WHEN: check_observer_mode() を OBSERVER_PARALLEL_CHECK_MODE unset で呼ぶ
+# THEN: "auto" を stdout に返す
+# RED: AC3（ps aux フォールバック削除）が未実装のため、フォールバック除去後に PASS
+# ---------------------------------------------------------------------------
+
+@test "AC9 #1134-1: mode=auto 取得 - session.json から mode=auto を返す" {
+  # AC3 前提: ps aux フォールバックブロックが削除されていること
+  # RED: 現在 L97 に ps aux フォールバックが残存しているため fail する
+  if grep -l 'ps aux' "$PARALLEL_CHECK_LIB" >/dev/null 2>&1; then
+    fail "AC3 未実装: observer-parallel-check.sh に ps aux フォールバックブロック (L95-101) が残存している（削除対象: check_observer_mode() 内の ps aux | grep 'cld\\b' | grep -oP ... ブロック）"
+  fi
+
+  # SUPERVISOR_DIR を tmpdir に設定（AC11: common_setup は SUPERVISOR_DIR を export しないため個別設定）
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+
+  mkdir -p "$SUPERVISOR_DIR"
+  echo '{"mode":"auto"}' > "$SUPERVISOR_DIR/session.json"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    check_observer_mode
+  "
+
+  assert_success
+  assert_output "auto"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario #1134-2: mode field 空 → unknown
+# GIVEN: .supervisor/session.json に {"mode":""} が書かれている
+# WHEN: check_observer_mode() を OBSERVER_PARALLEL_CHECK_MODE unset で呼ぶ
+# THEN: "unknown" を stdout に返す
+# RED: AC3（ps aux フォールバック削除）が未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC9 #1134-2: mode field 空 → unknown - session.json mode 空のとき unknown を返す" {
+  # AC3 前提: ps aux フォールバックブロックが削除されていること
+  # RED: 現在 L97 に ps aux フォールバックが残存しているため fail する
+  if grep -l 'ps aux' "$PARALLEL_CHECK_LIB" >/dev/null 2>&1; then
+    fail "AC3 未実装: observer-parallel-check.sh に ps aux フォールバックブロック (L95-101) が残存している（削除対象: check_observer_mode() 内の ps aux | grep 'cld\\b' | grep -oP ... ブロック）"
+  fi
+
+  # SUPERVISOR_DIR を tmpdir に設定（AC11: 個別設定必須）
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+
+  mkdir -p "$SUPERVISOR_DIR"
+  echo '{"mode":""}' > "$SUPERVISOR_DIR/session.json"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    check_observer_mode
+  "
+
+  assert_success
+  assert_output "unknown"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario #1134-3: file 不在 → unknown
+# GIVEN: .supervisor/session.json が存在しない
+# WHEN: check_observer_mode() を OBSERVER_PARALLEL_CHECK_MODE unset で呼ぶ
+# THEN: "unknown" を stdout に返す
+# RED: AC3（ps aux フォールバック削除）が未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC9 #1134-3: file 不在 → unknown - session.json 不在のとき unknown を返す" {
+  # AC3 前提: ps aux フォールバックブロックが削除されていること
+  # RED: 現在 L97 に ps aux フォールバックが残存しているため fail する
+  if grep -l 'ps aux' "$PARALLEL_CHECK_LIB" >/dev/null 2>&1; then
+    fail "AC3 未実装: observer-parallel-check.sh に ps aux フォールバックブロック (L95-101) が残存している（削除対象: check_observer_mode() 内の ps aux | grep 'cld\\b' | grep -oP ... ブロック）"
+  fi
+
+  # SUPERVISOR_DIR を tmpdir に設定（AC11: 個別設定必須）
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+
+  # session.json を作成しない（ディレクトリのみ作成）
+  mkdir -p "$SUPERVISOR_DIR"
+  # session.json は意図的に作成しない
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    check_observer_mode
+  "
+
+  assert_success
+  assert_output "unknown"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario #1134-4: fail-closed exit 2 with substring assert
+# GIVEN: .supervisor/session.json に {} （mode field なし）
+# AND: OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true, CONTROLLER_COUNT=2
+# AND: OBSERVER_PARALLEL_CHECK_MODE は unset（AC10: env バイパス防止）
+# WHEN: _check_parallel_spawn_eligibility() を呼ぶ
+# THEN: exit 2 かつ stderr に "bypass または auto mode が必要" を含む
+# RED: AC3（ps aux フォールバック削除）が未実装のため fail する
+# NOTE: assert_output --partial で substring 一致を確認（AC7 要件）
+# ---------------------------------------------------------------------------
+
+@test "AC9 #1134-4: fail-closed exit 2 - mode 不在で exit 2 かつ stderr substring assert" {
+  # AC3 前提: ps aux フォールバックブロックが削除されていること
+  # RED: 現在 L97 に ps aux フォールバックが残存しているため fail する
+  if grep -l 'ps aux' "$PARALLEL_CHECK_LIB" >/dev/null 2>&1; then
+    fail "AC3 未実装: observer-parallel-check.sh に ps aux フォールバックブロック (L95-101) が残存している（削除対象: check_observer_mode() 内の ps aux | grep 'cld\\b' | grep -oP ... ブロック）"
+  fi
+
+  # SUPERVISOR_DIR を tmpdir に設定（AC11: 個別設定必須）
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+
+  mkdir -p "$SUPERVISOR_DIR"
+  # mode field なし（AC7: mode 不在状態）
+  echo '{}' > "$SUPERVISOR_DIR/session.json"
+
+  # AC10: OBSERVER_PARALLEL_CHECK_MODE は unset のまま実行
+  # heartbeat と controller_count は pass させる（mode の fail-closed のみ観測）
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=2 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  # exit 2 であること
+  [[ "$status" -eq 2 ]] \
+    || fail "exit コードは 2 であるべきだが $status だった（mode 不在は必須条件失敗）"
+
+  # stderr に "bypass または auto mode が必要" が含まれること（AC7: assert_output --partial）
+  assert_output --partial "bypass または auto mode が必要"
+}


### PR DESCRIPTION
## 概要

Closes #1134

### 変更内容

**observer-parallel-check.sh::check_observer_mode() L95-101 の ps aux フォールバックを削除**
- 別 user プロセス誤認・grep self-match・race condition・head -1 順序非決定性を排除
- session.json の mode field 不在時は `"unknown"` を返す（fail-closed）

**session-init.sh に /proc/$PPID/cmdline 経由の --permission-mode 抽出を追加**
- self-pid ベースのため別 user 影響なし
- `/proc/$PPID/cmdline` 読取不能環境（macOS 等）では空文字 → 後段 fail-closed で対処
- session.json の data dict に `mode` field を追加

### テスト

`su-observer-parallel-check.bats` に 4 件のシナリオを追加（全 33 件 PASS）:
- `#1134-1`: mode=auto 取得（session.json から値を返す）
- `#1134-2`: mode field 空 → `"unknown"` を返す
- `#1134-3`: session.json 不在 → `"unknown"` を返す
- `#1134-4`: mode 不在で `_check_parallel_spawn_eligibility()` → exit 2 + stderr substring `"bypass または auto mode が必要"`

### セキュリティ改善

`ps aux` 撤去により host 共有時の別 user args 露出依存が消える。代替の `/proc/$PPID/cmdline` は self-pid なので別 user 影響なし。