### PR TITLE
feat(observer): IDLE_COMPLETED_AUTO_KILL=1 — idle 確定 window の自動 kill 実装 (#1132)

### DIFF
--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -468,7 +468,7 @@ declare -A IDLE_COMPLETED_TS
 
 # _check_idle_completed() の SSOT を source する
 # BASH_SOURCE[0] = plugins/session/scripts/cld-observe-any → ../twl/ = plugins/twl/
-_IDLE_CHECK_LIB="$(dirname "${BASH_SOURCE[0]}")/../twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+_IDLE_CHECK_LIB="$(dirname "${BASH_SOURCE[0]}")/../../twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
 if [[ -f "$_IDLE_CHECK_LIB" ]]; then
     # shellcheck source=/dev/null
     source "$_IDLE_CHECK_LIB"
@@ -527,6 +527,20 @@ while true; do
                 fi
                 # 60s ごとに継続 emit（observer が kill するまで繰り返す）
                 IDLE_COMPLETED_TS[$WIN]=$NOW
+                # opt-in auto-kill（IDLE_COMPLETED_AUTO_KILL=1 時のみ）
+                if [[ "${IDLE_COMPLETED_AUTO_KILL:-0}" == "1" ]]; then
+                    SAFE_WIN="${WIN//[^a-zA-Z0-9_-]/_}"
+                    if tmux kill-window -t "$WIN" 2>/dev/null; then
+                        echo "[IDLE-COMPLETED] $WIN: auto-killed (IDLE_COMPLETED_AUTO_KILL=1)"
+                        if [[ -n "$EVENT_DIR" ]]; then
+                            echo "{\"channel\":\"IDLE-COMPLETED-KILLED\",\"window\":\"${WIN}\",\"elapsed_sec\":$((NOW - FIRST_SEEN)),\"ts\":${NOW}}" \
+                                > "${EVENT_DIR}/idle-completed-killed-${SAFE_WIN}-$(date -u +%Y%m%dT%H%M%SZ).json"
+                        fi
+                        unset 'IDLE_COMPLETED_TS[$WIN]'
+                    else
+                        echo "[IDLE-COMPLETED] $WIN: auto-kill failed (window already gone or permission denied)" >&2
+                    fi
+                fi
             else
                 # completion phrase 初回検出 → first_seen_ts 記録
                 # C3: detect_thinking() で LLM indicator 不在確認（Thinking 中は false trigger を防ぐ）

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -530,7 +530,10 @@ while true; do
                 # opt-in auto-kill（IDLE_COMPLETED_AUTO_KILL=1 時のみ）
                 if [[ "${IDLE_COMPLETED_AUTO_KILL:-0}" == "1" ]]; then
                     SAFE_WIN="${WIN//[^a-zA-Z0-9_-]/_}"
-                    if tmux kill-window -t "$WIN" 2>/dev/null; then
+                    # evaluate_window() と同じ方法で session:index に解決し ambiguous target を回避
+                    KILL_TARGET=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null \
+                        | awk -v n="$WIN" '$2 == n { print $1; exit }')
+                    if [[ -n "$KILL_TARGET" ]] && tmux kill-window -t "$KILL_TARGET" 2>/dev/null; then
                         echo "[IDLE-COMPLETED] $WIN: auto-killed (IDLE_COMPLETED_AUTO_KILL=1)"
                         if [[ -n "$EVENT_DIR" ]]; then
                             echo "{\"channel\":\"IDLE-COMPLETED-KILLED\",\"window\":\"${WIN}\",\"elapsed_sec\":$((NOW - FIRST_SEEN)),\"ts\":${NOW}}" \

--- a/plugins/session/tests/ac-test-mapping.yaml
+++ b/plugins/session/tests/ac-test-mapping.yaml
@@ -1,105 +1,129 @@
+# ac-test-mapping.yaml — Issue #1132: feat(observer): IDLE_COMPLETED auto-kill
+# 生成: AC Scaffold Tests Agent
+# 対象テストファイル: plugins/session/tests/cld-observe-any.bats (Scenario 20-24)
+
 mappings:
   - ac_index: 1
