### PR TITLE
fix(session): SESSION_COMM_LOCK_DIR 不在ディレクトリ時の無警告終了を修正 (#1051)

### DIFF
--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -124,6 +124,11 @@ tests:
     path: tests/session-comm-usage-typo-1066.bats
     description: "session-comm.sh ファイルヘッダ usage の inject-file 行に --wait SECONDS 重複がないことを検証（#1066）"
 
+  session-comm-lock-dir-validation-test:
+    type: test
+    path: tests/session-comm-lock-dir-validation.bats
+    description: "SESSION_COMM_LOCK_DIR 不在時の mkdir-p 自動作成・作成不可時の明示エラー検証（#1051）"
+
   lib-tmux-resolve-test:
     type: test
     path: tests/lib-tmux-resolve.bats

--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -278,6 +278,10 @@ cmd_inject() {
             lock_dir="/tmp"
         fi
     fi
+    mkdir -p "$lock_dir" 2>/dev/null || {
+        echo "Error: SESSION_COMM_LOCK_DIR '$lock_dir' is not creatable" >&2
+        exit 1
+    }
     local lock_file="${lock_dir}/session-comm-${target//[^a-zA-Z0-9]/-}.lock"
     {
         flock -w 30 9 || {

--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -279,7 +279,7 @@ cmd_inject() {
         fi
     fi
     mkdir -p "$lock_dir" 2>/dev/null || {
-        echo "Error: SESSION_COMM_LOCK_DIR '$lock_dir' is not creatable" >&2
+        echo "Error: lock directory '$lock_dir' (SESSION_COMM_LOCK_DIR) is not creatable" >&2
         exit 1
     }
     local lock_file="${lock_dir}/session-comm-${target//[^a-zA-Z0-9]/-}.lock"

--- a/plugins/session/tests/ac-test-mapping-1051.yaml
+++ b/plugins/session/tests/ac-test-mapping-1051.yaml
@@ -1,0 +1,80 @@
+# ac-test-mapping.yaml — Issue #1051: tech-debt: session-comm SESSION_COMM_LOCK_DIR mkdir -p
+# 生成: AC Scaffold Tests Agent
+# 対象テストファイル: plugins/session/tests/session-comm-lock-dir-validation.bats
+
+mappings:
+  # ---------------------------------------------------------------------------
+  # AC1: session-comm.sh cmd_inject に採用案 A の mkdir -p ブロックを追加
+  # ---------------------------------------------------------------------------
+  - ac_index: 1
+    ac_text: "plugins/session/scripts/session-comm.sh の cmd_inject 内、L280 直後（local lock_file=... 直前）に mkdir -p \"$lock_dir\" 2>/dev/null || { echo \"Error: SESSION_COMM_LOCK_DIR '$lock_dir' is not creatable\" >&2; exit 1; } を追加する"
+    test_file: "plugins/session/tests/session-comm-lock-dir-validation.bats"
+    test_name: "session-comm-lock-dir[structural][RED]: cmd_inject に mkdir -p lock_dir ガードが含まれる"
+    status: RED
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+
+  - ac_index: 1b
+    ac_text: "mkdir -p 失敗時に 'is not creatable' エラーメッセージが stderr に出力される（AC1 の構造的サブ確認）"
+    test_file: "plugins/session/tests/session-comm-lock-dir-validation.bats"
+    test_name: "session-comm-lock-dir[structural][RED]: mkdir -p 失敗時の Error メッセージが含まれる"
+    status: RED
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+
+  # ---------------------------------------------------------------------------
+  # AC2-1: 不存在ディレクトリ → mkdir -p で自動作成
+  # ---------------------------------------------------------------------------
+  - ac_index: 2a
+    ac_text: "不存在ディレクトリ: SESSION_COMM_LOCK_DIR=/nonexistent_lock_dir_$$ → mkdir -p PASS（自動作成）→ flock 成功"
+    test_file: "plugins/session/tests/session-comm-lock-dir-validation.bats"
+    test_name: "session-comm-lock-dir[functional][RED]: 不存在ディレクトリは mkdir -p で自動作成される"
+    status: RED
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+
+  # ---------------------------------------------------------------------------
+  # AC2-2: 作成不可ディレクトリ → stderr Error + exit 1
+  # ---------------------------------------------------------------------------
+  - ac_index: 2b
+    ac_text: "作成不可ディレクトリ（permission denied）: SESSION_COMM_LOCK_DIR=/some_chmod_000_dir/sub → mkdir -p FAIL → stderr Error メッセージ + exit code 1"
+    test_file: "plugins/session/tests/session-comm-lock-dir-validation.bats"
+    test_name: "session-comm-lock-dir[functional][RED]: 作成不可ディレクトリで Error メッセージ + exit 1"
+    status: RED
+    note: "root 実行時は skip guard により自動スキップ（[[ $(id -u) == 0 ]] → skip）"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+
+  # ---------------------------------------------------------------------------
+  # AC2-3: 既存ディレクトリ /tmp → 回帰なし（mkdir -p 冪等）
+  # ---------------------------------------------------------------------------
+  - ac_index: 2c
+    ac_text: "既存ディレクトリ: SESSION_COMM_LOCK_DIR=/tmp → 通常動作（既存ケース回帰なし）"
+    test_file: "plugins/session/tests/session-comm-lock-dir-validation.bats"
+    test_name: "session-comm-lock-dir[regression]: 既存ディレクトリ /tmp では mkdir -p が冪等で成功する"
+    status: GREEN
+    note: "mkdir -p は既存ディレクトリに対して no-op で成功するため、実装前後どちらも GREEN。回帰ガードとして記載。"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+
+  # ---------------------------------------------------------------------------
+  # AC3: bats session-comm-lock-dir-validation.bats 全件 PASS（実装後）
+  # メタ AC のため専用テストは不要
+  # ---------------------------------------------------------------------------
+  - ac_index: 3
+    ac_text: "bats plugins/session/tests/session-comm-lock-dir-validation.bats が PASS する（実装後）"
+    test_file: null
+    test_name: null
+    impl_files: []
+    # メタ的な「全テスト PASS 確認」AC のため専用テストは不要（workflow が確認する）
+
+  # ---------------------------------------------------------------------------
+  # AC4: 既存 session-comm-*.bats の回帰なし PASS
+  # メタ AC のため専用テストは不要
+  # ---------------------------------------------------------------------------
+  - ac_index: 4
+    ac_text: "既存 bats plugins/session/tests/session-comm-*.bats（session-comm-script-dir-validate.bats / session-comm-usage-typo-1066.bats）の全件が回帰なく PASS する"
+    test_file: null
+    test_name: null
+    impl_files: []
+    # メタ的な「回帰なし確認」AC のため専用テストは不要（workflow が確認する）

--- a/plugins/session/tests/session-comm-lock-dir-validation.bats
+++ b/plugins/session/tests/session-comm-lock-dir-validation.bats
@@ -13,6 +13,7 @@ setup() {
     PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
     SANDBOX="$(mktemp -d)"
+    unset _PERM_DENY_PARENT
     export SANDBOX SCRIPT PLUGIN_ROOT
 }
 
@@ -40,8 +41,8 @@ teardown() {
 
 @test "session-comm-lock-dir[structural][RED]: mkdir -p 失敗時の Error メッセージが含まれる" {
     # エラーメッセージの存在を構造的に確認
-    grep -F "SESSION_COMM_LOCK_DIR" "$SCRIPT" | grep -F "is not creatable" || {
-        echo "FAIL: session-comm.sh に 'is not creatable' エラーメッセージが含まれていない" >&2
+    grep -F "is not creatable" "$SCRIPT" | grep -F "SESSION_COMM_LOCK_DIR" || {
+        echo "FAIL: session-comm.sh に 'is not creatable' + 'SESSION_COMM_LOCK_DIR' エラーメッセージが含まれていない" >&2
         return 1
     }
 }
@@ -59,7 +60,7 @@ teardown() {
     local nonexistent_dir="${SANDBOX}/nonexistent_lock_dir_$$"
     rm -rf "$nonexistent_dir" 2>/dev/null || true
 
-    # cmd_inject の lock_dir validation ブロックをサブシェルで再現
+    # cmd_inject の lock_dir validation ブロックをサブシェルで再現（session-comm.sh L274-284 と同期保持必要）
     # 実装後は mkdir -p が走り、ディレクトリが作成される
     # 実装前は mkdir -p が存在せず、ディレクトリが作成されない -> FAIL
     local created
@@ -118,7 +119,7 @@ teardown() {
     chmod 000 "$perm_deny_parent"
     local perm_deny_sub="${perm_deny_parent}/sub"
 
-    # cmd_inject の lock_dir validation ブロックをサブシェルで再現
+    # cmd_inject の lock_dir validation ブロックをサブシェルで再現（session-comm.sh L274-284 と同期保持必要）
     # 実装後は mkdir -p が失敗し、Error メッセージを stderr に出力して exit 1 する
     local stderr_output
     local exit_code=0

--- a/plugins/session/tests/session-comm-lock-dir-validation.bats
+++ b/plugins/session/tests/session-comm-lock-dir-validation.bats
@@ -1,0 +1,196 @@
+#!/usr/bin/env bats
+# session-comm-lock-dir-validation.bats
+# Requirement: SESSION_COMM_LOCK_DIR が不在の場合に mkdir -p で自動作成し、
+#   作成不可の場合は stderr エラー + exit 1 する（issue-1051）
+# Spec: issue-1051
+# Coverage: --type=unit --coverage=functional
+
+# ===========================================================================
+# setup / teardown
+# ===========================================================================
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
+    SANDBOX="$(mktemp -d)"
+    export SANDBOX SCRIPT PLUGIN_ROOT
+}
+
+teardown() {
+    [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+    # chmod 000 ディレクトリを残している場合に備えて cleanup
+    if [[ -n "${_PERM_DENY_PARENT:-}" && -d "${_PERM_DENY_PARENT:-}" ]]; then
+        chmod 755 "$_PERM_DENY_PARENT" 2>/dev/null || true
+        rm -rf "$_PERM_DENY_PARENT" 2>/dev/null || true
+    fi
+}
+
+# ===========================================================================
+# AC1 (structural): cmd_inject 内に mkdir -p + Error メッセージガードが存在する
+# RED: session-comm.sh に採用案 A の mkdir -p ブロックが未追加の時点で FAIL する
+# ===========================================================================
+
+@test "session-comm-lock-dir[structural][RED]: cmd_inject に mkdir -p lock_dir ガードが含まれる" {
+    # AC1 の採用案 A: mkdir -p "$lock_dir" 2>/dev/null || { ... } が存在することを確認
+    grep -F 'mkdir -p "$lock_dir"' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh の cmd_inject に [mkdir -p \"\$lock_dir\"] が含まれていない" >&2
+        return 1
+    }
+}
+
+@test "session-comm-lock-dir[structural][RED]: mkdir -p 失敗時の Error メッセージが含まれる" {
+    # エラーメッセージの存在を構造的に確認
+    grep -F "SESSION_COMM_LOCK_DIR" "$SCRIPT" | grep -F "is not creatable" || {
+        echo "FAIL: session-comm.sh に 'is not creatable' エラーメッセージが含まれていない" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC2-1 (functional): 不存在ディレクトリ → mkdir -p で自動作成 → flock 成功
+# RED: mkdir -p ガードが未追加の時点では cmd_inject が lock_dir を作成せず
+#      flock で lock_file の親ディレクトリが存在しないため失敗する
+#
+# 実装方針: cmd_inject の lock_dir validation ブロックのみをサブシェルで再現し、
+#   mkdir -p による自動作成が行われることを検証する
+# ===========================================================================
+
+@test "session-comm-lock-dir[functional][RED]: 不存在ディレクトリは mkdir -p で自動作成される" {
+    local nonexistent_dir="${SANDBOX}/nonexistent_lock_dir_$$"
+    rm -rf "$nonexistent_dir" 2>/dev/null || true
+
+    # cmd_inject の lock_dir validation ブロックをサブシェルで再現
+    # 実装後は mkdir -p が走り、ディレクトリが作成される
+    # 実装前は mkdir -p が存在せず、ディレクトリが作成されない -> FAIL
+    local created
+    created=$(SESSION_COMM_LOCK_DIR="$nonexistent_dir" bash -c '
+        set -euo pipefail
+        lock_dir="${SESSION_COMM_LOCK_DIR:-/tmp}"
+        if [[ -n "${SESSION_COMM_LOCK_DIR:-}" ]]; then
+            if [[ "${SESSION_COMM_LOCK_DIR}" != /* ]] || [[ "${SESSION_COMM_LOCK_DIR}" =~ \.\. ]]; then
+                echo "Warning: SESSION_COMM_LOCK_DIR invalid, using /tmp" >&2
+                lock_dir="/tmp"
+            fi
+        fi
+        # --- 採用案 A: 実装後に挿入されるブロック ---
+        # 実装前はここに mkdir -p が存在しない
+        mkdir -p "$lock_dir" 2>/dev/null || {
+            echo "Error: SESSION_COMM_LOCK_DIR '"'"'$lock_dir'"'"' is not creatable" >&2
+            exit 1
+        }
+        # -------------------------------------------
+        if [[ -d "$lock_dir" ]]; then
+            echo "created"
+        else
+            echo "not_created"
+        fi
+    ')
+
+    [[ "$created" == "created" ]] || {
+        echo "FAIL: SESSION_COMM_LOCK_DIR が不存在のとき mkdir -p で自動作成されなかった" >&2
+        return 1
+    }
+
+    # session-comm.sh 本体が実際に mkdir -p を呼ぶことを構造確認
+    grep -F 'mkdir -p "$lock_dir"' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh に mkdir -p \"\$lock_dir\" が存在しない（実装未完了）" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC2-2 (functional): 作成不可ディレクトリ → mkdir -p FAIL → stderr Error + exit 1
+# RED: mkdir -p ガードが未追加の時点では exit 1 せず、flock で別のエラーになる
+#
+# NOTE: root 実行時は chmod 000 を回避できるため skip guard が必要
+# ===========================================================================
+
+@test "session-comm-lock-dir[functional][RED]: 作成不可ディレクトリで Error メッセージ + exit 1" {
+    # root では chmod 000 が効かないためスキップ
+    if [[ "$(id -u)" == "0" ]]; then
+        skip "root 実行時は permission denied テストをスキップ"
+    fi
+
+    # chmod 000 の親ディレクトリを作成し、その下のサブディレクトリを lock_dir に指定
+    local perm_deny_parent="${SANDBOX}/perm_deny_parent_$$"
+    export _PERM_DENY_PARENT="$perm_deny_parent"
+    mkdir -p "$perm_deny_parent"
+    chmod 000 "$perm_deny_parent"
+    local perm_deny_sub="${perm_deny_parent}/sub"
+
+    # cmd_inject の lock_dir validation ブロックをサブシェルで再現
+    # 実装後は mkdir -p が失敗し、Error メッセージを stderr に出力して exit 1 する
+    local stderr_output
+    local exit_code=0
+    stderr_output=$(SESSION_COMM_LOCK_DIR="$perm_deny_sub" bash -c '
+        set -euo pipefail
+        lock_dir="${SESSION_COMM_LOCK_DIR:-/tmp}"
+        if [[ -n "${SESSION_COMM_LOCK_DIR:-}" ]]; then
+            if [[ "${SESSION_COMM_LOCK_DIR}" != /* ]] || [[ "${SESSION_COMM_LOCK_DIR}" =~ \.\. ]]; then
+                echo "Warning: SESSION_COMM_LOCK_DIR invalid, using /tmp" >&2
+                lock_dir="/tmp"
+            fi
+        fi
+        # --- 採用案 A: 実装後に挿入されるブロック ---
+        mkdir -p "$lock_dir" 2>/dev/null || {
+            echo "Error: SESSION_COMM_LOCK_DIR '"'"'$lock_dir'"'"' is not creatable" >&2
+            exit 1
+        }
+        # -------------------------------------------
+        echo "reached_flock"
+    ' 2>&1 >/dev/null) || exit_code=$?
+
+    # cleanup: teardown でも実施するが、ここで権限を戻しておく
+    chmod 755 "$perm_deny_parent" 2>/dev/null || true
+
+    [[ "$exit_code" -eq 1 ]] || {
+        echo "FAIL: 作成不可 lock_dir で exit code が 1 ではなく ${exit_code} だった" >&2
+        return 1
+    }
+
+    echo "$stderr_output" | grep -F "is not creatable" || {
+        echo "FAIL: stderr に 'is not creatable' メッセージが含まれていない" >&2
+        echo "  stderr: $stderr_output" >&2
+        return 1
+    }
+
+    # session-comm.sh 本体の構造確認（実装未完了なら FAIL）
+    grep -F 'mkdir -p "$lock_dir"' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh に mkdir -p \"\$lock_dir\" が存在しない（実装未完了）" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC2-3 (regression): 既存ディレクトリ /tmp → 通常動作（mkdir -p は冪等）
+# GREEN 期待: mkdir -p は既存ディレクトリに対して no-op で成功する
+# 実装前後どちらでも PASS するはずだが、実装後の回帰確認として定義する
+#
+# NOTE: このテストは cmd_inject の lock_dir validation ブロックを再現して
+#   /tmp に対して mkdir -p が冪等であることを確認する（exit 0 を期待）
+# ===========================================================================
+
+@test "session-comm-lock-dir[regression]: 既存ディレクトリ /tmp では mkdir -p が冪等で成功する" {
+    local exit_code=0
+    SESSION_COMM_LOCK_DIR="/tmp" bash -c '
+        set -euo pipefail
+        lock_dir="${SESSION_COMM_LOCK_DIR:-/tmp}"
+        if [[ -n "${SESSION_COMM_LOCK_DIR:-}" ]]; then
+            if [[ "${SESSION_COMM_LOCK_DIR}" != /* ]] || [[ "${SESSION_COMM_LOCK_DIR}" =~ \.\. ]]; then
+                echo "Warning: SESSION_COMM_LOCK_DIR invalid, using /tmp" >&2
+                lock_dir="/tmp"
+            fi
+        fi
+        # 採用案 A: 既存ディレクトリに対しては冪等（no-op）で成功するはず
+        mkdir -p "$lock_dir" 2>/dev/null || {
+            echo "Error: SESSION_COMM_LOCK_DIR '"'"'$lock_dir'"'"' is not creatable" >&2
+            exit 1
+        }
+        echo "ok"
+    ' || exit_code=$?
+
+    [[ "$exit_code" -eq 0 ]] || {
+        echo "FAIL: 既存ディレクトリ /tmp で mkdir -p が失敗した（exit $exit_code）" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## 概要

`plugins/session/scripts/session-comm.sh` の `cmd_inject` 関数で、`SESSION_COMM_LOCK_DIR` が不在ディレクトリを指していた場合に無警告終了していた問題を修正。

## 変更内容

### `plugins/session/scripts/session-comm.sh`

L280 直後（`local lock_file=...` 直前）に採用案 A を追加:

```bash
mkdir -p "$lock_dir" 2>/dev/null || {
    echo "Error: SESSION_COMM_LOCK_DIR '$lock_dir' is not creatable" >&2
    exit 1
}
```

### `plugins/session/tests/session-comm-lock-dir-validation.bats`（新規）

TDD テスト 5件:
- structural: mkdir -p ガード・エラーメッセージの存在確認
- functional: 不存在ディレクトリの自動作成 / 作成不可時の exit 1
- regression: 既存ディレクトリ /tmp の冪等動作

## テスト結果

```
bats plugins/session/tests/session-comm-lock-dir-validation.bats
1..5
ok 1 ... ok 5  # 全件 PASS
```

既存テスト（session-comm-script-dir-validate.bats / session-comm-usage-typo-1066.bats）8件も回帰なし PASS。

Closes #1051