### PR TITLE
feat(observer): IDLE-COMPLETED → 自動 next-action 機構（cleanup + 次 Wave spawn）

### DIFF
--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -566,6 +566,34 @@ while true; do
                                 > "${EVENT_DIR}/idle-completed-killed-${SAFE_WIN}-$(date -u +%Y%m%dT%H%M%SZ).json"
                         fi
                         unset 'IDLE_COMPLETED_TS[$WIN]'
+                        # ★ #1155: opt-in next-spawn 判定（IDLE_COMPLETED_AUTO_NEXT_SPAWN）
+                        # AUTO_KILL と独立評価。AUTO_KILL=0 の場合は warning + skip。
+                        if [[ "${IDLE_COMPLETED_AUTO_NEXT_SPAWN:-0}" != "0" ]]; then
+                            if [[ "${IDLE_COMPLETED_AUTO_KILL:-0}" != "1" ]]; then
+                                echo "[IDLE-COMPLETED] WARN: IDLE_COMPLETED_AUTO_NEXT_SPAWN requires AUTO_KILL=1 — next-spawn skip" >&2
+                            else
+                                _WAVE_QUEUE="${SUPERVISOR_DIR:-.supervisor}/wave-queue.json"
+                                _WAVE_CHECK_LIB="$(dirname "${BASH_SOURCE[0]}")/../../twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+                                _AUTO_NEXT_SPAWN="$(dirname "${BASH_SOURCE[0]}")/../../twl/skills/su-observer/scripts/auto-next-spawn.sh"
+                                if [[ -f "$_WAVE_CHECK_LIB" ]]; then
+                                    # shellcheck source=/dev/null
+                                    source "$_WAVE_CHECK_LIB"
+                                    if _all_current_wave_idle_completed "$_WAVE_QUEUE" IDLE_COMPLETED_TS; then
+                                        _DRY_RUN_FLAG=""
+                                        [[ "${IDLE_COMPLETED_AUTO_NEXT_SPAWN}" == "dry-run" ]] && _DRY_RUN_FLAG="--dry-run"
+                                        if [[ -f "$_AUTO_NEXT_SPAWN" ]]; then
+                                            bash "$_AUTO_NEXT_SPAWN" \
+                                                --queue "$_WAVE_QUEUE" \
+                                                --triggered-by "$WIN" \
+                                                ${_DRY_RUN_FLAG:+"$_DRY_RUN_FLAG"} 2>&1 \
+                                                | tee -a "${SUPERVISOR_DIR:-.supervisor}/intervention-log.md"
+                                        else
+                                            echo "[IDLE-COMPLETED] WARN: auto-next-spawn.sh not found: ${_AUTO_NEXT_SPAWN}" >&2
+                                        fi
+                                    fi
+                                fi
+                            fi
+                        fi
                     else
                         echo "[IDLE-COMPLETED] $WIN: auto-kill failed (window already gone or permission denied)" >&2
                     fi

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -357,6 +357,8 @@ skills:
       - script: session-init          # #814 Phase 1: SupervisorSession 初期化
       - script: step0-memory-ambient  # #830 Wave B: Step 0 ambient-hints.md TTL チェック・書き込み
       - script: observer-idle-check   # #1117: _check_idle_completed() stateless 関数 (IDLE-COMPLETED 検知)
+      - script: auto-next-spawn       # #1155: Wave 候補自動 spawn（exec argv 直接渡し, allowlist 検証）
+      - script: observer-wave-check   # #1155: _all_current_wave_idle_completed() Wave 全 window 判定
       - reference: pitfalls-catalog   # Phase A: 起動時 Step 0 Read MUST
       - reference: proxy-dialog-playbook  # #814 Phase 2: proxy 対話完全手順
       - reference: ref-invariants     # 不変条件 A-M 正典参照（境界説明）

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -59,6 +59,28 @@ spawnable_by:
 **`refs/su-observer-wave-management.md` を Read** して実行。
 問題検出時の介入: **`plugins/twl/refs/intervention-catalog.md` を Read** して 3 層分類（Auto/Confirm/Escalate）を照合（1-hop 直接参照）。
 
+### Wave N → Wave N+1 自動連鎖（#1155）
+
+`IDLE_COMPLETED_AUTO_NEXT_SPAWN=1` と `IDLE_COMPLETED_AUTO_KILL=1` を同時に設定すると、`[IDLE-COMPLETED]` kill 成功後に `.supervisor/wave-queue.json` から次 Wave を自動 spawn する。
+
+**wave-queue.json スキーマ**（`skills/su-observer/schemas/wave-queue.schema.json` 参照）:
+```json
+{
+  "version": 1,
+  "current_wave": 6,
+  "queue": [{
+    "wave": 7,
+    "issues": [1155],
+    "spawn_cmd_argv": ["bash", "plugins/twl/skills/su-observer/scripts/spawn-controller.sh", "..."],
+    "depends_on_waves": [6],
+    "spawn_when": "all_current_wave_idle_completed"
+  }]
+}
+```
+
+enqueue は `spawn-controller.sh` 起動時に `CHAIN_WAVE_QUEUE_ENTRY` 環境変数（JSON）で渡す（IF-2）。
+`auto-next-spawn.sh` は `--dry-run` で動作確認可能（実際の spawn なし）。
+
 ### compaction が必要な場合
 
 `Skill(twl:su-compact)` を呼び出して知識外部化し、`/compact` 手動実行をユーザーへ提案する（`/compact` は built-in CLI のためユーザー手動実行が必須）。

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -788,6 +788,8 @@ done
 
 **自動 kill オプション**: `IDLE_COMPLETED_AUTO_KILL=1`（opt-in、Issue #1132）で `[IDLE-COMPLETED]` 発火時に `tmux kill-window` を自動実行（Layer 0 Auto）。デフォルトは alert のみ（Layer 1 Confirm）。
 
+**自動 next-spawn オプション**: `IDLE_COMPLETED_AUTO_NEXT_SPAWN=1`（opt-in、Issue #1155）で kill 成功後に `.supervisor/wave-queue.json` を参照して次 Wave を自動 spawn（`AUTO_KILL=1` と独立評価、両方設定が必要）。`AUTO_NEXT_SPAWN=dry-run` で spawn コマンド echo のみ（実行なし）。未設定時は kill-only（#1132 既存動作維持）。
+
 ---
 
 ## Wave 種別ごとのチャネル選択ガイド

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -119,7 +119,7 @@ tmux capture-pane -t <worker-win> -p -S -50 | grep -E '⏵⏵ auto mode|permissi
 
 **S-1 の区別（Issue #1117）**:
 - **S-1a IDLE（一時的、継続観察）**: completion phrase 未確認、または debounce 未達。タスク進行中の一時的な非活性として放置可
-- **S-1b IDLE 確定（cleanup 対象）**: completion phrase 60s 安定 → `[IDLE-COMPLETED]` 発火。`SU-4 ≤5` 制約（§4.5）圧迫回避のため速やかに kill する。**`IDLE_COMPLETED_AUTO_KILL=1` 設定済みなら observer 介入不要（自動 cleanup、#1132）**
+- **S-1b IDLE 確定（cleanup 対象）**: completion phrase 60s 安定 → `[IDLE-COMPLETED]` 発火。`SU-4 ≤5` 制約（§4.5）圧迫回避のため速やかに kill する。**`IDLE_COMPLETED_AUTO_KILL=1` 設定済みなら observer 介入不要（自動 cleanup、#1132）**。**`IDLE_COMPLETED_AUTO_NEXT_SPAWN=1` 設定済みなら次 Wave 自動起動（#1155）**
 
 **S-1b と §4.3（LLM-active-override）の関係**: A2 に現在進行形 indicator がある場合は S-2 THINKING 確定のため `[IDLE-COMPLETED]` 絶対 emit 禁止。`_check_idle_completed()` の C3 条件で保証済み。
 

--- a/plugins/twl/skills/su-observer/refs/su-observer-wave-management.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-wave-management.md
@@ -85,3 +85,51 @@ _crg_path="${TWILL_REPO_ROOT}/main/.code-review-graph"
 2. `plugins/twl/refs/observation-pattern-catalog.md` を Read → パターンと照合
 3. 集約結果をユーザーに提示
 4. 新たな Issue 化が必要か確認し、承認時のみ Issue draft 生成
