### PR TITLE
fix(session): rename slash-containing mock fn to _mock_session_state (#1167)

### DIFF
--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -143,3 +143,8 @@ tests:
     type: test
     path: tests/cld-observe-any-test-mode-validate.bats
     description: "cld-observe-any _TEST_MODE flock/validation 設計改善の regression guard（Issue #1166: AC1-AC4）"
+
+  test-1167-ac-verify:
+    type: test
+    path: tests/test_1167_ac_verify.bats
+    description: "Issue #1167: cld-observe-any.bats L74 slash-in-function-name AC テスト（AC1-AC5: _mock_session_state rename 検証）"

--- a/plugins/session/tests/ac-test-mapping.yaml
+++ b/plugins/session/tests/ac-test-mapping.yaml
@@ -1,28 +1,50 @@
+# ac-test-mapping.yaml — Issue #1167: tech-debt(session): cld-observe-any.bats L74 slash-in-function-name
+# 生成: AC Scaffold Tests Agent
+# 対象テストファイル: plugins/session/tests/test_1167_ac_verify.bats
+#
+# Note: このファイルは per-issue scaffold で各 Issue が上書きする設計。
+# 過去の Issue（#1166: cld-observe-any-test-mode-validate.bats AC1-4）は
+# https://github.com/shuu5/twill/pull/1190 でマージ済み（traceability は git history 参照）。
+
 mappings:
   - ac_index: 1
-    ac_text: "cld-observe-any:144 の条件から _TEST_MODE を除去し、_TEST_MODE 設定下でも --window/--pattern 不在で exit 1 する"
-    test_file: "plugins/session/tests/cld-observe-any-test-mode-validate.bats"
-    test_name: "AC1: _TEST_MODE=1 かつ --window/--pattern 未指定 → exit 1 と validation エラー"
+    ac_text: "L74 の関数定義を _mock_session_state() { echo \"processing\"; } に rename する（slash 除去）"
+    test_file: "plugins/session/tests/test_1167_ac_verify.bats"
+    test_name: "ac1: L74 の関数定義が _mock_session_state() { ... } 形式になっている"
+    status: RED
     impl_files:
-      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/session/tests/cld-observe-any.bats"
 
   - ac_index: 2
-    ac_text: "スクリプト冒頭（引数解析完了直後）に unset _DAEMON_LOAD_ONLY を実行し、env から流入した値を破棄する"
-    test_file: "plugins/session/tests/cld-observe-any-test-mode-validate.bats"
-    test_name: "AC2: env 経由 _DAEMON_LOAD_ONLY=1 は unset され --window 未指定で exit 1 になる"
+    ac_text: "L75 の export -f \"$SCRIPT_DIR/session-state.sh\" 2>/dev/null || true を export -f _mock_session_state に置換する（2>/dev/null || true は不要になるため削除）"
+    test_file: "plugins/session/tests/test_1167_ac_verify.bats"
+    test_name: "ac2: L75 の export 行が export -f _mock_session_state になっている"
+    status: RED
     impl_files:
-      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/session/tests/cld-observe-any.bats"
 
   - ac_index: 3
-    ac_text: "_TEST_MODE set 時 LOCK_FILE を /tmp/cld-observe-any-test-$$.lock にリダイレクトし flock を実行する"
-    test_file: "plugins/session/tests/cld-observe-any-test-mode-validate.bats"
-    test_name: "AC3: _TEST_MODE=1 かつ --window 指定 → /tmp/cld-observe-any-test-*.lock が存在する"
+    ac_text: "L73 のコメント # session-state.sh モック を保持または # session-state.sh モック (関数名は slash-free) に更新する"
+    test_file: "plugins/session/tests/test_1167_ac_verify.bats"
+    test_name: "ac3: L73 の session-state.sh モックコメントが存在する"
+    status: GREEN
+    note: "修正前から comment が存在するため PASS。rename 後も保持を確認するためのリグレッション guard。"
     impl_files:
-      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/session/tests/cld-observe-any.bats"
 
   - ac_index: 4
-    ac_text: "regression test 3 シナリオ（Scenario A/B/C）を cld-observe-any-test-mode-validate.bats に実装する"
-    test_file: "plugins/session/tests/cld-observe-any-test-mode-validate.bats"
-    test_name: "（AC1〜AC3 テストがそのまま AC4 の regression guard として機能）"
+    ac_text: "bats plugins/session/tests/cld-observe-any.bats が PASS する（rename 前後で test 結果が変わらないこと）"
+    test_file: "plugins/session/tests/test_1167_ac_verify.bats"
+    test_name: "ac4: bats plugins/session/tests/cld-observe-any.bats が構文エラーなく読み込める"
+    status: GREEN
+    note: "bats -c による構文チェック。mock は元々非機能なため既存テスト結果は不変。"
     impl_files:
-      - "plugins/session/tests/cld-observe-any-test-mode-validate.bats"
+      - "plugins/session/tests/cld-observe-any.bats"
+
+  - ac_index: 5
+    ac_text: "grep で \"$SCRIPT_DIR/session-state.sh\"() が当該ファイルに残っていないことを確認する"
+    test_file: "plugins/session/tests/test_1167_ac_verify.bats"
+    test_name: "ac5: slash-containing 関数定義 \"$SCRIPT_DIR/session-state.sh\"() が残っていない"
+    status: RED
+    impl_files:
+      - "plugins/session/tests/cld-observe-any.bats"

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -68,9 +68,9 @@ tmux() {
 }
 export -f tmux
 
-# session-state.sh モック
-"$SCRIPT_DIR/session-state.sh"() { echo "processing"; }
-export -f "$SCRIPT_DIR/session-state.sh" 2>/dev/null || true
+# session-state.sh モック (関数名は slash-free)
+_mock_session_state() { echo "processing"; }
+export -f _mock_session_state
 
 _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
     bash "$CLD_OBSERVE_ANY" --window "$win" --once $extra_args

--- a/plugins/session/tests/test_1167_ac_verify.bats
+++ b/plugins/session/tests/test_1167_ac_verify.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# test_1167_ac_verify.bats
+# Issue #1167: tech-debt: cld-observe-any.bats L74 slash-containing function name
+# RED フェーズ — 修正前の現状では全テストが FAIL する
+# 修正後（実装完了後）は全テストが PASS する
+
+TARGET_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/cld-observe-any.bats"
+
+# ---------------------------------------------------------------------------
+# AC1: L74 の関数定義を _mock_session_state() に rename する（slash 除去）
+# RED: 修正前は "\"$SCRIPT_DIR/session-state.sh\"()" 形式が残っているため FAIL
+# ---------------------------------------------------------------------------
+@test "ac1: L74 の関数定義が _mock_session_state() { ... } 形式になっている" {
+    # 修正済みならこのパターンが存在する → PASS
+    grep -qE '^_mock_session_state\(\)[[:space:]]*\{' "$TARGET_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# AC2: L75 の export 行が export -f _mock_session_state に置換されている
+# RED: 修正前は export -f "$SCRIPT_DIR/session-state.sh" 形式が残っているため FAIL
+# ---------------------------------------------------------------------------
+@test "ac2: L75 の export 行が export -f _mock_session_state になっている" {
+    # 修正済みならこのパターンが存在する → PASS
+    grep -qE '^export -f _mock_session_state[[:space:]]*$' "$TARGET_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# AC3: L73 のコメントが保持または更新されている
+# GREEN 寄りだが、コメント行の存在確認として記録する
+# 修正前でもコメントは存在するため、このテストは PASS する可能性がある
+# ただし rename 前後でコメントが消去されていないことを担保するために配置する
+# ---------------------------------------------------------------------------
+@test "ac3: L73 の session-state.sh モックコメントが存在する" {
+    # コメント行（"session-state.sh" と "モック" を含む）が存在する → PASS
+    grep -qE '#.*session-state\.sh.*モック' "$TARGET_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# AC4: bats 実行が成功する（rename 前後で test 結果が変わらないこと）
+# RED: 修正前は bash の関数定義構文エラーで bats 自体が失敗する可能性がある
+# 注意: このテストは bats を入れ子で実行するため時間がかかる場合がある
+# ---------------------------------------------------------------------------
+@test "ac4: bats plugins/session/tests/cld-observe-any.bats が構文エラーなく読み込める" {
+    # bats -c でテスト数が取得できれば構文 OK
+    run bats -c "$TARGET_FILE"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC5: "$SCRIPT_DIR/session-state.sh"() というスラッシュ付き関数定義が残っていない
+# RED: 修正前はこのパターンが存在するため FAIL
+# grep が 0 件 → exit 1 → test PASS、1 件以上 → exit 0 → test FAIL
+# ---------------------------------------------------------------------------
+@test "ac5: slash-containing 関数定義 \"\$SCRIPT_DIR/session-state.sh\"() が残っていない" {
+    # このパターンが存在しない（grep が 1 を返す）なら修正済み → PASS
+    # 存在する（grep が 0 を返す）なら未修正 → FAIL
+    run grep -E '"[^"]+/session-state\.sh"\(\)' "$TARGET_FILE"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## 概要

`plugins/session/tests/cld-observe-any.bats` L74-75 のスラッシュ含む関数定義を修正。

bash 5.x ではスラッシュを含む関数名 `"/session-state.sh"()` が構文エラーで silent fail し、`export -f` も同様に失敗する。L75 末尾の `2>/dev/null || true` がエラーを抑制していたため気づきにくかった。

本変更は構文修正（rename）のみで、mock は元々非機能だったため動作変化なし。

## 変更内容

- L73: コメントに `(関数名は slash-free)` を追記
- L74: `"$SCRIPT_DIR/session-state.sh"()` → `_mock_session_state()`
- L75: `export -f "$SCRIPT_DIR/session-state.sh" 2>/dev/null || true` → `export -f _mock_session_state`

## テスト

`plugins/session/tests/test_1167_ac_verify.bats` を追加。全 5 AC が PASS することを確認。

Closes #1167