### PR TITLE
fix(observer): SKIP_PARALLEL_CHECK=1 時に intervention-log へ自動記録 (#1135)

### DIFF
--- a/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
@@ -113,11 +113,7 @@ _check_parallel_spawn_eligibility
 ### override（observer 判断による介入時のみ）
 
 ```bash
-SKIP_PARALLEL_CHECK=1 spawn-controller.sh <skill> <prompt>
+SKIP_PARALLEL_CHECK=1 SKIP_PARALLEL_REASON="<reason>" spawn-controller.sh <skill> <prompt>
 ```
 
-`SKIP_PARALLEL_CHECK=1` を設定した場合は intervention 記録 MUST:
-```bash
-# 必ず記録すること
-echo "SKIP_PARALLEL_CHECK=1 使用: <理由>" >> .supervisor/intervention-log.md
-```
+`SKIP_PARALLEL_CHECK=1` を設定した場合、`spawn-controller.sh` が自動的に `.supervisor/intervention-log.md` に記録する。理由は `SKIP_PARALLEL_REASON` 環境変数で渡すこと（未指定時は `(reason not provided)` が記録される）。手動上書き記録も許容する。

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -47,7 +47,21 @@ fi
 # SKIP_PARALLEL_CHECK=1 で bypass 可（intervention 記録 MUST）
 _PARALLEL_CHECK_LIB="$TWILL_ROOT/plugins/twl/scripts/lib/observer-parallel-check.sh"
 if [[ "${SKIP_PARALLEL_CHECK:-0}" == "1" ]]; then
-  echo "[spawn-controller] WARN: SKIP_PARALLEL_CHECK=1 — §11.3 チェックをスキップ（intervention 記録 MUST）" >&2
+  echo "[spawn-controller] WARN: SKIP_PARALLEL_CHECK=1 — §11.3 チェックをスキップ（intervention-log に自動記録。SKIP_PARALLEL_REASON で理由を渡すこと）" >&2
+  # 自動記録 (tech-debt #1135、fail-open ポリシー)
+  {
+    _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+    mkdir -p "$_supervisor_dir"
+    _reason="${SKIP_PARALLEL_REASON:-(reason not provided)}"
+    _reason="${_reason//$'\n'/ }"
+    printf '%s SKIP_PARALLEL_CHECK=1: %s\n' \
+      "$(date -u +%FT%TZ)" \
+      "$_reason" \
+      >> "$_supervisor_dir/intervention-log.md"
+  } || {
+    echo "[spawn-controller] WARN: intervention-log append failed (continuing spawn)" >&2
+    true
+  }
 elif [[ -f "$_PARALLEL_CHECK_LIB" ]]; then
   # shellcheck source=/dev/null
   source "$_PARALLEL_CHECK_LIB"

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -54,6 +54,7 @@ if [[ "${SKIP_PARALLEL_CHECK:-0}" == "1" ]]; then
     mkdir -p "$_supervisor_dir"
     _reason="${SKIP_PARALLEL_REASON:-(reason not provided)}"
     _reason="${_reason//$'\n'/ }"
+    _reason="${_reason//$'\r'/ }"
     printf '%s SKIP_PARALLEL_CHECK=1: %s\n' \
       "$(date -u +%FT%TZ)" \
       "$_reason" \

--- a/plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats
@@ -1,0 +1,289 @@
+#!/usr/bin/env bats
+# spawn-controller-skip-parallel-log.bats - Issue #1135 AC11 RED テスト
+#
+# AC11: SKIP_PARALLEL_CHECK=1 時の intervention-log 自動記録
+#
+# C1: SKIP_PARALLEL_CHECK=1 + SKIP_PARALLEL_REASON="test reason" → ログ append
+# C2: SKIP_PARALLEL_CHECK=1 のみ → (reason not provided) で記録
+# C3: SUPERVISOR_DIR=$(mktemp -d) で実 .supervisor/intervention-log.md を汚染しない
+# C4: SUPERVISOR_DIR 不在ディレクトリでも mkdir -p が成功し append される
+# C5: append 失敗時（SUPERVISOR_DIR=/dev/null/x 等）に WARN 出力 + spawn 継続（fail-open）
+# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる
+
+load '../helpers/common'
+
+SPAWN_CONTROLLER=""
+CLD_SPAWN_ARGS_LOG=""
+MOCK_CLD_SPAWN=""
+
+setup() {
+  common_setup
+
+  SPAWN_CONTROLLER="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+  export SPAWN_CONTROLLER
+
+  CLD_SPAWN_ARGS_LOG="$SANDBOX/cld-spawn-args.log"
+  export CLD_SPAWN_ARGS_LOG
+
+  cat > "$STUB_BIN/cld-spawn" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "${CLD_SPAWN_ARGS_LOG:-/dev/null}"
+exit 0
+MOCK
+  chmod +x "$STUB_BIN/cld-spawn"
+
+  MOCK_CLD_SPAWN="$STUB_BIN/cld-spawn"
+  export MOCK_CLD_SPAWN
+
+  # run-spawn-controller.sh wrapper（CLD_SPAWN パスを置換）
+  cat > "$SANDBOX/run-spawn-controller.sh" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+TMP_SCRIPT="\$(mktemp)"
+cp "$SPAWN_CONTROLLER" "\$TMP_SCRIPT"
+sed -i "s|CLD_SPAWN=\"\\\$TWILL_ROOT/plugins/session/scripts/cld-spawn\"|CLD_SPAWN=\"$MOCK_CLD_SPAWN\"|g" "\$TMP_SCRIPT"
+chmod +x "\$TMP_SCRIPT"
+exec bash "\$TMP_SCRIPT" "\$@"
+WRAPPER
+  chmod +x "$SANDBOX/run-spawn-controller.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# C1: SKIP_PARALLEL_CHECK=1 + SKIP_PARALLEL_REASON="test reason"
+#     → intervention-log.md に "<UTC>Z SKIP_PARALLEL_CHECK=1: test reason" が append
+# RED: spawn-controller.sh に自動記録実装がないため fail する
+# ---------------------------------------------------------------------------
+
+@test "C1: SKIP_PARALLEL_CHECK=1 + REASON が intervention-log に append される" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+
+  local log_dir
+  log_dir="$(mktemp -d)"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  SUPERVISOR_DIR="$log_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="test reason" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window"
+
+  # spawn 自体は成功すること
+  assert_success
+
+  # intervention-log.md が作成されていること
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  # ログ行に "SKIP_PARALLEL_CHECK=1: test reason" が含まれること
+  grep -q "SKIP_PARALLEL_CHECK=1: test reason" "$log_file" \
+    || fail "intervention-log.md に期待する記録がない。内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  rm -rf "$log_dir"
+}
+
+# ---------------------------------------------------------------------------
+# C2: SKIP_PARALLEL_CHECK=1 のみ（SKIP_PARALLEL_REASON 未指定）
+#     → "(reason not provided)" で記録
+# RED: 自動記録実装がないため fail する
+# ---------------------------------------------------------------------------
+
+@test "C2: SKIP_PARALLEL_REASON 未指定時は (reason not provided) で記録される" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+
+  local log_dir
+  log_dir="$(mktemp -d)"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  SUPERVISOR_DIR="$log_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window"
+
+  assert_success
+
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  grep -q "(reason not provided)" "$log_file" \
+    || fail "REASON 未指定時に '(reason not provided)' が記録されていない。内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  rm -rf "$log_dir"
+}
+
+# ---------------------------------------------------------------------------
+# C3: SUPERVISOR_DIR=$(mktemp -d) で実 .supervisor/intervention-log.md を汚染しない
+#     → 実プロジェクトの .supervisor/intervention-log.md に変更がないこと
+# RED: 自動記録実装がないため fail する（ただし環境汚染防止の観点では副次的 RED）
+# ---------------------------------------------------------------------------
+
+@test "C3: SUPERVISOR_DIR 指定時に実 .supervisor/intervention-log.md を汚染しない" {
+  # RED: spawn-controller.sh に自動記録実装がないため、ログが作成されないため fail する
+  # （ただしこのテスト自体は実 .supervisor 汚染がないことを確認する）
+
+  local log_dir
+  log_dir="$(mktemp -d)"
+
+  # 実 .supervisor のパスを記録しておく（汚染確認用）
+  local real_supervisor_dir
+  real_supervisor_dir="$(pwd)/.supervisor"
+  local real_log="$real_supervisor_dir/intervention-log.md"
+
+  # 実ログが事前に存在する場合、タイムスタンプを記録
+  local pre_mtime=""
+  if [[ -f "$real_log" ]]; then
+    pre_mtime="$(stat -c %Y "$real_log" 2>/dev/null || echo "")"
+  fi
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  SUPERVISOR_DIR="$log_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="isolation test" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window"
+
+  assert_success
+
+  # 指定した log_dir に記録されていること（RED ポイント）
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "SUPERVISOR_DIR 指定先に intervention-log.md が作成されていない: $log_file"
+
+  # 実 .supervisor/intervention-log.md が変更されていないこと
+  if [[ -n "$pre_mtime" ]]; then
+    local post_mtime
+    post_mtime="$(stat -c %Y "$real_log" 2>/dev/null || echo "")"
+    [[ "$pre_mtime" == "$post_mtime" ]] \
+      || fail "実 .supervisor/intervention-log.md が変更されてしまった（汚染）"
+  else
+    [[ ! -f "$real_log" ]] \
+      || fail "実 .supervisor/intervention-log.md が新規作成されてしまった（汚染）"
+  fi
+
+  rm -rf "$log_dir"
+}
+
+# ---------------------------------------------------------------------------
+# C4: SUPERVISOR_DIR が存在しないディレクトリを指定しても mkdir -p が成功し append される
+# RED: 自動記録実装がないため fail する
+# ---------------------------------------------------------------------------
+
+@test "C4: SUPERVISOR_DIR 不在ディレクトリでも mkdir -p が成功し append される" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+
+  local base_dir
+  base_dir="$(mktemp -d)"
+  local log_dir="$base_dir/non-existent/nested/supervisor"
+  # log_dir は事前作成しない
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  SUPERVISOR_DIR="$log_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="mkdir-p test" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window"
+
+  assert_success
+
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "mkdir -p 後に intervention-log.md が作成されていない: $log_file"
+
+  grep -q "SKIP_PARALLEL_CHECK=1: mkdir-p test" "$log_file" \
+    || fail "mkdir -p 成功後のログ内容が期待と異なる。内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  rm -rf "$base_dir"
+}
+
+# ---------------------------------------------------------------------------
+# C5: append 失敗時（SUPERVISOR_DIR=/dev/null/x 等）に WARN 出力 + spawn 継続（fail-open）
+# RED: 自動記録実装がないため fail する（WARN が出ないため）
+# ---------------------------------------------------------------------------
+
+@test "C5: append 失敗時に WARN 出力 + spawn 継続（fail-open）" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+  # fail-open WARN は実装後に '[spawn-controller] WARN: intervention-log append failed' として出力される
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  # /dev/null/x は書き込み不可なディレクトリ（mkdir -p も失敗する）
+  SUPERVISOR_DIR="/dev/null/x" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="fail-open test" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window" 2>&1
+
+  # spawn 自体は継続して成功すること（fail-open）
+  assert_success
+
+  # WARN メッセージが出力されていること
+  echo "$output" | grep -q "\[spawn-controller\] WARN: intervention-log append failed" \
+    || fail "fail-open WARN が出力されていない。出力: $output"
+}
+
+# ---------------------------------------------------------------------------
+# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる
+# RED: 自動記録実装がないため fail する（サニタイズ実装なし）
+# ---------------------------------------------------------------------------
+
+@test "C6: 改行を含む REASON はサニタイズされてログ 1 行に収まる" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+
+  local log_dir
+  log_dir="$(mktemp -d)"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  SUPERVISOR_DIR="$log_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON=$'line1\nline2' \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" \
+    --window-name "test-window"
+
+  assert_success
+
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  # SKIP_PARALLEL_CHECK=1: を含む行数が 1 であること（改行が除去または空白置換されていること）
+  local matching_lines
+  matching_lines="$(grep -c "SKIP_PARALLEL_CHECK=1:" "$log_file" 2>/dev/null || echo "0")"
+  [[ "$matching_lines" -eq 1 ]] \
+    || fail "SKIP_PARALLEL_CHECK=1: を含む行が $matching_lines 行（期待: 1 行）。ログ内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  # "line1" と "line2" が別行にならず同一行に収まっていること
+  local log_content
+  log_content="$(grep "SKIP_PARALLEL_CHECK=1:" "$log_file")"
+  [[ "$log_content" == *"line1"* && "$log_content" == *"line2"* ]] \
+    || fail "サニタイズ後のログ行に line1/line2 両方が含まれていない: $log_content"
+
+  rm -rf "$log_dir"
+}