-    ac_text: "並列で 10 並列送信しても全メッセージが正しい順で届く"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac1: flock による排他制御が実装されている"
-    status: GREEN
-    note: "flock 未実装のため FAIL"
+    ac_text: "IDLE_COMPLETED_AUTO_KILL 環境変数を参照し、未設定または 0 の場合は kill しない。1 の場合のみ自動 kill。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/1: IDLE_COMPLETED_AUTO_KILL 未設定 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 baseline）"
+    status: RED
+    note: "Scenario 20。opt-in env var の負例（未設定）。現実装でも PASS する baseline。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
   - ac_index: 1
-    ac_text: "並列で 10 並列送信しても全メッセージが正しい順で届く"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac1: send-keys が flock スコープ内にある"
-    status: GREEN
-    note: "flock 未実装のため FAIL"
-
-  - ac_index: 1
-    ac_text: "並列で 10 並列送信しても全メッセージが正しい順で届く"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac1: inject が flock を使用した排他送信を行う"
-    status: GREEN
-    note: "flock 未実装のため FAIL"
+    ac_text: "IDLE_COMPLETED_AUTO_KILL 環境変数を参照し、未設定または 0 の場合は kill しない。1 の場合のみ自動 kill。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/2: IDLE_COMPLETED_AUTO_KILL=0 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 explicit disable）"
+    status: RED
+    note: "Scenario 21。opt-in env var の負例（明示 0）。現実装でも PASS する baseline。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
   - ac_index: 2
-    ac_text: "受信側が input-waiting でない場合、送信は 5 秒待機後に retry"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac2: inject に retry ロジックが実装されている"
-    status: GREEN
-    note: "retry ロジック未実装のため FAIL"
+    ac_text: "IDLE_COMPLETED_TS[$WIN]=$NOW 直後で tmux kill-window -t $WIN を発行。成功時は stdout に [IDLE-COMPLETED] <WIN>: auto-killed (IDLE_COMPLETED_AUTO_KILL=1) log。失敗時は stderr に [IDLE-COMPLETED] <WIN>: auto-kill failed (...) log。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 22。auto-kill 未実装のため現状 fail。実装後 GREEN になる。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
   - ac_index: 2
-    ac_text: "受信側が input-waiting でない場合、送信は 5 秒待機後に retry"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac2: retry 前に 5 秒待機が実装されている"
-    status: GREEN
-    note: "sleep 5 未実装のため FAIL"
-
-  - ac_index: 2
-    ac_text: "受信側が input-waiting でない場合、送信は 5 秒待機後に retry"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac2: non-input-waiting 時に session-state.sh state が 2 回以上呼ばれる（retry 確認）"
-    status: GREEN
-    note: "retry 未実装: state は 1 回しか呼ばれず即 exit 2 するため FAIL"
-
-  - ac_index: 2
-    ac_text: "受信側が input-waiting でない場合、送信は 5 秒待機後に retry"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac2: 2 回目の状態確認で input-waiting になれば inject が exit 0 で成功する"
-    status: GREEN
-    note: "retry 未実装: 初回 processing で即 exit 2 するため FAIL"
+    ac_text: "IDLE_COMPLETED_TS[$WIN]=$NOW 直後で tmux kill-window -t $WIN を発行。成功時は stdout に [IDLE-COMPLETED] <WIN>: auto-killed (IDLE_COMPLETED_AUTO_KILL=1) log。失敗時は stderr に [IDLE-COMPLETED] <WIN>: auto-kill failed (...) log。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 23。auto-kill 未実装のため現状 fail。実装後 GREEN になる。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
   - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: cmd_inject 関数が定義されている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+    ac_text: "tmux kill-window exit 非 0 の場合、stderr に失敗 log を出力してメインループ継続。2>/dev/null で tmux stderr を抑制。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 23 で AC-3 も検証（exit 0 確認）。auto-kill 未実装のため現状 fail。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: cmd_inject_file 関数が定義されている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 4
