### PR TITLE
feat(1147): SessionStart hook - cld-observe-any 死活確認 + 自動再起動

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -118,6 +118,16 @@
             "timeout": 10000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/session-resume-observer-check.sh\"",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "Stop": [

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -142,6 +142,17 @@ if [[ ${#WINDOWS[@]} -eq 0 && ${#PATTERNS[@]} -eq 0 ]]; then
     exit 1
 fi
 
+# --- flock 多重起動防止 ---
+LOCK_FILE="/tmp/cld-observe-any.lock"
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    existing_pid=$(cat "$LOCK_FILE.pid" 2>/dev/null || echo "?")
+    echo "[cld-observe-any] ERROR: 既存 instance が起動中 (PID=$existing_pid)" >&2
+    exit 1
+fi
+echo $$ > "$LOCK_FILE.pid"
+trap 'rm -f "$LOCK_FILE.pid"' EXIT
+
 # --- クリーンアップ ---
 TMPFILES=()
 cleanup() {

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -151,14 +151,14 @@ if ! flock -n 9; then
     exit 1
 fi
 echo $$ > "$LOCK_FILE.pid"
-trap 'rm -f "$LOCK_FILE.pid"' EXIT
 
 # --- クリーンアップ ---
 TMPFILES=()
 cleanup() {
-    for f in "${TMPFILES[@]:-}"; do
+    for f in "${TMPFILES[@]:+${TMPFILES[@]}}"; do
         rm -f "$f" 2>/dev/null || true
     done
+    rm -f "$LOCK_FILE.pid"
 }
 trap cleanup EXIT
 trap 'echo ""; echo "[cld-observe-any] SIGINT/SIGTERM 受信 → 終了"; cleanup; exit 0' INT TERM

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -1246,3 +1246,75 @@ MOCKEOF
     [[ "$status" -eq 0 ]]
     echo "$output" | grep -q "PASS: emit なし・kill-window 呼び出しなし"
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1147 AC8: 多重起動防止（flock -n 9）
+#
+# テスト戦略:
+#   - flock を stub して「既にロック取得済み」状態をシミュレート
+#   - 第 2 instance 起動時に flock が exit 1（ロック失敗）→ cld-observe-any が exit 1
+#   - stderr に既存 PID が出力される
+#
+# RED: cld-observe-any に flock 多重起動防止が未実装のため fail する
+# PASS 条件（実装後）:
+#   - 既起動 instance あり → flock 失敗 → exit 1
+#   - stderr に既存 PID を含む出力
+# ---------------------------------------------------------------------------
+
+@test "AC8: 既起動 instance あり → flock -n 失敗 → exit 1 + stderr に既存 PID 出力（RED: 実装後 PASS）" {
+    # AC: cld-observe-any 起動時に flock -n 9 で /tmp/cld-observe-any.lock を取得。
+    #     取得失敗時は exit 1 + stderr に既存 PID を出力
+    # RED: flock 多重起動防止が未実装のため現状は fail する
+
+    run bash <<'MOCKEOF'
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+TMPD="$(mktemp -d)"
+LOCK_FILE="$TMPD/cld-observe-any.lock"
+FAKE_EXISTING_PID=54321
+
+# flock stub: ロック取得失敗をシミュレート（-n オプション付きで即 exit 1）
+flock() {
+    # "-n" オプションがある場合、ロック失敗をシミュレート
+    if [[ "$*" == *"-n"* ]]; then
+        return 1
+    fi
+    return 0
+}
+export -f flock
+
+# tmux モック（実際には呼ばれないが念のため）
+tmux() { return 0; }
+export -f tmux
+
+# 既存 PID のロックファイルを作成（実際の多重起動をシミュレート）
+echo "$FAKE_EXISTING_PID" > "$LOCK_FILE"
+
+STDERR_FILE="$TMPD/stderr.txt"
+bash "$CLD_OBSERVE_ANY" --window "test-win" --once \
+    2>"$STDERR_FILE" >/dev/null
+exit_code=$?
+stderr_text=$(cat "$STDERR_FILE" 2>/dev/null || echo "")
+
+# 検証1: exit 1 で終了すること
+if [[ "$exit_code" -ne 1 ]]; then
+    echo "FAIL: exit code $exit_code（期待: 1）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+# 検証2: stderr に既存 PID が含まれること
+if ! echo "$stderr_text" | grep -q "$FAKE_EXISTING_PID"; then
+    echo "FAIL: stderr に既存 PID ($FAKE_EXISTING_PID) が含まれていない（stderr=$stderr_text）"
+    rm -rf "$TMPD"
+    exit 1
+fi
+
+echo "PASS: flock 失敗 exit 1 + stderr に PID 出力"
+rm -rf "$TMPD"
+MOCKEOF
+
+    # RED: 実装前は失敗する
+    # 実装後は [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS:" に変わる
+    [[ "$status" -eq 0 ]] && echo "$output" | grep -q "PASS: flock 失敗 exit 1 + stderr に PID 出力"
+}

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -1270,7 +1270,8 @@ MOCKEOF
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
 CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 TMPD="$(mktemp -d)"
-LOCK_FILE="$TMPD/cld-observe-any.lock"
+# スクリプトが内部でハードコードする LOCK_FILE と同じパス
+ACTUAL_LOCK_PID_FILE="/tmp/cld-observe-any.lock.pid"
 FAKE_EXISTING_PID=54321
 
 # flock stub: ロック取得失敗をシミュレート（-n オプション付きで即 exit 1）
@@ -1287,8 +1288,8 @@ export -f flock
 tmux() { return 0; }
 export -f tmux
 
-# 既存 PID のロックファイルを作成（実際の多重起動をシミュレート）
-echo "$FAKE_EXISTING_PID" > "$LOCK_FILE"
+# 既存 PID のロックファイルを作成（スクリプトが cat で読むパスに書く）
+echo "$FAKE_EXISTING_PID" > "$ACTUAL_LOCK_PID_FILE"
 
 STDERR_FILE="$TMPD/stderr.txt"
 bash "$CLD_OBSERVE_ANY" --window "test-win" --once \
@@ -1296,22 +1297,23 @@ bash "$CLD_OBSERVE_ANY" --window "test-win" --once \
 exit_code=$?
 stderr_text=$(cat "$STDERR_FILE" 2>/dev/null || echo "")
 
+# クリーンアップ
+rm -f "$ACTUAL_LOCK_PID_FILE"
+rm -rf "$TMPD"
+
 # 検証1: exit 1 で終了すること
 if [[ "$exit_code" -ne 1 ]]; then
     echo "FAIL: exit code $exit_code（期待: 1）"
-    rm -rf "$TMPD"
     exit 1
 fi
 
 # 検証2: stderr に既存 PID が含まれること
 if ! echo "$stderr_text" | grep -q "$FAKE_EXISTING_PID"; then
     echo "FAIL: stderr に既存 PID ($FAKE_EXISTING_PID) が含まれていない（stderr=$stderr_text）"
-    rm -rf "$TMPD"
     exit 1
 fi
 
 echo "PASS: flock 失敗 exit 1 + stderr に PID 出力"
-rm -rf "$TMPD"
 MOCKEOF
 
     # RED: 実装前は失敗する

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2797,6 +2797,11 @@ scripts:
     path: scripts/hooks/explore-summary-link.sh
     description: "PostToolUse hook (Write|Edit): .explore/<N>/summary.md への書き込みを検知し gh issue comment で explore-summary リンクを自動追加。冪等チェック付き（#726）"
 
+  session-resume-observer-check:
+    type: script
+    path: scripts/hooks/session-resume-observer-check.sh
+    description: "SessionStart hook: cld-observe-any daemon の死活確認（kill -0）+ 自動再起動（tmux respawn-pane）。PID 死亡時に lock ファイルをクリアして respawn を試みる。失敗時は daemon-startup-failed.json, pane 消失時は daemon-restart-skipped.json を出力（#1147）"
+
   pr-review-manifest:
     type: script
     path: scripts/pr-review-manifest.sh

--- a/plugins/twl/scripts/hooks/session-resume-observer-check.sh
+++ b/plugins/twl/scripts/hooks/session-resume-observer-check.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# session-resume-observer-check.sh - SessionStart hook: cld-observe-any 死活確認 + 自動再起動
+# Issue #1147: SessionStart resume hook に cld-observe-any 死活確認 + 自動再起動
+
+set -uo pipefail
+
+# CWD を git toplevel に移動（SessionStart 時は任意 CWD の可能性あり）
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+SESSION_JSON="${SUPERVISOR_DIR}/session.json"
+
+# session.json 不在 → observer 未起動 host = no-op
+[[ ! -f "$SESSION_JSON" ]] && exit 0
+
+# session.json から cld_observe_any フィールドを読み取る
+PID=$(jq -r '.cld_observe_any.pid // empty' "$SESSION_JSON" 2>/dev/null || echo "")
+PANE_ID=$(jq -r '.cld_observe_any.pane_id // empty' "$SESSION_JSON" 2>/dev/null || echo "")
+SPAWN_CMD=$(jq -r '.cld_observe_any.spawn_cmd // empty' "$SESSION_JSON" 2>/dev/null || echo "")
+LOCK_FILE=$(jq -r '.cld_observe_any.lock_path // "/tmp/cld-observe-any.lock"' "$SESSION_JSON" 2>/dev/null || echo "/tmp/cld-observe-any.lock")
+
+# PID 未記録 → observer 未起動 = no-op
+[[ -z "$PID" ]] && exit 0
+
+# PID 生存確認: kill -0 で確認（生存なら exit 0）
+if kill -0 "$PID" 2>/dev/null; then
+    exit 0
+fi
+
+# PID 死亡 → lock ファイルをクリアして respawn を試みる
+rm -f "$LOCK_FILE" "${LOCK_FILE}.pid"
+
+# spawn_cmd が未記録の場合は再起動不能 → error log + exit 1
+if [[ -z "$SPAWN_CMD" ]]; then
+    echo "[session-resume-hook] ERROR: spawn_cmd が session.json に未記録。手動再起動が必要" >&2
+    exit 1
+fi
+
+# pane の存在確認
+PANE_EXISTS=false
+if [[ -n "$PANE_ID" ]] && tmux list-panes -a -F "#{pane_id}" 2>/dev/null | grep -qx "$PANE_ID"; then
+    PANE_EXISTS=true
+fi
+
+if [[ "$PANE_EXISTS" == "true" ]]; then
+    # pane 存在 → tmux respawn-pane で再起動
+    if tmux respawn-pane -k -t "$PANE_ID" "$SPAWN_CMD"; then
+        # 新 PID を取得して session.json を更新
+        new_pid=$(tmux display-message -t "$PANE_ID" -p '#{pane_pid}' 2>/dev/null || echo "")
+        if [[ -f "$SESSION_JSON" && -n "$new_pid" ]]; then
+            tmp_file=$(mktemp)
+            jq --arg pid "$new_pid" \
+               --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+               '.cld_observe_any.pid = ($pid | tonumber? // null) |
+                .cld_observe_any.started_at = $started_at' \
+               "$SESSION_JSON" > "$tmp_file" && mv "$tmp_file" "$SESSION_JSON" || rm -f "$tmp_file"
+        fi
+    else
+        # respawn 失敗 → daemon-startup-failed.json を出力
+        mkdir -p "${SUPERVISOR_DIR}/events"
+        jq -n \
+           --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+           --arg reason "tmux respawn-pane failed" \
+           --arg pid_old "${PID:-}" \
+           --argjson pid_new null \
+           --arg error_log "tmux respawn-pane -k -t ${PANE_ID} failed with non-zero exit" \
+           '{timestamp: $ts, reason: $reason, pid_old: $pid_old, pid_new: $pid_new, error_log: $error_log}' \
+           > "${SUPERVISOR_DIR}/events/daemon-startup-failed.json"
+    fi
+else
+    # pane 消失 → 再起動不能を記録して graceful exit
+    mkdir -p "${SUPERVISOR_DIR}/events"
+    jq -n \
+       --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+       --arg reason "pane not found" \
+       --arg pane_id "${PANE_ID:-}" \
+       '{timestamp: $ts, reason: $reason, pane_id: $pane_id}' \
+       > "${SUPERVISOR_DIR}/events/daemon-restart-skipped.json"
+fi

--- a/plugins/twl/scripts/hooks/session-resume-observer-check.sh
+++ b/plugins/twl/scripts/hooks/session-resume-observer-check.sh
@@ -2,7 +2,7 @@
 # session-resume-observer-check.sh - SessionStart hook: cld-observe-any 死活確認 + 自動再起動
 # Issue #1147: SessionStart resume hook に cld-observe-any 死活確認 + 自動再起動
 
-set -uo pipefail
+set -euo pipefail
 
 # CWD を git toplevel に移動（SessionStart 時は任意 CWD の可能性あり）
 cd "$(git rev-parse --show-toplevel)" || exit 1

--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -37,7 +37,15 @@ data = {
   'observer_window': observer_window,
   'mode': observer_mode,
   'status': 'active',
-  'started_at': datetime.datetime.utcnow().isoformat() + 'Z'
+  'started_at': datetime.datetime.utcnow().isoformat() + 'Z',
+  'cld_observe_any': {
+    'pid': None,
+    'pane_id': None,
+    'spawn_cmd': None,
+    'started_at': None,
+    'log_path': None,
+    'lock_path': '/tmp/cld-observe-any.lock'
+  }
 }
 json.dump(data, open(session_file, 'w'), indent=2)
 print(f'[session-init] session.json 作成: {session_file}')

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -317,9 +317,30 @@ PYEOF
   tmux split-window -v -d -l 67% -t "${observer_window}:1.$((base+1))" -c "$cwd" "bash '$budget_script'" || \
     tmux split-window -v -d -t "${observer_window}:1.$((base+1))" -c "$cwd" "bash '$budget_script'"
 
-  # Step 3: vertical split — 下段をさらに分割して cld-observe-any を起動
-  tmux split-window -v -d -l 50% -t "${observer_window}:1.$((base+2))" -c "$cwd" "bash '$cld_observe_any'" || \
-    tmux split-window -v -d -t "${observer_window}:1.$((base+2))" -c "$cwd" "bash '$cld_observe_any'"
+  # Step 3: vertical split — 下段をさらに分割して cld-observe-any を起動（必須引数 --window 付き）
+  local spawn_cmd="bash '$cld_observe_any' --window '$observer_window'"
+  tmux split-window -v -d -l 50% -t "${observer_window}:1.$((base+2))" -c "$cwd" "$spawn_cmd" || \
+    tmux split-window -v -d -t "${observer_window}:1.$((base+2))" -c "$cwd" "$spawn_cmd"
+
+  # cld-observe-any pane の PID・pane_id・spawn_cmd を session.json に記録
+  local obs_pane_id obs_pane_pid session_file
+  session_file="${supervisor_dir}/session.json"
+  obs_pane_id=$(tmux display-message -t "${observer_window}:1.$((base+3))" -p '#{pane_id}' 2>/dev/null || echo "")
+  obs_pane_pid=$(tmux display-message -t "${observer_window}:1.$((base+3))" -p '#{pane_pid}' 2>/dev/null || echo "")
+  if [[ -f "$session_file" && -n "$obs_pane_id" ]]; then
+    local tmp_file
+    tmp_file=$(mktemp)
+    jq --arg pid "$obs_pane_pid" \
+       --arg pane_id "$obs_pane_id" \
+       --arg spawn_cmd "$spawn_cmd" \
+       --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+       '.cld_observe_any.pid = ($pid | tonumber? // null) |
+        .cld_observe_any.pane_id = $pane_id |
+        .cld_observe_any.spawn_cmd = $spawn_cmd |
+        .cld_observe_any.started_at = $started_at' \
+       "$session_file" > "$tmp_file" && mv "$tmp_file" "$session_file" || rm -f "$tmp_file"
+    echo "[spawn-controller] ✓ cld_observe_any metadata 記録: pane_id=${obs_pane_id} pid=${obs_pane_pid}"
+  fi
 
   # pane 数を確認してログ出力
   local pane_count

--- a/plugins/twl/tests/bats/session-resume-observer-check.bats
+++ b/plugins/twl/tests/bats/session-resume-observer-check.bats
@@ -386,7 +386,7 @@ TMUXSTUB
     return 1
   }
 
-  # 必須フィールド確認: {timestamp, reason, pid_old, pid_new, error_log}
-  run jq -e '.timestamp and .reason and (.pid_old | . != null) and (.pid_new | . != null) and (.error_log | . != null)' "$failed_json"
+  # 必須フィールド確認: {timestamp, reason, pid_old, error_log}（pid_new は respawn 失敗時 null が正常）
+  run jq -e '.timestamp and .reason and (.pid_old | . != null) and (.error_log | . != null)' "$failed_json"
   assert_success
 }

--- a/plugins/twl/tests/bats/session-resume-observer-check.bats
+++ b/plugins/twl/tests/bats/session-resume-observer-check.bats
@@ -1,0 +1,392 @@
+#!/usr/bin/env bats
+# session-resume-observer-check.bats
+# RED tests for Issue #1147: SessionStart hook - observer resume on session restart
+#
+# AC coverage:
+#   AC4 - session-resume-observer-check.sh が以下を実行:
+#          - cwd を git toplevel に移動
+#          - .supervisor/session.json 不在 → exit 0 (no-op)
+#          - cld_observe_any.pid が kill -0 で生存 → exit 0
+#          - PID 死亡 → lock/pid ファイル削除 → respawn
+#          - pane_id 有効時 → tmux respawn-pane -k -t "$PANE_ID" "$SPAWN_CMD"
+#          - spawn_cmd null → error log + exit 1
+#          - pane 消失 → .supervisor/events/daemon-restart-skipped.json 出力
+#   AC5 - respawn 失敗時 → .supervisor/events/daemon-startup-failed.json 出力
+#          フィールド: {timestamp, reason, pid_old, pid_new, error_log}
+#   AC7 - bats test 5 ケース（本ファイル）
+#
+# テスト設計:
+#   - tmux コマンドは STUB_BIN に mock して挙動を制御する
+#   - kill コマンドも stub して PID 生死を制御する
+#   - session-resume-observer-check.sh は plugins/twl/scripts/hooks/ 配下に新規作成される予定
+#   - .supervisor/session.json を SANDBOX に作成して入力とする
+#
+# RED: session-resume-observer-check.sh が未実装のため全テストが fail する
+
+load 'helpers/common'
+
+RESUME_SCRIPT=""
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  RESUME_SCRIPT="${REPO_ROOT}/scripts/hooks/session-resume-observer-check.sh"
+
+  # .supervisor ディレクトリと events ディレクトリを SANDBOX に作成
+  mkdir -p "$SANDBOX/.supervisor/events"
+
+  # kill stub: デフォルト = PID 生存（exit 0）
+  stub_command "kill" 'exit 0'
+
+  # git stub: rev-parse --show-toplevel が SANDBOX を返す
+  cat > "$STUB_BIN/git" <<GITSTUB
+#!/usr/bin/env bash
+if [[ "\${*}" == *"rev-parse --show-toplevel"* ]]; then
+  echo "${SANDBOX}"
+  exit 0
+fi
+exit 0
+GITSTUB
+  chmod +x "$STUB_BIN/git"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Helper: session.json を SANDBOX/.supervisor/ に書き出す
+# ---------------------------------------------------------------------------
+_create_session_json() {
+  local pid="${1:-12345}"
+  local pane_id="${2:-%42}"
+  local spawn_cmd="${3:-cld-observe-any --window observer-test}"
+  local lock_path="${4:-/tmp/cld-observe-any.lock}"
+
+  python3 -c "
+import json, sys
+pid_val = None if '${pid}' == 'null' else int('${pid}')
+pane_val = None if '${pane_id}' == 'null' else '${pane_id}'
+spawn_val = None if '${spawn_cmd}' == 'null' else '${spawn_cmd}'
+data = {
+  'session_id': 'test-session-1147',
+  'claude_session_id': 'test-claude-id',
+  'observer_window': 'observer-test',
+  'status': 'active',
+  'started_at': '2026-04-30T00:00:00Z',
+  'cld_observe_any': {
+    'pid': pid_val,
+    'pane_id': pane_val,
+    'spawn_cmd': spawn_val,
+    'started_at': '2026-04-30T00:00:00Z',
+    'log_path': '/tmp/cld-observe-any.log',
+    'lock_path': '${lock_path}'
+  }
+}
+json.dump(data, open('${SANDBOX}/.supervisor/session.json', 'w'), indent=2)
+print('session.json created')
+"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: session-resume-observer-check.sh を SANDBOX 内で実行する
+# ---------------------------------------------------------------------------
+_run_resume_check() {
+  run bash -c "
+set -euo pipefail
+export PATH='${STUB_BIN}:${PATH}'
+export SUPERVISOR_DIR='${SANDBOX}/.supervisor'
+export HOME='${SANDBOX}'
+bash '${RESUME_SCRIPT}'
+"
+}
+
+# ===========================================================================
+# AC7 ケース1: session.json 不在 → exit 0 (no-op)
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - スクリプトが exit 0 で終了する
+#   - tmux respawn-pane は呼ばれない
+# ===========================================================================
+
+@test "ac7/1: session.json 不在 → exit 0 (no-op)" {
+  # AC: .supervisor/session.json 存在確認 → 不在は no-op で exit 0
+  # RED: 実装前は fail する（スクリプト不在）
+
+  # session.json を作成しない状態で実行
+  rm -f "$SANDBOX/.supervisor/session.json"
+
+  # tmux stub: 呼び出しを記録
+  cat > "$STUB_BIN/tmux" <<'TMUXSTUB'
+#!/usr/bin/env bash
+echo "tmux-stub-called: $*" >&2
+exit 0
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+
+  _run_resume_check
+
+  assert_success
+}
+
+# ===========================================================================
+# AC7 ケース2: PID 生存時 → exit 0、再起動なし
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - kill -0 で PID が生存確認できる（kill stub が exit 0）
+#   - スクリプトが exit 0 で終了する
+#   - tmux respawn-pane は呼ばれない
+# ===========================================================================
+
+@test "ac7/2: PID 生存時 → exit 0、再起動なし" {
+  # AC: cld_observe_any.pid が kill -0 で生存確認 → 生存なら exit 0
+  # RED: 実装前は fail する（スクリプト不在）
+
+  _create_session_json "12345" "%42" "cld-observe-any --window observer-test"
+
+  # kill stub: exit 0 = PID 生存
+  stub_command "kill" 'exit 0'
+
+  # tmux stub: 呼び出しを記録（respawn-pane が呼ばれたらフラグを残す）
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+exit 0
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  _run_resume_check
+
+  assert_success
+
+  # respawn-pane が呼ばれていないことを確認
+  run grep "respawn-pane" "$SANDBOX/tmux.log"
+  assert_failure
+}
+
+# ===========================================================================
+# AC7 ケース3: PID 死亡 + pane 存在 + spawn_cmd あり → lock ファイル削除 → respawn 実行
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - kill -0 が exit 1 = PID 死亡
+#   - lock_path ファイルを削除する
+#   - tmux respawn-pane -k -t pane_id spawn_cmd が実行される
+# ===========================================================================
+
+@test "ac7/3: PID 死亡 + pane 存在 + spawn_cmd あり → lock 削除 → respawn 実行" {
+  # AC: PID 死亡時 → lock ファイル削除 → pane_id 有効なら tmux respawn-pane で再起動
+  # RED: 実装前は fail する（スクリプト不在）
+
+  local lock_file="$SANDBOX/cld-observe-any.lock"
+  local lock_pid_file="${lock_file}.pid"
+  touch "$lock_file"
+  touch "$lock_pid_file"
+
+  _create_session_json "99999" "%42" "cld-observe-any --window observer-test" "$lock_file"
+
+  # kill stub: exit 1 = PID 死亡
+  stub_command "kill" 'exit 1'
+
+  # tmux stub: list-panes で pane 存在を返し、respawn-pane を記録する
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+case "\${1:-}" in
+  list-panes)
+    # pane %42 が存在する
+    echo "%42"
+    exit 0
+    ;;
+  respawn-pane)
+    echo "respawn-pane-called: \$*" >> "${SANDBOX}/tmux.log"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  _run_resume_check
+
+  assert_success
+
+  # lock ファイルが削除されていることを確認
+  [ ! -f "$lock_file" ] || {
+    echo "FAIL: lock_file still exists: $lock_file"
+    return 1
+  }
+
+  # lock.pid ファイルが削除されていることを確認
+  [ ! -f "$lock_pid_file" ] || {
+    echo "FAIL: lock.pid file still exists: $lock_pid_file"
+    return 1
+  }
+
+  # respawn-pane が呼ばれたことを確認
+  run grep "respawn-pane" "$SANDBOX/tmux.log"
+  assert_success
+}
+
+# ===========================================================================
+# AC7 ケース4: PID 死亡 + spawn_cmd null → error log 出力、exit 1
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - kill -0 が exit 1 = PID 死亡
+#   - spawn_cmd が null → respawn 不可
+#   - error ログを出力し exit 1
+# ===========================================================================
+
+@test "ac7/4: PID 死亡 + spawn_cmd null → error log 出力、exit 1" {
+  # AC: spawn_cmd が null の場合は error log + exit 1
+  # RED: 実装前は fail する（スクリプト不在）
+
+  _create_session_json "99999" "%42" "null"
+
+  # kill stub: exit 1 = PID 死亡
+  stub_command "kill" 'exit 1'
+
+  # tmux stub
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+exit 0
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  _run_resume_check
+
+  # spawn_cmd null → exit 1
+  # RED: スクリプト不在時は status=127、実装後は status=1 で fail する
+  # 実装後の PASS 条件: exit 1（スクリプトが spawn_cmd null を正しく扱う）
+  # かつ stderr に error ログが含まれること
+  assert_failure
+  # スクリプト不在の exit 127 ではなく、実装後に exit 1 であることを確認する
+  # （実装前: status=127 は assert_failure で PASS してしまうが、exit 1 チェックで RED になる）
+  [ "$status" -eq 1 ] || {
+    echo "RED: status=$status (expected 1 after implementation, got 127 means script missing)"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC7 ケース5: pane 消失 → events ファイル出力、exit 0
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - kill -0 が exit 1 = PID 死亡
+#   - tmux list-panes で pane_id が見つからない = pane 消失
+#   - .supervisor/events/daemon-restart-skipped.json を出力
+#   - exit 0（再起動不能と記録して graceful exit）
+# ===========================================================================
+
+@test "ac7/5: pane 消失 → daemon-restart-skipped.json 出力、exit 0" {
+  # AC: pane 自体が消失した場合 → .supervisor/events/daemon-restart-skipped.json を出力
+  # RED: 実装前は fail する（スクリプト不在）
+
+  _create_session_json "99999" "%99" "cld-observe-any --window observer-test"
+
+  # kill stub: exit 1 = PID 死亡
+  stub_command "kill" 'exit 1'
+
+  # tmux stub: list-panes で pane %99 が存在しない
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+case "\${1:-}" in
+  list-panes)
+    # pane %99 が存在しない（空を返す）
+    echo ""
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  _run_resume_check
+
+  assert_success
+
+  # daemon-restart-skipped.json が生成されていることを確認
+  local skipped_json="$SANDBOX/.supervisor/events/daemon-restart-skipped.json"
+  [ -f "$skipped_json" ] || {
+    echo "FAIL: daemon-restart-skipped.json が生成されていない"
+    ls -la "$SANDBOX/.supervisor/events/" 2>/dev/null || echo "events dir empty"
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5: respawn 失敗時 → daemon-startup-failed.json 出力
+#
+# RED: session-resume-observer-check.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - kill -0 が exit 1 = PID 死亡
+#   - pane_id 有効 = pane 存在
+#   - tmux respawn-pane が exit 1（失敗）
+#   - .supervisor/events/daemon-startup-failed.json が生成される
+#   - JSON フィールド: {timestamp, reason, pid_old, pid_new, error_log}
+# ===========================================================================
+
+@test "ac5: respawn 失敗時 → daemon-startup-failed.json 出力" {
+  # AC: 再起動 attempt が失敗した場合に .supervisor/events/daemon-startup-failed.json を出力
+  # RED: 実装前は fail する（スクリプト不在）
+
+  _create_session_json "99999" "%42" "cld-observe-any --window observer-test"
+
+  # kill stub: exit 1 = PID 死亡
+  stub_command "kill" 'exit 1'
+
+  # tmux stub: list-panes で pane 存在を返すが、respawn-pane は失敗
+  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+#!/usr/bin/env bash
+echo "tmux-stub: \$*" >> "${SANDBOX}/tmux.log"
+case "\${1:-}" in
+  list-panes)
+    echo "%42"
+    exit 0
+    ;;
+  respawn-pane)
+    # respawn 失敗
+    echo "respawn-pane-failed" >&2
+    exit 1
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+  touch "$SANDBOX/tmux.log"
+
+  _run_resume_check
+
+  # daemon-startup-failed.json が生成されていることを確認
+  local failed_json
+  failed_json=$(find "$SANDBOX/.supervisor/events" -name "daemon-startup-failed.json" 2>/dev/null | head -1)
+  [ -n "$failed_json" ] || {
+    echo "FAIL: daemon-startup-failed.json が生成されていない"
+    ls -la "$SANDBOX/.supervisor/events/" 2>/dev/null || echo "events dir empty"
+    return 1
+  }
+
+  # 必須フィールド確認: {timestamp, reason, pid_old, pid_new, error_log}
+  run jq -e '.timestamp and .reason and (.pid_old | . != null) and (.pid_new | . != null) and (.error_log | . != null)' "$failed_json"
+  assert_success
+}


### PR DESCRIPTION
## 概要

su-observer セッション crash → resume 時に cld-observe-any daemon が自動再起動されるよう SessionStart hook を実装する。

Closes #1147

## 変更内容

- **session-init.sh**: `cld_observe_any` フィールドを session.json schema に追加（AC1）
- **cld-observe-any**: flock 多重起動防止を実装（AC2）
- **spawn-controller.sh**: `_setup_observer_panes()` の既存バグ修正（引数なし起動 → `--window` 付き）+ pane metadata を session.json に atomic write（AC3）
- **session-resume-observer-check.sh** (新規): SessionStart hook 本体（AC4/AC5）
  - `.supervisor/session.json` の `cld_observe_any.pid` を kill -0 で確認
  - PID 死亡時 → lock クリア → `tmux respawn-pane` で再起動
  - pane 消失 → `daemon-restart-skipped.json` 出力（graceful）
  - respawn 失敗 → `daemon-startup-failed.json` 出力（AC5）
- **.claude/settings.json**: SessionStart hook に新規スクリプトを登録（timeout 5000）（AC6）

## 手動再現テスト手順

1. su-observer session を起動（spawn-controller.sh が session.json に pane metadata を記録）
2. `pkill -f cld-observe-any` で daemon を強制終了
3. `rm -f /tmp/cld-observe-any.lock /tmp/cld-observe-any.lock.pid` でロックファイルを手動削除
4. `claude --resume` で session を再起動
5. SessionStart hook が発火し、cld-observe-any が自動再起動されることを確認

## Defense in depth

- 本 PR (#1147 Option B): resume 後の復元
- #1146 Option A: systemd / nohup による独立 daemon（crash 中も生存）

両者は補完関係（重複ではない）。