### PR TITLE
fix(types): _FALLBACK_TYPE_RULES を types.yaml と完全同期 (#1122)

### DIFF
--- a/cli/twl/src/twl/core/types.py
+++ b/cli/twl/src/twl/core/types.py
@@ -24,14 +24,14 @@ _FALLBACK_TOKEN_THRESHOLDS: Dict[str, Tuple[int, int]] = {
 }
 
 _FALLBACK_TYPE_RULES = {
-    'controller':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference'}, 'spawnable_by': {'user', 'launcher'}},
+    'controller':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference', 'script', 'controller'}, 'spawnable_by': {'user', 'launcher', 'supervisor'}},
     'workflow':    {'section': 'skills',   'can_spawn': {'atomic', 'composite', 'specialist', 'reference', 'script'},  'spawnable_by': {'controller', 'user'}},
-    'atomic':      {'section': 'commands', 'can_spawn': {'reference', 'script'},                  'spawnable_by': {'workflow', 'controller', 'supervisor'}},
-    'composite':   {'section': 'commands', 'can_spawn': {'specialist', 'script'},               'spawnable_by': {'workflow', 'controller'}},
+    'atomic':      {'section': 'commands', 'can_spawn': {'reference', 'script', 'atomic'},       'spawnable_by': {'workflow', 'controller', 'supervisor', 'user', 'atomic'}},
+    'composite':   {'section': 'commands', 'can_spawn': {'specialist', 'script', 'reference'},   'spawnable_by': {'workflow', 'controller'}},
     'specialist':  {'section': 'agents',   'can_spawn': set(),                                  'spawnable_by': {'workflow', 'composite', 'controller', 'supervisor'}},
     'reference':   {'section': 'skills',   'can_spawn': set(),                                  'spawnable_by': {'controller', 'atomic', 'composite', 'workflow', 'supervisor', 'agents.skills', 'all'}},
-    'script':      {'section': 'scripts',  'can_spawn': {'script'},                              'spawnable_by': {'atomic', 'composite', 'script'}},
-    'supervisor':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference', 'script'}, 'spawnable_by': {'user'}},
+    'script':      {'section': 'scripts',  'can_spawn': {'script'},                              'spawnable_by': {'atomic', 'composite', 'script', 'controller', 'workflow', 'supervisor'}},
+    'supervisor':  {'section': 'skills',   'can_spawn': {'workflow', 'atomic', 'composite', 'specialist', 'reference', 'script'}, 'can_supervise': {'controller'}, 'spawnable_by': {'user'}},
 }
 TYPE_ALIASES = {}
 

--- a/cli/twl/tests/test_v3_schema.py
+++ b/cli/twl/tests/test_v3_schema.py
@@ -447,15 +447,36 @@ class TestV2BackwardCompat:
 
 
 class TestFallbackTypeRulesConsistency:
-    """_FALLBACK_TYPE_RULES と types.yaml の整合性テスト (Issue #1122)"""
+    """_FALLBACK_TYPE_RULES と types.yaml の整合性テスト (Issue #1122)
+
+    This class reads from the real repository (no tmpdir needed).
+    setup_method/teardown_method are no-ops for __main__ runner compatibility.
+    """
+
+    def setup_method(self):
+        pass
+
+    def teardown_method(self):
+        pass
 
     def _loom_root(self) -> Path:
         return Path(__file__).parent.parent
 
+    def _load_and_validate(self):
+        """types.yaml の存在確認と型ルールの読み込み。"""
+        loom_root = self._loom_root()
+        assert (loom_root / "types.yaml").exists(), f"types.yaml が見つかりません: {loom_root / 'types.yaml'}"
+        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
+        loaded = load_type_rules(loom_root)
+        assert set(loaded.keys()) == set(_FALLBACK_TYPE_RULES.keys()), (
+            f"型の集合が不一致: yaml={sorted(loaded.keys())} != fallback={sorted(_FALLBACK_TYPE_RULES.keys())}"
+        )
+        return loaded
+
     def test_ac1_can_spawn_synced_with_types_yaml(self):
         # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
-        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
-        loaded = load_type_rules(self._loom_root())
+        from twl.core.types import _FALLBACK_TYPE_RULES
+        loaded = self._load_and_validate()
         for type_name, fallback in _FALLBACK_TYPE_RULES.items():
             expected = loaded[type_name]['can_spawn']
             actual = set(fallback['can_spawn'])
@@ -465,8 +486,8 @@ class TestFallbackTypeRulesConsistency:
 
     def test_ac1_spawnable_by_synced_with_types_yaml(self):
         # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
-        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
-        loaded = load_type_rules(self._loom_root())
+        from twl.core.types import _FALLBACK_TYPE_RULES
+        loaded = self._load_and_validate()
         for type_name, fallback in _FALLBACK_TYPE_RULES.items():
             expected = loaded[type_name]['spawnable_by']
             actual = set(fallback['spawnable_by'])
@@ -477,8 +498,8 @@ class TestFallbackTypeRulesConsistency:
     def test_ac1_can_supervise_synced_with_types_yaml(self):
         # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
         # supervisor の can_supervise が types.yaml にあるが _FALLBACK_TYPE_RULES に未定義
-        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
-        loaded = load_type_rules(self._loom_root())
+        from twl.core.types import _FALLBACK_TYPE_RULES
+        loaded = self._load_and_validate()
         for type_name, fallback in _FALLBACK_TYPE_RULES.items():
             expected = loaded[type_name]['can_supervise']
             actual = set(fallback.get('can_supervise', []))

--- a/cli/twl/tests/test_v3_schema.py
+++ b/cli/twl/tests/test_v3_schema.py
@@ -446,6 +446,47 @@ class TestV2BackwardCompat:
         assert result.returncode == 0
 
 
+class TestFallbackTypeRulesConsistency:
+    """_FALLBACK_TYPE_RULES と types.yaml の整合性テスト (Issue #1122)"""
+
+    def _loom_root(self) -> Path:
+        return Path(__file__).parent.parent
+
+    def test_ac1_can_spawn_synced_with_types_yaml(self):
+        # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
+        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
+        loaded = load_type_rules(self._loom_root())
+        for type_name, fallback in _FALLBACK_TYPE_RULES.items():
+            expected = loaded[type_name]['can_spawn']
+            actual = set(fallback['can_spawn'])
+            assert actual == expected, (
+                f"{type_name}.can_spawn: fallback={sorted(actual)} != types.yaml={sorted(expected)}"
+            )
+
+    def test_ac1_spawnable_by_synced_with_types_yaml(self):
+        # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
+        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
+        loaded = load_type_rules(self._loom_root())
+        for type_name, fallback in _FALLBACK_TYPE_RULES.items():
+            expected = loaded[type_name]['spawnable_by']
+            actual = set(fallback['spawnable_by'])
+            assert actual == expected, (
+                f"{type_name}.spawnable_by: fallback={sorted(actual)} != types.yaml={sorted(expected)}"
+            )
+
+    def test_ac1_can_supervise_synced_with_types_yaml(self):
+        # AC: `_FALLBACK_TYPE_RULES` を `types.yaml` の定義と完全同期させる
+        # supervisor の can_supervise が types.yaml にあるが _FALLBACK_TYPE_RULES に未定義
+        from twl.core.types import _FALLBACK_TYPE_RULES, load_type_rules
+        loaded = load_type_rules(self._loom_root())
+        for type_name, fallback in _FALLBACK_TYPE_RULES.items():
+            expected = loaded[type_name]['can_supervise']
+            actual = set(fallback.get('can_supervise', []))
+            assert actual == expected, (
+                f"{type_name}.can_supervise: fallback={sorted(actual)} != types.yaml={sorted(expected)}"
+            )
+
+
 if __name__ == "__main__":
     import traceback
 
@@ -456,6 +497,7 @@ if __name__ == "__main__":
         TestV3StepIn,
         TestV3Chain,
         TestV2BackwardCompat,
+        TestFallbackTypeRulesConsistency,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## 概要

Issue #1122 の対応。`_FALLBACK_TYPE_RULES` が `types.yaml` と乖離していたため同期。

## 変更内容

### `cli/twl/src/twl/core/types.py`

| 型 | フィールド | 追加要素 |
|---|---|---|
| controller | can_spawn | script, controller |
| controller | spawnable_by | supervisor |
| atomic | can_spawn | atomic |
| atomic | spawnable_by | user, atomic |
| composite | can_spawn | reference |
| script | spawnable_by | controller, workflow, supervisor |
| supervisor | can_supervise | controller（新規フィールド） |

### `cli/twl/tests/test_v3_schema.py`

`TestFallbackTypeRulesConsistency` クラスを追加:
- `test_ac1_can_spawn_synced_with_types_yaml`
- `test_ac1_spawnable_by_synced_with_types_yaml`
- `test_ac1_can_supervise_synced_with_types_yaml`

`types.yaml` を動的に読み込むため、将来の変更も CI で自動検知される。

## テスト

```
3 passed in 0.06s (TestFallbackTypeRulesConsistency)
```

Closes #1122