+    ac_text: "kill 成功時に unset 'IDLE_COMPLETED_TS[$WIN]'。kill 失敗時は cleanup しない（IDLE_COMPLETED_TS[$WIN] は $NOW を保持）。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 22 で AC-4 も検証（state cleanup は killed JSON 非重複生成で間接確認）。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: inject が --force オプションをサポートしている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 5
+    ac_text: "EVENT_DIR 設定時、kill 成功後に idle-completed-killed-<safe_win>-<ts>.json を書き出し。フィールド: {channel:IDLE-COMPLETED-KILLED, window:<WIN>, elapsed_sec:<秒>, ts:<unix>}。kill 失敗時は生成しない。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 22 で idle-completed-killed-*.json 生成を検証。auto-kill 未実装のため現状 fail。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: inject が --no-enter オプションをサポートしている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 5
+    ac_text: "EVENT_DIR 設定時、kill 成功後に idle-completed-killed-<safe_win>-<ts>.json を書き出し。フィールド: {channel:IDLE-COMPLETED-KILLED, window:<WIN>, elapsed_sec:<秒>, ts:<unix>}。kill 失敗時は生成しない。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
+    status: RED
+    note: "Scenario 23 で kill 失敗時の JSON 非生成を検証。auto-kill 未実装のため現状 fail。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: inject-file が --wait オプションをサポートしている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 6
+    ac_text: "IDLE_COMPLETED_AUTO_KILL=0 または未設定の場合、既存 alert 動作を変更しない。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/1: IDLE_COMPLETED_AUTO_KILL 未設定 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 baseline）"
+    status: RED
+    note: "Scenario 20。AC-6 は現実装でも PASS する baseline regression テスト。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: inject が non-input-waiting かつ --force なしで exit 2 を返す（既存 API 維持）"
-    status: GREEN
-    note: "既存動作の確認テスト。実装後もタイムアウト時は exit 2 を維持すること"
+  - ac_index: 6
+    ac_text: "IDLE_COMPLETED_AUTO_KILL=0 または未設定の場合、既存 alert 動作を変更しない。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/2: IDLE_COMPLETED_AUTO_KILL=0 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 explicit disable）"
+    status: RED
+    note: "Scenario 21。AC-6 明示 0 ケース。現実装でも PASS する baseline regression テスト。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: メインディスパッチに inject-file が登録されている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 7
+    ac_text: "_check_idle_completed() C3 条件（LLM indicator 存在）で false return の場合は emit/kill 両方発生しない。コード変更なし、bats 検証のみ。"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC-9/5: LLM-active indicator 存在時 → IDLE_COMPLETED_AUTO_KILL=1 でも emit/kill 両方発生しない（AC-7 baseline）"
+    status: RED
+    note: "Scenario 24。AC-7 は現実装でも PASS する baseline。LLM indicator guard（C3）の検証。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
 
-  - ac_index: 3
-    ac_text: "既存の caller（autopilot-orchestrator, inject-next-workflow, su-observer 介入経路）の API 互換維持"
-    test_file: "plugins/session/tests/session-comm-robustness.test.sh"
-    test_name: "ac3: メインディスパッチに inject が登録されている"
-    status: GREEN
-    note: "既存実装のため PASS（baseline）"
+  - ac_index: 8
+    ac_text: "window pattern 制約維持。スコープ外、テスト不要。"
+    test_file: ""
+    test_name: ""
+    status: SKIP
+    note: "AC-8 はスコープ外。テスト不要。"
+    impl_files: []
+
+  - ac_index: 9
+    ac_text: "bats fixture 5 ケースを実装: ケース1-5 (Scenario 20-24)"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "Scenario 20-24（5 テスト）"
+    status: RED
+    note: "AC-9 自体はテスト生成完了。Scenario 20/21/24 は baseline（現状 PASS 可能）。Scenario 22/23 は実装後 GREEN。"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: 10
+    ac_text: "ドキュメント更新。bats テスト不要。"
+    test_file: ""
+    test_name: ""
+    status: SKIP
+    note: "AC-10 はドキュメント更新のみ。テスト不要。"
+    impl_files: []

--- a/plugins/session/tests/ac-test-mapping.yaml
+++ b/plugins/session/tests/ac-test-mapping.yaml
@@ -7,7 +7,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_AUTO_KILL 環境変数を参照し、未設定または 0 の場合は kill しない。1 の場合のみ自動 kill。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/1: IDLE_COMPLETED_AUTO_KILL 未設定 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 baseline）"
-    status: RED
+    status: GREEN
     note: "Scenario 20。opt-in env var の負例（未設定）。現実装でも PASS する baseline。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -16,7 +16,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_AUTO_KILL 環境変数を参照し、未設定または 0 の場合は kill しない。1 の場合のみ自動 kill。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/2: IDLE_COMPLETED_AUTO_KILL=0 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 explicit disable）"
