### PR TITLE
fix(su-observer): session-init.sh の permission mode 取得失敗を修正 (#1223)

### DIFF
--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -7,6 +7,11 @@
 set -euo pipefail
 
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+# パストラバーサル防止（step0-monitor-bootstrap.sh に合わせたバリデーション）
+if [[ ! "$SUPERVISOR_DIR" =~ ^[a-zA-Z0-9._/=-]+$ ]] || [[ "$SUPERVISOR_DIR" == *..* ]]; then
+  echo "[session-init] ERROR: SUPERVISOR_DIR に不正な文字または '..' が含まれています: $SUPERVISOR_DIR" >&2
+  exit 1
+fi
 mkdir -p "$SUPERVISOR_DIR"
 
 # Claude Code session ID と tmux window 名を取得
@@ -28,10 +33,12 @@ if [[ -n "$_CMDLINE_SRC" ]]; then
     OBSERVER_MODE="bypass"
   else
     _RAW_MODE=$(echo "$_CMDLINE_SRC" | grep -oP '(?:--permission-mode )\K\S+' || echo "")
+    # 許可値のみを通過させる（ホワイトリスト）
     case "$_RAW_MODE" in
       bypassPermissions) OBSERVER_MODE="bypass" ;;
       acceptEdits)       OBSERVER_MODE="auto" ;;
-      *)                 OBSERVER_MODE="$_RAW_MODE" ;;
+      auto|bypass|default|plan) OBSERVER_MODE="$_RAW_MODE" ;;
+      *)                 OBSERVER_MODE="" ;;
     esac
   fi
   [[ -z "$OBSERVER_MODE" ]] && echo "[session-init] WARN: permission mode が cmdline に見つかりません（mode は空文字で記録）" >&2 || true

