### PR TITLE
feat(observer): record-detection-gap.sh 新設 — 検知漏れ自動記録 helper (#1187)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -568,3 +568,56 @@ issue_1168:
       note: "回帰ガード。行末 \\ 付き env-prefix 行が 1 件以上存在することを確認"
       impl_files:
         - "plugins/session/tests/cld-observe-any.bats"
+
+# --- Issue #1187 ---
+issue_1187:
+  issue: 1187
+  framework: bats
+  test_file: "plugins/twl/tests/bats/observer/record-detection-gap.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "AC4.1: plugins/twl/skills/su-observer/scripts/record-detection-gap.sh を新規作成 (--type, --detail, --related-issue, --severity 引数; 動作1: intervention-log.md 追記; 動作2: doobidoo hint→stderr; 動作3: --severity high のみ gh issue create hint→stderr)"
+      test_names:
+        - "ac4.1: record-detection-gap.sh exists at expected path"
+        - "ac4.1: record-detection-gap.sh is executable"
+        - "ac4.1: record-detection-gap.sh has set -euo pipefail"
+        - "ac4.1 action2: doobidoo memory_store hint is output to stderr"
+        - "ac4.1 action2: doobidoo hint includes content field"
+        - "ac4.1: default severity is medium when --severity is not specified"
+        - "ac4.1: --related-issue value appears in log or hint output"
+      status: RED
+      red_mechanism: "record-detection-gap.sh が存在しないため全テストが fail する"
+      impl_files:
+        - "plugins/twl/skills/su-observer/scripts/record-detection-gap.sh"
+
+    - ac_index: 2
+      ac_text: "AC4.2: bats test plugins/twl/tests/bats/observer/record-detection-gap.bats — C1a: log regex マッチ, C1b: ファイル新規作成, C2: --severity high gh issue create hint, C3: 必須引数欠落 exit 1"
+      test_names:
+        - "ac4.2 C1a: log entry has ISO 8601 timestamp prefix"
+        - "ac4.2 C1a: log entry matches full regex pattern"
+        - "ac4.2 C1b: creates intervention-log.md when file does not exist"
+        - "ac4.2 C1b: creates parent directory with mkdir -p when not exists"
+        - "ac4.2 C1b: new file contains exactly one appended line"
+        - "ac4.2 C2: --severity high outputs gh issue create hint to stderr"
+        - "ac4.2 C2: --severity high hint includes required labels"
+        - "ac4.2 C2: --severity high also appends to intervention-log.md"
+        - "ac4.2 C2: --severity medium does NOT output gh issue create hint"
+        - "ac4.2 C3: missing --type exits with code 1"
+        - "ac4.2 C3: missing --detail exits with code 1"
+        - "ac4.2 C3: missing --type outputs usage to stderr"
+        - "ac4.2 C3: missing --detail outputs usage to stderr"
+      status: RED
+      red_mechanism: "record-detection-gap.sh が存在しないため全テストが fail する"
+      impl_files:
+        - "plugins/twl/skills/su-observer/scripts/record-detection-gap.sh"
+
+    - ac_index: 3
+      ac_text: "AC4.3: SKILL.md (または委譲先 refs/su-observer-supervise-channels.md) の Step 1 supervise loop に「検知漏れ発生時 record-detection-gap.sh 呼出 SHOULD」を文書化"
+      test_names:
+        - "ac4.3: SKILL.md or supervise-channels.md documents record-detection-gap.sh call"
+        - "ac4.3: documentation includes SHOULD keyword for the call"
+      status: RED
+      red_mechanism: "SKILL.md および refs/su-observer-supervise-channels.md に record-detection-gap.sh の記述が存在しないため fail する"
+      impl_files:
+        - "plugins/twl/skills/su-observer/SKILL.md"
+        - "plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md"

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -52,6 +52,16 @@ spawnable_by:
 
 > **Monitor tool 連携経路（SHOULD）**: cld-observe-any 起動時は `refs/monitor-channel-catalog.md` の「Monitor tool 連携経路（方式 A: 共有 logfile tail）」セクションを参照し、stdout を `.supervisor/cld-observe-any.log` に `tee -a` redirect した上で Monitor tool を `tail -F` で起動すること。これにより `[MENU-READY]`/`[REVIEW-READY]`/`[FREEFORM-READY]` 等の event を Monitor tool でリアルタイム受信できる（#1144）。
 
+> **検知漏れ記録（SHOULD）**: Monitor 不在・pitfall 適用漏れ・observer 自身の介入失敗など「検知漏れ」が発生した判断ポイントでは `scripts/record-detection-gap.sh` を呼び出すこと。SHOULD — 完全自動では難しいが、介入後に気づいた場合は積極的に記録する。
+> ```bash
+> bash skills/su-observer/scripts/record-detection-gap.sh \
+>   --type <missing-monitor|pitfall-miss|intervention-fail|proxy-stuck|kill-miss> \
+>   --detail "<状況の詳細>" \
+>   [--related-issue "#<N>"] \
+>   [--severity <low|medium|high>]
+> ```
+> script は `.supervisor/intervention-log.md` に追記し、stderr に doobidoo memory_store hint を出力する。LLM は hint を読んで自身で `mcp__doobidoo__memory_store` を実行すること（#1187）。
+
 ### controller spawn が必要な場合
 
 ユーザーが実装・作成・設計・テスト等の実行を求めた場合、**`refs/su-observer-controller-spawn-playbook.md` を Read** して実行。対話型 controller（co-issue / co-architect）の proxy 対話は **`refs/proxy-dialog-playbook.md` を Read** して実行。

--- a/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
@@ -24,10 +24,17 @@ EOF
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --type)           TYPE="$2";           shift 2 ;;
-    --detail)         DETAIL="$2";         shift 2 ;;
-    --related-issue)  RELATED_ISSUE="$2";  shift 2 ;;
-    --severity)       SEVERITY="$2";       shift 2 ;;
+    --type|--detail|--related-issue|--severity)
+      if [[ $# -lt 2 ]]; then
+        echo "ERROR: $1 requires a value" >&2; usage; exit 1
+      fi
+      case "$1" in
+        --type)           TYPE="$2" ;;
+        --detail)         DETAIL="$2" ;;
+        --related-issue)  RELATED_ISSUE="$2" ;;
+        --severity)       SEVERITY="$2" ;;
+      esac
+      shift 2 ;;
     *) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
   esac
 done