+
+---
+
+## Wave 自動連鎖（auto-next-spawn、#1155）
+
+`IDLE_COMPLETED_AUTO_NEXT_SPAWN=1`（`AUTO_KILL=1` 必須）で Wave N → Wave N+1 の連鎖実行を自動化する。
+
+### 設定方法
+
+```bash
+export IDLE_COMPLETED_AUTO_KILL=1
+export IDLE_COMPLETED_AUTO_NEXT_SPAWN=1  # or "dry-run" for testing
+```
+
+### wave-queue.json 管理
+
+- パス: `.supervisor/wave-queue.json`
+- スキーマ: `skills/su-observer/schemas/wave-queue.schema.json`（JSON Schema v7）
+- enqueue: `spawn-controller.sh` 起動時に `CHAIN_WAVE_QUEUE_ENTRY` 環境変数（JSON）で渡す
+
+```json
+{
+  "version": 1,
+  "current_wave": 6,
+  "queue": [{
+    "wave": 7,
+    "issues": [1155],
+    "spawn_cmd_argv": ["bash", "plugins/twl/skills/su-observer/scripts/spawn-controller.sh", "..."],
+    "depends_on_waves": [6],
+    "spawn_when": "all_current_wave_idle_completed"
+  }]
+}
+```
+
+### auto-next-spawn.sh フロー
+
+```
+kill 成功 → IDLE_COMPLETED_AUTO_NEXT_SPAWN=1 チェック
+  → observer-wave-check.sh::_all_current_wave_idle_completed()
+    → 全 window IDLE-COMPLETED? Yes → auto-next-spawn.sh 呼び出し
+      → JSON Schema validation → allowlist チェック → exec argv 直接渡し
+      → wave-queue.json dequeue + current_wave 更新
+      → intervention-log.md に記録
+```
+
+**参照スクリプト**:
+- `skills/su-observer/scripts/auto-next-spawn.sh`（メイン spawn スクリプト、#1155）
+- `skills/su-observer/scripts/lib/observer-wave-check.sh`（Wave 判定ライブラリ、#1155）

--- a/plugins/twl/skills/su-observer/schemas/wave-queue.schema.json
+++ b/plugins/twl/skills/su-observer/schemas/wave-queue.schema.json
@@ -1,0 +1,61 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "WaveQueue",
+  "description": "Wave 候補キュー管理スキーマ (#1155)",
+  "type": "object",
+  "required": ["version", "current_wave", "queue"],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "current_wave": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "queue": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/WaveEntry"
+      }
+    }
+  },
+  "definitions": {
+    "WaveEntry": {
+      "type": "object",
+      "required": ["wave", "issues", "spawn_cmd_argv", "depends_on_waves", "spawn_when"],
+      "additionalProperties": false,
+      "properties": {
+        "wave": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "issues": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "spawn_cmd_argv": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "description": "shell 文字列ではなく argv 配列で保持（shell injection 防止）"
+        },
+        "depends_on_waves": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "spawn_when": {
+          "type": "string",
+          "enum": ["all_current_wave_idle_completed"]
+        }
+      }
+    }
+  }
+}

--- a/plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh
+++ b/plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# auto-next-spawn.sh — Wave 候補自動 spawn (#1155)
+#
+# Usage:
+#   bash auto-next-spawn.sh --queue <path> --triggered-by <window> [--dry-run]
+#
+# 動作:
+#   wave-queue.json から次 Wave 1 件 dequeue → spawn_cmd_argv を exec で argv 直接渡し
+#   → wave-queue.json 更新 → intervention-log 記録
+#
+# 引数:
+#   --queue <path>         wave-queue.json パス（必須）
+#   --triggered-by <win>   kill トリガーの window 名（必須）
+#   --dry-run              spawn コマンドの echo のみ（実際の exec なし）
+#
+# spawn_cmd_argv[0] allowlist: bash / /bin/bash / /usr/bin/bash / cld-spawn
+# allowlist 外の場合は abort + intervention-log に拒否ログ
+
+set -uo pipefail
+
+# ---- 引数パース ----
+QUEUE_FILE=""
+TRIGGERED_BY=""
+DRY_RUN=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --queue)        QUEUE_FILE="$2"; shift 2 ;;
+    --triggered-by) TRIGGERED_BY="$2"; shift 2 ;;
+    --dry-run)      DRY_RUN=1; shift ;;
+    *) echo "[auto-next-spawn] WARN: unknown argument: $1" >&2; shift ;;
+  esac
+done
+
+if [[ -z "$QUEUE_FILE" || -z "$TRIGGERED_BY" ]]; then
+  echo "[auto-next-spawn] ERROR: --queue and --triggered-by are required" >&2
+  exit 1
+fi
+
+# ---- intervention-log パス（SUPERVISOR_DIR 環境変数またはデフォルト .supervisor）----
+_SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+INTERVENTION_LOG="${_SUPERVISOR_DIR}/intervention-log.md"
+
+_append_log() {
+  mkdir -p "$_SUPERVISOR_DIR" 2>/dev/null || true
+  {
+    printf '%s %s\n' "$(date -u +%FT%TZ)" "$1"
+  } >> "$INTERVENTION_LOG" || {
+    echo "[auto-next-spawn] WARN: intervention-log append failed (continuing)" >&2
+  }
+}
+
+# ---- wave-queue.json 不在チェック ----
+if [[ ! -f "$QUEUE_FILE" ]]; then
+  echo "[auto-next-spawn] WARN: wave-queue.json not found: ${QUEUE_FILE}" >&2
+  _append_log "auto-cleanup+next-spawn-skipped: triggered_by=${TRIGGERED_BY}, reason=wave-queue.json not found"
+  exit 0
+fi
+
+# jq schema validation: version=1, current_wave(int), queue[].wave/issues/spawn_cmd_argv(≥1)/depends_on_waves/spawn_when
+_schema_ok=1
+if ! jq -e '
+  .version == 1 and
+  (.current_wave | type == "number") and
+  (.queue | type == "array") and
+  (
+    (.queue | length == 0) or
+    (
+      .queue[] |
+      (.wave | type == "number") and
+      (.issues | type == "array") and
+      (.spawn_cmd_argv | type == "array" and length >= 1) and
+      (.depends_on_waves | type == "array") and
+      (.spawn_when == "all_current_wave_idle_completed")
+    )
+  )
+' "$QUEUE_FILE" > /dev/null 2>&1; then
+  _schema_ok=0
+fi
+
+if [[ "$_schema_ok" -eq 0 ]]; then
+  echo "[auto-next-spawn] WARN: JSON Schema validation failed for ${QUEUE_FILE}" >&2
+  _append_log "auto-cleanup+next-spawn-skipped: triggered_by=${TRIGGERED_BY}, reason=JSON Schema validation failed"
+  exit 0
+fi
+
+# ---- queue が空なら skip ----
+QUEUE_LEN=$(jq '.queue | length' "$QUEUE_FILE" 2>/dev/null || echo "0")
+if [[ "$QUEUE_LEN" -eq 0 ]]; then
+  echo "[auto-next-spawn] INFO: queue is empty, no next wave to spawn" >&2
+  exit 0
+fi
+
+# ---- 次 Wave エントリ取得 ----
+NEXT_WAVE=$(jq -r '.queue[0].wave' "$QUEUE_FILE")
+NEXT_ISSUES=$(jq -r '[.queue[0].issues[] | tostring] | join(",")' "$QUEUE_FILE")
+
+# spawn_cmd_argv を bash 配列に読み込む
+mapfile -t SPAWN_ARGV < <(jq -r '.queue[0].spawn_cmd_argv[]' "$QUEUE_FILE")
+
+# ---- allowlist チェック（shell injection 防止、AC-4）----
+CMD0="${SPAWN_ARGV[0]:-}"
+_ALLOWED=0
+case "$CMD0" in
+  bash|/bin/bash|/usr/bin/bash) _ALLOWED=1 ;;
+  *) [[ "$(basename "$CMD0")" == "cld-spawn" ]] && _ALLOWED=1 ;;
+esac
+
+if [[ "$_ALLOWED" -eq 0 ]]; then
+  echo "[auto-next-spawn] ABORT: spawn_cmd_argv[0] not in allowlist: ${CMD0}" >&2
+  _append_log "auto-cleanup+next-spawn-aborted: triggered_by=${TRIGGERED_BY}, reason=spawn_cmd_argv[0] not in allowlist: ${CMD0}"
+  exit 1
+fi
+
+# ---- dry-run モード（AC-8）----
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  echo "[auto-next-spawn] DRY-RUN: would exec: ${SPAWN_ARGV[*]}"
+  _append_log "auto-cleanup+next-spawn-dryrun: triggered_by=${TRIGGERED_BY}, next_wave=${NEXT_WAVE}, spawned=[${NEXT_ISSUES}]"
+  exit 0
+fi
+
+# ---- actual spawn ----
+# dequeue + current_wave 更新（spawn 前に永続化）
+ORIGINAL_JSON=$(cat "$QUEUE_FILE")
+UPDATED_JSON=$(jq --argjson nw "$NEXT_WAVE" '
+  .current_wave = $nw |
+  .queue = .queue[1:]
+' "$QUEUE_FILE") && printf '%s\n' "$UPDATED_JSON" > "$QUEUE_FILE" || {
+  echo "[auto-next-spawn] ERROR: failed to update wave-queue.json" >&2
+  exit 1
+}
+
+echo "[auto-next-spawn] spawning wave ${NEXT_WAVE}: ${SPAWN_ARGV[*]}"
+_append_log "auto-cleanup+next-spawn: triggered_by=${TRIGGERED_BY}, killed=${TRIGGERED_BY}, next_wave=${NEXT_WAVE}, spawned=[${NEXT_ISSUES}]"
+
+exec "${SPAWN_ARGV[@]}"
+# exec 失敗時（通常ここには到達しない）
+printf '%s\n' "$ORIGINAL_JSON" > "$QUEUE_FILE"
+_append_log "auto-cleanup+next-spawn-failed: triggered_by=${TRIGGERED_BY}, next_wave=${NEXT_WAVE}, reason=exec failed"
+exit 1

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# observer-wave-check.sh — Wave 全 window IDLE-COMPLETED 判定ライブラリ (#1155)
+#
+# Usage (source):
+#   source observer-wave-check.sh
+#   _all_current_wave_idle_completed "$wave_queue_file" IDLE_COMPLETED_TS
+#
+# Returns:
+#   exit 0  → 同 Wave 全 window が IDLE-COMPLETED（next-spawn 可）
+#   exit 1  → 同 Wave に active window が残存（next-spawn skip）
+#
+# SRP: _all_current_wave_idle_completed のみ定義。_check_idle_completed は observer-idle-check.sh 参照。
+
+# _all_current_wave_idle_completed wave_queue_file ts_array_name
+#
+# 引数:
+#   $1 = wave-queue.json パス
+#   $2 = IDLE_COMPLETED_TS 連想配列の変数名（nameref 経由でアクセス）
+#
+# 判定基準（AC-3）:
+#   (i)  wave-queue.json の current_wave を取得
+#   (ii) tmux list-windows で ^(ap|wt|coi)-.*  パターンの window 集合を取得
+#   (iii) 全 window で IDLE_COMPLETED_TS[$WIN] > 0 が真なら 0 を返す
+_all_current_wave_idle_completed() {
+  local queue_file="${1:-}"
+  local ts_array_name="${2:-IDLE_COMPLETED_TS}"
+
+  if [[ -z "$queue_file" || ! -f "$queue_file" ]]; then
+    echo "[observer-wave-check] WARN: wave-queue.json not found: ${queue_file}" >&2
+    return 1
+  fi
+
+  local current_wave
+  current_wave=$(jq -r '.current_wave // empty' "$queue_file" 2>/dev/null || echo "")
+  if [[ -z "$current_wave" ]]; then
+    echo "[observer-wave-check] WARN: current_wave not found in ${queue_file}" >&2
+    return 1
+  fi
+
+  # tmux list-windows から ^(ap|wt|coi)-.*  パターンの window を取得
+  local wave_windows
+  wave_windows=$(tmux list-windows -a -F '#{window_name}' 2>/dev/null \
+    | grep -E '^(ap|wt|coi)-' || true)
+
+  if [[ -z "$wave_windows" ]]; then
+    echo "[observer-wave-check] WARN: no (ap|wt|coi)-* windows found" >&2
+    return 1
+  fi
+
+  local win ts
+  while IFS= read -r win; do
+    [[ -z "$win" ]] && continue
+    # nameref で IDLE_COMPLETED_TS[$WIN] を参照
+    local -n _ts_ref="${ts_array_name}" 2>/dev/null || true
+    ts="${_ts_ref[$win]:-0}"
+    if [[ "$ts" -le 0 ]]; then
+      echo "[observer-wave-check] active window found: ${win} (IDLE_COMPLETED_TS=0)" >&2
+      return 1
+    fi
+  done <<< "$wave_windows"
+
+  return 0
+}

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -193,6 +193,24 @@ WARN
     printf '{"wave":%s,"watcher_pids":[]}\n' "$CHAIN_ISSUE" > "$_watcher_pids_file" 2>/dev/null || true
   fi
 
