### PR TITLE
tech-debt(autopilot): SNAPSHOT_DIR auto-set for ac-scaffold-tests in autopilot Worker — permission prompt stall 防止 (#1176)

### DIFF
--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -382,6 +382,14 @@ fi
 QUOTED_ISSUE=$(printf '%q' "$ISSUE")
 WORKER_ISSUE_NUM_ENV="WORKER_ISSUE_NUM=${QUOTED_ISSUE}"
 
+# --- SNAPSHOT_DIR 環境変数構築 (#1176) ---
+# Worker が spawn する子 agent (ac-scaffold-tests 等) で SNAPSHOT_DIR 未継承時の
+# fallback (~/.claude/plugins/twl/.dev-session/...) を回避するため、
+# cld parent process レベルで明示的に設定する (defense in depth)。
+# chain-runner.sh:330 の step_init 内 export は SSOT として維持。
+QUOTED_SNAPSHOT_DIR=$(printf '%q' "${LAUNCH_DIR}/.dev-session/issue-${ISSUE}")
+SNAPSHOT_DIR_ENV="SNAPSHOT_DIR=${QUOTED_SNAPSHOT_DIR}"
+
 # --- PYTHONPATH 環境変数構築 ---
 # Worker の cld セッション内で python3 -m twl.autopilot.* が動作するために必要
 # bare repo 構造: PROJECT_DIR/.bare が存在 → main/ 配下に cli/twl/src がある
@@ -488,7 +496,7 @@ QUOTED_CLD=$(printf '%q' "$CLD_PATH")
 QUOTED_PROMPT=$(printf '%q' "$PROMPT")
 # プロンプトは positional arg で渡す。-p/--print は禁止（非対話モードで即終了する）
 tmux new-window -d -n "$WINDOW_NAME" -c "$LAUNCH_DIR" \
-  "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} ${PYTHONPATH_ENV} ${CLD_ENV_FILE_ENV} ${EFFORT_ENV} ${AUDIT_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
+  "env ${AUTOPILOT_ENV} ${TRACE_ENV} ${REPO_ENV} ${WORKER_ISSUE_NUM_ENV} ${SNAPSHOT_DIR_ENV} ${PYTHONPATH_ENV} ${CLD_ENV_FILE_ENV} ${EFFORT_ENV} ${AUDIT_ENV} $QUOTED_CLD --model $MODEL $CONTEXT_ARGS $QUOTED_PROMPT"
 
 # --- #897-B: pipe-pane で Worker 会話履歴を audit dir に永続化 ---
 # tmux scrollback のみでは window kill で消失するため、pipe-pane で

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -650,12 +650,15 @@ gate deny (1 回目) → STOP（即時停止、追加試行禁止）→ AskUserQ
 | 14.2 | Worker CWD が git 管理外になる経路 | `bash -c "cd /tmp && ..."` などで呼び出された chain-runner.sh が tier 1 失敗後に `pwd` = `/tmp` を採用する | tier 2 (script-path fallback) が `BASH_SOURCE[0]` のディレクトリから git rev-parse を試みる。script が worktree 内 symlink 経由で常駐している前提で救済可能 |
 | 14.3 | script 自体が worktree 外に配置される異常状態（tier 2 も fail） | script が `/tmp` にコピーされた状態で実行される | tier 3 が `[chain-runner] FATAL: resolve_project_root failed (cwd=..., script=...)` を stderr に出力し `return 1` で abort。誤 root への書き込みは構造的に不可能 |
 
+| 14.4 | autopilot Worker 起動時に `SNAPSHOT_DIR` が env inject されず、子 agent が user-global fallback path に mkdir する | `ac-scaffold-tests` 等の sub-agent が `~/.claude/plugins/twl/.dev-session/issue-N/` への mkdir を要求し permission prompt で stall する。`chain-runner.sh:330` の `export SNAPSHOT_DIR=` は `step_init` 経由の Worker にしか届かない（#1176） | **defense in depth**: `autopilot-launch.sh` の tmux new-window env inject に `SNAPSHOT_DIR=${LAUNCH_DIR}/.dev-session/issue-${ISSUE}` を追加する（#1176）。chain-runner.sh の SSOT は維持し、env 伝搬経路を補完する二重設定として実装 |
+
 **正しい設計原則**:
 - `resolve_project_root()` で `pwd` を fallback として使ってはならない（ADR-027）
 - 他の `resolve_*` 関数（例: `resolve_autopilot_dir()`）でも同様の `|| pwd` fallback は禁止
 - 残骸 cleanup: `~/.claude/plugins/twl/.dev-session/` に孤児ファイルが残る場合は `plugins/twl/commands/cleanup-orphan-snapshots.md` の手順を参照
+- **§14.4 別軸対策**: §14.1-14.3 は `resolve_project_root()` 自体の bug（ADR-027 軸）、§14.4 は env 伝搬経路の補完（#1176 軸）。両者は独立した対策として共存する
 
-**参照**: ADR-027, Issue #966, Issue #938 (per-issue namespace), doobidoo `b81b1962`
+**参照**: ADR-027, Issue #966, Issue #938 (per-issue namespace), Issue #1176, doobidoo `b81b1962`
 
 ---
 

--- a/plugins/twl/tests/bats/scripts/autopilot-launch-snapshot-dir.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-launch-snapshot-dir.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# autopilot-launch-snapshot-dir.bats
+# Spec: #1176 — SNAPSHOT_DIR auto-set in autopilot Worker
+#
+# Coverage:
+#   AC1: tmux new-window env inject に SNAPSHOT_DIR= が含まれる
+#   AC3: --worktree-dir 指定で LAUNCH_DIR が SNAPSHOT_DIR の base path になる
+#   AC5: chain-runner.sh の export SNAPSHOT_DIR= が削除されていないこと（guard）
+#   AC6: pitfalls-catalog.md §14.4 が追加されていること
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  TMUX_CMD_FILE="$SANDBOX/tmux-new-window.txt"
+  export TMUX_CMD_FILE
+  cat > "$STUB_BIN/tmux" <<STUB
+#!/usr/bin/env bash
+case "\$1" in
+  new-window)
+    printf '%s\n' "\$*" >> "${TMUX_CMD_FILE}"
+    exit 0 ;;
+  set-option|set-hook|display-message|list-windows)
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/tmux"
+
+  cat > "$STUB_BIN/cld" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$STUB_BIN/cld"
+
+  stub_command "gh" '
+    case "$*" in
+      *"project item-list"*)
+        echo "{\"items\":[{\"id\":\"I_1176\",\"content\":{\"number\":1176,\"type\":\"Issue\"},\"status\":\"In Progress\"},{\"id\":\"I_42\",\"content\":{\"number\":42,\"type\":\"Issue\"},\"status\":\"Refined\"},{\"id\":\"I_999\",\"content\":{\"number\":999,\"type\":\"Issue\"},\"status\":\"In Progress\"}]}" ;;
+      *"repo view"*"--json owner"*)
+        echo "shuu5" ;;
+      *"issue view"*"--json labels"*)
+        echo "" ;;
+      *)
+        echo "{}" ;;
+    esac
+  '
+
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse"*) echo "$SANDBOX" ;;
+      *"worktree list"*) echo "" ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  cat > "$STUB_BIN/python3" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  *"worktree create"*) exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/python3"
+
+  mkdir -p "$SANDBOX/.autopilot/trace"
+  cat > "$SANDBOX/.autopilot/session.json" <<JSON
+{"session_id": "test-session-1176", "started_at": "2026-04-30T00:00:00Z"}
+JSON
+
+  mkdir -p "$SANDBOX/project/.git"
+  TEST_PROJECT_DIR="$SANDBOX/project"
+  export TEST_PROJECT_DIR
+
+  mkdir -p "$SANDBOX/wt/.git"
+}
+
+teardown() {
+  common_teardown
+}
+
+_run_launch() {
+  local issue="${1:-1176}"
+  local extra_args="${2:-}"
+  # shellcheck disable=SC2086
+  run bash "$SANDBOX/scripts/autopilot-launch.sh" \
+    --issue "$issue" \
+    --project-dir "$TEST_PROJECT_DIR" \
+    --autopilot-dir "$SANDBOX/.autopilot" \
+    $extra_args
+}
+
+_get_tmux_cmd() {
+  cat "$TMUX_CMD_FILE" 2>/dev/null || echo ""
+}
+
+_tmux_cmd_contains() {
+  local keyword="$1"
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  echo "$tmux_cmd" | tr -d '\\' | grep -qF "$keyword"
+}
+
+# ---------------------------------------------------------------------------
+# AC1: tmux new-window の env inject に SNAPSHOT_DIR= が含まれる
+# ---------------------------------------------------------------------------
+
+@test "snapshot-dir: SNAPSHOT_DIR= が tmux new-window の env inject に含まれる" {
+  _run_launch 1176
+
+  assert_success
+  _tmux_cmd_contains "SNAPSHOT_DIR="
+}
+
+@test "snapshot-dir: SNAPSHOT_DIR に .dev-session/issue-1176 が含まれる" {
+  _run_launch 1176
+
+  assert_success
+  _tmux_cmd_contains ".dev-session/issue-1176"
+}
+
+@test "snapshot-dir: Issue 番号が異なる場合も SNAPSHOT_DIR に正しい Issue 番号が含まれる" {
+  _run_launch 42
+
+  assert_success
+  _tmux_cmd_contains ".dev-session/issue-42"
+}
+
+# ---------------------------------------------------------------------------
+# AC3: --worktree-dir 指定で LAUNCH_DIR が SNAPSHOT_DIR の base path になる
+# ---------------------------------------------------------------------------
+
+@test "snapshot-dir: --worktree-dir 指定時に SNAPSHOT_DIR の base path が WORKTREE_DIR になる" {
+  _run_launch 1176 "--worktree-dir $SANDBOX/wt"
+
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  # SNAPSHOT_DIR=$SANDBOX/wt/.dev-session/issue-1176 相当が含まれること
+  echo "$tmux_cmd" | tr -d '\\' | grep -qF "wt/.dev-session/issue-1176"
+}
+
+@test "snapshot-dir: --worktree-dir 指定時に SNAPSHOT_DIR が project-dir 配下にならない" {
+  _run_launch 1176 "--worktree-dir $SANDBOX/wt"
+
+  assert_success
+  local tmux_cmd
+  tmux_cmd=$(_get_tmux_cmd)
+  # worktree-dir が指定された場合、project/.dev-session ではなく wt/.dev-session になること
+  # (LAUNCH_DIR = WORKTREE_DIR であることの検証)
+  echo "$tmux_cmd" | tr -d '\\' | grep -qF "wt/.dev-session/issue-1176"
+}
+
+# ---------------------------------------------------------------------------
+# AC5: chain-runner.sh の export SNAPSHOT_DIR= が削除されていないこと（guard）
+# ---------------------------------------------------------------------------
+
+@test "snapshot-dir: chain-runner.sh L330 の export SNAPSHOT_DIR= が保持されている（SSOT 維持）" {
+  local chain_runner
+  chain_runner="$SANDBOX/scripts/chain-runner.sh"
+  [[ -f "$chain_runner" ]] || skip "chain-runner.sh が sandbox にコピーされていない"
+
+  grep -q 'export SNAPSHOT_DIR=' "$chain_runner"
+}
+
+# ---------------------------------------------------------------------------
+# AC6: pitfalls-catalog.md §14.4 が追加されていること
+# ---------------------------------------------------------------------------
+
+@test "snapshot-dir: pitfalls-catalog.md に §14.4 エントリが存在する" {
+  local catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+  [[ -f "$catalog" ]] || skip "pitfalls-catalog.md が見つからない"
+
+  grep -F '14.4' "$catalog"
+}
+
+@test "snapshot-dir: pitfalls-catalog.md §14.4 に #1176 への言及が含まれる" {
+  local catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+  [[ -f "$catalog" ]] || skip "pitfalls-catalog.md が見つからない"
+
+  grep -A5 '14.4' "$catalog" | grep -qF '#1176'
+}
+
+@test "snapshot-dir: pitfalls-catalog.md §14.4 に defense in depth への言及が含まれる" {
+  local catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+  [[ -f "$catalog" ]] || skip "pitfalls-catalog.md が見つからない"
+
+  grep -A5 '14.4' "$catalog" | grep -qF 'defense in depth'
+}