@@ -43,23 +50,43 @@ if [[ -z "$DETAIL" ]]; then
   exit 1
 fi
 
-# Action 1: .supervisor/intervention-log.md に追記（prior art: spawn-controller.sh L58）
+# --severity validation
+case "$SEVERITY" in
+  low|medium|high) ;;
+  *) echo "ERROR: --severity must be low|medium|high (got: $SEVERITY)" >&2; usage; exit 1 ;;
+esac
+
+# SUPERVISOR_DIR basic path safety (reject traversal patterns)
 _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+if [[ "$_supervisor_dir" == *..* ]]; then
+  echo "ERROR: SUPERVISOR_DIR must not contain '..'" >&2; exit 1
+fi
+
+# Sanitize DETAIL: strip newlines and control characters to prevent log injection
+DETAIL="${DETAIL//$'\n'/ }"
+DETAIL="${DETAIL//$'\r'/ }"
+
+# Action 1: .supervisor/intervention-log.md に追記（prior art: spawn-controller.sh L58）
 mkdir -p "$_supervisor_dir"
 _ts="$(date -u +%FT%TZ)"
-printf '%s [detection-gap] type=%s severity=%s: %s\n' \
-  "$_ts" "$TYPE" "$SEVERITY" "$DETAIL" \
-  >> "$_supervisor_dir/intervention-log.md"
+if [[ -n "$RELATED_ISSUE" ]]; then
+  printf '%s [detection-gap] type=%s severity=%s related=%s: %s\n' \
+    "$_ts" "$TYPE" "$SEVERITY" "$RELATED_ISSUE" "$DETAIL" \
+    >> "$_supervisor_dir/intervention-log.md"
+else
+  printf '%s [detection-gap] type=%s severity=%s: %s\n' \
+    "$_ts" "$TYPE" "$SEVERITY" "$DETAIL" \
+    >> "$_supervisor_dir/intervention-log.md"
+fi
 
 # Action 2: doobidoo memory_store hint → stderr（MCP は shell から呼出不可のため hint のみ）
 {
   echo "[hint] doobidoo memory_store recommended:"
   echo "  content: \"detection-gap: ${DETAIL}\""
+  echo "  tags: [\"observer-pitfall\", \"detection-gap\", \"${TYPE}\"]"
   if [[ -n "$RELATED_ISSUE" ]]; then
-    echo "  tags: [\"observer-pitfall\", \"detection-gap\", \"${TYPE}\"]"
     echo "  metadata: { \"severity\": \"${SEVERITY}\", \"related_issue\": \"${RELATED_ISSUE}\" }"
   else
-    echo "  tags: [\"observer-pitfall\", \"detection-gap\", \"${TYPE}\"]"
     echo "  metadata: { \"severity\": \"${SEVERITY}\" }"
   fi
 } >&2

