### PR TITLE
fix(#1098): workflow-pr-merge/SKILL.md ★HUMAN GATE を独立節へ移動（意味的精度向上）

### DIFF
--- a/plugins/twl/skills/workflow-pr-merge/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-merge/SKILL.md
@@ -94,10 +94,15 @@ EOF
 fi
 ```
 
+## merge-gate ユーザー介入要件
+
+ADR-030 §適用条件: merge-gate REJECT によりエスカレーションが必要な場合 / Layer 2 Escalate
+
+★HUMAN GATE — merge-gate REJECT エスカレーション時はユーザーの明示的承認が必要（自動マージ禁止）
+
 ## compaction 復帰プロトコル
 
 `refs/ref-compaction-recovery.md` を Read し従うこと。ステップリスト: `all-pass-check pr-cycle-report`
 
-★HUMAN GATE — merge-gate REJECT エスカレーション時はユーザーの明示的承認が必要（自動マージ禁止）
 - merge-gate エスカレーションは LLM ステップのため状態を確認してから再実行すること
 - all-pass-check スキップ時は PR の CI 結果を直接確認すること

--- a/plugins/twl/tests/scenarios/ac-test-mapping.yaml
+++ b/plugins/twl/tests/scenarios/ac-test-mapping.yaml
@@ -1,0 +1,71 @@
+mappings:
+  - ac_index: 1
+    ac_text: "★HUMAN GATE を新設の ## merge-gate ユーザー介入要件 節に移動する。compaction 復帰プロトコル節には移動後 ★HUMAN GATE が含まれないこと"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC1: ## merge-gate ユーザー介入要件 節が存在する"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 1b
+    ac_text: "★HUMAN GATE が ## merge-gate ユーザー介入要件 節内に配置されていること"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC1: ★HUMAN GATE が ## merge-gate ユーザー介入要件 節内に配置されている"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 1c
+    ac_text: "compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていないこと"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC1: compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていない"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 2
+    ac_text: "移動後の ★HUMAN GATE 行の前後（同節内）に ADR-030 §適用条件「merge-gate REJECT によりエスカレーションが必要な場合 / Layer 2 Escalate」を 1 行で明示"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC2: 新節内に merge-gate REJECT エスカレーション条件が明示されている"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 2b
+    ac_text: "新節内に Layer 2 Escalate への言及が含まれていること"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC2: 新節内に Layer 2 Escalate への言及が含まれている"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 3
+    ac_text: "co-autopilot/SKILL.md と co-architect/SKILL.md の配置スタイルと比較し PR description に 1 段落追記"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC3: PR description への比較結果追記 (SKIP)"
+    impl_files: []
+    # impl_files 推定失敗: プロセス AC — PR description は静的ファイル検証不能
+
+  - ac_index: 4
+    ac_text: "grep -rln '★HUMAN GATE' plugins/ | wc -l >= 8（ファイル数保全）"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC4: ★HUMAN GATE を含むファイル数が 8 以上（修正前と同数）"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 4b
+    ac_text: "UTF-8 健全性: SKILL.md 内に ★HUMAN GATE が UTF-8 エンコードで存在する"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC4: UTF-8 健全性 — SKILL.md 内に ★HUMAN GATE が存在する"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 4c
+    ac_text: "#1084 AC3(d) anchor 保全: grep -n 'merge-gate エスカレーション' SKILL.md が 1 件以上ヒット"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC4: #1084 AC3(d) anchor 'merge-gate エスカレーション' が保全されている"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+
+  - ac_index: 5
+    ac_text: "修正案が ADR-030 §Decision §適用条件 §段階導入方針 のいずれにも矛盾しない。★HUMAN GATE 件数を変えず位置・文脈を変えるのみ"
+    test_file: "plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh"
+    test_name: "AC5: SKILL.md 内の ★HUMAN GATE 件数が 1（追加・削除なし）"
+    impl_files:
+      - "plugins/twl/skills/workflow-pr-merge/SKILL.md"
+      - "plugins/twl/architecture/decisions/ADR-030-human-gate-marker.md"

--- a/plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh
+++ b/plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh
@@ -30,16 +30,6 @@ assert_file_contains() {
   [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"
 }
 
-assert_file_not_contains() {
-  local file="$1"
-  local pattern="$2"
-  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
-  if grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"; then
-    return 1
-  fi
-  return 0
-}
-
 assert_count_ge() {
   local count="$1"
   local min="$2"
@@ -118,12 +108,25 @@ run_test "AC1: ★HUMAN GATE が ## merge-gate ユーザー介入要件 節内�
 
 # WHEN: SKILL.md が修正済みである
 # THEN: compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていない
-# grep -A 5 'compaction 復帰プロトコル' ... | grep -c '★HUMAN GATE' == 0
 test_ac1_compaction_section_no_human_gate() {
   assert_file_exists "$SKILL_MD" || return 1
-  local count
-  count=$(grep -A 10 'compaction 復帰プロトコル' "${PROJECT_ROOT}/${SKILL_MD}" | grep -c '★HUMAN GATE' || true)
-  [[ "$count" -eq 0 ]]
+  SKILL_MD_ABS="$SKILL_MD_ABS" python3 - <<'PYEOF'
+import re, sys, os
+
+skill_md_path = os.environ.get("SKILL_MD_ABS", "")
+with open(skill_md_path, encoding="utf-8") as f:
+    content = f.read()
+
+m = re.search(r'^## compaction 復帰プロトコル.*?(?=^##|\Z)', content, re.MULTILINE | re.DOTALL)
+if not m:
+    sys.exit(0)  # 節が存在しない場合は PASS（★HUMAN GATE も含まれない）
+
+section = m.group(0)
+if '★HUMAN GATE' in section:
+    print("ERROR: ★HUMAN GATE found in '## compaction 復帰プロトコル' section", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
 }
 run_test "AC1: compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていない" test_ac1_compaction_section_no_human_gate
 

--- a/plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh
+++ b/plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh
@@ -1,0 +1,288 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Document Verification Tests: workflow-pr-merge/SKILL.md ★HUMAN GATE placement
+# Issue: #1098 (tech-debt: ★HUMAN GATE 配置の意味的精度向上)
+# Coverage level: full-ac
+#
+# AC1: ★HUMAN GATE を独立節 ## merge-gate ユーザー介入要件 に移動
+# AC2: 移動後節内に ADR-030 適用条件（merge-gate REJECT / Layer 2 Escalate）を明示
+# AC3: PR description に比較結果段落追記（プロセス AC — ここでは SKILL.md の構造のみ検証）
+# AC4: grep 検証（ファイル数保全・UTF-8 健全性・anchor 保全）
+# AC5: ADR-030 整合性（★HUMAN GATE 件数変更なし）
+# =============================================================================
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+
+PASS=0
+FAIL=0
+SKIP=0
+ERRORS=()
+
+assert_file_exists() {
+  local file="$1"
+  [[ -f "${PROJECT_ROOT}/${file}" ]]
+}
+
+assert_file_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] && grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  [[ -f "${PROJECT_ROOT}/${file}" ]] || return 1
+  if grep -qP -- "$pattern" "${PROJECT_ROOT}/${file}"; then
+    return 1
+  fi
+  return 0
+}
+
+assert_count_ge() {
+  local count="$1"
+  local min="$2"
+  [[ "$count" -ge "$min" ]]
+}
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result
+  result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+run_test_skip() {
+  local name="$1"
+  local reason="$2"
+  echo "  SKIP: ${name} (${reason})"
+  ((SKIP++)) || true
+}
+
+SKILL_MD="skills/workflow-pr-merge/SKILL.md"
+SKILL_MD_ABS="${PROJECT_ROOT}/${SKILL_MD}"
+
+# =============================================================================
+# AC1: ★HUMAN GATE の独立節移動
+# =============================================================================
+echo ""
+echo "--- AC1: ★HUMAN GATE の独立節移動 ---"
+
+# WHEN: SKILL.md が修正済みである
+# THEN: ## merge-gate ユーザー介入要件 という独立節が存在する
+test_ac1_independent_section_exists() {
+  assert_file_exists "$SKILL_MD" || return 1
+  assert_file_contains "$SKILL_MD" '^## merge-gate ユーザー介入要件'
+}
+run_test "AC1: ## merge-gate ユーザー介入要件 節が存在する" test_ac1_independent_section_exists
+
+# WHEN: SKILL.md が修正済みである
+# THEN: ★HUMAN GATE は ## merge-gate ユーザー介入要件 節内に配置されている
+test_ac1_human_gate_in_new_section() {
+  assert_file_exists "$SKILL_MD" || return 1
+  # merge-gate ユーザー介入要件 節内に ★HUMAN GATE が含まれること
+  # （節の開始から次の ## まで）
+  SKILL_MD_ABS="$SKILL_MD_ABS" python3 - <<'PYEOF'
+import re, sys
+
+import os
+skill_md_path = os.environ.get("SKILL_MD_ABS", "plugins/twl/skills/workflow-pr-merge/SKILL.md")
+with open(skill_md_path, encoding="utf-8") as f:
+    content = f.read()
+
+# セクション抽出: ## merge-gate ユーザー介入要件 から次の ## まで
+m = re.search(r'^## merge-gate ユーザー介入要件.*?(?=^##|\Z)', content, re.MULTILINE | re.DOTALL)
+if not m:
+    print("ERROR: '## merge-gate ユーザー介入要件' section not found", file=sys.stderr)
+    sys.exit(1)
+
+section = m.group(0)
+if '★HUMAN GATE' not in section:
+    print("ERROR: ★HUMAN GATE not found in '## merge-gate ユーザー介入要件' section", file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)
+PYEOF
+}
+run_test "AC1: ★HUMAN GATE が ## merge-gate ユーザー介入要件 節内に配置されている" test_ac1_human_gate_in_new_section
+
+# WHEN: SKILL.md が修正済みである
+# THEN: compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていない
+# grep -A 5 'compaction 復帰プロトコル' ... | grep -c '★HUMAN GATE' == 0
+test_ac1_compaction_section_no_human_gate() {
+  assert_file_exists "$SKILL_MD" || return 1
+  local count
+  count=$(grep -A 10 'compaction 復帰プロトコル' "${PROJECT_ROOT}/${SKILL_MD}" | grep -c '★HUMAN GATE' || true)
+  [[ "$count" -eq 0 ]]
+}
+run_test "AC1: compaction 復帰プロトコル節内に ★HUMAN GATE が含まれていない" test_ac1_compaction_section_no_human_gate
+
+# =============================================================================
+# AC2: ★HUMAN GATE の意味的整合性確保
+# =============================================================================
+echo ""
+echo "--- AC2: ★HUMAN GATE の意味的整合性確保 ---"
+
+# WHEN: SKILL.md が修正済みである
+# THEN: 新節内に「merge-gate REJECT によりエスカレーションが必要な場合」が明示されている
+test_ac2_reject_escalation_condition_explicit() {
+  assert_file_exists "$SKILL_MD" || return 1
+  SKILL_MD_ABS="$SKILL_MD_ABS" python3 - <<'PYEOF'
+import re, sys
+
+import os
+skill_md_path = os.environ.get("SKILL_MD_ABS", "plugins/twl/skills/workflow-pr-merge/SKILL.md")
+with open(skill_md_path, encoding="utf-8") as f:
+    content = f.read()
+
+m = re.search(r'^## merge-gate ユーザー介入要件.*?(?=^##|\Z)', content, re.MULTILINE | re.DOTALL)
+if not m:
+    print("ERROR: section not found", file=sys.stderr)
+    sys.exit(1)
+
+section = m.group(0)
+if 'merge-gate REJECT' not in section or 'エスカレーション' not in section:
+    print("ERROR: ADR-030 condition 'merge-gate REJECT ... エスカレーション' not found in section", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+run_test "AC2: 新節内に merge-gate REJECT エスカレーション条件が明示されている" test_ac2_reject_escalation_condition_explicit
+
+# WHEN: SKILL.md が修正済みである
+# THEN: 新節内に「Layer 2 Escalate」が明示されている（ADR-030 §適用条件との整合）
+test_ac2_layer2_escalate_explicit() {
+  assert_file_exists "$SKILL_MD" || return 1
+  SKILL_MD_ABS="$SKILL_MD_ABS" python3 - <<'PYEOF'
+import re, sys
+
+import os
+skill_md_path = os.environ.get("SKILL_MD_ABS", "plugins/twl/skills/workflow-pr-merge/SKILL.md")
+with open(skill_md_path, encoding="utf-8") as f:
+    content = f.read()
+
+m = re.search(r'^## merge-gate ユーザー介入要件.*?(?=^##|\Z)', content, re.MULTILINE | re.DOTALL)
+if not m:
+    print("ERROR: section not found", file=sys.stderr)
+    sys.exit(1)
+
+section = m.group(0)
+if 'Layer 2' not in section:
+    print("ERROR: 'Layer 2' not found in '## merge-gate ユーザー介入要件' section", file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+run_test "AC2: 新節内に Layer 2 Escalate への言及が含まれている" test_ac2_layer2_escalate_explicit
+
+# =============================================================================
+# AC3: 関連配置との粒度整合性確認（プロセス AC — SKILL.md 構造のみ検証）
+# =============================================================================
+echo ""
+echo "--- AC3: 関連配置との粒度整合性確認（SKILL.md 構造）---"
+
+# AC3 の主体は PR description への追記であり SKILL.md ファイル検証では確認不能のため SKIP
+run_test_skip "AC3: PR description への比較結果追記" "プロセス AC — PR description は本 test では検証不能"
+
+# ただし co-autopilot/SKILL.md と co-architect/SKILL.md の参照元が存在することを確認
+test_ac3_co_autopilot_skill_exists() {
+  assert_file_exists "skills/co-autopilot/SKILL.md"
+}
+run_test "AC3 前提: co-autopilot/SKILL.md が存在する" test_ac3_co_autopilot_skill_exists
+
+test_ac3_co_architect_skill_exists() {
+  assert_file_exists "skills/co-architect/SKILL.md"
+}
+run_test "AC3 前提: co-architect/SKILL.md が存在する" test_ac3_co_architect_skill_exists
+
+# =============================================================================
+# AC4: grep 検証
+# =============================================================================
+echo ""
+echo "--- AC4: grep 検証 ---"
+
+# ファイル数保全: grep -rln '★HUMAN GATE' plugins/ | wc -l >= 8
+test_ac4_file_count_preserved() {
+  local count
+  # PROJECT_ROOT = plugins/twl — plugins/ から再帰検索するとループするため REPO_ROOT を使用
+  local repo_root
+  repo_root="$(cd "${PROJECT_ROOT}/../.." && pwd)"
+  count=$(grep -rln '★HUMAN GATE' "${repo_root}/plugins/" | wc -l)
+  assert_count_ge "$count" 8
+}
+run_test "AC4: ★HUMAN GATE を含むファイル数が 8 以上（修正前と同数）" test_ac4_file_count_preserved
+
+# UTF-8 健全性: SKILL.md 内に ★HUMAN GATE が UTF-8 エンコードで存在すること
+test_ac4_utf8_integrity() {
+  assert_file_exists "$SKILL_MD" || return 1
+  # LC_ALL=C でバイト単位マッチ: ★(U+2605)= e2 98 85
+  LC_ALL=C grep -qP '\xe2\x98\x85HUMAN GATE' "${PROJECT_ROOT}/${SKILL_MD}"
+}
+run_test "AC4: UTF-8 健全性 — SKILL.md 内に ★HUMAN GATE が存在する" test_ac4_utf8_integrity
+
+# #1084 AC3(d) anchor 保全: 'merge-gate エスカレーション' が 1 件以上ヒット
+test_ac4_anchor_preserved() {
+  assert_file_exists "$SKILL_MD" || return 1
+  local count
+  count=$(grep -c 'merge-gate エスカレーション' "${PROJECT_ROOT}/${SKILL_MD}" || true)
+  [[ "$count" -ge 1 ]]
+}
+run_test "AC4: #1084 AC3(d) anchor 'merge-gate エスカレーション' が保全されている" test_ac4_anchor_preserved
+
+# =============================================================================
+# AC5: ADR-030 整合性
+# =============================================================================
+echo ""
+echo "--- AC5: ADR-030 整合性 ---"
+
+# ADR-030 本体が存在すること
+test_ac5_adr030_exists() {
+  assert_file_exists "architecture/decisions/ADR-030-human-gate-marker.md"
+}
+run_test "AC5: ADR-030 ファイルが存在する" test_ac5_adr030_exists
+
+# workflow-pr-merge/SKILL.md の ★HUMAN GATE 件数が修正後も 1 件であること（位置変更のみ）
+test_ac5_human_gate_count_in_skill_md() {
+  assert_file_exists "$SKILL_MD" || return 1
+  local count
+  count=$(grep -c '★HUMAN GATE' "${PROJECT_ROOT}/${SKILL_MD}" || true)
+  [[ "$count" -eq 1 ]]
+}
+run_test "AC5: SKILL.md 内の ★HUMAN GATE 件数が 1（追加・削除なし）" test_ac5_human_gate_count_in_skill_md
+
+# ADR-030 の ★HUMAN GATE 件数が変化していないこと（ADR-030 本体改訂不要）
+test_ac5_adr030_not_modified_unnecessarily() {
+  local adr="architecture/decisions/ADR-030-human-gate-marker.md"
+  assert_file_exists "$adr" || return 1
+  # ADR-030 に ★HUMAN GATE マーカー定義が含まれていること（健全性確認）
+  assert_file_contains "$adr" '★HUMAN GATE'
+}
+run_test "AC5: ADR-030 に ★HUMAN GATE 定義が含まれている（本体健全性）" test_ac5_adr030_not_modified_unnecessarily
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "Results: ${PASS} passed, ${FAIL} failed, ${SKIP} skipped"
+echo "==========================================="
+
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed tests:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+
+exit $FAIL


### PR DESCRIPTION
## 概要

Issue #1098 対応。`workflow-pr-merge/SKILL.md` の ★HUMAN GATE 配置の意味的精度を向上させる。

## 変更内容

- `## merge-gate ユーザー介入要件` 独立節を新設
- ★HUMAN GATE を `## compaction 復帰プロトコル` 節内から移動
- 同節内に ADR-030 §適用条件（merge-gate REJECT / Layer 2 Escalate）を明示

## AC3: 関連配置との粒度整合性確認

| ファイル | 配置パターン | ADR-030 副目的 |
|---|---|---|
| `co-autopilot/SKILL.md:61` | `## Step 2: 計画承認` 節内、AskUserQuestion 直前 | 前者（AskUserQuestion 直前） |
| `co-architect/SKILL.md:88` | `## Step 4: ユーザー確認` 節内、AskUserQuestion 直前 | 前者（AskUserQuestion 直前） |
| `workflow-pr-merge/SKILL.md`（本 PR 後） | `## merge-gate ユーザー介入要件` 独立節内 | 後者（merge-gate REJECT エスカレーション） |

**結果**: 両者ともに「専用の節（見出し）内に ★HUMAN GATE を配置し、適用文脈を見出しで明示」という配置スタイルで整合している。前者は AskUserQuestion という具体的なインタラクション手順の文脈、後者は merge-gate REJECT エスカレーションという workflow 制約の文脈であり、目的の違いを反映した独立節として統一された。不一致なし。別 Issue 作成不要。

## テスト

`plugins/twl/tests/scenarios/workflow-pr-merge-human-gate-placement.test.sh` 全 13 テスト PASS（1 SKIP: プロセス AC）。

Closes #1098