+  # ★ #1155: wave-queue.json へ enqueue（IF-2）
+  # CHAIN_WAVE_QUEUE_ENTRY が設定されている場合のみ実行（JSON 文字列で渡す）
+  # 例: CHAIN_WAVE_QUEUE_ENTRY='{"wave":7,"issues":[1155],"spawn_cmd_argv":["bash","..."],"depends_on_waves":[6],"spawn_when":"all_current_wave_idle_completed"}'
+  _wave_queue_file="${_supervisor_dir}/wave-queue.json"
+  if [[ -n "${CHAIN_WAVE_QUEUE_ENTRY:-}" ]]; then
+    if [[ ! -f "$_wave_queue_file" ]]; then
+      # 初期化: current_wave は CHAIN_ISSUE を使う
+      printf '{"version":1,"current_wave":%s,"queue":[]}\n' "${CHAIN_ISSUE:-0}" > "$_wave_queue_file" 2>/dev/null || true
+    fi
+    # エントリを queue に append（jq で安全に結合）
+    {
+      _updated=$(jq --argjson entry "$CHAIN_WAVE_QUEUE_ENTRY" '.queue += [$entry]' "$_wave_queue_file" 2>/dev/null)
+      [[ -n "$_updated" ]] && printf '%s\n' "$_updated" > "$_wave_queue_file"
+    } || {
+      echo "[spawn-controller] WARN: wave-queue.json enqueue failed (continuing spawn)" >&2
+    }
+  fi
+
   # prompt-file の内容を --context として注入
   CHAIN_CONTEXT="$(cat "$PROMPT_FILE" 2>/dev/null || true)"
   CONTEXT_ARG=()