-    status: RED
+    status: GREEN
     note: "Scenario 21。opt-in env var の負例（明示 0）。現実装でも PASS する baseline。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -25,7 +25,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_TS[$WIN]=$NOW 直後で tmux kill-window -t $WIN を発行。成功時は stdout に [IDLE-COMPLETED] <WIN>: auto-killed (IDLE_COMPLETED_AUTO_KILL=1) log。失敗時は stderr に [IDLE-COMPLETED] <WIN>: auto-kill failed (...) log。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 22。auto-kill 未実装のため現状 fail。実装後 GREEN になる。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -34,7 +34,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_TS[$WIN]=$NOW 直後で tmux kill-window -t $WIN を発行。成功時は stdout に [IDLE-COMPLETED] <WIN>: auto-killed (IDLE_COMPLETED_AUTO_KILL=1) log。失敗時は stderr に [IDLE-COMPLETED] <WIN>: auto-kill failed (...) log。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 23。auto-kill 未実装のため現状 fail。実装後 GREEN になる。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -43,7 +43,7 @@ mappings:
     ac_text: "tmux kill-window exit 非 0 の場合、stderr に失敗 log を出力してメインループ継続。2>/dev/null で tmux stderr を抑制。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 23 で AC-3 も検証（exit 0 確認）。auto-kill 未実装のため現状 fail。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -52,7 +52,7 @@ mappings:
     ac_text: "kill 成功時に unset 'IDLE_COMPLETED_TS[$WIN]'。kill 失敗時は cleanup しない（IDLE_COMPLETED_TS[$WIN] は $NOW を保持）。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 22 で AC-4 も検証（state cleanup は killed JSON 非重複生成で間接確認）。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -61,7 +61,7 @@ mappings:
     ac_text: "EVENT_DIR 設定時、kill 成功後に idle-completed-killed-<safe_win>-<ts>.json を書き出し。フィールド: {channel:IDLE-COMPLETED-KILLED, window:<WIN>, elapsed_sec:<秒>, ts:<unix>}。kill 失敗時は生成しない。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 22 で idle-completed-killed-*.json 生成を検証。auto-kill 未実装のため現状 fail。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -70,7 +70,7 @@ mappings:
     ac_text: "EVENT_DIR 設定時、kill 成功後に idle-completed-killed-<safe_win>-<ts>.json を書き出し。フィールド: {channel:IDLE-COMPLETED-KILLED, window:<WIN>, elapsed_sec:<秒>, ts:<unix>}。kill 失敗時は生成しない。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）"
-    status: RED
+    status: GREEN
     note: "Scenario 23 で kill 失敗時の JSON 非生成を検証。auto-kill 未実装のため現状 fail。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -79,7 +79,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_AUTO_KILL=0 または未設定の場合、既存 alert 動作を変更しない。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/1: IDLE_COMPLETED_AUTO_KILL 未設定 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 baseline）"
-    status: RED
+    status: GREEN
     note: "Scenario 20。AC-6 は現実装でも PASS する baseline regression テスト。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -88,7 +88,7 @@ mappings:
     ac_text: "IDLE_COMPLETED_AUTO_KILL=0 または未設定の場合、既存 alert 動作を変更しない。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/2: IDLE_COMPLETED_AUTO_KILL=0 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 explicit disable）"
-    status: RED
+    status: GREEN
     note: "Scenario 21。AC-6 明示 0 ケース。現実装でも PASS する baseline regression テスト。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -97,7 +97,7 @@ mappings:
     ac_text: "_check_idle_completed() C3 条件（LLM indicator 存在）で false return の場合は emit/kill 両方発生しない。コード変更なし、bats 検証のみ。"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "AC-9/5: LLM-active indicator 存在時 → IDLE_COMPLETED_AUTO_KILL=1 でも emit/kill 両方発生しない（AC-7 baseline）"
-    status: RED
+    status: GREEN
     note: "Scenario 24。AC-7 は現実装でも PASS する baseline。LLM indicator guard（C3）の検証。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"
