### PR TITLE
feat(#1201): deps.yaml に record-detection-gap.sh の component entry を追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2914,6 +2914,12 @@ scripts:
     path: skills/su-observer/scripts/budget-monitor-watcher.sh
     description: "su-observer budget 専用 Monitor watcher: 60s ループで threshold_percent を監視し [BUDGET-ALERT] を stdout に出力。Monitor tool と並行起動する。環境変数: PILOT_WINDOW（必須）"
 
+  # su-observer 検知漏れ自動記録 helper (#1187)
+  record-detection-gap:
+    type: script
+    path: skills/su-observer/scripts/record-detection-gap.sh
+    description: "su-observer 検知漏れ自動記録 helper: --type <gap-type> --detail <text> [--related-issue <#N>] [--severity low|medium|high]。missing-monitor / pitfall-miss / intervention-fail / proxy-stuck / kill-miss 等の検知漏れを .supervisor/detection-gaps.jsonl に記録（#1187）"
+
   # su-observer heartbeat watcher (#948 Phase AA 2026-04-24)
   heartbeat-watcher:
     type: script

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2918,7 +2918,7 @@ scripts:
   record-detection-gap:
     type: script
     path: skills/su-observer/scripts/record-detection-gap.sh
-    description: "su-observer 検知漏れ自動記録 helper: --type <gap-type> --detail <text> [--related-issue <#N>] [--severity low|medium|high]。missing-monitor / pitfall-miss / intervention-fail / proxy-stuck / kill-miss 等の検知漏れを .supervisor/detection-gaps.jsonl に記録（#1187）"
+    description: "su-observer 検知漏れ自動記録 helper: --type <gap-type> --detail <text> [--related-issue <#N>] [--severity low|medium|high]。missing-monitor / pitfall-miss / intervention-fail / proxy-stuck / kill-miss 等の検知漏れを .supervisor/intervention-log.md に追記（#1187）"
 
   # su-observer heartbeat watcher (#948 Phase AA 2026-04-24)
   heartbeat-watcher:

--- a/plugins/twl/tests/bats/scripts/record-detection-gap-deps-registered.bats
+++ b/plugins/twl/tests/bats/scripts/record-detection-gap-deps-registered.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# record-detection-gap-deps-registered.bats
+#
+# SSoT 完備性テスト: plugins/twl/deps.yaml に record-detection-gap.sh の
+# component entry が正しく登録されていることを assert する
+#
+# Coverage: --type=unit --coverage=deps-yaml-ssot
+#
+# AC3: deps.yaml を grep し、record-detection-gap.sh entry の存在と
+#      path フィールドが正しいことを検証する
+
+load '../helpers/common'
+
+DEPS_YAML=""
+
+setup() {
+    common_setup
+    DEPS_YAML="${REPO_ROOT}/deps.yaml"
+}
+
+teardown() {
+    common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC3-1: record-detection-gap entry の存在確認
+# WHEN plugins/twl/deps.yaml を grep する
+# THEN record-detection-gap キーが存在する
+# ---------------------------------------------------------------------------
+
+@test "ac3: deps.yaml に record-detection-gap entry が存在する" {
+    # AC: deps.yaml に record-detection-gap.sh の component entry が登録されている
+    # RED: AC1 実装前は entry が存在しないため fail する
+    run grep -q "^  record-detection-gap:" "$DEPS_YAML"
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC3-2: path フィールドの正確性確認
+# WHEN plugins/twl/deps.yaml の record-detection-gap entry を grep する
+# THEN path: skills/su-observer/scripts/record-detection-gap.sh が存在する
+# ---------------------------------------------------------------------------
+
+@test "ac3: deps.yaml の record-detection-gap entry に正しい path フィールドがある" {
+    # AC: path フィールドが skills/su-observer/scripts/record-detection-gap.sh であること
+    # RED: AC1 実装前は entry が存在しないため fail する
+    run grep -q "path: skills/su-observer/scripts/record-detection-gap.sh" "$DEPS_YAML"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

Issue #1201 対応。`plugins/twl/deps.yaml` に `record-detection-gap.sh` の component entry が未登録だった tech-debt を解消する。

## 変更内容

- `plugins/twl/deps.yaml` に `record-detection-gap` エントリ追加（spawn-controller と同パターンの 3 フィールド: type/path/description）
- `plugins/twl/tests/bats/scripts/record-detection-gap-deps-registered.bats` 追加（SSoT 完備性テスト）

## AC 確認

- [x] AC1: deps.yaml に `record-detection-gap.sh` の component entry 追加（3 フィールド）
- [x] AC2: `twl check` Missing: 0 PASS
- [x] AC3: bats テスト追加・GREEN 確認済み
- [x] AC4: `twl check --deps-integrity` PASS

Closes #1201