### PR TITLE
fix(#1242): pr-review-manifest.sh L184 glob を *architecture/*.md に修正

### DIFF
--- a/.autopilot/wave-unknown-summary.md
+++ b/.autopilot/wave-unknown-summary.md
@@ -4,6 +4,18 @@
 
 **全タスク完了**。次 session は新規 Wave or 新規タスク着手。Open bug fix なし。
 
+---
+
+## #1242 fix 記録 (2026-05-02)
+
+**architecture spec PR で worker-arch-doc-reviewer が抜け落ちる bug を修正**
+
+- 対象: `plugins/twl/scripts/pr-review-manifest.sh` L184
+- 修正: glob `*/architecture/*.md` → `*architecture/*.md`（top-level 相対パスにマッチするよう修正）
+- テスト: B-1〜B-6 regression tests 追加（phase-review/merge-gate × top-level/nested-1/nested-2）
+- CI: `.github/workflows/pr-review-manifest-bats.yml` 追加
+- PR: #1251 (Closes #1242)
+
 ## 本 session 完了 PRs
 
 ### twill main

--- a/.github/workflows/pr-review-manifest-bats.yml
+++ b/.github/workflows/pr-review-manifest-bats.yml
@@ -1,0 +1,30 @@
+name: pr-review-manifest bats tests
+
+on:
+  push:
+    paths:
+      - 'plugins/twl/scripts/pr-review-manifest.sh'
+      - 'plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats'
+  pull_request:
+    paths:
+      - 'plugins/twl/scripts/pr-review-manifest.sh'
+      - 'plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats'
+
+permissions: {}
+
+jobs:
+  pr-review-manifest-bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+          rm -rf plugins/twl/tests/lib/bats-support
+          git clone --depth 1 https://github.com/bats-core/bats-support.git plugins/twl/tests/lib/bats-support
+          rm -rf plugins/twl/tests/lib/bats-assert
+          git clone --depth 1 https://github.com/bats-core/bats-assert.git plugins/twl/tests/lib/bats-assert
+      - name: Run pr-review-manifest architecture tests
+        working-directory: plugins/twl
+        run: bats tests/bats/scripts/pr-review-manifest-mode-architecture.bats

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -178,6 +178,7 @@ if [[ "$MODE" == "merge-gate" ]]; then
 fi
 
 # phase-review / merge-gate モード: architecture/ 配下の .md 変更 → worker-arch-doc-reviewer
+# glob は L159 の worker-architecture 条件と同一パターン（意図的）。条件: phase-review|merge-gate（L159 は phase-review のみ）
 if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
   for f in "${FILES[@]}"; do
     case "$f" in

--- a/plugins/twl/scripts/pr-review-manifest.sh
+++ b/plugins/twl/scripts/pr-review-manifest.sh
@@ -181,7 +181,7 @@ fi
 if [[ "$MODE" == "phase-review" || "$MODE" == "merge-gate" ]]; then
   for f in "${FILES[@]}"; do
     case "$f" in
-      */architecture/*.md|*/architecture/*/*.md|*/architecture/*/*/*.md)
+      *architecture/*.md|*architecture/*/*.md|*architecture/*/*/*.md)
         SPECIALISTS["worker-arch-doc-reviewer"]=1
         break
         ;;

--- a/plugins/twl/tests/bats/scripts/ac-test-mapping.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping.yaml
@@ -1,0 +1,37 @@
+mappings:
+  - ac_index: 1
+    ac_text: "phase-review + top-level architecture/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-1: phase-review + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"
+  - ac_index: 2
+    ac_text: "phase-review + nested-1 architecture/contexts/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-2: phase-review + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"
+  - ac_index: 3
+    ac_text: "phase-review + nested-2 architecture/decisions/sub/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-3: phase-review + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"
+  - ac_index: 4
+    ac_text: "merge-gate + top-level architecture/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-4: merge-gate + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"
+  - ac_index: 5
+    ac_text: "merge-gate + nested-1 architecture/contexts/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-5: merge-gate + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"
+  - ac_index: 6
+    ac_text: "merge-gate + nested-2 architecture/decisions/sub/foo.md で worker-arch-doc-reviewer が含まれる"
+    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
+    test_name: "B-6: merge-gate + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)"
+    impl_files:
+      - "plugins/twl/scripts/pr-review-manifest.sh"