--- a/plugins/twl/tests/bats/ac-test-mapping-1155.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1155.yaml
@@ -1,0 +1,347 @@
+mappings:
+  # ===========================================================================
+  # AC-1: IDLE_COMPLETED_AUTO_NEXT_SPAWN 環境変数新設（AUTO_KILL と独立評価）
+  # ===========================================================================
+  - ac_index: 1
+    ac_text: "IDLE_COMPLETED_AUTO_NEXT_SPAWN 環境変数を新設。IDLE_COMPLETED_AUTO_KILL=1 と独立評価。AUTO_NEXT_SPAWN=1 時のみ next-spawn 判定実行。デフォルト 0（disabled = #1132 既存 kill-only 動作維持）。AUTO_KILL=0 & AUTO_NEXT_SPAWN=1 は warning log + next-spawn skip。bats fixture で AUTO_KILL 各組み合わせ動作検証。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac1: cld-observe-any has IDLE_COMPLETED_AUTO_NEXT_SPAWN branch"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "1b"
+    ac_text: "AUTO_NEXT_SPAWN と AUTO_KILL が独立評価される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac1: AUTO_NEXT_SPAWN and AUTO_KILL are evaluated independently"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "1c"
+    ac_text: "AUTO_KILL=0 & AUTO_NEXT_SPAWN=1 の場合に warning log が出力される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac1: AUTO_KILL=0 and AUTO_NEXT_SPAWN=1 triggers warning"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-2: wave-queue.json JSON Schema 管理 + validation
+  # ===========================================================================
+  - ac_index: 2
+    ac_text: ".supervisor/wave-queue.json に JSON Schema で Wave 候補を管理。auto-next-spawn.sh 起動時に JSON Schema validation MUST（jq 検証 or validate-schema.sh）。不正なら warning log + skip。必須フィールド: version(int=1), current_wave(int), queue[].wave(int), queue[].issues(int[]), queue[].spawn_cmd_argv(string[], 1+), queue[].depends_on_waves(int[]), queue[].spawn_when(enum: all_current_wave_idle_completed)。不在時は warning log + skip（exit 0）。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac9-case5: wave-queue.schema.json exists and is valid JSON"
+    impl_files:
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "2b"
+    ac_text: "wave-queue.schema.json に version フィールド（int=1）が必須として定義される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac2: wave-queue.json schema has required version field (int=1)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+
+  - ac_index: "2c"
+    ac_text: "wave-queue.schema.json に current_wave フィールドが必須として定義される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac2: wave-queue.json schema has required current_wave field (int)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+
+  - ac_index: "2d"
+    ac_text: "wave-queue.schema.json に spawn_cmd_argv（string[], minItems=1）が定義される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac2: wave-queue.json schema has required queue[].spawn_cmd_argv field (string[], minItems=1)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+
+  - ac_index: "2e"
+    ac_text: "wave-queue.schema.json に spawn_when enum（all_current_wave_idle_completed）が定義される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac2: wave-queue.json schema has spawn_when enum (all_current_wave_idle_completed)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+
+  - ac_index: "2f"
+    ac_text: "auto-next-spawn.sh 起動時に jq または validate-schema.sh で JSON Schema validation を実行する"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac2: auto-next-spawn.sh performs jq schema validation on startup"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-3: observer-wave-check.sh 新設（_all_current_wave_idle_completed 判定）
+  # ===========================================================================
+  - ac_index: 3
+    ac_text: "kill 成功後、_all_current_wave_idle_completed（observer-wave-check.sh 新規）で「同 Wave 全 controller window が IDLE-COMPLETED 状態」判定。判定観測可能基準: (i) wave-queue.json.current_wave 取得、(ii) 同 wave の monitor 対象 window 集合を tmux list-windows ^(ap|wt|coi)-.*フィルタから取得、(iii) 全 window で IDLE_COMPLETED_TS[$WIN] > 0 が真の場合のみ判定真。判定偽（同 Wave 他 window が active）の場合は kill のみ終了。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac3: scripts/lib/observer-wave-check.sh exists"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+
+  - ac_index: "3b"
+    ac_text: "_all_current_wave_idle_completed() 関数が定義されている"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac3: observer-wave-check.sh defines _all_current_wave_idle_completed function"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+
+  - ac_index: "3c"
+    ac_text: "関数内で wave-queue.json の current_wave を取得している"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac3: _all_current_wave_idle_completed uses wave-queue.json current_wave"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+
+  - ac_index: "3d"
+    ac_text: "tmux list-windows の結果を ^(ap|wt|coi)-.* パターンでフィルタする"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac3: _all_current_wave_idle_completed uses tmux list-windows with (ap|wt|coi) filter"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+
+  - ac_index: "3e"
+    ac_text: "同 Wave 全 window の IDLE_COMPLETED_TS[$WIN] > 0 を確認する"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac3: _all_current_wave_idle_completed checks IDLE_COMPLETED_TS for all wave windows"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+
+  # ===========================================================================
+  # AC-4: auto-next-spawn.sh 新設
+  # ===========================================================================
+  - ac_index: 4
+    ac_text: "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh 新設。引数: --queue <path> --triggered-by <window> [--dry-run]。動作: queue から次 Wave 1 件 dequeue → spawn_cmd_argv 配列を exec で argv 直接渡し（eval/bash -c 禁止）→ wave-queue.json から該当 entry 削除 + current_wave 更新 → stdout 実行サマリ。spawn 失敗時 queue に残し exit 1。spawn_cmd_argv[0] は allowlist（bash / cld-spawn 絶対パスのみ）検証、外れる場合 abort + intervention-log に拒否ログ。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh exists"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "4b"
+    ac_text: "auto-next-spawn.sh が --queue 引数を受け付ける"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh accepts --queue argument"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "4c"
+    ac_text: "auto-next-spawn.sh が --triggered-by 引数を受け付ける"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh accepts --triggered-by argument"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "4d"
+    ac_text: "spawn_cmd_argv の実行に exec を使用し eval/bash -c は禁止"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh uses exec not eval for spawn_cmd_argv"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "4e"
+    ac_text: "spawn_cmd_argv[0] を allowlist（bash / cld-spawn 絶対パス）で検証する"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh validates spawn_cmd_argv[0] against allowlist"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "4f"
+    ac_text: "アローリスト外の spawn_cmd_argv[0] を abort し intervention-log に拒否ログを書く"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac4: auto-next-spawn.sh rejects spawn_cmd_argv[0] outside allowlist with intervention-log"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-5: intervention-log.md への記録
+  # ===========================================================================
+  - ac_index: 5
+    ac_text: "auto-cleanup + auto-next-spawn 実行時に .supervisor/intervention-log.md に append。形式: <ISO8601 UTC> auto-cleanup+next-spawn: triggered_by=<window>, killed=<window>, next_wave=<N>, spawned=[<issue_csv>]。spawn skip 時: auto-cleanup+next-spawn-skipped: triggered_by=<window>, reason=<理由>。append 失敗時は stderr 警告のみで継続。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac5: auto-next-spawn.sh appends ISO8601 UTC timestamp to intervention-log"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "5b"
+    ac_text: "intervention-log の形式が triggered_by=<window>, killed=<window> を含む"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac5: intervention-log format includes triggered_by and killed fields"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "5c"
+    ac_text: "spawn 成功時のログに next_wave=<N>, spawned=[<issue_csv>] を含む"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac5: intervention-log format includes next_wave and spawned fields on success"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "5d"
+    ac_text: "skip 時に auto-cleanup+next-spawn-skipped: triggered_by=<w>, reason=<理由> を記録する"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac5: intervention-log records spawn-skipped with reason on skip"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-6: AUTO_NEXT_SPAWN=0 / 未設定時の #1132 既存 kill-only 動作保全
+  # ===========================================================================
+  - ac_index: 6
+    ac_text: "IDLE_COMPLETED_AUTO_NEXT_SPAWN=0 または未設定の場合、#1132 既存 kill-only 動作変更しない。bats fixture で「AUTO_KILL=1 のみ設定 → kill 実行 / wave-queue.json 不参照 / intervention-log auto- 記録なし / unset IDLE_COMPLETED_TS[$WIN] のみ」検証。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac6: AUTO_KILL=1 only (no AUTO_NEXT_SPAWN) -> kill executes"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "6b"
+    ac_text: "kill-only パスでは wave-queue.json を参照しない"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac6: AUTO_KILL=1 only -> wave-queue.json not referenced in kill-only path"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "6c"
+    ac_text: "kill 後 intervention-log に auto-cleanup+next-spawn 行がない"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac6: AUTO_KILL=1 only -> no auto-cleanup+next-spawn in intervention-log"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "6d"
+    ac_text: "kill 成功後に IDLE_COMPLETED_TS[$WIN] を unset する（既存動作）"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac6: AUTO_KILL=1 only -> unset IDLE_COMPLETED_TS[WIN] after kill"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  # ===========================================================================
+  # AC-7: 誤 spawn シナリオ全 spawn-skip（5 シナリオ）
+  # ===========================================================================
+  - ac_index: "7a"
+    ac_text: "同 Wave に active window 残存 → spawn skip"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac7-a: active window remaining in wave -> spawn skipped"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "7b"
+    ac_text: "_check_idle_completed C3(LLM-active-override)が真の window 存在 → spawn skip"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac7-b: LLM-active-override (C3) window exists -> spawn skipped"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: "7c"
+    ac_text: "wave-queue.json 不在 → warning log + spawn skip（exit 0）"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac7-c: wave-queue.json absent -> spawn skipped (exit 0)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "7d"
+    ac_text: "JSON Schema validation 失敗（e.g. version=2） → warning log + spawn skip"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac7-d: JSON schema validation failure -> spawn skipped"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+      - "plugins/twl/skills/su-observer/schemas/wave-queue.schema.json"
+
+  - ac_index: "7e"
+    ac_text: "current_wave mismatch（kill 対象 window が current_wave に属さない） → spawn skip"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac7-e: current_wave mismatch (triggered window not in current_wave) -> spawn skipped"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-8: dry-run モード
+  # ===========================================================================
+  - ac_index: 8
+    ac_text: "IDLE_COMPLETED_AUTO_NEXT_SPAWN=dry-run で判定実行 + spawn コマンド echo のみ、実際の spawn なし。auto-next-spawn.sh --dry-run も同等。intervention-log に auto-cleanup+next-spawn-dryrun: として記録。queue は dequeue しない（dry-run なので状態保持）。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac8: IDLE_COMPLETED_AUTO_NEXT_SPAWN=dry-run in env -> dry-run mode activated"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: "8b"
+    ac_text: "auto-next-spawn.sh --dry-run フラグで実際の spawn が抑制される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac8: auto-next-spawn.sh --dry-run flag suppresses exec"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "8c"
+    ac_text: "dry-run 時の intervention-log エントリに auto-cleanup+next-spawn-dryrun: プレフィックスを使う"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac8: dry-run intervention-log uses dryrun prefix"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  - ac_index: "8d"
+    ac_text: "dry-run 後に wave-queue.json の queue が変化しない（dequeue しない）"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac9-case6: dry-run -> wave-queue.json queue state preserved (not dequeued)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+
+  # ===========================================================================
+  # AC-9: observer-auto-next-spawn.bats 6 ケース GREEN
+  # （本ファイルそのものの AC であるため test_file = 本ファイル）
+  # ===========================================================================
+  - ac_index: 9
+    ac_text: "plugins/twl/tests/bats/observer-auto-next-spawn.bats 新規作成、6 ケース全 GREEN: (1) AUTO_NEXT_SPAWN 未設定→kill のみ (2) AUTO_NEXT_SPAWN=1+全idle+valid queue→spawn実行+log+json更新 (3) AUTO_NEXT_SPAWN=1+一部active→skip+log (4) AUTO_NEXT_SPAWN=1+queue不在→warning+skip (5) AUTO_NEXT_SPAWN=1+schema invalid→warning+skip (6) AUTO_NEXT_SPAWN=dry-run→echo+queue保持+dryrunlog"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac9-case1: AUTO_NEXT_SPAWN unset -> kill only, wave-queue.json not referenced"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-wave-check.sh"
+      - "plugins/session/scripts/cld-observe-any"
+
+  # ===========================================================================
+  # AC-10: ドキュメント 5 箇所更新
+  # ===========================================================================
+  - ac_index: 10
+    ac_text: "以下 5 箇所 update: (1) monitor-channel-catalog.md §[IDLE-COMPLETED] に AUTO_NEXT_SPAWN 説明追加、(2) pitfalls-catalog.md §4.10 S-1b 行に記述追記、(3) SKILL.md の Wave 管理セクション更新、(4) deps.yaml に auto-next-spawn.sh と observer-wave-check.sh 登録、(5) su-observer-wave-management.md に参照リンク追加。"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: monitor-channel-catalog.md has IDLE_COMPLETED_AUTO_NEXT_SPAWN description"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md"
+
+  - ac_index: "10b"
+    ac_text: "pitfalls-catalog.md §4.10 S-1b 行に AUTO_NEXT_SPAWN 関連の記述が追記される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: pitfalls-catalog.md section 4.10 S-1b row has AUTO_NEXT_SPAWN description"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"
+
+  - ac_index: "10c"
+    ac_text: "SKILL.md の Wave 管理セクションが auto-next-spawn を反映して更新される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: SKILL.md Wave management section is updated"
+    impl_files:
+      - "plugins/twl/skills/su-observer/SKILL.md"
+
+  - ac_index: "10d"
+    ac_text: "deps.yaml に auto-next-spawn.sh が登録される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: deps.yaml registers auto-next-spawn.sh"
+    impl_files:
+      - "plugins/twl/deps.yaml"
+
+  - ac_index: "10e"
+    ac_text: "deps.yaml に observer-wave-check.sh が登録される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: deps.yaml registers observer-wave-check.sh"
+    impl_files:
+      - "plugins/twl/deps.yaml"
+
+  - ac_index: "10f"
+    ac_text: "su-observer-wave-management.md に auto-next-spawn.sh への参照リンクが追加される"
+    test_file: "plugins/twl/tests/bats/observer-auto-next-spawn.bats"
+    test_name: "ac10: su-observer-wave-management.md has reference link to auto-next-spawn"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/su-observer-wave-management.md"