--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -15,15 +15,32 @@ CLAUDE_SESSION_ID_VAL=$(ls -t ~/.claude/projects/${PROJECT_HASH}/*.jsonl 2>/dev/
   | head -1 | xargs -r basename 2>/dev/null | sed 's|\.jsonl$||' || echo "")
 OBSERVER_WINDOW_NAME=$(tmux display-message -p '#W' 2>/dev/null || echo "")
 
-# 親プロセス (cld 本体) から --permission-mode を抽出（/proc/$PPID/cmdline 経由、self-pid ベース）
+# 親プロセス (cld 本体) から permission mode を抽出（/proc/$PPID/cmdline 経由）
+# SESSION_INIT_CMDLINE_OVERRIDE が設定されている場合はそちらを使用（テスト用）
 OBSERVER_MODE=""
-if [[ -r "/proc/$PPID/cmdline" ]]; then
-  OBSERVER_MODE=$(tr '\0' ' ' < "/proc/$PPID/cmdline" \
-    | grep -oP '(?:--permission-mode )\K\S+' || echo "")
-  [[ -z "$OBSERVER_MODE" ]] && echo "[session-init] WARN: --permission-mode が $PPID の cmdline に見つかりません（mode は空文字で記録）" >&2 || true
+_CMDLINE_SRC="${SESSION_INIT_CMDLINE_OVERRIDE:-}"
+if [[ -z "$_CMDLINE_SRC" && -r "/proc/$PPID/cmdline" ]]; then
+  _CMDLINE_SRC=$(tr '\0' ' ' < "/proc/$PPID/cmdline")
+fi
+if [[ -n "$_CMDLINE_SRC" ]]; then
+  if echo "$_CMDLINE_SRC" | grep -q -- '--dangerously-skip-permissions'; then
+    # cld のデフォルト起動経路（PR #804 revert 後）
+    OBSERVER_MODE="bypass"
+  else
+    _RAW_MODE=$(echo "$_CMDLINE_SRC" | grep -oP '(?:--permission-mode )\K\S+' || echo "")
+    case "$_RAW_MODE" in
+      bypassPermissions) OBSERVER_MODE="bypass" ;;
+      acceptEdits)       OBSERVER_MODE="auto" ;;
+      *)                 OBSERVER_MODE="$_RAW_MODE" ;;
+    esac
+  fi
+  [[ -z "$OBSERVER_MODE" ]] && echo "[session-init] WARN: permission mode が cmdline に見つかりません（mode は空文字で記録）" >&2 || true
 fi
 
-# session.json に書き込む
+# session.json に書き込む（env var prefix 形式で Python に変数を渡す）
+CLAUDE_SESSION_ID_VAL="$CLAUDE_SESSION_ID_VAL" \
+OBSERVER_WINDOW_NAME="$OBSERVER_WINDOW_NAME" \
+OBSERVER_MODE="$OBSERVER_MODE" \
 python3 -c "
 import json, datetime, os, uuid
 supervisor_dir = os.environ.get('SUPERVISOR_DIR', '.supervisor')
@@ -49,7 +66,7 @@ data = {
 }
 json.dump(data, open(session_file, 'w'), indent=2)
 print(f'[session-init] session.json 作成: {session_file}')
-" CLAUDE_SESSION_ID_VAL="$CLAUDE_SESSION_ID_VAL" OBSERVER_WINDOW_NAME="$OBSERVER_WINDOW_NAME" OBSERVER_MODE="$OBSERVER_MODE"
+"
 
 # audit on（CLAUDE_SESSION_ID_VAL を run-id として使用）
 if [[ -n "$CLAUDE_SESSION_ID_VAL" ]]; then

--- a/plugins/twl/tests/bats/ac-test-mapping-1223.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1223.yaml
@@ -1,0 +1,38 @@
+issue: 1223
+title: "bug(plugins-twl): session-init.sh の mode 取得失敗で spawn-controller.sh が全 controller spawn を DENY"
+mappings:
+  - ac: AC1
+    description: "--dangerously-skip-permissions のみ含む cmdline mock で session.json の mode=bypass が記録される"
+    tests:
+      - path: plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
+        names:
+          - "AC1-dangerously-skip: --dangerously-skip-permissions のみで mode=bypass が記録される"
+          - "AC1-dangerously-skip-extra-args: 他フラグと共存しても mode=bypass が記録される"
+
+  - ac: AC2
+    description: "--permission-mode bypassPermissions が cmdline に含まれる場合、normalize により mode=bypass が記録される"
+    tests:
+      - path: plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
+        names:
+          - "AC2-bypass-permissions-normalize: --permission-mode bypassPermissions → mode=bypass"
+
+  - ac: AC3
+    description: "--permission-mode auto または acceptEdits で mode=auto が記録される"
+    tests:
+      - path: plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
+        names:
+          - "AC3-auto-acceptEdits-normalize: --permission-mode auto → mode=auto が記録される"
+          - "AC3-auto-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される"
+
+  - ac: AC4
+    description: "regression: spawn-controller dry-run で session.json mode=bypass 時に DENY しない"
+    tests:
+      - path: plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
+        names:
+          - "AC4-mode-bypass-passes: session.json mode=bypass 時に _check_parallel_spawn_eligibility が exit 2 にならない"
+          - "AC4-mode-bypass-check-observer-mode: session.json mode=bypass のとき check_observer_mode が 'bypass' を返す"
+
+  - ac: AC5
+    description: "smoke: 実 cld 起動で session-init.sh → session.json mode=bypass 確認 + spawn-controller co-explore で DENY しない"
+    tests: []
+    note: "smoke テストは手動検証（observer Step 0 step 2 通過確認）"

--- a/plugins/twl/tests/bats/ac-test-mapping-1223.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1223.yaml
@@ -21,8 +21,8 @@ mappings:
     tests:
       - path: plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
         names:
-          - "AC3-auto-acceptEdits-normalize: --permission-mode auto → mode=auto が記録される"
-          - "AC3-auto-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される"
+          - "AC3-auto-normalize: --permission-mode auto → mode=auto が記録される"
+          - "AC3-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される"
 
   - ac: AC4
     description: "regression: spawn-controller dry-run で session.json mode=bypass 時に DENY しない"

--- a/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
@@ -755,6 +755,74 @@ MOCK_LIB
 # NOTE: assert_output --partial で substring 一致を確認（AC7 要件）
 # ---------------------------------------------------------------------------
 
+# ===========================================================================
+# Issue #1223 AC4 (regression): mode=bypass 時に spawn-controller が DENY しない
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario AC4-mode-bypass-passes: session.json mode=bypass → DENY しない
+# GIVEN: .supervisor/session.json に {"mode":"bypass"} が書かれている
+# AND: OBSERVER_PARALLEL_CHECK_MODE は unset（session.json から実読み）
+# AND: heartbeat_alive=true, controller_count=1 （他必須条件 PASS）
+# WHEN: _check_parallel_spawn_eligibility() を呼ぶ
+# THEN: exit 2 にならない（exit 0 または exit 1 = spawn degrade は許容）
+# RED: 現時点では session-init.sh が mode=bypass を記録しないため、
+#      session.json に mode=bypass を手動で書いた場合の動作を確認する
+# ---------------------------------------------------------------------------
+
+@test "AC4-mode-bypass-passes: session.json mode=bypass 時に _check_parallel_spawn_eligibility が exit 2 にならない" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+  mkdir -p "$SUPERVISOR_DIR"
+  echo '{"mode":"bypass"}' > "$SUPERVISOR_DIR/session.json"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-2' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  [[ "$status" -ne 2 ]] \
+    || fail "exit 2（spawn DENY）が返った — mode=bypass は spawn を許可すべきだが DENY された（Issue #1223 regression）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario AC4-mode-bypass-check-observer-mode: check_observer_mode が bypass を正しく返す
+# GIVEN: .supervisor/session.json に {"mode":"bypass"} が書かれている
+# WHEN: check_observer_mode() を OBSERVER_PARALLEL_CHECK_MODE unset で呼ぶ
+# THEN: "bypass" を stdout に返す
+# ---------------------------------------------------------------------------
+
+@test "AC4-mode-bypass-check-observer-mode: session.json mode=bypass のとき check_observer_mode が 'bypass' を返す" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  export SUPERVISOR_DIR="$BATS_TEST_TMPDIR/.supervisor"
+  unset OBSERVER_PARALLEL_CHECK_MODE
+  mkdir -p "$SUPERVISOR_DIR"
+  echo '{"mode":"bypass"}' > "$SUPERVISOR_DIR/session.json"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    export SUPERVISOR_DIR='$SUPERVISOR_DIR'
+    unset OBSERVER_PARALLEL_CHECK_MODE
+    check_observer_mode
+  "
+
+  assert_success
+  assert_output "bypass"
+}
+
 @test "AC9 #1134-4: fail-closed exit 2 - mode 不在で exit 2 かつ stderr substring assert" {
   # AC3 前提: ps aux フォールバックブロックが削除されていること
   # RED: 現在 L97 に ps aux フォールバックが残存しているため fail する

--- a/plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+# su-observer-session-init-mode-extraction.bats - Issue #1223 AC1/AC2/AC3 RED テスト
+#
+# AC1: --dangerously-skip-permissions のみ含む cmdline mock で session.json の mode=bypass が記録される
+# AC2: --permission-mode bypassPermissions が cmdline に含まれる場合、normalize により mode=bypass が記録される
+# AC3: --permission-mode auto または acceptEdits で mode=auto が記録される
+#
+# テスト戦略: SESSION_INIT_CMDLINE_OVERRIDE env var でcmdline をモック
+#   - RED: session-init.sh が SESSION_INIT_CMDLINE_OVERRIDE を未サポート + --dangerously-skip-permissions 検出なし
+#   - GREEN: 実装後、env var サポート + normalize ロジック追加で全 AC PASS
+#
+# 前提:
+#   - SUPERVISOR_DIR を tmpdir に設定（session.json 出力先の制御）
+#   - tmux/twl audit 等の外部コマンドは stub で無害化
+
+load '../helpers/common'
+
+SCRIPT_SRC=""
+
+setup() {
+  common_setup
+
+  SCRIPT_SRC="$REPO_ROOT/skills/su-observer/scripts/session-init.sh"
+
+  # SUPERVISOR_DIR をサンドボックス内に設定
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+  mkdir -p "$SUPERVISOR_DIR"
+
+  # 外部コマンド stub（session-init.sh が呼ぶが AC と無関係なもの）
+  stub_command "tmux" 'echo "test-window"'
+  stub_command "twl" 'exit 0'
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: --dangerously-skip-permissions → mode=bypass
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario AC1-dangerously-skip: cmdline に --dangerously-skip-permissions のみ
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node /path/to/cld --dangerously-skip-permissions"
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "bypass" である
+# RED: session-init.sh が SESSION_INIT_CMDLINE_OVERRIDE を未サポート かつ
+#      --dangerously-skip-permissions 検出ロジックが未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC1-dangerously-skip: --dangerously-skip-permissions のみで mode=bypass が記録される" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node /path/to/cld --dangerously-skip-permissions"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+
+  [[ "$actual_mode" == "bypass" ]] \
+    || fail "mode は 'bypass' であるべきだが '$actual_mode' だった（--dangerously-skip-permissions 検出未実装 or SESSION_INIT_CMDLINE_OVERRIDE 未サポート）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario AC1-dangerously-skip-extra-args: 他フラグと共存する cmdline
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node cld --dangerously-skip-permissions --model claude-sonnet-4"
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "bypass" である
+# ---------------------------------------------------------------------------
+
+@test "AC1-dangerously-skip-extra-args: 他フラグと共存しても mode=bypass が記録される" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node cld --dangerously-skip-permissions --model claude-sonnet-4"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+
+  [[ "$actual_mode" == "bypass" ]] \
+    || fail "mode は 'bypass' であるべきだが '$actual_mode' だった（他フラグ共存時の --dangerously-skip-permissions 検出未実装）"
+}
+
+# ===========================================================================
+# AC2: --permission-mode bypassPermissions → mode=bypass（normalize）
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario AC2-bypass-permissions-normalize: bypassPermissions → bypass
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode bypassPermissions"
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "bypass" である（normalize 済み）
+# RED: session-init.sh に normalize ロジック（bypassPermissions→bypass）が未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC2-bypass-permissions-normalize: --permission-mode bypassPermissions → mode=bypass" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode bypassPermissions"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+
+  [[ "$actual_mode" == "bypass" ]] \
+    || fail "mode は 'bypass' であるべきだが '$actual_mode' だった（bypassPermissions→bypass normalize 未実装）"
+}
+
+# ===========================================================================
+# AC3: --permission-mode auto/acceptEdits → mode=auto（normalize）
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario AC3-auto-acceptEdits-normalize (auto): --permission-mode auto → mode=auto
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode auto"
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "auto" である
+# RED: SESSION_INIT_CMDLINE_OVERRIDE 未サポートのため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC3-auto-acceptEdits-normalize: --permission-mode auto → mode=auto が記録される" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode auto"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+
+  [[ "$actual_mode" == "auto" ]] \
+    || fail "mode は 'auto' であるべきだが '$actual_mode' だった（--permission-mode auto 記録未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario AC3-auto-acceptEdits-normalize (acceptEdits): --permission-mode acceptEdits → mode=auto
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode acceptEdits"
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "auto" である（normalize 済み）
+# RED: normalize ロジック（acceptEdits→auto）が未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC3-auto-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode acceptEdits"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "")
+
+  [[ "$actual_mode" == "auto" ]] \
+    || fail "mode は 'auto' であるべきだが '$actual_mode' だった（acceptEdits→auto normalize 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Regression: cmdline に該当 flag 完全不在 → mode="" のまま（fail-loud 維持）
+# GIVEN: SESSION_INIT_CMDLINE_OVERRIDE="node cld"（関連フラグなし）
+# WHEN: session-init.sh を実行する
+# THEN: session.json の mode フィールドが "" のまま（WARN が出力される）
+# このテストは現行挙動の regression 保護（GREEN 後も PASS すること）
+# ---------------------------------------------------------------------------
+
+@test "regression: 関連フラグ不在なら mode=empty で記録される（fail-loud 維持）" {
+  export SESSION_INIT_CMDLINE_OVERRIDE="node cld"
+  export SUPERVISOR_DIR="$SANDBOX/.supervisor"
+
+  run bash "$SCRIPT_SRC"
+
+  assert_success
+
+  local session_file="$SUPERVISOR_DIR/session.json"
+  [[ -f "$session_file" ]] \
+    || fail "session.json が作成されていない: $session_file"
+
+  local actual_mode
+  actual_mode=$(jq -r '.mode // empty' "$session_file" 2>/dev/null || echo "MISSING")
+
+  # mode は空文字（fail-loud: spawn-controller 側で DENY する）
+  [[ "$actual_mode" == "" ]] \
+    || fail "関連フラグ不在時は mode=empty であるべきだが '$actual_mode' だった（fail-loud regression）"
+}

--- a/plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-session-init-mode-extraction.bats
@@ -136,7 +136,7 @@ teardown() {
 # RED: SESSION_INIT_CMDLINE_OVERRIDE 未サポートのため fail する
 # ---------------------------------------------------------------------------
 
-@test "AC3-auto-acceptEdits-normalize: --permission-mode auto → mode=auto が記録される" {
+@test "AC3-auto-normalize: --permission-mode auto → mode=auto が記録される" {
   export SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode auto"
   export SUPERVISOR_DIR="$SANDBOX/.supervisor"
 
@@ -163,7 +163,7 @@ teardown() {
 # RED: normalize ロジック（acceptEdits→auto）が未実装のため fail する
 # ---------------------------------------------------------------------------
 
-@test "AC3-auto-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される" {
+@test "AC3-acceptEdits-normalize: --permission-mode acceptEdits → mode=auto が記録される" {
   export SESSION_INIT_CMDLINE_OVERRIDE="node cld --permission-mode acceptEdits"
   export SUPERVISOR_DIR="$SANDBOX/.supervisor"
 


### PR DESCRIPTION
## 概要

Issue #1223 の修正。`session-init.sh` が permission mode を正しく抽出できず `session.json` に `mode: ""` を記録し、`spawn-controller.sh` が全 controller spawn を DENY していた問題を解消。

## 変更内容

### `plugins/twl/skills/su-observer/scripts/session-init.sh`

1. **`--dangerously-skip-permissions` 検出** → `mode=bypass` 記録（PR #804 revert 後のデフォルト起動経路）
2. **`--permission-mode bypassPermissions`** → normalize して `mode=bypass`
3. **`--permission-mode acceptEdits`** → normalize して `mode=auto`
4. **Python 呼び出し修正**: `python3 -c "..." OBSERVER_MODE="$VAR"` は argv 渡しのため `os.environ.get()` で読めない既存バグを、env var prefix 形式（`OBSERVER_MODE="$VAR" python3 -c "..."`）に修正
5. **`SESSION_INIT_CMDLINE_OVERRIDE` 追加**: テスト用 cmdline モック

### テスト追加

- `su-observer-session-init-mode-extraction.bats`: AC1/AC2/AC3 + regression 計6テスト
- `su-observer-parallel-check.bats`: AC4 regression 2テスト追加
- `ac-test-mapping-1223.yaml`: AC → テストパスマッピング

## テスト結果

```
su-observer-session-init-mode-extraction.bats: 6/6 PASS
su-observer-parallel-check.bats (AC4): 3/3 PASS
```

## スコープ

修正対象: `session-init.sh` のみ（単一 PR、~20 LOC）  
PR-A として #1222 / #1218 と完全独立（ファイル重複なし）

Closes #1223