--- a/plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats
+++ b/plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats
@@ -1,9 +1,9 @@
 #!/usr/bin/env bats
 # pr-review-manifest-mode-architecture.bats
-# AC A-3: phase-review mode での architecture/ ファイル変更時 worker-architecture 追加テスト
+# A-3: phase-review mode での architecture/ ファイル変更時 worker-architecture 追加テスト
+# B-1〜B-6: #1242 regression — top-level/nested architecture/*.md で worker-arch-doc-reviewer 追加テスト
 #
-# RED テスト: A-3-i, A-3-iv, A-3-v は現状の pr-review-manifest.sh では FAIL する
-# PASS テスト: A-3-ii, A-3-iii は現状でも PASS するが、テストとして明示する
+# テスト名末尾の (RED) は TDD RED フェーズで生成されたテストを示す慣例表記（PASS になった後も維持）
 
 load '../helpers/common'
 

--- a/plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats
+++ b/plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats
@@ -95,3 +95,82 @@ teardown() {
   assert_success
   assert_output --partial "worker-architecture"
 }
+
+# ===========================================================================
+# B-1: phase-review + top-level architecture/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*.md は先頭に1文字以上を要求するため top-level にマッチしない
+#      fix: *architecture/*.md|... に変更すると PASS
+# ===========================================================================
+
+@test "B-1: phase-review + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture"
+
+  run bash -c "echo 'architecture/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode phase-review"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}
+
+# ===========================================================================
+# B-2: phase-review + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*/*.md は先頭に1文字以上を要求するため top-level nested にマッチしない
+# ===========================================================================
+
+@test "B-2: phase-review + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture/contexts"
+
+  run bash -c "echo 'architecture/contexts/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode phase-review"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}
+
+# ===========================================================================
+# B-3: phase-review + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*/*/*.md は先頭に1文字以上を要求するため top-level nested-2 にマッチしない
+# ===========================================================================
+
+@test "B-3: phase-review + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture/decisions/sub"
+
+  run bash -c "echo 'architecture/decisions/sub/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode phase-review"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}
+
+# ===========================================================================
+# B-4: merge-gate + top-level architecture/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*.md は先頭に1文字以上を要求するため top-level にマッチしない
+# ===========================================================================
+
+@test "B-4: merge-gate + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture"
+
+  run bash -c "echo 'architecture/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}
+
+# ===========================================================================
+# B-5: merge-gate + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*/*.md は先頭に1文字以上を要求するため top-level nested にマッチしない
+# ===========================================================================
+
+@test "B-5: merge-gate + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture/contexts"
+
+  run bash -c "echo 'architecture/contexts/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}
+
+# ===========================================================================
+# B-6: merge-gate + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer 含む
+# RED: L184 の */architecture/*/*/*.md は先頭に1文字以上を要求するため top-level nested-2 にマッチしない
+# ===========================================================================
+
+@test "B-6: merge-gate + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)" {
+  mkdir -p "$SANDBOX/architecture/decisions/sub"
+
+  run bash -c "echo 'architecture/decisions/sub/foo.md' | bash '$SANDBOX/scripts/pr-review-manifest.sh' --mode merge-gate"
+  assert_success
+  assert_output --partial "worker-arch-doc-reviewer"
+}


### PR DESCRIPTION
## 概要

`plugins/twl/scripts/pr-review-manifest.sh` L184 の glob パターン `*/architecture/*.md` を `*architecture/*.md|*architecture/*/*.md|*architecture/*/*/*.md` に修正。

top-level の `architecture/foo.md` が bash case pattern `*/architecture/*.md` にマッチしなかった bug を解消。

L159 の `worker-architecture` 選択条件と同パターン（`*architecture/...`）を採用。

## 変更内容

- `plugins/twl/scripts/pr-review-manifest.sh` L184: 1-line fix
- `plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats`: B-1〜B-6 regression tests 追加

## テスト

```
bats plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats
```
- A-3-i〜A-3-v: 5件 PASS（既存テスト変更なし）
- B-1〜B-6: 6件 PASS（fix 後 GREEN）

## architecture spec PR で worker-arch-doc-reviewer が抜け落ちる bug を修正

- 影響: phase-review / merge-gate モードで top-level `architecture/*.md` が対象の PR
- 確認済み影響: shuu5/soap-copilot-mock の Wave D PR 全件で pre-merge では worker-arch-doc-reviewer 未起動

Closes #1242