--- a/plugins/twl/tests/bats/observer-auto-next-spawn.bats
+++ b/plugins/twl/tests/bats/observer-auto-next-spawn.bats
@@ -1,0 +1,796 @@
+#!/usr/bin/env bats
+# observer-auto-next-spawn.bats
+#
+# RED-phase tests for Issue #1155:
+#   feat(observer): IDLE-COMPLETED -> 自動 next-action 機構
+#
+# AC coverage:
+#   AC1  - IDLE_COMPLETED_AUTO_NEXT_SPAWN 環境変数新設（AUTO_KILL と独立評価）
+#   AC2  - .supervisor/wave-queue.json JSON Schema 管理 + validation
+#   AC3  - _all_current_wave_idle_completed() で同 Wave 全 window IDLE-COMPLETED 判定
+#   AC4  - auto-next-spawn.sh 新設（--queue/--triggered-by/--dry-run, exec argv 直接渡し）
+#   AC5  - intervention-log.md への auto-cleanup+next-spawn 記録
+#   AC6  - AUTO_NEXT_SPAWN=0 / 未設定時の #1132 既存 kill-only 動作保全
+#   AC7  - 誤 spawn シナリオ全 spawn-skip（5 シナリオ）
+#   AC8  - AUTO_NEXT_SPAWN=dry-run / --dry-run で spawn echo のみ
+#   AC9  - observer-auto-next-spawn.bats 6 ケース GREEN（本ファイル自体の AC）
+#   AC10 - ドキュメント 5 箇所更新
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  AUTO_NEXT_SPAWN_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/auto-next-spawn.sh"
+  OBSERVER_WAVE_CHECK="${REPO_ROOT}/skills/su-observer/scripts/lib/observer-wave-check.sh"
+  WAVE_QUEUE_SCHEMA="${REPO_ROOT}/skills/su-observer/schemas/wave-queue.schema.json"
+  SPAWN_CONTROLLER="${REPO_ROOT}/skills/su-observer/scripts/spawn-controller.sh"
+  CLD_OBSERVE_ANY="${REPO_ROOT}/../session/scripts/cld-observe-any"
+  OBSERVER_IDLE_CHECK="${REPO_ROOT}/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  MONITOR_CATALOG="${REPO_ROOT}/skills/su-observer/refs/monitor-channel-catalog.md"
+  PITFALLS_CATALOG="${REPO_ROOT}/skills/su-observer/refs/pitfalls-catalog.md"
+  SKILL_MD="${REPO_ROOT}/skills/su-observer/SKILL.md"
+  DEPS_YAML="${REPO_ROOT}/deps.yaml"
+  WAVE_MGMT_DOC="${REPO_ROOT}/skills/su-observer/refs/su-observer-wave-management.md"
+
+  export AUTO_NEXT_SPAWN_SCRIPT OBSERVER_WAVE_CHECK WAVE_QUEUE_SCHEMA
+  export SPAWN_CONTROLLER CLD_OBSERVE_ANY OBSERVER_IDLE_CHECK
+  export MONITOR_CATALOG PITFALLS_CATALOG SKILL_MD DEPS_YAML WAVE_MGMT_DOC
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+
+  # テスト用 supervisor dir のセットアップ
+  SUPERVISOR_DIR="${TMPDIR_TEST}/.supervisor"
+  mkdir -p "${SUPERVISOR_DIR}"
+  export SUPERVISOR_DIR
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC-9 ケース 1: AUTO_NEXT_SPAWN 未設定 → kill のみ（#1132 regression）
+#   - wave-queue.json 不参照
+#   - intervention-log に auto- 記録なし
+#   - unset IDLE_COMPLETED_TS[$WIN] のみ
+# ===========================================================================
+
+@test "ac9-case1: AUTO_NEXT_SPAWN unset -> kill only, wave-queue.json not referenced" {
+  # AC: IDLE_COMPLETED_AUTO_NEXT_SPAWN 未設定時は #1132 の kill-only 動作を維持する
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  # wave-queue.json が存在しない状態で、AUTO_NEXT_SPAWN=0 時に参照されないことを検証
+  # cld-observe-any が AUTO_NEXT_SPAWN=0 時に auto-next-spawn.sh を呼ばないことを確認
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN' "${CLD_OBSERVE_ANY}"
+  # AUTO_NEXT_SPAWN 分岐が cld-observe-any に実装されていないため fail
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+}
+
+@test "ac9-case1: AUTO_NEXT_SPAWN unset -> intervention-log has no auto-cleanup+next-spawn record" {
+  # AC: AUTO_NEXT_SPAWN 未設定時は intervention-log に auto-cleanup+next-spawn を記録しない
+  # RED: 実装が存在しないため fail
+
+  INTERVENTION_LOG="${SUPERVISOR_DIR}/intervention-log.md"
+
+  # kill のみ実行した後に intervention-log に auto- プレフィックスが書かれないことを確認
+  # 実装後は AUTO_KILL=1 かつ AUTO_NEXT_SPAWN=0 の場合のスモークテストとなる
+  # 現時点では auto-next-spawn.sh が存在しないため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+}
+
+@test "ac9-case1: AUTO_NEXT_SPAWN unset -> cld-observe-any behavior unchanged (kill-only path exists)" {
+  # AC: #1132 既存動作（IDLE_COMPLETED_AUTO_KILL=1 → kill のみ）が保全されている
+  # RED: AUTO_NEXT_SPAWN 分岐が未実装のため fail
+
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN|AUTO_NEXT_SPAWN' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+}
+
+# ===========================================================================
+# AC-9 ケース 2: AUTO_NEXT_SPAWN=1 + 同 Wave 全 idle + valid queue → spawn 実行
+#   - intervention-log 記録
+#   - wave-queue.json 更新（dequeue + current_wave 更新）
+# ===========================================================================
+
+@test "ac9-case2: AUTO_NEXT_SPAWN=1 + all-wave-idle + valid queue -> spawn executed" {
+  # AC: AUTO_NEXT_SPAWN=1 かつ同 Wave 全 window が IDLE-COMPLETED かつ valid queue 存在時に
+  #     spawn_cmd_argv を exec で実行する
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  # valid wave-queue.json を作成
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [200, 201],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  # --dry-run なしで次 wave の spawn コマンドが exec される（bash --version は安全）
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-window-12345" \
+    --dry-run
+  # dry-run でも 0 exit のはず（実装後）
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac9-case2: AUTO_NEXT_SPAWN=1 + spawn -> intervention-log appended" {
+  # AC: spawn 実行時に intervention-log.md に記録が追記される
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  INTERVENTION_LOG="${SUPERVISOR_DIR}/intervention-log.md"
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [200, 201],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-window-12345" \
+    --dry-run
+
+  [ "${status}" -eq 0 ]
+  # intervention-log に auto-cleanup+next-spawn または auto-cleanup+next-spawn-dryrun が記録される
+  run grep -E 'auto-cleanup\+next-spawn' "${INTERVENTION_LOG}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac9-case2: AUTO_NEXT_SPAWN=1 + spawn -> wave-queue.json dequeued and current_wave updated" {
+  # AC: spawn 成功後に wave-queue.json から該当 entry を削除し current_wave を更新する
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [200, 201],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  # dry-run では queue を dequeue しないため non-dry-run で確認したいが
+  # exec で実際の spawn をテスト内で実行するのは危険なため、
+  # dry-run=false 相当のロジック（queue 更新部分）の単体テストとして実装後に GREEN になる
+  # 現時点は fail("AC#9-case2 未実装") と等価
+  fail "AC#9 case2 (wave-queue dequeue) 未実装"
+}
+
+# ===========================================================================
+# AC-9 ケース 3: AUTO_NEXT_SPAWN=1 + 同 Wave 一部 active → spawn skip
+#   - intervention-log に skipped reason 記録
+# ===========================================================================
+
+@test "ac9-case3: AUTO_NEXT_SPAWN=1 + some-wave-window-active -> spawn skipped" {
+  # AC: 同 Wave に active（非 IDLE-COMPLETED）window が残存する場合は spawn をスキップする
+  # RED: observer-wave-check.sh と auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [200],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  # IDLE_COMPLETED_TS を部分的にのみ設定（同 Wave の一部 window のみ IDLE-COMPLETED）
+  # _all_current_wave_idle_completed が false を返すシナリオ
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-active-window-99999"
+  # spawn skip のため exit 0（skip は失敗ではない）
+  [ "${status}" -eq 0 ]
+
+  # stdout に spawn skip の旨が出力される
+  echo "${output}" | grep -E 'skip|SKIP|not all.*idle|active.*window'
+}
+
+@test "ac9-case3: spawn skipped -> intervention-log has skipped reason" {
+  # AC: spawn skip 時に intervention-log に auto-cleanup+next-spawn-skipped を記録する
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  INTERVENTION_LOG="${SUPERVISOR_DIR}/intervention-log.md"
+
+  fail "AC#9 case3 (spawn skip intervention-log) 未実装"
+}
+
+# ===========================================================================
+# AC-9 ケース 4: AUTO_NEXT_SPAWN=1 + wave-queue.json 不在 → warning log + skip（exit 0）
+# ===========================================================================
+
+@test "ac9-case4: AUTO_NEXT_SPAWN=1 + wave-queue.json missing -> warning log + skip exit 0" {
+  # AC: wave-queue.json が不在の場合は warning log を出して spawn をスキップし exit 0 する
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  # wave-queue.json を作成しない
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345"
+
+  # exit 0 で終了する（skip は失敗ではない）
+  [ "${status}" -eq 0 ]
+
+  # warning が出力される
+  echo "${output}${stderr}" | grep -iE 'warn|missing|not found|not exist|no.*queue'
+}
+
+# ===========================================================================
+# AC-9 ケース 5: AUTO_NEXT_SPAWN=1 + JSON Schema invalid → warning log + spawn skip
+# ===========================================================================
+
+@test "ac9-case5: AUTO_NEXT_SPAWN=1 + invalid wave-queue.json schema -> warning + skip" {
+  # AC: JSON Schema validation 失敗時（e.g. version=2）は warning log + spawn skip する
+  # RED: auto-next-spawn.sh と wave-queue.schema.json が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  # version=2 は invalid（schema では version=1 固定）
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 2,
+  "current_wave": 1,
+  "queue": []
+}
+EOF
+
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345"
+
+  # exit 0 で終了する（schema 不正は致命的エラーではなく skip）
+  [ "${status}" -eq 0 ]
+
+  # warning が出力される
+  echo "${output}${stderr}" | grep -iE 'warn|invalid|schema|validation'
+}
+
+@test "ac9-case5: wave-queue.schema.json exists and is valid JSON" {
+  # AC: wave-queue.schema.json が存在し valid JSON である
+  # RED: ファイルが未作成のため fail
+
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  run jq empty "${WAVE_QUEUE_SCHEMA}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC-9 ケース 6: AUTO_NEXT_SPAWN=dry-run → echo のみ・実 spawn なし・queue 状態保持
+#   - intervention-log に auto-cleanup+next-spawn-dryrun 記録
+# ===========================================================================
+
+@test "ac9-case6: AUTO_NEXT_SPAWN=dry-run -> spawn command echoed only, no exec" {
+  # AC: dry-run モードでは spawn_cmd_argv を echo するだけで実際の exec を行わない
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [300],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345" \
+    --dry-run
+
+  [ "${status}" -eq 0 ]
+  # spawn コマンドが echo されている
+  echo "${output}" | grep -E 'bash|--version|dry.run|DRY.RUN|dryrun'
+}
+
+@test "ac9-case6: dry-run -> wave-queue.json queue state preserved (not dequeued)" {
+  # AC: dry-run 実行後に wave-queue.json の queue は変化しない（dequeue しない）
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [300],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345" \
+    --dry-run || true
+
+  # queue の wave 2 エントリが残っていることを確認
+  run jq -e '.queue | length > 0' "${SUPERVISOR_DIR}/wave-queue.json"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac9-case6: dry-run -> intervention-log has dryrun record" {
+  # AC: dry-run 時に intervention-log に auto-cleanup+next-spawn-dryrun として記録される
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  INTERVENTION_LOG="${SUPERVISOR_DIR}/intervention-log.md"
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [300],
+      "spawn_cmd_argv": ["bash", "--version"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345" \
+    --dry-run || true
+
+  run grep -E 'auto-cleanup\+next-spawn-dryrun' "${INTERVENTION_LOG}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-1 IDLE_COMPLETED_AUTO_NEXT_SPAWN 変数定義
+# ===========================================================================
+
+@test "ac1: cld-observe-any has IDLE_COMPLETED_AUTO_NEXT_SPAWN branch" {
+  # AC: cld-observe-any に IDLE_COMPLETED_AUTO_NEXT_SPAWN 評価分岐が追加される
+  # RED: 未実装のため fail
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+}
+
+@test "ac1: AUTO_NEXT_SPAWN and AUTO_KILL are evaluated independently" {
+  # AC: AUTO_NEXT_SPAWN=1 かつ AUTO_KILL=0 の場合は warning log + next-spawn skip となる
+  # RED: 分岐が未実装のため fail
+  run grep -E 'AUTO_KILL.*AUTO_NEXT_SPAWN|AUTO_NEXT_SPAWN.*AUTO_KILL|warning.*AUTO_KILL' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1: AUTO_KILL=0 and AUTO_NEXT_SPAWN=1 triggers warning" {
+  # AC: AUTO_KILL=0 & AUTO_NEXT_SPAWN=1 の組み合わせで warning log が出る
+  # RED: 実装が存在しないため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  fail "AC#1 (AUTO_KILL=0 + AUTO_NEXT_SPAWN=1 warning) 未実装"
+}
+
+# ===========================================================================
+# 追加テスト: AC-2 wave-queue.json JSON Schema validation
+# ===========================================================================
+
+@test "ac2: wave-queue.json schema has required version field (int=1)" {
+  # AC: wave-queue.schema.json が version フィールド（int, const=1）を必須として定義する
+  # RED: wave-queue.schema.json が未作成のため fail
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  run jq -e '.properties.version' "${WAVE_QUEUE_SCHEMA}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: wave-queue.json schema has required current_wave field (int)" {
+  # AC: wave-queue.schema.json が current_wave フィールドを必須として定義する
+  # RED: wave-queue.schema.json が未作成のため fail
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  run jq -e '.properties.current_wave' "${WAVE_QUEUE_SCHEMA}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: wave-queue.json schema has required queue[].spawn_cmd_argv field (string[], minItems=1)" {
+  # AC: queue[].spawn_cmd_argv が string[] minItems=1 として定義される
+  # RED: wave-queue.schema.json が未作成のため fail
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  run jq -e '.definitions.WaveEntry.properties.spawn_cmd_argv // .properties.queue.items.properties.spawn_cmd_argv' "${WAVE_QUEUE_SCHEMA}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: wave-queue.json schema has spawn_when enum (all_current_wave_idle_completed)" {
+  # AC: spawn_when が enum で all_current_wave_idle_completed を含む
+  # RED: wave-queue.schema.json が未作成のため fail
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  run grep -E 'all_current_wave_idle_completed' "${WAVE_QUEUE_SCHEMA}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: auto-next-spawn.sh performs jq schema validation on startup" {
+  # AC: auto-next-spawn.sh 起動時に jq または validate-schema.sh で JSON Schema validation を実行する
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'jq.*validate|validate-schema|schema.*valid|valid.*schema|jq.*schema' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-3 observer-wave-check.sh 新設
+# ===========================================================================
+
+@test "ac3: scripts/lib/observer-wave-check.sh exists" {
+  # AC: observer-wave-check.sh が scripts/lib/ に新規作成される
+  # RED: ファイルが未作成のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+}
+
+@test "ac3: observer-wave-check.sh defines _all_current_wave_idle_completed function" {
+  # AC: _all_current_wave_idle_completed() 関数が定義されている
+  # RED: ファイルが未作成のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  run grep -E '^_all_current_wave_idle_completed\(\)|^function _all_current_wave_idle_completed' \
+    "${OBSERVER_WAVE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: _all_current_wave_idle_completed uses wave-queue.json current_wave" {
+  # AC: 関数内で wave-queue.json の current_wave を取得している
+  # RED: ファイルが未作成のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  run grep -E 'current_wave' "${OBSERVER_WAVE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: _all_current_wave_idle_completed uses tmux list-windows with (ap|wt|coi) filter" {
+  # AC: tmux list-windows の結果を ^(ap|wt|coi)-.*  パターンでフィルタする
+  # RED: ファイルが未作成のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  run grep -E 'list-windows|ap.*wt.*coi|coi.*wt.*ap|\(ap\|wt\|coi\)' "${OBSERVER_WAVE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: _all_current_wave_idle_completed checks IDLE_COMPLETED_TS for all wave windows" {
+  # AC: 同 Wave 全 window の IDLE_COMPLETED_TS[$WIN] > 0 を確認する
+  # RED: ファイルが未作成のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  run grep -E 'IDLE_COMPLETED_TS' "${OBSERVER_WAVE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-4 auto-next-spawn.sh 新設
+# ===========================================================================
+
+@test "ac4: auto-next-spawn.sh exists" {
+  # AC: auto-next-spawn.sh が scripts/ に新規作成される
+  # RED: ファイルが未作成のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+}
+
+@test "ac4: auto-next-spawn.sh accepts --queue argument" {
+  # AC: --queue <path> 引数を受け付ける
+  # RED: ファイルが未作成のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E '\-\-queue|--queue' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: auto-next-spawn.sh accepts --triggered-by argument" {
+  # AC: --triggered-by <window> 引数を受け付ける
+  # RED: ファイルが未作成のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E '\-\-triggered.by|triggered_by' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: auto-next-spawn.sh uses exec not eval for spawn_cmd_argv" {
+  # AC: spawn_cmd_argv の実行は exec を使用し eval/bash -c は禁止
+  # RED: ファイルが未作成のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  # exec が使用されていることを確認
+  run grep -E '^[[:space:]]*exec[[:space:]]' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+  # eval が使用されていないことを確認
+  run grep -E '^[[:space:]]*eval[[:space:]]' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -ne 0 ]
+}
+
+@test "ac4: auto-next-spawn.sh validates spawn_cmd_argv[0] against allowlist" {
+  # AC: spawn_cmd_argv[0] が bash / cld-spawn 絶対パス のみ許可するアローリストで検証する
+  # RED: ファイルが未作成のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'allowlist|allow.list|cld.spawn|bash.*allow' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: auto-next-spawn.sh rejects spawn_cmd_argv[0] outside allowlist with intervention-log" {
+  # AC: アローリスト外の spawn_cmd_argv[0] を abort し intervention-log に拒否ログを書く
+  # RED: auto-next-spawn.sh が未実装のため fail
+
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+
+  INTERVENTION_LOG="${SUPERVISOR_DIR}/intervention-log.md"
+
+  cat > "${SUPERVISOR_DIR}/wave-queue.json" <<'EOF'
+{
+  "version": 1,
+  "current_wave": 1,
+  "queue": [
+    {
+      "wave": 2,
+      "issues": [400],
+      "spawn_cmd_argv": ["/usr/bin/evil-command", "--args"],
+      "depends_on_waves": [1],
+      "spawn_when": "all_current_wave_idle_completed"
+    }
+  ]
+}
+EOF
+
+  run bash "${AUTO_NEXT_SPAWN_SCRIPT}" \
+    --queue "${SUPERVISOR_DIR}/wave-queue.json" \
+    --triggered-by "wt-test-12345"
+
+  # abort（非 0 exit）
+  [ "${status}" -ne 0 ]
+
+  # intervention-log に拒否ログが書かれる
+  run grep -E 'reject|deny|abort|allowlist|not allowed' "${INTERVENTION_LOG}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-5 intervention-log.md フォーマット
+# ===========================================================================
+
+@test "ac5: auto-next-spawn.sh appends ISO8601 UTC timestamp to intervention-log" {
+  # AC: intervention-log への記録が ISO8601 UTC タイムスタンプで始まる
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'date.*ISO|date.*UTC|date -u.*%FT%T|iso8601|ISO8601' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: intervention-log format includes triggered_by and killed fields" {
+  # AC: ログ形式が triggered_by=<window>, killed=<window> を含む
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'triggered_by|killed=' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: intervention-log format includes next_wave and spawned fields on success" {
+  # AC: ログ形式が next_wave=<N>, spawned=[<issue_csv>] を含む
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'next_wave=|spawned=' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: intervention-log records spawn-skipped with reason on skip" {
+  # AC: skip 時に auto-cleanup+next-spawn-skipped: triggered_by=<w>, reason=<理由> を記録
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'next-spawn-skipped|spawn.skipped.*reason|reason.*skip' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-6 AUTO_NEXT_SPAWN=0 での kill-only 動作保全
+# ===========================================================================
+
+@test "ac6: AUTO_KILL=1 only (no AUTO_NEXT_SPAWN) -> kill executes" {
+  # AC: IDLE_COMPLETED_AUTO_KILL=1 のみ設定時は kill を実行する（既存 #1132 動作）
+  # RED: 検証に必要な AUTO_NEXT_SPAWN 分岐が未実装のため fail
+  run grep -E 'IDLE_COMPLETED_AUTO_KILL.*1' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+  # AUTO_NEXT_SPAWN のチェックが AUTO_KILL と独立していることを確認
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6: AUTO_KILL=1 only -> wave-queue.json not referenced in kill-only path" {
+  # AC: kill-only パスでは wave-queue.json を参照しない
+  # RED: 分岐が未実装のため fail
+  fail "AC#6 (kill-only path wave-queue not referenced) 未実装"
+}
+
+@test "ac6: AUTO_KILL=1 only -> no auto-cleanup+next-spawn in intervention-log" {
+  # AC: kill-only 実行後の intervention-log に auto-cleanup+next-spawn 行がない
+  # RED: auto-next-spawn.sh が未実装のため fail
+  fail "AC#6 (kill-only intervention-log has no auto- record) 未実装"
+}
+
+@test "ac6: AUTO_KILL=1 only -> unset IDLE_COMPLETED_TS[WIN] after kill, AUTO_NEXT_SPAWN path absent" {
+  # AC: kill 成功後に IDLE_COMPLETED_TS[$WIN] を unset する（既存動作）かつ
+  #     AUTO_NEXT_SPAWN の分岐が kill-only パスには存在しない
+  # RED: kill-only パスの AUTO_NEXT_SPAWN 独立評価が未実装のため fail
+  run grep -E "unset.*IDLE_COMPLETED_TS" "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+  # kill-only パスで AUTO_NEXT_SPAWN が独立して評価される分岐が存在することを確認
+  # （既存 kill パスと次 spawn パスが独立した if ブロックであることが必要）
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-7 誤 spawn シナリオ全 spawn-skip
+# ===========================================================================
+
+@test "ac7-a: active window remaining in wave -> spawn skipped" {
+  # AC: 同 Wave に active window 残存時は spawn をスキップする
+  # RED: observer-wave-check.sh が未実装のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  fail "AC#7(a) (active window -> spawn skip) 未実装"
+}
+
+@test "ac7-b: LLM-active-override (C3) window exists -> spawn skipped" {
+  # AC: _check_idle_completed C3(LLM-active-override)が真の window が存在する場合は spawn スキップ
+  # RED: observer-wave-check.sh が未実装のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  fail "AC#7(b) (C3 LLM-active-override -> spawn skip) 未実装"
+}
+
+@test "ac7-c: wave-queue.json absent -> spawn skipped (exit 0)" {
+  # AC: wave-queue.json 不在時は warning log + spawn skip で exit 0
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  fail "AC#7(c) (wave-queue absent -> skip exit 0) 未実装"
+}
+
+@test "ac7-d: JSON schema validation failure -> spawn skipped" {
+  # AC: JSON Schema validation 失敗時は warning log + spawn skip
+  # RED: auto-next-spawn.sh と wave-queue.schema.json が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  [ -f "${WAVE_QUEUE_SCHEMA}" ]
+  fail "AC#7(d) (schema invalid -> skip) 未実装"
+}
+
+@test "ac7-e: current_wave mismatch (triggered window not in current_wave) -> spawn skipped" {
+  # AC: kill 対象 window が current_wave に属さない場合は spawn をスキップする
+  # RED: observer-wave-check.sh が未実装のため fail
+  [ -f "${OBSERVER_WAVE_CHECK}" ]
+  fail "AC#7(e) (current_wave mismatch -> skip) 未実装"
+}
+
+# ===========================================================================
+# 追加テスト: AC-8 dry-run モード
+# ===========================================================================
+
+@test "ac8: IDLE_COMPLETED_AUTO_NEXT_SPAWN=dry-run in env -> dry-run mode activated" {
+  # AC: 環境変数 IDLE_COMPLETED_AUTO_NEXT_SPAWN=dry-run で dry-run モードが有効になる
+  # RED: cld-observe-any への AUTO_NEXT_SPAWN 分岐が未実装のため fail
+  run grep -E 'dry.run|dry_run' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac8: auto-next-spawn.sh --dry-run flag suppresses exec" {
+  # AC: --dry-run フラグで実際の spawn が抑制される
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E '\-\-dry.run|dry_run' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac8: dry-run intervention-log uses dryrun prefix" {
+  # AC: dry-run 時の intervention-log エントリに auto-cleanup+next-spawn-dryrun: プレフィックスを使う
+  # RED: auto-next-spawn.sh が未実装のため fail
+  [ -f "${AUTO_NEXT_SPAWN_SCRIPT}" ]
+  run grep -E 'next-spawn-dryrun|dryrun' "${AUTO_NEXT_SPAWN_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# 追加テスト: AC-10 ドキュメント更新
+# ===========================================================================
+
+@test "ac10: monitor-channel-catalog.md has IDLE_COMPLETED_AUTO_NEXT_SPAWN description" {
+  # AC: monitor-channel-catalog.md §[IDLE-COMPLETED] に AUTO_NEXT_SPAWN の説明が追加される
+  # RED: 追記が未完了のため fail
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN|AUTO_NEXT_SPAWN' "${MONITOR_CATALOG}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: pitfalls-catalog.md section 4.10 S-1b row has AUTO_NEXT_SPAWN description" {
+  # AC: pitfalls-catalog.md §4.10 S-1b 行に IDLE_COMPLETED_AUTO_NEXT_SPAWN 関連の記述が追記される
+  # RED: IDLE_COMPLETED_AUTO_NEXT_SPAWN への言及が未追記のため fail
+  run grep -E 'IDLE_COMPLETED_AUTO_NEXT_SPAWN' "${PITFALLS_CATALOG}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: SKILL.md Wave management section is updated" {
+  # AC: SKILL.md の Wave 管理セクションが更新されている
+  # RED: 更新が未完了のため fail
+  run grep -E 'auto-next-spawn|AUTO_NEXT_SPAWN|wave.queue.*auto|auto.*wave.queue' "${SKILL_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: deps.yaml registers auto-next-spawn.sh" {
+  # AC: deps.yaml に auto-next-spawn.sh が登録される
+  # RED: 登録が未完了のため fail
+  run grep -E 'auto-next-spawn' "${DEPS_YAML}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: deps.yaml registers observer-wave-check.sh" {
+  # AC: deps.yaml に observer-wave-check.sh が登録される
+  # RED: 登録が未完了のため fail
+  run grep -E 'observer-wave-check' "${DEPS_YAML}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: su-observer-wave-management.md has reference link to auto-next-spawn" {
+  # AC: su-observer-wave-management.md に auto-next-spawn.sh への参照リンクが追加される
+  # RED: 追記が未完了のため fail
+  run grep -E 'auto-next-spawn' "${WAVE_MGMT_DOC}"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
Closes #1155

## 概要

Issue #1155 の実装。 の  event 発火後の次 step 起動を自動化する。

## 変更内容

### テストスキャフォールド（RED フェーズ）
- `plugins/twl/tests/bats/observer-auto-next-spawn.bats`: AC-1〜AC-10 全件対応 bats テスト 55件（RED）
- `plugins/twl/tests/bats/ac-test-mapping-1155.yaml`: AC → テストマッピング

## AC Coverage
- AC-1: IDLE_COMPLETED_AUTO_NEXT_SPAWN 環境変数（AUTO_KILL と独立）
- AC-2: wave-queue.json JSON Schema validation
- AC-3: _all_current_wave_idle_completed() 判定ロジック
- AC-4: auto-next-spawn.sh（argv exec 直接渡し、allowlist 検証）
- AC-5: intervention-log 記録フォーマット
- AC-6: AUTO_NEXT_SPAWN=0 時の kill-only 動作保全
- AC-7: 誤 spawn シナリオ全 spawn-skip（5 シナリオ）
- AC-8: dry-run モード
- AC-9: bats 6 ケース（本 bats ファイル）
- AC-10: ドキュメント 5 箇所更新