--- a/plugins/twl/tests/bats/scripts/autopilot-launch-snapshot-dir.bats
+++ b/plugins/twl/tests/bats/scripts/autopilot-launch-snapshot-dir.bats
@@ -148,9 +148,10 @@ _tmux_cmd_contains() {
   assert_success
   local tmux_cmd
   tmux_cmd=$(_get_tmux_cmd)
-  # worktree-dir が指定された場合、project/.dev-session ではなく wt/.dev-session になること
-  # (LAUNCH_DIR = WORKTREE_DIR であることの検証)
+  # worktree-dir が指定された場合、wt/.dev-session になること（正）
   echo "$tmux_cmd" | tr -d '\\' | grep -qF "wt/.dev-session/issue-1176"
+  # project/.dev-session ではないこと（負の検証）
+  ! echo "$tmux_cmd" | tr -d '\\' | grep -qF "project/.dev-session"
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

autopilot Worker（cld）起動時に `SNAPSHOT_DIR=${LAUNCH_DIR}/.dev-session/issue-${ISSUE}` を tmux new-window の env inject に含めることで、Worker が spawn する子 agent (`ac-scaffold-tests` 等) で `SNAPSHOT_DIR` 未継承時の fallback (`~/.claude/plugins/twl/` 配下) を回避する。

## Changes

- `plugins/twl/scripts/autopilot-launch.sh`: SNAPSHOT_DIR_ENV を WORKER_ISSUE_NUM_ENV の直後に追加し、tmux new-window env inject に含める
- `plugins/twl/tests/bats/scripts/autopilot-launch-snapshot-dir.bats`: 新規 bats（AC1/AC3/AC5/AC6 カバー）
- `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md`: §14.4 を追加（defense in depth の文書化）

## AC Checklist

- [x] AC1: tmux new-window env inject に `SNAPSHOT_DIR=` が含まれる
- [x] AC2: `autopilot-launch-snapshot-dir.bats` 新規追加、merge-context.bats ヘルパーを流用
- [x] AC3: --worktree-dir 指定時に LAUNCH_DIR が SNAPSHOT_DIR の base path になる
- [x] AC4: 既存 bats 回帰なし（pre-existing failures はこの PR 以前から存在）
- [x] AC5: chain-runner.sh:330 の `export SNAPSHOT_DIR=` を削除しない（SSOT 維持）
- [x] AC6: pitfalls-catalog.md §14.4 追加（#1176 + defense in depth 含む）

Closes #1176