@@ -115,7 +115,7 @@ mappings:
     ac_text: "bats fixture 5 ケースを実装: ケース1-5 (Scenario 20-24)"
     test_file: "plugins/session/tests/cld-observe-any.bats"
     test_name: "Scenario 20-24（5 テスト）"
-    status: RED
+    status: GREEN
     note: "AC-9 自体はテスト生成完了。Scenario 20/21/24 は baseline（現状 PASS 可能）。Scenario 22/23 は実装後 GREEN。"
     impl_files:
       - "plugins/session/scripts/cld-observe-any"

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -918,3 +918,331 @@ MOCKEOF
     # indicator なし + stagnate 超過 → STAGNATE は emit される（これは AC1/AC2 実装後も保持される仕様）
     echo "$output" | grep -q "STAGNATE"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1132: IDLE_COMPLETED_AUTO_KILL 機能 — AC-9 の 5 ケース
+#
+# テスト戦略:
+#   - IDLE-COMPLETED emit を発生させるには --max-cycles 2 + --interval 1 が必要
+#     Cycle 1: phrase 検出 → IDLE_COMPLETED_TS[$WIN]=$NOW を記録
+#     Cycle 2: FIRST_SEEN>0 かつ DEBOUNCE=0 → _check_idle_completed true → emit/kill 分岐
+#   - IDLE_COMPLETED_PHRASE_REGEX は readonly のため override 不可。
+#     既存 regex に含まれる "nothing pending" をキャプチャテキストに使用する。
+#   - kill stub 呼び出し検証: CALL_LOG ファイルへの記録で確認する
+#   - RED テスト（ケース3・4）: IDLE_COMPLETED_AUTO_KILL 実装前は fail する。
+#     auto-kill 実装後に GREEN になることを期待する。
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
+# Scenario 20: AC-9 ケース1 — IDLE_COMPLETED_AUTO_KILL 未設定 → alert のみ、kill なし
+#   AC-6 regression: 既存 alert 動作を変更しない baseline テスト
+#   このテストは現実装でも PASS する（自動 kill 機能がないため）
+# ---------------------------------------------------------------------------
+@test "AC-9/1: IDLE_COMPLETED_AUTO_KILL 未設定 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 baseline）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+CALL_LOG="$TMPD/tmux-calls.log"
+win="ap-ac9-case1-win"
+
+# IDLE_COMPLETED_PHRASE_REGEX にマッチするキャプチャ（"nothing pending" は regex SSOT に含まれる）
+capture="All tasks are done.
+nothing pending
+System is idle."
+export capture
+
+tmux() {
+    echo "$1 $*" >> "$CALL_LOG"
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        kill-window) return 0;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+# IDLE_COMPLETED_AUTO_KILL を未設定にする（unset で明示的に削除）
+unset IDLE_COMPLETED_AUTO_KILL
+
+IDLE_COMPLETED_DEBOUNCE_SEC=0 \
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" \
+    --max-cycles 2 --interval 1 2>/dev/null
+
+# kill-window が呼ばれていないことを確認
+if grep -q "kill-window" "$CALL_LOG" 2>/dev/null; then
+    echo "FAIL: kill-window が呼ばれた（IDLE_COMPLETED_AUTO_KILL 未設定なのに）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+echo "PASS: kill-window 呼び出しなし"
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    echo "$output" | grep -q "PASS: kill-window 呼び出しなし"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 21: AC-9 ケース2 — IDLE_COMPLETED_AUTO_KILL=0 → alert のみ、kill なし
+#   AC-6: 明示的に無効化した場合も既存動作を維持する baseline テスト
+#   このテストは現実装でも PASS する（自動 kill 機能がないため）
+# ---------------------------------------------------------------------------
+@test "AC-9/2: IDLE_COMPLETED_AUTO_KILL=0 → IDLE-COMPLETED emit のみ、kill-window 呼び出しなし（AC-6 explicit disable）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+CALL_LOG="$TMPD/tmux-calls.log"
+win="ap-ac9-case2-win"
+
+capture="All tasks are done.
+nothing pending
+System is idle."
+export capture
+
+tmux() {
+    echo "$1 $*" >> "$CALL_LOG"
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        kill-window) return 0;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+IDLE_COMPLETED_AUTO_KILL=0 \
+IDLE_COMPLETED_DEBOUNCE_SEC=0 \
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" \
+    --max-cycles 2 --interval 1 2>/dev/null
+
+if grep -q "kill-window" "$CALL_LOG" 2>/dev/null; then
+    echo "FAIL: kill-window が呼ばれた（IDLE_COMPLETED_AUTO_KILL=0 なのに）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+echo "PASS: kill-window 呼び出しなし"
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    echo "$output" | grep -q "PASS: kill-window 呼び出しなし"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 22: AC-9 ケース3 — IDLE_COMPLETED_AUTO_KILL=1 + kill-window stub 成功
+#   RED: auto-kill 未実装のため現状は fail する。実装後に GREEN になる。
+#   検証内容:
+#     - kill-window が 1 回呼び出される（AC-2）
+#     - stdout に "[IDLE-COMPLETED] <win>: auto-killed" ログが出る（AC-2）
+#     - idle-completed-killed-*.json が EVENT_DIR に生成される（AC-5）
+# ---------------------------------------------------------------------------
+@test "AC-9/3: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 成功 → kill 1回・auto-killed log・killed JSON 生成（RED: 実装後 PASS）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+EVENT_DIR_PATH="$TMPD/events"
+mkdir -p "$EVENT_DIR_PATH"
+win="ap-ac9-case3-win"
+export win
+
+capture="All tasks are done.
+nothing pending
+System is idle."
+export capture
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        kill-window)
+            # stub: 成功（exit 0）
+            return 0;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+output_text=$(IDLE_COMPLETED_AUTO_KILL=1 \
+    IDLE_COMPLETED_DEBOUNCE_SEC=0 \
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" \
+    --event-dir "$EVENT_DIR_PATH" \
+    --max-cycles 2 --interval 1 2>/dev/null)
+
+# 検証1: stdout に auto-killed ログが出たか（AC-2）
+if ! echo "$output_text" | grep -q "auto-killed"; then
+    echo "FAIL: stdout に auto-killed ログがない（output=$output_text）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+# 検証2: idle-completed-killed-*.json が生成されたか（AC-5）
+killed_json=$(find "$EVENT_DIR_PATH" -name "idle-completed-killed-*.json" 2>/dev/null | head -1)
+if [[ -z "$killed_json" ]]; then
+    echo "FAIL: idle-completed-killed-*.json が生成されなかった"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+echo "PASS: kill 1回・auto-killed log・killed JSON 生成"
+rm -rf "$TMPD"
+MOCKEOF
+
+    # RED: auto-kill 実装前は失敗する
+    # 実装後は [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS:" に変わる
+    [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS:"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 23: AC-9 ケース4 — IDLE_COMPLETED_AUTO_KILL=1 + kill-window stub 失敗
+#   RED: auto-kill 未実装のため現状は fail する。実装後に GREEN になる。
+#   検証内容:
+#     - メインループが継続する（exit 0）（AC-3）
+#     - stderr に "auto-kill failed" ログが出る（AC-2/AC-3）
+#     - idle-completed-killed-*.json は生成されない（AC-5 fail 時非生成）
+# ---------------------------------------------------------------------------
+@test "AC-9/4: IDLE_COMPLETED_AUTO_KILL=1 + kill-window 失敗 → exit 0・stderr failed log・killed JSON 非生成（RED: 実装後 PASS）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+EVENT_DIR_PATH="$TMPD/events"
+mkdir -p "$EVENT_DIR_PATH"
+win="ap-ac9-case4-win"
+export win
+
+capture="All tasks are done.
+nothing pending
+System is idle."
+export capture
+
+tmux() {
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        kill-window)
+            # stub: 失敗（exit 1）
+            return 1;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+# stderr を別ファイルに保存して確認
+STDERR_FILE="$TMPD/stderr.txt"
+IDLE_COMPLETED_AUTO_KILL=1 \
+    IDLE_COMPLETED_DEBOUNCE_SEC=0 \
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" \
+    --event-dir "$EVENT_DIR_PATH" \
+    --max-cycles 2 --interval 1 >/dev/null 2>"$STDERR_FILE"
+exit_code=$?
+stderr_text=$(cat "$STDERR_FILE" 2>/dev/null || echo "")
+
+# 検証1: exit 0（メインループ継続、graceful）（AC-3）
+if [[ "$exit_code" -ne 0 ]]; then
+    echo "FAIL: exit code $exit_code（期待: 0）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+# 検証2: stderr に auto-kill failed ログが出たか（AC-2/AC-3）
+if ! echo "$stderr_text" | grep -q "auto-kill failed"; then
+    echo "FAIL: stderr に auto-kill failed ログがない（stderr=$stderr_text）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+# 検証3: idle-completed-killed-*.json は生成されていないか（AC-5 kill 失敗時非生成）
+killed_json=$(find "$EVENT_DIR_PATH" -name "idle-completed-killed-*.json" 2>/dev/null | head -1)
+if [[ -n "$killed_json" ]]; then
+    echo "FAIL: kill 失敗なのに idle-completed-killed-*.json が生成された"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+echo "PASS: exit 0・failed log・killed JSON 非生成"
+rm -rf "$TMPD"
+MOCKEOF
+
+    # RED: auto-kill 実装前は失敗する
+    # 実装後は [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS:" に変わる
+    [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS:"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 24: AC-9 ケース5 — LLM-active indicator（"Thinking..."）存在時
+#   AC-7: _check_idle_completed C3 条件により emit/kill 両方発生しない
+#   このテストは現実装でも PASS する（LLM indicator guard は既存実装済み）
+# ---------------------------------------------------------------------------
+@test "AC-9/5: LLM-active indicator 存在時 → IDLE_COMPLETED_AUTO_KILL=1 でも emit/kill 両方発生しない（AC-7 baseline）" {
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+CALL_LOG="$TMPD/tmux-calls.log"
+win="ap-ac9-case5-win"
+
+# "nothing pending" は IDLE_COMPLETED_PHRASE_REGEX にマッチするが、
+# "Thinking..." は LLM indicator（C3 条件）として _check_idle_completed を false にする
+capture="All tasks are done.
+nothing pending
+Thinking... (5s)
+Analyzing next steps."
+export capture
+
+tmux() {
+    echo "$1 $*" >> "$CALL_LOG"
+    case "$1" in
+        list-windows) echo "test-session:0 $win";;
+        display-message) echo "0 claude";;
+        capture-pane)
+            if [[ "${*}" == *"-S -1"* ]]; then echo ""; else printf '%s\n' "$capture"; fi;;
+        kill-window)
+            return 0;;
+        *) return 0;;
+    esac
+}
+export -f tmux
+
+output_text=$(IDLE_COMPLETED_AUTO_KILL=1 \
+    IDLE_COMPLETED_DEBOUNCE_SEC=0 \
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
+    bash "$CLD_OBSERVE_ANY" --window "$win" \
+    --max-cycles 2 --interval 1 2>/dev/null)
+
+# 検証1: IDLE-COMPLETED は emit されていないか（C3 guard による）
+if echo "$output_text" | grep -q "IDLE-COMPLETED"; then
+    echo "FAIL: LLM indicator 存在時に IDLE-COMPLETED が emit された"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+# 検証2: kill-window は呼ばれていないか
+if grep -q "kill-window" "$CALL_LOG" 2>/dev/null; then
+    echo "FAIL: LLM indicator 存在時に kill-window が呼ばれた"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+echo "PASS: emit なし・kill-window 呼び出しなし"
+rm -rf "$TMPD"
+MOCKEOF
+
+    [[ "$status" -eq 0 ]]
+    echo "$output" | grep -q "PASS: emit なし・kill-window 呼び出しなし"
+}

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -19,7 +19,7 @@ Wave 開始時に本カタログから Wave 種別に応じたチャネルを選
 | **PILOT-PHASE-COMPLETE** | Pilot 内部 chain の Phase/Issue 完了 signal | 即時 | Auto |
 | **PILOT-ISSUE-MERGED** | Pilot が merge-gate で Issue merge を完了した signal | 即時 | Auto |
 | **PILOT-WAVE-COLLECTED** | Pilot が wave-collect を完了した signal | 即時 | Auto |