--- a/plugins/twl/tests/bats/scripts/spawn-controller.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller.bats
@@ -250,3 +250,54 @@ make_prompt_file() {
   [[ "$output" == *"co-explore"* ]] \
     || fail "エラーメッセージに有効な skill リストが含まれない: $output"
 }
+
+# ===========================================================================
+# AC12: SKIP_PARALLEL_CHECK=1 パスで実 .supervisor/intervention-log.md を汚染しない
+# Regression fix: SUPERVISOR_DIR=$(mktemp -d) 注入により実ログを保護
+# RED: spawn-controller.sh に自動記録実装がないため fail する
+# ===========================================================================
+
+@test "skip-parallel-check: SKIP_PARALLEL_CHECK=1 + SUPERVISOR_DIR 注入で実ログを汚染しない（regression fix）" {
+  # RED: spawn-controller.sh に自動記録実装がないため fail する
+  # （実装後は SUPERVISOR_DIR 指定先にのみ記録され、実 .supervisor は汚染されない）
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  local tmp_supervisor_dir
+  tmp_supervisor_dir="$(mktemp -d)"
+
+  SUPERVISOR_DIR="$tmp_supervisor_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="regression-fix test" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --window-name "test-window"
+
+  assert_success
+
+  # 指定した tmp_supervisor_dir に intervention-log.md が作成されていること（RED ポイント）
+  [[ -f "$tmp_supervisor_dir/intervention-log.md" ]] \
+    || fail "SUPERVISOR_DIR 指定先に intervention-log.md が作成されていない: $tmp_supervisor_dir/intervention-log.md"
+
+  rm -rf "$tmp_supervisor_dir"
+}
+
+@test "skip-parallel-check: SKIP_PARALLEL_CHECK=1 で spawn は継続される" {
+  # 実装後も PASS すべき regression guard
+  # SKIP_PARALLEL_CHECK=1 設定時に spawn が abort せず cld-spawn が呼ばれること
+  make_prompt_file 5 "$SANDBOX/prompt.txt"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  local tmp_supervisor_dir
+  tmp_supervisor_dir="$(mktemp -d)"
+
+  SUPERVISOR_DIR="$tmp_supervisor_dir" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="spawn-continues test" \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$SANDBOX/prompt.txt" \
+    --window-name "test-window"
+
+  assert_success
+  [[ -f "$CLD_SPAWN_ARGS_LOG" ]] || fail "cld-spawn が呼ばれなかった"
+
+  rm -rf "$tmp_supervisor_dir"
+}


### PR DESCRIPTION
## 概要

`spawn-controller.sh` の `SKIP_PARALLEL_CHECK=1` bypass 時に `.supervisor/intervention-log.md` への append を機械的に実行する（Issue #1135）。

## 変更ファイル

- `plugins/twl/skills/su-observer/scripts/spawn-controller.sh` — L49-51 直後への自動記録コード + WARN 文言更新
- `plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md` — L116, L119-123 更新（自動記録説明・SKIP_PARALLEL_REASON 例示）
- `plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats` — 新規（C1-C6）
- `plugins/twl/tests/bats/scripts/spawn-controller.bats` — SUPERVISOR_DIR 注入 regression fix

## テスト結果

C1-C6 全件 PASS + 既存テスト regression なし

Closes #1135