--- a/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# record-detection-gap.sh — 検知漏れ自動記録 helper (#1187)
+# Usage: record-detection-gap.sh --type <gap-type> --detail <text> [--related-issue <#N>] [--severity {low,medium,high}]
+set -euo pipefail
+
+TYPE=""
+DETAIL=""
+RELATED_ISSUE=""
+SEVERITY="medium"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: record-detection-gap.sh --type <gap-type> --detail <text> [options]
+
+Required:
+  --type <gap-type>    free-text (e.g. missing-monitor / pitfall-miss / intervention-fail / proxy-stuck / kill-miss)
+  --detail <text>      description of the detection gap
+
+Optional:
+  --related-issue <#N> related issue number (e.g. #1179)
+  --severity <level>   low|medium|high (default: medium)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type)           TYPE="$2";           shift 2 ;;
+    --detail)         DETAIL="$2";         shift 2 ;;
+    --related-issue)  RELATED_ISSUE="$2";  shift 2 ;;
+    --severity)       SEVERITY="$2";       shift 2 ;;
+    *) echo "ERROR: Unknown argument: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$TYPE" ]]; then
+  echo "ERROR: --type is required" >&2
+  usage
+  exit 1
+fi
+if [[ -z "$DETAIL" ]]; then
+  echo "ERROR: --detail is required" >&2
+  usage
+  exit 1
+fi
+
+# Action 1: .supervisor/intervention-log.md に追記（prior art: spawn-controller.sh L58）
+_supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
+mkdir -p "$_supervisor_dir"
+_ts="$(date -u +%FT%TZ)"
+printf '%s [detection-gap] type=%s severity=%s: %s\n' \
+  "$_ts" "$TYPE" "$SEVERITY" "$DETAIL" \
+  >> "$_supervisor_dir/intervention-log.md"
+
+# Action 2: doobidoo memory_store hint → stderr（MCP は shell から呼出不可のため hint のみ）
+{
+  echo "[hint] doobidoo memory_store recommended:"
+  echo "  content: \"detection-gap: ${DETAIL}\""
+  if [[ -n "$RELATED_ISSUE" ]]; then
+    echo "  tags: [\"observer-pitfall\", \"detection-gap\", \"${TYPE}\"]"
+    echo "  metadata: { \"severity\": \"${SEVERITY}\", \"related_issue\": \"${RELATED_ISSUE}\" }"
+  else
+    echo "  tags: [\"observer-pitfall\", \"detection-gap\", \"${TYPE}\"]"
+    echo "  metadata: { \"severity\": \"${SEVERITY}\" }"
+  fi
+} >&2
+
+# Action 3: --severity high のみ gh issue create hint → stderr（script 自体は実起票しない）
+if [[ "$SEVERITY" == "high" ]]; then
+  {
+    echo "[hint] gh issue create recommended (pitfalls-catalog.md update PR candidate):"
+    printf '  gh issue create \\\n'
+    printf '    --title "pitfall: detection-gap type=%s" \\\n' "$TYPE"
+    printf '    --body "## 検知漏れ概要\n%s" \\\n' "$DETAIL"
+    printf '    --label "scope/plugins-twl,ctx/supervision,enhancement,P1"\n'
+  } >&2
+fi