-| [IDLE-COMPLETED] | completion phrase 確認済み controller の idle 確定 (cleanup-trigger) | 60s debounce | Confirm |
+| [IDLE-COMPLETED] | completion phrase 確認済み controller の idle 確定 (cleanup-trigger) | 60s debounce | Confirm（IDLE_COMPLETED_AUTO_KILL=1 時は Auto） |
 
 ---
 
@@ -786,7 +786,7 @@ for WIN in "${TARGET_WINS[@]}"; do
 done
 ```
 
-**自動 kill オプション (`IDLE_COMPLETED_AUTO_KILL=1`) は別 Issue に切出済み。本 Issue は alert (Confirm) のみ。**
+**自動 kill オプション**: `IDLE_COMPLETED_AUTO_KILL=1`（opt-in、Issue #1132）で `[IDLE-COMPLETED]` 発火時に `tmux kill-window` を自動実行（Layer 0 Auto）。デフォルトは alert のみ（Layer 1 Confirm）。
 
 ---
 

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -119,7 +119,7 @@ tmux capture-pane -t <worker-win> -p -S -50 | grep -E '⏵⏵ auto mode|permissi
 
 **S-1 の区別（Issue #1117）**:
 - **S-1a IDLE（一時的、継続観察）**: completion phrase 未確認、または debounce 未達。タスク進行中の一時的な非活性として放置可
-- **S-1b IDLE 確定（cleanup 対象）**: completion phrase 60s 安定 → `[IDLE-COMPLETED]` 発火。`SU-4 ≤5` 制約（§4.5）圧迫回避のため速やかに kill する
+- **S-1b IDLE 確定（cleanup 対象）**: completion phrase 60s 安定 → `[IDLE-COMPLETED]` 発火。`SU-4 ≤5` 制約（§4.5）圧迫回避のため速やかに kill する。**`IDLE_COMPLETED_AUTO_KILL=1` 設定済みなら observer 介入不要（自動 cleanup、#1132）**
 
 **S-1b と §4.3（LLM-active-override）の関係**: A2 に現在進行形 indicator がある場合は S-2 THINKING 確定のため `[IDLE-COMPLETED]` 絶対 emit 禁止。`_check_idle_completed()` の C3 条件で保証済み。
 


### PR DESCRIPTION
## 概要

Issue #1132 の実装。`[IDLE-COMPLETED]` 発火時に `IDLE_COMPLETED_AUTO_KILL=1` 環境変数でオプトイン auto-kill を実行。

## 変更内容

### 実装
- `cld-observe-any`: `IDLE_COMPLETED_TS[$WIN]=$NOW` 直後に opt-in auto-kill 分岐追加（~14 lines）
  - `IDLE_COMPLETED_AUTO_KILL=1` のみ `tmux kill-window` を実行
  - 成功時: stdout ログ + `idle-completed-killed-<win>-<ts>.json` 書き出し + state cleanup
  - 失敗時: stderr ログのみ、state 保持（次サイクル再試行可能）
- パスバグ修正: `_IDLE_CHECK_LIB` の `../twl` → `../../twl`（`plugins/session/scripts/` → `plugins/twl/` への正しい相対パス）

### ドキュメント
- `monitor-channel-catalog.md` §[IDLE-COMPLETED]: note 更新 + 介入層表の Confirm → Auto 記載追加
- `pitfalls-catalog.md` §4.10 S-1b: `IDLE_COMPLETED_AUTO_KILL=1` note 追記

### テスト
- `cld-observe-any.bats` に AC-9 の 5 ケース追加（全 GREEN）
- `ac-test-mapping.yaml` を Issue #1132 用に更新

## AC 対応

- AC-1 ✓ opt-in env var（未設定/0 は kill なし）
- AC-2 ✓ kill 実行 + stdout/stderr log
- AC-3 ✓ kill 失敗時 graceful continue
- AC-4 ✓ kill 成功時 state cleanup（unset）
- AC-5 ✓ EVENT_DIR 設定時 JSON 書き出し
- AC-6 ✓ alert mode 後方互換（bats ケース1/2）
- AC-7 ✓ LLM-active-override 維持（bats ケース5）
- AC-8 ✓ out-of-scope
- AC-9 ✓ bats 5 ケース全 GREEN
- AC-10 ✓ ドキュメント 3 箇所更新

Closes #1132