### PR TITLE
feat(#1211): architect-completeness-check に Severity 列追加と動的化

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md
+++ b/plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md
@@ -1,0 +1,27 @@
+# ADR-032: architect-completeness-check に Severity 列を導入し動的化する
+
+## Status
+
+accepted
+
+## Context
+
+`architect-completeness-check` コマンドの Step 1 必須テーブルは、不在時のレポートレベル（`WARNING` / `INFO`）がハードコードされていた。TI-1（`--lightweight` フラグ導入）の設計では、一部の必須チェックを `RECOMMENDED`（不在 = INFO）に段階的に降格させることで、軽量チェックモードを実現する予定がある。このハードコード構造のままでは、TI-1 の実装時に `architect-completeness-check.md` 自体を書き換える必要があり、変更コストと回帰リスクが高い。
+
+また、`ref-architecture-spec.md` がアーキテクチャ仕様の SSOT として機能しているにもかかわらず、`architect-completeness-check.md` の Step 1 テーブルが独立した定義を持つ二重管理状態であった（lightweight noise）。
+
+## Decision
+
+`ref-architecture-spec.md` の `## 必須ファイル` テーブルに `Severity` 列（値域: `WARNING` または `RECOMMENDED`）を追加し、`architect-completeness-check.md` の Step 1 がこのテーブルを Read して Severity を動的に参照する設計に変更する。
+
+- `Severity=WARNING` のパスが不在 → `[WARNING]` で報告
+- `Severity=RECOMMENDED` のパスが不在 → `[INFO]` で報告（WARNING より低い）
+- `ref-architecture-spec.md` が Severity の SSOT となる（architect-completeness-check.md へのハードコード禁止）
+
+既定状態では現行 5 必須ファイル（`vision.md`, `domain/model.md`, `domain/glossary.md`, `domain/contexts/*.md`, `phases/*.md`）が `WARNING`、任意ファイル（`decisions/*.md`, `contracts/*.md`）が `RECOMMENDED` に設定し、既存の動作を regression なく維持する。
+
+## Consequences
+
+- **良い面**: `ref-architecture-spec.md` のテーブル変更のみで Severity を切替可能になる（TI-1 が選択肢として活用可）。`architect-completeness-check.md` の保守コストが低減し、仕様と実装の乖離が防止される。
+- **悪い面**: `architect-completeness-check` 実行時に `ref-architecture-spec.md` の Read が必須となる（軽微なオーバーヘッド）。
+- **TI-1 接続**: TI-1（`--lightweight` フラグ）の実装時は、`ref-architecture-spec.md` の Severity 列を `RECOMMENDED` に変更するだけで軽量チェックモードが実現可能となる。

--- a/plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md
+++ b/plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md
@@ -20,8 +20,14 @@ accepted
 
 既定状態では現行 5 必須ファイル（`vision.md`, `domain/model.md`, `domain/glossary.md`, `domain/contexts/*.md`, `phases/*.md`）が `WARNING`、任意ファイル（`decisions/*.md`, `contracts/*.md`）が `RECOMMENDED` に設定し、既存の動作を regression なく維持する。
 
+## Alternatives
+
+1. **ハードコード維持（現状案）**: `architect-completeness-check.md` の Step 1 テーブルを書き換えず、TI-1 実装時にコマンド自体を修正する。変更コストは低いが、TI-1 実装毎に `architect-completeness-check.md` への変更が必要となり、仕様と実装が分散したまま残る。
+2. **専用設定ファイル分離案**: `severity-config.yaml` のような独立した設定ファイルを導入し、Severity を外部化する。柔軟性は高いが、新規ファイルの追加と管理コストが発生し、既存 `ref-architecture-spec.md` との二重管理になる。
+3. **採用案（ref-architecture-spec.md への Severity 列追加）**: SSOT を既存の参照ファイル（`ref-architecture-spec.md`）に集約する。新規ファイル追加不要、既存 Read 操作の延長で実現可能、TI-1 対応もテーブル変更のみで済む。
+
 ## Consequences
 
 - **良い面**: `ref-architecture-spec.md` のテーブル変更のみで Severity を切替可能になる（TI-1 が選択肢として活用可）。`architect-completeness-check.md` の保守コストが低減し、仕様と実装の乖離が防止される。
-- **悪い面**: `architect-completeness-check` 実行時に `ref-architecture-spec.md` の Read が必須となる（軽微なオーバーヘッド）。
+- **悪い面**: `architect-completeness-check` 実行時に `ref-architecture-spec.md` の Read が毎回必須となる（コマンド呼び出し 1 回あたり Read 1 回の追加）。`ref-architecture-spec.md` が不在の場合は Severity 情報が取得できないため、フォールバック挙動（デフォルト WARNING）を実装側で考慮する必要がある。また、`ref-architecture-spec.md` の Severity 列が意図せず変更された場合（WARNING → RECOMMENDED）、既存プロジェクトのチェックが警告なく降格するリスクがある。
 - **TI-1 接続**: TI-1（`--lightweight` フラグ）の実装時は、`ref-architecture-spec.md` の Severity 列を `RECOMMENDED` に変更するだけで軽量チェックモードが実現可能となる。

--- a/plugins/twl/commands/architect-completeness-check.md
+++ b/plugins/twl/commands/architect-completeness-check.md
@@ -27,8 +27,8 @@ architecture/ ディレクトリの完全性を検証し、不足ファイル・
 | `domain/glossary.md` | YES | 動的読み出し |
 | `domain/contexts/*.md` | 1つ以上 | 動的読み出し |
 | `phases/*.md` | 1つ以上 | 動的読み出し |
-| `decisions/` | NO | 動的読み出し |
-| `contracts/` | NO | 動的読み出し |
+| `decisions/*.md` | NO | 動的読み出し |
+| `contracts/*.md` | NO | 動的読み出し |
 
 各パスを Glob で確認し、不在時は `ref-architecture-spec.md` テーブルの `Severity` 値に従ってレベルを決定する:
 - `Severity=WARNING` → `[WARNING]`

--- a/plugins/twl/commands/architect-completeness-check.md
+++ b/plugins/twl/commands/architect-completeness-check.md
@@ -16,17 +16,23 @@ architecture/ ディレクトリの完全性を検証し、不足ファイル・
 
 ### 1. 必須ファイル存在チェック
 
-以下のファイル/ディレクトリの存在を Glob で確認:
+**Step 1 冒頭**: `ref-architecture-spec.md` を Read し、`## 必須ファイル` セクションの必須テーブルから各パスの `Severity` 列を動的に読み出す。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。
 
-| パス | 必須 | 不在時レベル |
-|------|------|-------------|
-| `vision.md` | YES | WARNING |
-| `domain/model.md` | YES | WARNING |
-| `domain/glossary.md` | YES | WARNING |
-| `domain/contexts/*.md` | 1つ以上 | WARNING |
-| `phases/*.md` | 1つ以上 | WARNING |
-| `decisions/` | NO | INFO（未作成） |
-| `contracts/` | NO | INFO（未作成） |
+テーブル形式（`ref-architecture-spec.md` の `## 必須ファイル` テーブルを参照）:
+
+| パス | 必須 | Severity（ref-architecture-spec.md から読み出し） |
+|------|------|------------------------------------------------|
+| `vision.md` | YES | 動的読み出し |
+| `domain/model.md` | YES | 動的読み出し |
+| `domain/glossary.md` | YES | 動的読み出し |
+| `domain/contexts/*.md` | 1つ以上 | 動的読み出し |
+| `phases/*.md` | 1つ以上 | 動的読み出し |
+| `decisions/` | NO | 動的読み出し |
+| `contracts/` | NO | 動的読み出し |
+
+各パスを Glob で確認し、不在時は `ref-architecture-spec.md` テーブルの `Severity` 値に従ってレベルを決定する:
+- `Severity=WARNING` → `[WARNING]`
+- `Severity=RECOMMENDED` → `[INFO]`（RECOMMENDED 不在は WARNING より低い INFO レベル）
 
 ### 2. 必須セクションチェック
 

--- a/plugins/twl/refs/ref-architecture-spec.md
+++ b/plugins/twl/refs/ref-architecture-spec.md
@@ -27,17 +27,17 @@ architecture/
 
 ## 必須ファイル
 
-アーキテクチャ完全性チェックで検証される必須ファイル:
+アーキテクチャ完全性チェックで検証される必須ファイル。`Severity` 列は不在時の報告レベルを定義する（`WARNING` または `RECOMMENDED`）。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。テーブル変更のみで `Severity` 値を切替可能な設計とする（テーブル駆動）。
 
-| ファイル | 必須 | 説明 |
-|---------|------|------|
-| vision.md | YES | プロジェクトの目的・制約・非目標 |
-| domain/model.md | YES | コアドメインモデル |
-| domain/glossary.md | YES | ユビキタス言語定義 |
-| domain/contexts/*.md | 1つ以上 | Bounded Context 定義 |
-| phases/*.md | 1つ以上 | Phase 計画 |
-| decisions/*.md | NO | ADR（任意） |
-| contracts/*.md | NO | API 境界（任意） |
+| ファイル | 必須 | Severity | 説明 |
+|---------|------|----------|------|
+| vision.md | YES | WARNING | プロジェクトの目的・制約・非目標 |
+| domain/model.md | YES | WARNING | コアドメインモデル |
+| domain/glossary.md | YES | WARNING | ユビキタス言語定義 |
+| domain/contexts/*.md | 1つ以上 | WARNING | Bounded Context 定義 |
+| phases/*.md | 1つ以上 | WARNING | Phase 計画 |
+| decisions/*.md | NO | RECOMMENDED | ADR（任意） |
+| contracts/*.md | NO | RECOMMENDED | API 境界（任意） |
 
 ## ファイルフォーマット
 

--- a/plugins/twl/tests/bats/ac-test-mapping-1211.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1211.yaml
@@ -1,0 +1,70 @@
+mappings:
+  - ac_index: 1
+    ac_text: "ref-architecture-spec.md の必須テーブルに Severity 列が追加される (値域: WARNING または RECOMMENDED)"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac1-severity-col-present: ref-architecture-spec.md の必須テーブルに Severity 列が存在する"
+      - "ac1-severity-values: ref-architecture-spec.md の Severity 値が WARNING または RECOMMENDED のみ"
+      - "ac1-severity-no-invalid-values: Severity 列に WARNING/RECOMMENDED 以外の値が存在しない"
+    impl_files:
+      - "plugins/twl/refs/ref-architecture-spec.md"
+
+  - ac_index: 2
+    ac_text: "architect-completeness-check.md の Step 1 必須テーブル部分（現ハードコード箇所）が ref-architecture-spec.md の必須テーブルから Severity を動的に読み出して出力する。RECOMMENDED 不在は INFO レベルで報告。ref-architecture-spec.md の Read は Step 1 冒頭で実施する。"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac2-dynamic-read-ref: architect-completeness-check.md が ref-architecture-spec.md の Read を Step 1 冒頭で指示している"
+      - "ac2-severity-dynamic-output: architect-completeness-check.md が Severity を動的に出力する記述がある"
+      - "ac2-recommended-info-level: architect-completeness-check.md に RECOMMENDED 不在が INFO レベルという記述がある"
+      - "ac2-step1-read-before-table: Step 1 の Read が必須テーブルチェック前に配置されている"
+    impl_files:
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 3
+    ac_text: "既定状態 (現行 5 ファイル全件 = WARNING) で architect-completeness-check の動作が変化しない (regression なし)"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac3-default-warning-rows: ref-architecture-spec.md の WARNING 行が 5 件以上存在する"
+      - "ac3-contexts-warning: domain/contexts/*.md エントリが WARNING Severity を持つ"
+      - "ac3-phases-warning: phases/*.md エントリが WARNING Severity を持つ"
+      - "ac3-no-existing-warning-removed: 既存の WARNING 定義が削除されていない"
+    impl_files:
+      - "plugins/twl/refs/ref-architecture-spec.md"
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 4
+    ac_text: "新規 bats test (plugins/twl/tests/bats/architect-completeness-check-severity.bats) を追加し、(a) 必須テーブルパース、(b) WARNING/RECOMMENDED 出力区別、(c) 既定動作 regression を検証する。前提: 既存テスト名との重複を避けること。"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac4-test-file-exists: architect-completeness-check-severity.bats が存在する"
+      - "ac4-no-duplicate-test-names: 既存 bats テストと test 名が重複しない"
+      - "ac4-table-parse-required-col: Severity 列がテーブルヘッダーで識別できる"
+      - "ac4-warning-output-distinct-from-recommended: RECOMMENDED 不在が INFO で出力されることが仕様に明記されている"
+    impl_files:
+      - "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+      - "plugins/twl/refs/ref-architecture-spec.md"
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 5
+    ac_text: "軽量 ADR を plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md として PR 内で同時起草 (Status: accepted、Context: lightweight noise + TI-1 接続、Decision: Severity 列導入で動的化、Consequences: TI-1 が選択肢として活用可)"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac5-adr032-exists: ADR-032-completeness-severity-staging.md が decisions/ に存在する"
+      - "ac5-adr032-status-accepted: ADR-032 の Status が accepted"
+      - "ac5-adr032-context-lightweight-noise: ADR-032 の Context に lightweight noise または TI-1 への言及がある"
+      - "ac5-adr032-decision-severity-col: ADR-032 の Decision に Severity 列導入と動的化への言及がある"
+      - "ac5-adr032-consequences-ti1: ADR-032 の Consequences に TI-1 が選択肢として活用可能という記述がある"
+      - "ac5-adr032-number-is-max-plus-1: decisions/ の最大 ADR 番号が 032 である"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md"
+
+  - ac_index: 6
+    ac_text: "TI-1 (--lightweight フラグ) の前提となる基盤として、後続 Issue で Severity=RECOMMENDED への切替が容易な設計になっている (テーブル変更のみで切替可能なこと)"
+    test_file: "plugins/twl/tests/bats/architect-completeness-check-severity.bats"
+    test_names:
+      - "ac6-table-driven-design: architect-completeness-check.md が ref-architecture-spec.md のテーブルを動的に参照する設計になっている"
+      - "ac6-recommended-entries-possible: ref-architecture-spec.md の Severity 列が RECOMMENDED を許容する値域定義がある"
+      - "ac6-single-source-of-truth: Severity 定義が ref-architecture-spec.md のみで管理されている"
+    impl_files:
+      - "plugins/twl/refs/ref-architecture-spec.md"
+      - "plugins/twl/commands/architect-completeness-check.md"

--- a/plugins/twl/tests/bats/architect-completeness-check-severity.bats
+++ b/plugins/twl/tests/bats/architect-completeness-check-severity.bats
@@ -1,0 +1,314 @@
+#!/usr/bin/env bats
+# architect-completeness-check-severity.bats - Issue #1211: architect-completeness-check に Severity 列を追加する RED テスト
+#
+# AC coverage:
+#   AC1 - ref-architecture-spec.md の必須テーブルに Severity 列が追加される (値域: WARNING または RECOMMENDED)
+#   AC2 - architect-completeness-check.md の Step 1 が ref-architecture-spec.md の Severity を動的に読み出す
+#   AC3 - 既定状態 (全件 WARNING) で動作が regression しない
+#   AC4 - このテストファイル自体が存在し、bats 実行可能であること（自己参照テスト）
+#   AC5 - ADR-032-completeness-severity-staging.md が decisions/ に作成されている
+#   AC6 - Severity=RECOMMENDED 切替がテーブル変更のみで可能な設計になっている
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  REF_ARCH_SPEC="${REPO_ROOT}/refs/ref-architecture-spec.md"
+  COMPLETENESS_CHECK_CMD="${REPO_ROOT}/commands/architect-completeness-check.md"
+  ADR_032="${REPO_ROOT}/architecture/decisions/ADR-032-completeness-severity-staging.md"
+  DECISIONS_DIR="${REPO_ROOT}/architecture/decisions"
+  export REF_ARCH_SPEC COMPLETENESS_CHECK_CMD ADR_032 DECISIONS_DIR
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC1: ref-architecture-spec.md の必須テーブルに Severity 列が追加されている
+#      値域は WARNING または RECOMMENDED に限定される
+# ===========================================================================
+
+@test "ac1-severity-col-present: ref-architecture-spec.md の必須テーブルに Severity 列が存在する" {
+  # AC: ref-architecture-spec.md の ## 必須ファイル テーブルヘッダーに "Severity" 列が含まれる
+  # RED: 現在 ref-architecture-spec.md の必須テーブルに Severity 列が存在しないため fail
+  run grep -E "^\| ?ファイル" "${REF_ARCH_SPEC}"
+  [ "${status}" -eq 0 ]
+  echo "${output}" | grep -qE "Severity"
+}
+
+@test "ac1-severity-values: ref-architecture-spec.md の Severity 値が WARNING または RECOMMENDED のみ" {
+  # AC: ref-architecture-spec.md の必須テーブル内の Severity 列の値が WARNING または RECOMMENDED のみ
+  # RED: Severity 列が存在しないため fail
+  #
+  # テーブル行（| で始まり | で終わる行）から Severity 値を抽出し、WARNING/RECOMMENDED 以外が存在しないことを確認する
+  run bash -c "
+    # 必須テーブルのヘッダーを探し、Severity 列インデックスを取得して値を抽出
+    # 実装後はテーブル行から Severity セルのみを取り出す
+    grep -E '^\| *vision\.md|\| *domain/model|\| *domain/glossary|\| *domain/contexts|\| *phases/|\| *decisions/|\| *contracts/' '${REF_ARCH_SPEC}' \
+      | grep -qE 'WARNING|RECOMMENDED'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1-severity-no-invalid-values: Severity 列に WARNING/RECOMMENDED 以外の値が存在しない" {
+  # AC: 必須テーブルの Severity セルは WARNING または RECOMMENDED のみ（INFO や ERROR は不可）
+  # RED: Severity 列が存在しないため fail（列が存在した場合は値域バリデーション）
+  run bash -c "
+    # テーブル行の Severity セルとして想定されるセルを抽出し、WARNING/RECOMMENDED 以外がないことを確認
+    severity_lines=\$(grep -E '^\| *(vision\.md|domain/model\.md|domain/glossary\.md|domain/contexts|phases/)' '${REF_ARCH_SPEC}')
+    if [ -z \"\${severity_lines}\" ]; then
+      echo 'FAIL: no required file rows found with Severity column'
+      exit 1
+    fi
+    # WARNING または RECOMMENDED が含まれること
+    echo \"\${severity_lines}\" | grep -qE 'WARNING|RECOMMENDED'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: architect-completeness-check.md が ref-architecture-spec.md から
+#      Severity を動的に読み出すよう記述されている
+# ===========================================================================
+
+@test "ac2-dynamic-read-ref: architect-completeness-check.md が ref-architecture-spec.md の Read を Step 1 冒頭で指示している" {
+  # AC: architect-completeness-check.md の Step 1 に ref-architecture-spec.md の Read が記述されている
+  # RED: 現在 architect-completeness-check.md の Step 1 は静的なハードコードテーブルのため fail
+  run bash -c "
+    # Step 1 セクションの中で ref-architecture-spec.md の Read または参照が記述されているか確認
+    awk '/### 1\./{found=1} found && /### 2\./{exit} found{print}' '${COMPLETENESS_CHECK_CMD}' \
+      | grep -qE 'ref-architecture-spec|Read.*ref-arch|ref-arch.*Read'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2-severity-dynamic-output: architect-completeness-check.md が Severity を動的に出力する記述がある" {
+  # AC: architect-completeness-check.md の出力テーブルまたは指摘一覧に Severity を参照する記述がある
+  # RED: 現在の出力フォーマットに Severity の動的参照がないため fail
+  run grep -qE "Severity|severity" "${COMPLETENESS_CHECK_CMD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2-recommended-info-level: architect-completeness-check.md に RECOMMENDED 不在が INFO レベルという記述がある" {
+  # AC: RECOMMENDED 項目の不在は WARNING より低い INFO レベルで報告されること
+  # RED: 現在 RECOMMENDED の概念が存在しないため fail
+  run bash -c "
+    grep -qE 'RECOMMENDED.*INFO|INFO.*RECOMMENDED|RECOMMENDED.*低い|RECOMMENDED.*lower' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2-step1-read-before-table: Step 1 の Read が必須テーブルチェック前に配置されている" {
+  # AC: ref-architecture-spec.md の Read 指示が Step 1 のファイル存在チェックテーブルより前に記述されている
+  # RED: 現在 Step 1 冒頭に Read 指示が存在しないため fail
+  run bash -c "
+    # Step 1 セクションの最初の段落 (テーブル行より前) に Read が含まれることを確認
+    awk '/### 1\./{found=1; next} found && /^\|/{exit} found{print}' '${COMPLETENESS_CHECK_CMD}' \
+      | grep -qiE 'Read|ref-architecture-spec'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: 既定状態 (全 5 ファイル = WARNING) で regression なし
+# ===========================================================================
+
+@test "ac3-default-warning-rows: ref-architecture-spec.md の WARNING 行が 5 件以上存在する" {
+  # AC: 現行 5 ファイル (vision.md, domain/model.md, domain/glossary.md, contexts/*, phases/*) が
+  #     すべて WARNING であること（既定動作 regression チェック）
+  # RED: Severity 列が存在しないため fail
+  run bash -c "
+    count=\$(grep -E '^\| *(vision\.md|domain/model\.md|domain/glossary\.md).*WARNING' '${REF_ARCH_SPEC}' | wc -l)
+    echo \"WARNING count: \${count}\"
+    [ \"\${count}\" -ge 3 ]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3-contexts-warning: domain/contexts/*.md エントリが WARNING Severity を持つ" {
+  # AC: domain/contexts/*.md の必須エントリが WARNING Severity で定義されている
+  # RED: Severity 列が存在しないため fail
+  run grep -E "^\| *domain/contexts.*WARNING" "${REF_ARCH_SPEC}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3-phases-warning: phases/*.md エントリが WARNING Severity を持つ" {
+  # AC: phases/*.md の必須エントリが WARNING Severity で定義されている
+  # RED: Severity 列が存在しないため fail
+  run grep -E "^\| *phases/.*WARNING" "${REF_ARCH_SPEC}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3-no-existing-warning-removed: 既存の WARNING 定義が削除されていない" {
+  # AC: 既存の必須ファイル行 (vision.md 等) が ref-architecture-spec.md に引き続き存在する
+  # RED: regression チェック - Severity 列追加で既存行が消えていないことを確認
+  #      現状も通過しうるが、Severity 列追加後に regression しないことを担保する
+  run bash -c "
+    grep -qE '^\| *vision\.md' '${REF_ARCH_SPEC}' || exit 1
+    grep -qE '^\| *domain/model\.md' '${REF_ARCH_SPEC}' || exit 1
+    grep -qE '^\| *domain/glossary\.md' '${REF_ARCH_SPEC}' || exit 1
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: bats テストファイル自体の存在とテスト名重複チェック
+# ===========================================================================
+
+@test "ac4-test-file-exists: architect-completeness-check-severity.bats が存在する" {
+  # AC: plugins/twl/tests/bats/architect-completeness-check-severity.bats が存在する
+  # RED: このファイル自体が存在するため PASS するが、意図的に設計観点を記述する
+  #      実際の RED は他の AC テストが担保する
+  [ -f "${REPO_ROOT}/tests/bats/architect-completeness-check-severity.bats" ]
+}
+
+@test "ac4-no-duplicate-test-names: 既存 bats テストと test 名が重複しない" {
+  # AC: 既存 bats テストファイル群に "ac1-severity-col-present" "ac2-dynamic-read-ref" 等の
+  #     このファイル固有のテスト名が存在しない
+  # RED: 実装前確認用 - 重複があれば fail（現状は重複なしのため PASS）
+  run bash -c "
+    # このファイル固有のテスト名プレフィックスを既存テストから検索（このファイル除外）
+    found=\$(grep -rh '@test' '${REPO_ROOT}/tests/bats/' \
+      --include='*.bats' \
+      --exclude='architect-completeness-check-severity.bats' \
+      | grep -E 'ac[1-6]-severity-col-present|ac[1-6]-dynamic-read-ref|ac[1-6]-default-warning-rows|ac[1-6]-adr032-exists|ac[1-6]-table-driven-design' \
+      | wc -l)
+    echo \"Duplicate count: \${found}\"
+    [ \"\${found}\" -eq 0 ]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4-table-parse-required-col: Severity 列がテーブルヘッダーで識別できる" {
+  # AC: ref-architecture-spec.md の必須テーブルヘッダーに Severity が列として識別できる
+  # RED: Severity 列が存在しないため fail
+  run bash -c "
+    # テーブルヘッダー行に Severity が含まれること
+    grep -E '^\| *ファイル' '${REF_ARCH_SPEC}' | grep -qF 'Severity'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4-warning-output-distinct-from-recommended: RECOMMENDED 不在が INFO で出力されることが仕様に明記されている" {
+  # AC: architect-completeness-check.md の出力仕様で RECOMMENDED 項目の不在が INFO で出力されることが
+  #     明記されている（単に [INFO] が存在するだけでなく、RECOMMENDED と紐付いていること）
+  # RED: 現在 architect-completeness-check.md に RECOMMENDED の概念が存在しないため fail
+  run bash -c "
+    # RECOMMENDED と INFO が同一の文脈で記述されていること
+    grep -qE 'RECOMMENDED.*INFO|INFO.*RECOMMENDED' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC5: ADR-032-completeness-severity-staging.md が作成されている
+# ===========================================================================
+
+@test "ac5-adr032-exists: ADR-032-completeness-severity-staging.md が decisions/ に存在する" {
+  # AC: plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md が存在する
+  # RED: ADR-032 はまだ作成されていないため fail
+  [ -f "${ADR_032}" ]
+}
+
+@test "ac5-adr032-status-accepted: ADR-032 の Status が accepted" {
+  # AC: ADR-032 の ## Status セクションに accepted が記述されている
+  # RED: ADR-032 が存在しないため fail
+  run grep -qE "^accepted$|accepted" "${ADR_032}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-adr032-context-lightweight-noise: ADR-032 の Context に lightweight noise または TI-1 への言及がある" {
+  # AC: ADR-032 の ## Context セクションに lightweight noise および/または TI-1 への言及がある
+  # RED: ADR-032 が存在しないため fail
+  run bash -c "
+    grep -qE 'lightweight.*noise|noise.*lightweight|TI-1' '${ADR_032}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-adr032-decision-severity-col: ADR-032 の Decision に Severity 列導入と動的化への言及がある" {
+  # AC: ADR-032 の ## Decision セクションに Severity 列導入と動的化が記述されている
+  # RED: ADR-032 が存在しないため fail
+  run bash -c "
+    grep -qE 'Severity|動的化|dynamic' '${ADR_032}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-adr032-consequences-ti1: ADR-032 の Consequences に TI-1 が選択肢として活用可能という記述がある" {
+  # AC: ADR-032 の ## Consequences セクションに TI-1 への言及がある
+  # RED: ADR-032 が存在しないため fail
+  run bash -c "
+    awk '/## Consequences/{found=1} found{print}' '${ADR_032}' | grep -qE 'TI-1'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-adr032-number-is-max-plus-1: decisions/ の最大 ADR 番号が 032 である" {
+  # AC: decisions/ ディレクトリ内の最大 ADR 番号 = 031 の次の 032 が ADR-032 になっている
+  # RED: ADR-032 が存在しないため fail
+  run bash -c "
+    # decisions/ 配下の最大 ADR 番号を取得
+    max_num=\$(ls '${DECISIONS_DIR}'/ADR-*.md 2>/dev/null \
+      | sed 's/.*ADR-0*\([0-9]*\)-.*/\1/' \
+      | sort -n \
+      | tail -1)
+    echo \"max ADR number: \${max_num}\"
+    [ \"\${max_num}\" -eq 32 ]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC6: Severity=RECOMMENDED への切替がテーブル変更のみで可能な設計
+# ===========================================================================
+
+@test "ac6-table-driven-design: architect-completeness-check.md が ref-architecture-spec.md のテーブルを動的に参照する設計になっている" {
+  # AC: architect-completeness-check.md が Severity を ref-architecture-spec.md テーブルから動的に読み込む
+  #     ため、テーブルのみ変更すれば動作が変わる設計になっている
+  # RED: 現在 Step 1 のテーブルがハードコードのため fail
+  run bash -c "
+    # ハードコードされた Severity 値 (WARNING が Step 1 テーブルに直書きされている) が存在しないこと
+    # または ref-architecture-spec.md から動的に読む旨が記述されていること
+    step1_content=\$(awk '/### 1\./{found=1; next} found && /### 2\./{exit} found{print}' '${COMPLETENESS_CHECK_CMD}')
+    # Step 1 内に動的参照の記述があること (ref-architecture-spec 参照 or Severity 動的読み出し)
+    echo \"\${step1_content}\" | grep -qE 'ref-architecture-spec|Severity.*読み出|動的|dynamic'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6-recommended-entries-possible: ref-architecture-spec.md の Severity 列が RECOMMENDED を許容する値域定義がある" {
+  # AC: ref-architecture-spec.md で Severity の値域として RECOMMENDED が明示されている
+  # RED: Severity 列が存在しないため fail
+  run bash -c "
+    grep -qE 'RECOMMENDED' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6-single-source-of-truth: Severity 定義が ref-architecture-spec.md のみで管理されている" {
+  # AC: architect-completeness-check.md に Severity のハードコード値 (WARNING/RECOMMENDED) が
+  #     Step 1 テーブルとして直書きされていない（ref-architecture-spec.md が SSOT）
+  # RED: 現在 Step 1 のテーブルに WARNING がハードコードされているため fail
+  run bash -c "
+    # Step 1 のテーブル行に WARNING が直書きされているかチェック
+    # 実装後は ref-architecture-spec.md の Read + 動的参照に置き換わる
+    step1_table=\$(awk '/### 1\./{found=1; next} found && /### 2\./{exit} found && /^\|/{print}' '${COMPLETENESS_CHECK_CMD}')
+    if echo \"\${step1_table}\" | grep -qE '^\| .*\| *(YES|NO) *\| *WARNING'; then
+      echo 'FAIL: Step 1 still has hardcoded WARNING in table - not table-driven design'
+      exit 1
+    fi
+    exit 0
+  "
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Closes #1211

architect-completeness-check の必須ファイルチェックに `Severity` 列を導入し、`ref-architecture-spec.md` を SSOT として動的に参照する設計に変更する。

## Changes

- **`plugins/twl/refs/ref-architecture-spec.md`**: 必須テーブルに `Severity` 列（値域: `WARNING` / `RECOMMENDED`）を追加。現行 5 ファイルは `WARNING`、任意ファイルは `RECOMMENDED`。
- **`plugins/twl/commands/architect-completeness-check.md`**: Step 1 を `ref-architecture-spec.md` の Read + 動的 Severity 参照に変更。`RECOMMENDED` 不在は `INFO` レベルで報告。
- **`plugins/twl/architecture/decisions/ADR-032-completeness-severity-staging.md`**: 軽量 ADR を起草（Status: accepted）。

## AC Coverage

- [x] AC1: `ref-architecture-spec.md` 必須テーブルに Severity 列追加 (WARNING/RECOMMENDED)
- [x] AC2: `architect-completeness-check.md` が Severity を動的読み出し / RECOMMENDED 不在 = INFO
- [x] AC3: 既定状態 (全件 WARNING) regression なし
- [x] AC4: bats テスト 24 件追加（全件 GREEN）
- [x] AC5: ADR-032 起草（accepted、lightweight noise + TI-1 接続）
- [x] AC6: テーブル変更のみで Severity 切替可能な設計

## Test Results

```
bats tests/bats/architect-completeness-check-severity.bats
24/24 tests passed
```