### PR TITLE
fix(autopilot): orchestrator.pid で alive check を追加し resume を許可 (#1208)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -621,3 +621,62 @@ issue_1187:
       impl_files:
         - "plugins/twl/skills/su-observer/SKILL.md"
         - "plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md"
+
+# --- Issue #1208 ---
+issue_1208:
+  issue: 1208
+  framework: pytest+bats
+  mappings:
+    - ac_index: 1
+      ac_text: "session.json 存在 + < 24h + 未完了 でも orchestrator.pid 不在なら resume 許可（resume_safe）"
+      test_file: "cli/twl/tests/test_autopilot_init_resume.py"
+      test_name: "test_ac1_resume_when_orchestrator_dead"
+      status: RED
+      red_mechanism: "現行実装は orchestrator.pid をチェックせず session.json < 24h + 未完了なら常に InitError を raise する"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/init.py"
+
+    - ac_index: 2
+      ac_text: "session.json 存在 + orchestrator.pid 生 PID（kill -0 成功）→ InitError で block"
+      test_file: "cli/twl/tests/test_autopilot_init_resume.py"
+      test_name: "test_ac2_block_when_orchestrator_alive"
+      status: RED
+      red_mechanism: "現行実装は orchestrator.pid を参照しないため alive PID チェックによる block ができない"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/init.py"
+
+    - ac_index: 3
+      ac_text: "autopilot-orchestrator.sh 起動時に ${AUTOPILOT_DIR}/orchestrator.pid を atomic write し、書かれた PID が現プロセス PID に一致する"
+      test_file: "plugins/twl/tests/integration/orchestrator-pid-write.bats"
+      test_name: "orchestrator_writes_pid_on_startup"
+      status: RED
+      red_mechanism: "現行実装の autopilot-orchestrator.sh には orchestrator.pid 書き込みコードが存在しない"
+      impl_files:
+        - "plugins/twl/scripts/autopilot-orchestrator.sh"
+
+    - ac_index: 4
+      ac_text: "autopilot-orchestrator.sh の EXIT trap で orchestrator.pid が削除される"
+      test_file: "plugins/twl/tests/integration/orchestrator-pid-cleanup.bats"
+      test_name: "orchestrator_clears_pid_on_exit"
+      status: RED
+      red_mechanism: "現行実装の autopilot-orchestrator.sh には EXIT trap での orchestrator.pid 削除が存在しない"
+      impl_files:
+        - "plugins/twl/scripts/autopilot-orchestrator.sh"
+
+    - ac_index: 5
+      ac_text: "stale orchestrator.pid（dead PID を指す）の場合 resume 許可"
+      test_file: "cli/twl/tests/test_autopilot_init_resume.py"
+      test_name: "test_ac5_resume_when_orchestrator_pid_stale"
+      status: RED
+      red_mechanism: "現行実装は orchestrator.pid をチェックしないため stale pid でも session.json < 24h + 未完了なら InitError を raise する"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/init.py"
+
+    - ac_index: 6
+      ac_text: "bash 版 autopilot-init.sh も同等の orchestrator alive check を持つ"
+      test_file: "plugins/twl/tests/integration/autopilot-init-resume.bats"
+      test_name: "init_sh_resumes_when_orchestrator_dead"
+      status: RED
+      red_mechanism: "現行の autopilot-init.sh には orchestrator.pid 参照コードが存在しない"
+      impl_files:
+        - "plugins/twl/scripts/autopilot-init.sh"

--- a/cli/twl/src/twl/autopilot/init.py
+++ b/cli/twl/src/twl/autopilot/init.py
@@ -63,15 +63,24 @@ class AutopilotInitializer:
         self.autopilot_dir = autopilot_dir or _autopilot_dir()
 
     def _is_orchestrator_alive(self) -> bool:
-        """Return True if orchestrator.pid exists and the PID is alive (kill -0 succeeds)."""
+        """Return True if orchestrator.pid exists and the PID is alive (kill -0 succeeds).
+
+        PermissionError means the process exists but is owned by another user — still alive.
+        ProcessLookupError (ESRCH) means the process does not exist — dead/stale.
+        """
         pid_file = self.autopilot_dir / "orchestrator.pid"
         if not pid_file.is_file():
             return False
         try:
             pid = int(pid_file.read_text(encoding="utf-8").strip())
+            if pid <= 0:
+                return False
             os.kill(pid, 0)
             return True
-        except (ValueError, ProcessLookupError, PermissionError):
+        except PermissionError:
+            # EPERM: process exists but is owned by a different user → treat as alive
+            return True
+        except (ValueError, ProcessLookupError, OSError):
             return False
 
     def run(self, check_only: bool = False, force: bool = False) -> str:

--- a/cli/twl/src/twl/autopilot/init.py
+++ b/cli/twl/src/twl/autopilot/init.py
@@ -62,6 +62,18 @@ class AutopilotInitializer:
     def __init__(self, autopilot_dir: Path | None = None) -> None:
         self.autopilot_dir = autopilot_dir or _autopilot_dir()
 
+    def _is_orchestrator_alive(self) -> bool:
+        """Return True if orchestrator.pid exists and the PID is alive (kill -0 succeeds)."""
+        pid_file = self.autopilot_dir / "orchestrator.pid"
+        if not pid_file.is_file():
+            return False
+        try:
+            pid = int(pid_file.read_text(encoding="utf-8").strip())
+            os.kill(pid, 0)
+            return True
+        except (ValueError, ProcessLookupError, PermissionError):
+            return False
+
     def run(self, check_only: bool = False, force: bool = False) -> str:
         """Initialize .autopilot/ directory.
 
@@ -76,13 +88,14 @@ class AutopilotInitializer:
                 pass  # session removed, proceed
             elif result == "stale_warn":
                 raise InitError(
-                    f"stale セッションが検出されました。削除するには --force を指定してください"
+                    "stale セッションが検出されました。削除するには --force を指定してください"
                 )
             elif result == "running":
                 raise InitError(
-                    "既存セッションが実行中です。"
+                    "orchestrator プロセスが実行中です（alive PID confirmed）。"
                     "同一プロジェクトでの複数 autopilot セッションの同時実行は禁止されています"
                 )
+            # "resume_safe": orchestrator dead/absent → proceed silently
 
         if check_only:
             return "OK: 実行中のセッションはありません"
@@ -90,7 +103,10 @@ class AutopilotInitializer:
         return self._initialize_directories()
 
     def _check_existing_session(self, session_file: Path, force: bool) -> str:
-        """Check existing session. Returns 'removed', 'stale_warn', or 'running'."""
+        """Check existing session.
+
+        Returns one of: 'removed', 'stale_warn', 'running', 'resume_safe'.
+        """
         try:
             data = json.loads(session_file.read_text(encoding="utf-8"))
         except Exception:
@@ -133,7 +149,10 @@ class AutopilotInitializer:
             else:
                 return "stale_warn"
 
-        return "running"
+        # < 24h + not completed: check orchestrator alive before blocking
+        if self._is_orchestrator_alive():
+            return "running"
+        return "resume_safe"
 
     def _initialize_directories(self) -> str:
         """Create directory structure. Returns OK message."""

--- a/cli/twl/tests/test_autopilot_init_resume.py
+++ b/cli/twl/tests/test_autopilot_init_resume.py
@@ -1,0 +1,175 @@
+"""TDD RED phase tests for Issue #1208: orchestrator.pid based resume control.
+
+AC-1: session.json 存在 + < 24h + 未完了 でも orchestrator.pid 不在なら resume 許可
+AC-2: session.json 存在 + orchestrator.pid 生 PID (kill -0 成功) → InitError で block
+AC-5: stale orchestrator.pid (dead PID を指す) の場合 resume 許可
+
+現行実装 (_check_existing_session) には orchestrator.pid チェックが存在しないため、
+AC-1 と AC-5 は InitError が raise される（誤った block）。
+AC-2 は InitError が raise されない（誤った allow）。
+全テストは RED (fail) 状態で始まる。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from twl.autopilot.init import AutopilotInitializer, InitError
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def autopilot_dir(tmp_path: Path) -> Path:
+    d = tmp_path / ".autopilot"
+    d.mkdir()
+    (d / "issues").mkdir()
+    (d / "archive").mkdir()
+    return d
+
+
+def _write_session_json(autopilot_dir: Path, hours_ago: float = 1.0) -> None:
+    """Write a session.json that is hours_ago old and has no issues (= not completed)."""
+    from datetime import timedelta
+
+    started = datetime.now(timezone.utc) - timedelta(hours=hours_ago)
+    data = {
+        "session_id": "test-session-001",
+        "started_at": started.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+    (autopilot_dir / "session.json").write_text(
+        json.dumps(data), encoding="utf-8"
+    )
+    # issues/ に running issue を1件置いて「未完了」状態を作る
+    issue = {
+        "issue": 9999,
+        "status": "running",
+        "branch": "feat/9999-test",
+        "started_at": data["started_at"],
+    }
+    (autopilot_dir / "issues" / "issue-9999.json").write_text(
+        json.dumps(issue), encoding="utf-8"
+    )
+
+
+def _write_orchestrator_pid(autopilot_dir: Path, pid: int) -> None:
+    (autopilot_dir / "orchestrator.pid").write_text(str(pid), encoding="utf-8")
+
+
+def _get_dead_pid() -> int:
+    """Return a PID that is guaranteed to be dead."""
+    # Start a short-lived process, wait for it, then return its PID.
+    proc = subprocess.Popen(["true"])
+    proc.wait()
+    return proc.pid
+
+
+# ---------------------------------------------------------------------------
+# AC-1: orchestrator.pid 不在 → resume 許可 (InitError を raise しない)
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_resume_when_orchestrator_dead(autopilot_dir: Path) -> None:
+    """AC-1: session.json 存在 + < 24h + 未完了 でも orchestrator.pid 不在なら resume 許可。
+
+    RED: 現行実装は orchestrator.pid をチェックしないため、
+         session.json が < 24h + 未完了の場合は常に InitError を raise してしまう。
+         このテストは InitError が raise されないことを期待するが、現行では raise される → FAIL。
+    """
+    _write_session_json(autopilot_dir, hours_ago=1.0)
+    # orchestrator.pid を作らない（不在状態）
+    assert not (autopilot_dir / "orchestrator.pid").exists()
+
+    initializer = AutopilotInitializer(autopilot_dir=autopilot_dir)
+
+    # 期待: orchestrator.pid がないので resume 許可 → InitError を raise しない
+    # 現行実装: orchestrator.pid チェックなし → "running" 判定 → InitError を raise → FAIL
+    try:
+        initializer.run(check_only=True)
+    except InitError as e:
+        pytest.fail(
+            f"AC-1 FAIL: orchestrator.pid 不在にもかかわらず InitError が raise された: {e}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: orchestrator.pid あり + alive PID → InitError で block
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_block_when_orchestrator_alive(autopilot_dir: Path) -> None:
+    """AC-2: orchestrator.pid が存在し PID が alive (kill -0 成功) → InitError で block。
+
+    RED: 現行実装は orchestrator.pid をチェックしないため、
+         alive PID の orchestrator.pid があっても block できない。
+         このテストは InitError が raise されることを期待するが、
+         現行では session.json 未完了チェックで raise されるか、
+         またはそもそも orchestrator.pid を参照しないため期待する理由での block ができない。
+
+    Note: 現行実装だと session.json が < 24h + 未完了なら
+          orchestrator.pid に関係なく InitError が raise される。
+          しかし AC-2 の意図は「alive PID のチェックによる block」であり、
+          このテストは alive PID チェックを検証するため、check_only=True で呼び出す。
+    """
+    _write_session_json(autopilot_dir, hours_ago=1.0)
+    # 現在のプロセス自身の PID を alive PID として書き込む
+    alive_pid = os.getpid()
+    _write_orchestrator_pid(autopilot_dir, alive_pid)
+
+    initializer = AutopilotInitializer(autopilot_dir=autopilot_dir)
+
+    # 期待: orchestrator.pid の PID が alive → InitError で block
+    # 現行実装: orchestrator.pid を参照しない → AC-2 の意図での block はできない
+    with pytest.raises(InitError, match="orchestrator|実行中|alive"):
+        # 現行実装はこの match に失敗するため FAIL
+        initializer.run(check_only=True)
+
+
+# ---------------------------------------------------------------------------
+# AC-5: orchestrator.pid あり + stale PID (dead) → resume 許可
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_resume_when_orchestrator_pid_stale(autopilot_dir: Path) -> None:
+    """AC-5: orchestrator.pid があるが PID が dead (kill -0 失敗) → resume 許可。
+
+    RED: 現行実装は orchestrator.pid をチェックしないため、
+         stale pid ファイルがあっても session.json が < 24h + 未完了なら
+         常に InitError を raise してしまう → FAIL。
+    """
+    _write_session_json(autopilot_dir, hours_ago=1.0)
+    dead_pid = _get_dead_pid()
+    _write_orchestrator_pid(autopilot_dir, dead_pid)
+
+    # dead PID は kill -0 で失敗することを前提確認（実装のデバッグ補助）
+    try:
+        os.kill(dead_pid, 0)
+        # もし生きていたらテストの前提が崩れるためスキップ
+        pytest.skip(f"PID {dead_pid} が予期せず alive のためスキップ")
+    except ProcessLookupError:
+        pass  # 期待通り dead
+    except PermissionError:
+        # 別ユーザーのプロセスが同 PID を使っている場合は alive とみなす
+        pytest.skip(f"PID {dead_pid} が別ユーザーに割り当て済みのためスキップ")
+
+    initializer = AutopilotInitializer(autopilot_dir=autopilot_dir)
+
+    # 期待: stale pid → resume 許可 → InitError を raise しない
+    # 現行実装: orchestrator.pid チェックなし → "running" 判定 → InitError raise → FAIL
+    try:
+        initializer.run(check_only=True)
+    except InitError as e:
+        pytest.fail(
+            f"AC-5 FAIL: stale orchestrator.pid にもかかわらず InitError が raise された: {e}"
+        )

--- a/cli/twl/uv.lock
+++ b/cli/twl/uv.lock
@@ -1660,7 +1660,6 @@ full = [
 ]
 mcp = [
     { name = "fastmcp" },
-    { name = "pytest-asyncio" },
 ]
 test = [
     { name = "pytest" },
@@ -1671,7 +1670,6 @@ test = [
 requires-dist = [
     { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=3.0" },
     { name = "pytest", marker = "extra == 'test'" },
-    { name = "pytest-asyncio", marker = "extra == 'mcp'", specifier = ">=0.23" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.23" },
     { name = "pyyaml" },
     { name = "rich", marker = "extra == 'full'" },

--- a/plugins/twl/scripts/autopilot-init.sh
+++ b/plugins/twl/scripts/autopilot-init.sh
@@ -106,8 +106,13 @@ if [[ -f "$SESSION_FILE" ]]; then
       _orch_alive=false
       if [[ -f "$_orch_pid_file" ]]; then
         _orch_pid=$(cat "$_orch_pid_file" 2>/dev/null || echo "")
-        if [[ "$_orch_pid" =~ ^[0-9]+$ ]] && kill -0 "$_orch_pid" 2>/dev/null; then
-          _orch_alive=true
+        if [[ "$_orch_pid" =~ ^[0-9]+$ && "$_orch_pid" -gt 0 ]]; then
+          if kill -0 "$_orch_pid" 2>/dev/null; then
+            _orch_alive=true
+          elif kill -0 "$_orch_pid" 2>&1 | grep -q "Operation not permitted"; then
+            # EPERM: process exists but owned by another user → treat as alive
+            _orch_alive=true
+          fi
         fi
       fi
       if [[ "$_orch_alive" == "true" ]]; then

--- a/plugins/twl/scripts/autopilot-init.sh
+++ b/plugins/twl/scripts/autopilot-init.sh
@@ -101,14 +101,22 @@ if [[ -f "$SESSION_FILE" ]]; then
         exit 2
       fi
     else
-      if [[ "$force" == "true" ]]; then
-        echo "ERROR: 実行中の issue があるセッションです (session_id=$session_id, ${hours}h経過)" >&2
-        echo "24h 経過後に再試行してください" >&2
-      else
-        echo "ERROR: 既存セッションが実行中です (session_id=$session_id, ${hours}h経過)" >&2
-        echo "同一プロジェクトでの複数 autopilot セッションの同時実行は禁止されています" >&2
+      # < 24h + not completed: check orchestrator.pid before blocking
+      _orch_pid_file="$AUTOPILOT_DIR/orchestrator.pid"
+      _orch_alive=false
+      if [[ -f "$_orch_pid_file" ]]; then
+        _orch_pid=$(cat "$_orch_pid_file" 2>/dev/null || echo "")
+        if [[ "$_orch_pid" =~ ^[0-9]+$ ]] && kill -0 "$_orch_pid" 2>/dev/null; then
+          _orch_alive=true
+        fi
       fi
-      exit 1
+      if [[ "$_orch_alive" == "true" ]]; then
+        echo "ERROR: orchestrator プロセスが実行中です (pid=$_orch_pid, session_id=$session_id)" >&2
+        echo "同一プロジェクトでの複数 autopilot セッションの同時実行は禁止されています" >&2
+        exit 1
+      else
+        echo "INFO: orchestrator 不在または dead PID — resume_safe として続行します (session_id=$session_id, ${hours}h経過)" >&2
+      fi
     fi
   fi
 fi

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -1211,9 +1211,10 @@ echo "[orchestrator] Phase ${PHASE} 開始" >&2
 # --- orchestrator.pid: atomic write (mktemp + mv) + EXIT trap ---
 _orch_pid_file="${AUTOPILOT_DIR}/orchestrator.pid"
 _orch_pid_tmp=$(mktemp "${AUTOPILOT_DIR}/.orchestrator.pid.XXXXXX")
+# Register cleanup before write so tmp file is always removed (even if mv fails or on signal)
+trap 'rm -f "$_orch_pid_file" "${_orch_pid_tmp:-}"' EXIT INT TERM HUP
 echo "$$" > "$_orch_pid_tmp"
 mv "$_orch_pid_tmp" "$_orch_pid_file"
-trap 'rm -f "$_orch_pid_file"' EXIT
 # --- trace: PID と起動時刻を記録（ログ名に session_id を付与して Wave 間分離） ---
 _orch_started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 _orch_session_id=$(jq -r '.session_id // "unknown"' "${SESSION_FILE}" 2>/dev/null || echo "unknown")

--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -1208,6 +1208,12 @@ if [[ -z "$WORKER_MODEL" ]]; then
 fi
 
 echo "[orchestrator] Phase ${PHASE} 開始" >&2
+# --- orchestrator.pid: atomic write (mktemp + mv) + EXIT trap ---
+_orch_pid_file="${AUTOPILOT_DIR}/orchestrator.pid"
+_orch_pid_tmp=$(mktemp "${AUTOPILOT_DIR}/.orchestrator.pid.XXXXXX")
+echo "$$" > "$_orch_pid_tmp"
+mv "$_orch_pid_tmp" "$_orch_pid_file"
+trap 'rm -f "$_orch_pid_file"' EXIT
 # --- trace: PID と起動時刻を記録（ログ名に session_id を付与して Wave 間分離） ---
 _orch_started_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 _orch_session_id=$(jq -r '.session_id // "unknown"' "${SESSION_FILE}" 2>/dev/null || echo "unknown")

--- a/plugins/twl/tests/integration/autopilot-init-resume.bats
+++ b/plugins/twl/tests/integration/autopilot-init-resume.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# autopilot-init-resume.bats
+# AC-6: bash 版 autopilot-init.sh も orchestrator alive check を持つ
+#
+# RED フェーズ: 現行実装 (autopilot-init.sh) には orchestrator.pid チェックが
+#              存在しないため、全テストは FAIL する。
+#
+# 現行の autopilot-init.sh の挙動:
+#   session.json 存在 + < 24h + 未完了 → 常に exit 1 (block)
+#   orchestrator.pid の有無・PID の生死を参照しない
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  mkdir -p "$SANDBOX/scripts"
+  mkdir -p "$SANDBOX/.autopilot/issues"
+  mkdir -p "$SANDBOX/.autopilot/archive"
+
+  # スクリプトをコピー
+  cp "$REPO_ROOT/scripts/"*.sh "$SANDBOX/scripts/" 2>/dev/null || true
+
+  export AUTOPILOT_DIR="$SANDBOX/.autopilot"
+  export PROJECT_ROOT="$SANDBOX"
+
+  SCRIPT="$SANDBOX/scripts/autopilot-init.sh"
+}
+
+teardown() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: session.json + running issue を作成する（未完了セッション）
+# ---------------------------------------------------------------------------
+
+_create_active_session() {
+  local hours_ago="${1:-1}"
+  local started_at
+  started_at=$(date -u -d "${hours_ago} hours ago" +"%Y-%m-%dT%H:%M:%SZ")
+
+  cat > "$SANDBOX/.autopilot/session.json" <<JSON
+{
+  "session_id": "test-session-ac6",
+  "started_at": "${started_at}"
+}
+JSON
+
+  # running issue を1件作成（未完了状態）
+  cat > "$SANDBOX/.autopilot/issues/issue-9999.json" <<JSON
+{
+  "issue": 9999,
+  "status": "running",
+  "branch": "feat/9999-test",
+  "started_at": "${started_at}"
+}
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# AC-6-1: orchestrator.pid 不在 → init.sh は resume を許可する (exit 0)
+# GIVEN: session.json 存在 + < 24h + 未完了 + orchestrator.pid 不在
+# WHEN: autopilot-init.sh --check-only を実行
+# THEN: exit 0 で resume 許可
+# ---------------------------------------------------------------------------
+
+@test "ac6: init_sh_resumes_when_orchestrator_dead" {
+  # RED: 現行実装は orchestrator.pid をチェックしないため、
+  #      session.json が < 24h + 未完了なら常に exit 1 → FAIL
+  _create_active_session 1
+
+  # orchestrator.pid を作らない（不在状態）
+  assert [ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+
+  run bash "$SCRIPT" --check-only
+
+  # 期待: exit 0 (resume 許可)
+  # 現行実装: exit 1 (orchestrator.pid チェックなし → 常に block) → FAIL
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC-6-2: orchestrator.pid が alive PID を指す → init.sh は block する (exit 1)
+# GIVEN: session.json 存在 + orchestrator.pid に alive PID が書かれている
+# WHEN: autopilot-init.sh --check-only を実行
+# THEN: exit 1 で block（alive orchestrator が存在するため）
+# ---------------------------------------------------------------------------
+
+@test "ac6: init_sh_blocks_when_orchestrator_alive" {
+  # このテストは現行実装でも偶然 PASS する可能性があるが、
+  # AC-6 の意図（alive PID チェックによる block）を検証する。
+  # 現行実装は orchestrator.pid を無視して session.json < 24h で block するため、
+  # 結果は同じでも「理由」が違う。実装後は alive PID チェックで block されることを期待する。
+  _create_active_session 1
+
+  # 現在プロセスの PID を alive PID として書き込む
+  echo $$ > "$SANDBOX/.autopilot/orchestrator.pid"
+
+  run bash "$SCRIPT" --check-only
+
+  # 期待: exit 1 (alive orchestrator により block)
+  assert_failure
+  assert_output --partial "orchestrator"
+  # RED: 現行実装は "orchestrator" という語を出力しない → assert_output が FAIL
+}
+
+# ---------------------------------------------------------------------------
+# AC-6-3: orchestrator.pid が stale PID (dead) を指す → init.sh は resume 許可 (exit 0)
+# GIVEN: session.json 存在 + orchestrator.pid に dead PID が書かれている
+# WHEN: autopilot-init.sh --check-only を実行
+# THEN: exit 0 (stale pid は無視して resume 許可)
+# ---------------------------------------------------------------------------
+
+@test "ac6: init_sh_resumes_when_orchestrator_pid_stale" {
+  # RED: 現行実装は orchestrator.pid をチェックしないため、
+  #      session.json < 24h + 未完了なら常に exit 1 → FAIL
+  _create_active_session 1
+
+  # dead な PID を取得して orchestrator.pid に書き込む
+  bash -c 'exit 0' &
+  DEAD_PID=$!
+  wait "$DEAD_PID" 2>/dev/null || true
+  echo "$DEAD_PID" > "$SANDBOX/.autopilot/orchestrator.pid"
+
+  # dead PID であることを確認（前提）
+  if kill -0 "$DEAD_PID" 2>/dev/null; then
+    skip "PID ${DEAD_PID} が予期せず alive のためスキップ"
+  fi
+
+  run bash "$SCRIPT" --check-only
+
+  # 期待: exit 0 (stale pid → resume 許可)
+  # 現行実装: orchestrator.pid チェックなし → session.json < 24h で exit 1 → FAIL
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC-6-4: autopilot-init.sh スクリプト内に orchestrator.pid チェックが存在する (静的検査)
+# GIVEN: autopilot-init.sh スクリプト
+# WHEN: スクリプト内容を静的に検査する
+# THEN: orchestrator.pid を参照するコードが存在する
+# ---------------------------------------------------------------------------
+
+@test "ac6: autopilot-init.sh に orchestrator.pid チェックが存在する (静的検査)" {
+  # RED: 現行実装には orchestrator.pid のチェックが存在しない → FAIL
+  run grep -E "orchestrator\.pid" "$REPO_ROOT/scripts/autopilot-init.sh"
+  assert_success
+}

--- a/plugins/twl/tests/integration/orchestrator-pid-cleanup.bats
+++ b/plugins/twl/tests/integration/orchestrator-pid-cleanup.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# orchestrator-pid-cleanup.bats
+# AC-4: autopilot-orchestrator.sh の EXIT trap で orchestrator.pid が削除される
+#
+# RED フェーズ: 現行実装 (autopilot-orchestrator.sh) には orchestrator.pid の
+#              EXIT trap クリーンアップが存在しないため、全テストは FAIL する。
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  mkdir -p "$SANDBOX/scripts"
+  mkdir -p "$SANDBOX/.autopilot/issues"
+  mkdir -p "$SANDBOX/.autopilot/archive"
+
+  # スクリプトと lib/ をコピー（orchestrator は lib/python-env.sh を source する）
+  cp "$REPO_ROOT/scripts/"*.sh "$SANDBOX/scripts/" 2>/dev/null || true
+  cp -r "$REPO_ROOT/scripts/lib/" "$SANDBOX/scripts/lib/" 2>/dev/null || true
+
+  export AUTOPILOT_DIR="$SANDBOX/.autopilot"
+  export PROJECT_ROOT="$SANDBOX"
+
+  ORCHESTRATOR="$SANDBOX/scripts/autopilot-orchestrator.sh"
+}
+
+teardown() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+_create_minimal_plan() {
+  local session_id="${1:-test-session-cleanup-001}"
+  cat > "$SANDBOX/.autopilot/plan.yaml" <<EOF
+session_id: ${session_id}
+phases:
+  - phase: 1
+    issues: []
+EOF
+  cat > "$SANDBOX/.autopilot/session.json" <<EOF
+{
+  "session_id": "${session_id}",
+  "started_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# AC-4-1: 正常終了後に orchestrator.pid が削除される
+# GIVEN: autopilot-orchestrator.sh が起動し orchestrator.pid が作成されている
+# WHEN: スクリプトが正常終了する
+# THEN: ${AUTOPILOT_DIR}/orchestrator.pid が削除されている
+# ---------------------------------------------------------------------------
+
+@test "ac4: 正常終了後に orchestrator.pid が削除される" {
+  # フェーズ実行モード（no issues → 素早く完了）で orchestrator を完走させ、
+  # EXIT trap により pid ファイルが削除されることを確認する。
+  _create_minimal_plan
+
+  # まず PID ファイルが存在しないことを確認（前提）
+  assert [ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+
+  # orchestrator を完走させる（issues なし → 素早く exit）
+  timeout 30 bash "$ORCHESTRATOR" \
+    --plan "$SANDBOX/.autopilot/plan.yaml" \
+    --phase 1 \
+    --session "$SANDBOX/.autopilot/session.json" \
+    --project-dir "$SANDBOX" \
+    --autopilot-dir "$SANDBOX/.autopilot" 2>/dev/null || true
+
+  # 終了後に orchestrator.pid が存在しないことを確認（EXIT trap で削除済み）
+  assert [ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4-2: シグナル終了 (SIGTERM) 後にも orchestrator.pid が削除される
+# GIVEN: autopilot-orchestrator.sh が起動し pid ファイルが作成されている
+# WHEN: SIGTERM でプロセスを終了させる
+# THEN: EXIT trap が発火し orchestrator.pid が削除される
+# ---------------------------------------------------------------------------
+
+@test "ac4: SIGTERM 後に orchestrator.pid が削除される (EXIT trap)" {
+  # RED: 現行実装は EXIT trap で orchestrator.pid を削除しないため FAIL する
+  _create_minimal_plan
+
+  # バックグラウンドで起動
+  timeout 15 bash "$ORCHESTRATOR" \
+    --plan "$SANDBOX/.autopilot/plan.yaml" \
+    --phase 1 \
+    --session "$SANDBOX/.autopilot/session.json" \
+    --project-dir "$SANDBOX" \
+    --autopilot-dir "$SANDBOX/.autopilot" 2>/dev/null &
+  ORCH_PID=$!
+
+  # orchestrator.pid が作成されるまで待つ（最大 5 秒）
+  local waited=0
+  while [[ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]] && (( waited < 50 )); do
+    sleep 0.1
+    waited=$(( waited + 1 ))
+  done
+
+  # pid ファイルが存在することを確認（前提条件）
+  # RED: 現行実装は pid ファイルを作成しないため、ここで FAIL する
+  assert [ -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+
+  # SIGTERM 送信
+  kill -TERM "$ORCH_PID" 2>/dev/null || true
+  wait "$ORCH_PID" 2>/dev/null || true
+
+  # 終了後に pid ファイルが削除されていることを確認
+  assert [ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4-3: スクリプト内に EXIT trap で orchestrator.pid を削除するコードが存在する
+# GIVEN: autopilot-orchestrator.sh スクリプト
+# WHEN: スクリプト内容を静的に検査する
+# THEN: EXIT trap 内で orchestrator.pid を削除するパターンが存在する
+# ---------------------------------------------------------------------------
+
+@test "ac4: EXIT trap で orchestrator.pid を削除するコードが存在する (静的検査)" {
+  # RED: 現行実装には orchestrator.pid の EXIT trap クリーンアップが存在しない → FAIL
+  # 期待パターン: trap '... rm -f "$AUTOPILOT_DIR/orchestrator.pid" ...' EXIT
+  run grep -E "trap.*EXIT" "$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  assert_success
+
+  # trap 内に orchestrator.pid の削除が含まれることを確認
+  run grep -E "orchestrator\.pid" "$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  assert_success
+}

--- a/plugins/twl/tests/integration/orchestrator-pid-write.bats
+++ b/plugins/twl/tests/integration/orchestrator-pid-write.bats
@@ -1,0 +1,143 @@
+#!/usr/bin/env bats
+# orchestrator-pid-write.bats
+# AC-3: autopilot-orchestrator.sh 起動時に ${AUTOPILOT_DIR}/orchestrator.pid を
+#       atomic write し、書かれた PID が現プロセス PID に一致する
+#
+# RED フェーズ: 現行実装 (autopilot-orchestrator.sh) には orchestrator.pid 書き込みが
+#              存在しないため、全テストは FAIL する。
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  mkdir -p "$SANDBOX/scripts"
+  mkdir -p "$SANDBOX/.autopilot/issues"
+  mkdir -p "$SANDBOX/.autopilot/archive"
+
+  # スクリプトと lib/ をコピー（orchestrator は lib/python-env.sh を source する）
+  cp "$REPO_ROOT/scripts/"*.sh "$SANDBOX/scripts/" 2>/dev/null || true
+  cp -r "$REPO_ROOT/scripts/lib/" "$SANDBOX/scripts/lib/" 2>/dev/null || true
+
+  export AUTOPILOT_DIR="$SANDBOX/.autopilot"
+  export PROJECT_ROOT="$SANDBOX"
+
+  ORCHESTRATOR="$SANDBOX/scripts/autopilot-orchestrator.sh"
+}
+
+teardown() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Helper: 最小限の plan.yaml を作成する
+# ---------------------------------------------------------------------------
+
+_create_minimal_plan() {
+  local session_id="${1:-test-session-001}"
+  cat > "$SANDBOX/.autopilot/plan.yaml" <<EOF
+session_id: ${session_id}
+phases:
+  - phase: 1
+    issues: []
+EOF
+  cat > "$SANDBOX/.autopilot/session.json" <<EOF
+{
+  "session_id": "${session_id}",
+  "started_at": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# AC-3-1: orchestrator.pid ファイルが起動時に作成される
+# GIVEN: AUTOPILOT_DIR が設定された状態で autopilot-orchestrator.sh を起動
+# WHEN: スクリプトが起動して初期化処理を行う
+# THEN: ${AUTOPILOT_DIR}/orchestrator.pid ファイルが存在する
+# ---------------------------------------------------------------------------
+
+@test "ac3: orchestrator.pid が起動時に作成される" {
+  # PID write はフェーズ実行パスにのみ存在する（--summary は早期 exit）。
+  # バックグラウンドで起動し、PID ファイルが現れるまで待ってから confirm する。
+  _create_minimal_plan
+
+  timeout 15 bash "$ORCHESTRATOR" \
+    --plan "$SANDBOX/.autopilot/plan.yaml" \
+    --phase 1 \
+    --session "$SANDBOX/.autopilot/session.json" \
+    --project-dir "$SANDBOX" \
+    --autopilot-dir "$SANDBOX/.autopilot" 2>/dev/null &
+  ORCH_PID=$!
+
+  # pid ファイルが作成されるまで待つ（最大 5 秒）
+  local waited=0
+  while [[ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]] && (( waited < 50 )); do
+    sleep 0.1
+    waited=$(( waited + 1 ))
+  done
+
+  # pid ファイルが存在することを確認（まだ orchestrator 起動中）
+  assert [ -f "$SANDBOX/.autopilot/orchestrator.pid" ]
+
+  wait "$ORCH_PID" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# AC-3-2: orchestrator.pid に書かれた PID が実プロセス PID と一致する
+# GIVEN: autopilot-orchestrator.sh が起動している
+# WHEN: orchestrator.pid を読み取る
+# THEN: 書かれた PID が orchestrator プロセスの PID と一致する
+# ---------------------------------------------------------------------------
+
+@test "ac3: orchestrator.pid の内容がプロセス PID と一致する" {
+  _create_minimal_plan
+
+  timeout 15 bash "$ORCHESTRATOR" \
+    --plan "$SANDBOX/.autopilot/plan.yaml" \
+    --phase 1 \
+    --session "$SANDBOX/.autopilot/session.json" \
+    --project-dir "$SANDBOX" \
+    --autopilot-dir "$SANDBOX/.autopilot" 2>/dev/null &
+  ORCH_PID=$!
+
+  # pid ファイルが作成されるまで待つ（最大 5 秒）
+  local waited=0
+  while [[ ! -f "$SANDBOX/.autopilot/orchestrator.pid" ]] && (( waited < 50 )); do
+    sleep 0.1
+    waited=$(( waited + 1 ))
+  done
+
+  # pid ファイルの内容が数値 (PID) であること
+  local written_pid
+  written_pid=$(cat "$SANDBOX/.autopilot/orchestrator.pid" 2>/dev/null || echo "")
+  [[ "$written_pid" =~ ^[0-9]+$ ]] || fail "orchestrator.pid の内容が数値でない: '$written_pid'"
+
+  wait "$ORCH_PID" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# AC-3-3: orchestrator.pid は atomic write (一時ファイル経由の mv) で作成される
+# GIVEN: autopilot-orchestrator.sh スクリプト
+# WHEN: スクリプト内容を検査する
+# THEN: pid 書き込みが mv (atomic) パターンで実装されている
+# ---------------------------------------------------------------------------
+
+@test "ac3: orchestrator.pid は atomic write (mv) で書き込まれる" {
+  # RED: 現行実装には orchestrator.pid 書き込みコードが存在しない → grep が失敗 → FAIL
+  # atomic write パターン: echo $$ > tmpfile && mv tmpfile orchestrator.pid
+  run grep -E "orchestrator\.pid" "$REPO_ROOT/scripts/autopilot-orchestrator.sh"
+  assert_success
+}


### PR DESCRIPTION
## 概要

Issue #1208 の修正。autopilot-init が session.json の存在だけで「実行中」と断定する問題を解消。orchestrator.pid の alive check を追加し、pid 不在 or dead PID の場合は resume_safe として続行できるようにした。

## 変更内容

- **init.py**: `_is_orchestrator_alive()` メソッドを追加。orchestrator.pid の PID に対して `kill -0` を実行し alive を判定。dead/不在なら `resume_safe` を返す
- **autopilot-orchestrator.sh**: 起動時に `orchestrator.pid` を atomic write (mktemp + mv)、EXIT trap で自動削除
- **autopilot-init.sh**: orchestrator.pid の alive check を追加。pid 不在 or dead PID の場合は `resume_safe` として続行
- **テスト**: AC-1〜6 の GREEN テスト（pytest 3 件 + BATS 10 件）

## AC 対応

- [x] AC-1: pid 不在 → resume 許可
- [x] AC-2: alive PID → InitError で block
- [x] AC-3: orchestrator.sh 起動時に pid を atomic write
- [x] AC-4: EXIT trap で pid 削除
- [x] AC-5: stale PID (dead) → resume 許可
- [x] AC-6: bash 版 init.sh も alive check 実装

Closes #1208