--- a/plugins/twl/tests/bats/observer/record-detection-gap.bats
+++ b/plugins/twl/tests/bats/observer/record-detection-gap.bats
@@ -1,0 +1,284 @@
+#!/usr/bin/env bats
+# record-detection-gap.bats
+#
+# RED-phase tests for Issue #1187:
+#   feat(observer): record-detection-gap.sh 新設 — 検知漏れ自動記録 helper
+#
+# AC coverage:
+#   AC4.1 - plugins/twl/skills/su-observer/scripts/record-detection-gap.sh 新規作成
+#           (引数: --type, --detail, --related-issue, --severity)
+#           (動作1: intervention-log.md 追記, 動作2: doobidoo hint→stderr,
+#            動作3: --severity high のみ gh issue create hint→stderr)
+#   AC4.2 - bats test (本ファイル) — C1a, C1b, C2, C3
+#   AC4.3 - SKILL.md または refs/su-observer-supervise-channels.md に
+#            record-detection-gap.sh 呼出 SHOULD 文書化
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${this_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/record-detection-gap.sh"
+  SKILL_MD="${REPO_ROOT}/skills/su-observer/SKILL.md"
+  SUPERVISE_CHANNELS="${REPO_ROOT}/skills/su-observer/refs/su-observer-supervise-channels.md"
+
+  export SCRIPT SKILL_MD SUPERVISE_CHANNELS
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC4.1: scripts/record-detection-gap.sh 存在・実行可能
+# ===========================================================================
+
+@test "ac4.1: record-detection-gap.sh exists at expected path" {
+  # AC: plugins/twl/skills/su-observer/scripts/record-detection-gap.sh が新規作成される
+  # RED: ファイルが存在しないため fail
+  [ -f "${SCRIPT}" ]
+}
+
+@test "ac4.1: record-detection-gap.sh is executable" {
+  # AC: script が実行可能である
+  # RED: ファイルが存在しないため fail
+  [ -f "${SCRIPT}" ]
+  [ -x "${SCRIPT}" ]
+}
+
+@test "ac4.1: record-detection-gap.sh has set -euo pipefail" {
+  # AC: set -euo pipefail で安全に実行される（prior art と整合）
+  # RED: ファイルが存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run grep -E 'set -.*e.*u|set -euo' "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4.2 C1a: --type test-gap --detail "smoke" --severity medium
+#            intervention-log.md 末尾 1 行が ISO 8601 regex にマッチ
+# ===========================================================================
+
+@test "ac4.2 C1a: log entry has ISO 8601 timestamp prefix" {
+  # AC: log 末尾行が <ISO 8601> [detection-gap] type=test-gap severity=medium: smoke にマッチ
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  local log_file="${TMPDIR_TEST}/intervention-log.md"
+  SUPERVISOR_DIR="${TMPDIR_TEST}" \
+    bash "${SCRIPT}" --type test-gap --detail "smoke" --severity medium
+  run tail -1 "${log_file}"
+  [[ "${output}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\ \[detection-gap\]\ type=test-gap\ severity=medium:\ smoke$ ]]
+}
+
+@test "ac4.2 C1a: log entry matches full regex pattern" {
+  # AC: 末尾行が \d{4}-...-\d{2}T\d{2}:\d{2}:\d{2}Z \[detection-gap\] type=.* severity=.*: .* にマッチ
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  local log_file="${TMPDIR_TEST}/intervention-log.md"
+  SUPERVISOR_DIR="${TMPDIR_TEST}" \
+    bash "${SCRIPT}" --type test-gap --detail "smoke" --severity medium
+  run bash -c "tail -1 '${log_file}' | grep -E '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z \[detection-gap\] type=[^ ]+ severity=[^:]+: .+$'"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4.2 C1b: log ファイル不在 → 新規作成 + 1 行 append (mkdir -p で親 dir 作成)
+# ===========================================================================
+
+@test "ac4.2 C1b: creates intervention-log.md when file does not exist" {
+  # AC: .supervisor/intervention-log.md が存在しない状態で実行 → ファイル新規作成
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  local supervisor_dir="${TMPDIR_TEST}/.supervisor-new"
+  [ ! -d "${supervisor_dir}" ]
+  SUPERVISOR_DIR="${supervisor_dir}" \
+    bash "${SCRIPT}" --type missing-monitor --detail "test creation"
+  [ -f "${supervisor_dir}/intervention-log.md" ]
+}
+
+@test "ac4.2 C1b: creates parent directory with mkdir -p when not exists" {
+  # AC: 親ディレクトリが存在しない場合でも mkdir -p で作成される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  local supervisor_dir="${TMPDIR_TEST}/nested/deep/.supervisor"
+  [ ! -d "${supervisor_dir}" ]
+  SUPERVISOR_DIR="${supervisor_dir}" \
+    bash "${SCRIPT}" --type pitfall-miss --detail "deep dir test"
+  [ -d "${supervisor_dir}" ]
+  [ -f "${supervisor_dir}/intervention-log.md" ]
+}
+
+@test "ac4.2 C1b: new file contains exactly one appended line" {
+  # AC: 新規作成後のファイルに 1 行（追記分）が存在する
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  local supervisor_dir="${TMPDIR_TEST}/.supervisor-c1b"
+  SUPERVISOR_DIR="${supervisor_dir}" \
+    bash "${SCRIPT}" --type intervention-fail --detail "single line test"
+  run wc -l "${supervisor_dir}/intervention-log.md"
+  [[ "${output}" =~ ^[[:space:]]*1 ]]
+}
+
+# ===========================================================================
+# AC4.2 C2: --severity high → stderr に gh issue create を含む hint
+#            (hint のみで実起票なし、log 追記は同時に発生)
+# ===========================================================================
+
+@test "ac4.2 C2: --severity high outputs gh issue create hint to stderr" {
+  # AC: --severity high 実行時に stderr へ gh issue create hint が出力される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type proxy-stuck --detail 'high severity test' --severity high 2>&1 >/dev/null"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ "gh issue create" ]]
+}
+
+@test "ac4.2 C2: --severity high hint includes required labels" {
+  # AC: hint の label に scope/plugins-twl,ctx/supervision,enhancement,P1 が含まれる
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type kill-miss --detail 'label check' --severity high 2>&1 >/dev/null"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ "scope/plugins-twl" ]]
+}
+
+@test "ac4.2 C2: --severity high also appends to intervention-log.md" {
+  # AC: --severity high でも動作1（log 追記）が実行される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  SUPERVISOR_DIR="${TMPDIR_TEST}" \
+    bash "${SCRIPT}" --type kill-miss --detail "high severity log check" --severity high
+  [ -f "${TMPDIR_TEST}/intervention-log.md" ]
+  run grep '\[detection-gap\]' "${TMPDIR_TEST}/intervention-log.md"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4.2 C2: --severity medium does NOT output gh issue create hint" {
+  # AC: --severity medium では gh issue create hint は出力されない（high のみ）
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type test-gap --detail 'medium check' --severity medium 2>&1 >/dev/null"
+  [ "${status}" -eq 0 ]
+  [[ ! "${output}" =~ "gh issue create" ]]
+}
+
+# ===========================================================================
+# AC4.2 C3: 必須引数 (--type または --detail) 欠落時 → exit 1 + stderr に usage
+# ===========================================================================
+
+@test "ac4.2 C3: missing --type exits with code 1" {
+  # AC: --type が省略されると exit 1 する
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash "${SCRIPT}" --detail "no type provided"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac4.2 C3: missing --detail exits with code 1" {
+  # AC: --detail が省略されると exit 1 する
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash "${SCRIPT}" --type missing-monitor
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac4.2 C3: missing --type outputs usage to stderr" {
+  # AC: --type 欠落時に stderr へ usage が出力される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "bash '${SCRIPT}' --detail 'no type' 2>&1 >/dev/null"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" =~ "--type" ]] || [[ "${output}" =~ "usage" ]] || [[ "${output}" =~ "Usage" ]]
+}
+
+@test "ac4.2 C3: missing --detail outputs usage to stderr" {
+  # AC: --detail 欠落時に stderr へ usage が出力される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "bash '${SCRIPT}' --type intervention-fail 2>&1 >/dev/null"
+  [ "${status}" -eq 1 ]
+  [[ "${output}" =~ "--detail" ]] || [[ "${output}" =~ "usage" ]] || [[ "${output}" =~ "Usage" ]]
+}
+
+# ===========================================================================
+# AC4.1 動作2: doobidoo memory_store hint が常時 stderr に出力される
+# ===========================================================================
+
+@test "ac4.1 action2: doobidoo memory_store hint is output to stderr" {
+  # AC: 動作2 — doobidoo memory_store の推奨 content/tags/metadata が stderr に出力される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type test-gap --detail 'hint check' 2>&1 >/dev/null"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ "doobidoo" ]] || [[ "${output}" =~ "memory_store" ]] || [[ "${output}" =~ "[hint]" ]]
+}
+
+@test "ac4.1 action2: doobidoo hint includes content field" {
+  # AC: hint に content フィールドが含まれる
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type test-gap --detail 'content check' 2>&1 >/dev/null"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ "content" ]] || [[ "${output}" =~ "tags" ]]
+}
+
+# ===========================================================================
+# AC4.1: --severity default が medium になる
+# ===========================================================================
+
+@test "ac4.1: default severity is medium when --severity is not specified" {
+  # AC: --severity 未指定時のデフォルトが medium
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  SUPERVISOR_DIR="${TMPDIR_TEST}" \
+    bash "${SCRIPT}" --type test-gap --detail "default severity test"
+  run grep 'severity=medium' "${TMPDIR_TEST}/intervention-log.md"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4.1: --related-issue オプション引数が log に反映される
+# ===========================================================================
+
+@test "ac4.1: --related-issue value appears in log or hint output" {
+  # AC: --related-issue #N が指定された場合、log または hint に反映される
+  # RED: script が存在しないため fail
+  [ -f "${SCRIPT}" ]
+  run bash -c "SUPERVISOR_DIR='${TMPDIR_TEST}' bash '${SCRIPT}' --type test-gap --detail 'issue ref test' --related-issue '#1187' 2>&1"
+  [ "${status}" -eq 0 ]
+  [[ "${output}" =~ "1187" ]] || grep -q '1187' "${TMPDIR_TEST}/intervention-log.md" 2>/dev/null
+}
+
+# ===========================================================================
+# AC4.3: SKILL.md または refs に record-detection-gap.sh 呼出 SHOULD 文書化
+# ===========================================================================
+
+@test "ac4.3: SKILL.md or supervise-channels.md documents record-detection-gap.sh call" {
+  # AC: SKILL.md または refs/su-observer-supervise-channels.md の Step 1 supervise loop に
+  #     「検知漏れ発生時 record-detection-gap.sh 呼出 SHOULD」が明記される
+  # RED: 文書化がまだ存在しないため fail
+  run bash -c "
+    grep -rE 'record-detection-gap' '${SKILL_MD}' '${SUPERVISE_CHANNELS}' 2>/dev/null
+  "
+  [ "${status}" -eq 0 ]
+  [ -n "${output}" ]
+}
+
+@test "ac4.3: documentation includes SHOULD keyword for the call" {
+  # AC: 文書化に「SHOULD」が含まれる（観察 LLM の判断ポイントとして明記）
+  # RED: 文書化がまだ存在しないため fail
+  run bash -c "
+    grep -A5 -E 'record-detection-gap' '${SKILL_MD}' '${SUPERVISE_CHANNELS}' 2>/dev/null | grep -E 'SHOULD|should'
+  "
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Issue #1187 の実装。検知漏れ（Monitor 不在 / pitfall 適用漏れ / observer 自身の介入失敗）を自動記録する helper script を新設。

## Changes

### AC4.1: `plugins/twl/skills/su-observer/scripts/record-detection-gap.sh` 新規作成
- 引数: `--type` (required) / `--detail` (required) / `--related-issue` (optional) / `--severity` (default: medium)
- 動作1: `.supervisor/intervention-log.md` に `<ISO 8601> [detection-gap] type=<type> severity=<severity>: <detail>` 形式で追記
- 動作2: doobidoo memory_store 推奨 hint を stderr に出力（MCP 直接呼出不可のため hint のみ）
- 動作3: `--severity high` 時のみ `gh issue create` hint を stderr に出力（script 自体は実起票しない）

### AC4.2: `plugins/twl/tests/bats/observer/record-detection-gap.bats` 新規作成
- 22 tests: C1a (log regex), C1b (file creation), C2 (severity high hint), C3 (required args validation)

### AC4.3: `plugins/twl/skills/su-observer/SKILL.md` 編集
- Step 1 supervise loop に「検知漏れ発生時 record-detection-gap.sh 呼出 SHOULD」を文書化

## Test Results

```
22/22 PASS (bats)
```

Closes #1187