### PR TITLE
feat(#1245): observer-supervise-checklist.md 新規作成 + reference 追加

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -363,6 +363,7 @@ skills:
       - reference: pitfalls-catalog   # Phase A: 起動時 Step 0 Read MUST
       - reference: proxy-dialog-playbook  # #814 Phase 2: proxy 対話完全手順
       - reference: ref-invariants     # 不変条件 A-M 正典参照（境界説明）
+      - reference: observer-supervise-checklist         # #1245: supervise cycle MUST verify 7 項目チェックリスト
       - reference: su-observer-supervise-channels      # #984: supervise 必須並行チャンネル詳細
       - reference: su-observer-controller-spawn-playbook  # #984: controller spawn パターン・並列度・spawn prompt 規約
       - reference: su-observer-wave-management         # #984: Wave 管理・問題検出・過去介入記録確認
@@ -818,6 +819,13 @@ refs:
     description: "負荷テスト level の定量基準"
 
   # su-observer split refs (#984: SKILL.md token_bloat 解消)
+  observer-supervise-checklist:
+    type: reference
+    path: skills/su-observer/refs/observer-supervise-checklist.md
+    spawnable_by: [controller, workflow, atomic]
+    can_spawn: []
+    description: "supervise loop 各 cycle で MUST verify する 7 項目チェックリスト（#1189 AC9.2）"
+
   su-observer-supervise-channels:
     type: reference
     path: skills/su-observer/refs/su-observer-supervise-channels.md

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -54,6 +54,8 @@ spawnable_by:
 
 **`refs/su-observer-supervise-channels.md` を Read** して実行。
 
+> **supervise cycle 開始前 checklist（SHOULD）**: **`refs/observer-supervise-checklist.md` を Read** して 7 項目を確認し、未設定項目があれば補完すること（#1245）。
+
 > **Monitor tool 連携経路（SHOULD）**: cld-observe-any 起動時は `refs/monitor-channel-catalog.md` の「Monitor tool 連携経路（方式 A: 共有 logfile tail）」セクションを参照し、stdout を `.supervisor/cld-observe-any.log` に `tee -a` redirect した上で Monitor tool を `tail -F` で起動すること。これにより `[MENU-READY]`/`[REVIEW-READY]`/`[FREEFORM-READY]` 等の event を Monitor tool でリアルタイム受信できる（#1144）。
 
 > **検知漏れ記録（SHOULD）**: Monitor 不在・pitfall 適用漏れ・observer 自身の介入失敗など「検知漏れ」が発生した判断ポイントでは `scripts/record-detection-gap.sh` を呼び出すこと。SHOULD — 完全自動では難しいが、介入後に気づいた場合は積極的に記録する。

--- a/plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md
+++ b/plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md
@@ -1,0 +1,20 @@
+# observer supervise checklist
+
+supervise loop 各 cycle で MUST verify する 7 項目チェックリスト（#1189 AC9.2）。
+
+## cycle MUST verify チェックリスト
+
+1. **MUST**: Monitor primary break condition が controller type に対応しているか確認
+   → `refs/monitor-channel-catalog.md` の「controller type 別 primary completion signal mapping」table を参照
+2. **MUST**: `IDLE_COMPLETED_AUTO_KILL=1` が Wave 起動時 env として設定されているか確認
+3. **MUST**: window 消失単独依存ではなく多軸 AND 条件（completion phrase event + window 消失 OR session-state idle）を採用しているか確認
+4. **SHOULD**: log mtime / pane state / LLM idle indicator の少なくとも 2 軸で session 状態を判定しているか確認
+5. **SHOULD**: completion phrase の grep regex が `refs/pilot-completion-signals.md` SSOT と一致しているか確認
+6. **MAY**: STAGNATE event 監視 task が起動しているか確認（長時間 idle 時の自動介入用）
+7. **MAY**: Discord DM 自律報告 channel が活きているか確認（compaction 後の reset 検知用）
+
+## 使用タイミング
+
+`refs/su-observer-supervise-channels.md` の supervise 1 iteration 開始時に参照する（SHOULD）。
+
+各チャンネル起動前に本 checklist を確認し、未設定の項目があれば起動前に補完すること。

--- a/plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md
@@ -1,5 +1,7 @@
 # supervise 1 iteration — 必須並行チャンネル
 
+> **cycle 開始前 checklist（SHOULD）**: 各 iteration 開始前に **`refs/observer-supervise-checklist.md` を Read** して 7 項目を確認すること（#1245）。チャンネル起動前の前提確認が目的。
+
 co-autopilot を supervise している間、1 iteration で以下のチャンネルを並行実行しなければならない（SHALL）:
 
 | チャンネル | 目的 | Worker spawn あり | Pilot-only chain | 閾値/間隔 |

--- a/plugins/twl/tests/bats/ac-test-mapping-1245.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1245.yaml
@@ -1,0 +1,56 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md が新規作成されている"
+    test_file: "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    test_names:
+      - "ac1: observer-supervise-checklist.md exists at expected path"
+      - "ac1: observer-supervise-checklist.md is non-empty"
+      - "ac1: observer-supervise-checklist.md contains checklist items (at least one checkbox or list item)"
+      - "ac1: observer-supervise-checklist.md filename includes 'supervise' and 'checklist'"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md"
+    # impl_files 注記: 実装前は存在しない新規作成ファイル。RED 状態で全 AC1 テストが fail する。
+
+  - ac_index: 2
+    ac_text: "plugins/twl/skills/su-observer/SKILL.md Step 1 supervise loop から checklist への reference が追加されている"
+    test_file: "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    test_names:
+      - "ac2: SKILL.md contains reference to observer-supervise-checklist"
+      - "ac2: SKILL.md reference to checklist is in Step 1 supervise loop section"
+      - "ac2: SKILL.md checklist reference uses Read directive or link format"
+    impl_files:
+      - "plugins/twl/skills/su-observer/SKILL.md"
+
+  - ac_index: 3
+    ac_text: "plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md から checklist への reference が追加されている"
+    test_file: "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    test_names:
+      - "ac3: su-observer-supervise-channels.md contains reference to observer-supervise-checklist"
+      - "ac3: su-observer-supervise-channels.md checklist reference is not a comment-only line"
+      - "ac3: su-observer-supervise-channels.md checklist reference appears as Read directive or link"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md"
+
+  - ac_index: 4
+    ac_text: "plugins/twl/deps.yaml に observer-supervise-checklist エントリが登録されている（type=reference）"
+    test_file: "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    test_names:
+      - "ac4: deps.yaml contains observer-supervise-checklist entry"
+      - "ac4: deps.yaml observer-supervise-checklist entry has type: reference"
+      - "ac4: deps.yaml observer-supervise-checklist entry has path pointing to checklist md"
+      - "ac4: deps.yaml observer-supervise-checklist entry has description field"
+      - "ac4: deps.yaml observer-supervise-checklist is placed in su-observer split refs section"
+    impl_files:
+      - "plugins/twl/deps.yaml"
+
+  - ac_index: 5
+    ac_text: "bats テストが追加されている（plugins/twl/tests/bats/issue-1245-observer-checklist.bats）"
+    test_file: "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    test_names:
+      - "ac5: this bats test file exists at expected path"
+      - "ac5: this bats test file contains at least 5 test blocks"
+    impl_files:
+      - "plugins/twl/tests/bats/issue-1245-observer-checklist.bats"
+    # 注記: AC5 のテストは self-referential。本ファイル書き出し時点で GREEN になる。
+    #       「対象ファイルが存在し、かつ 5 件以上の @test ブロックを含む」として検証する。
+    #       他の AC1-4 と異なり、RED -> GREEN の遷移はファイル生成完了後に即座に発生する。

--- a/plugins/twl/tests/bats/issue-1245-observer-checklist.bats
+++ b/plugins/twl/tests/bats/issue-1245-observer-checklist.bats
@@ -1,0 +1,232 @@
+#!/usr/bin/env bats
+# issue-1245-observer-checklist.bats
+#
+# RED-phase tests for Issue #1245:
+#   tech-debt(observer): observer supervise checklist 新規作成
+#     - observer-supervise-checklist.md 新規作成
+#     - SKILL.md Step 1 supervise loop に checklist への reference 追加
+#     - su-observer-supervise-channels.md に checklist への reference 追加
+#     - deps.yaml に observer-supervise-checklist エントリ登録（type=reference）
+#     - bats テスト追加（本ファイル）
+#
+# AC coverage:
+#   AC1 - plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md が新規作成されている
+#   AC2 - SKILL.md Step 1 supervise loop から checklist への reference が追加されている
+#   AC3 - su-observer-supervise-channels.md から checklist への reference が追加されている
+#   AC4 - deps.yaml に observer-supervise-checklist エントリが登録されている（type=reference）
+#   AC5 - bats テスト自身が存在し、5 件以上のテストを含む（self-referential）
+#
+# 全テストは実装前（RED）状態で fail する（AC5 を除く）。
+# AC5 のみ self-referential のため、このファイルが書き出された時点で GREEN になる。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  CHECKLIST_MD="${REPO_ROOT}/skills/su-observer/refs/observer-supervise-checklist.md"
+  SKILL_MD="${REPO_ROOT}/skills/su-observer/SKILL.md"
+  CHANNELS_MD="${REPO_ROOT}/skills/su-observer/refs/su-observer-supervise-channels.md"
+  DEPS_YAML="${REPO_ROOT}/deps.yaml"
+  THIS_BATS="${REPO_ROOT}/tests/bats/issue-1245-observer-checklist.bats"
+
+  export CHECKLIST_MD SKILL_MD CHANNELS_MD DEPS_YAML THIS_BATS
+}
+
+# ===========================================================================
+# AC1: observer-supervise-checklist.md が新規作成されている
+# ===========================================================================
+
+@test "ac1: observer-supervise-checklist.md exists at expected path" {
+  # AC: skills/su-observer/refs/observer-supervise-checklist.md が存在する
+  # RED: ファイルがまだ作成されていないため fail
+  [ -f "${CHECKLIST_MD}" ]
+}
+
+@test "ac1: observer-supervise-checklist.md is non-empty" {
+  # AC: checklist ファイルが空でない（実装内容を含む）
+  # RED: ファイルが存在しないため fail
+  [ -s "${CHECKLIST_MD}" ]
+}
+
+@test "ac1: observer-supervise-checklist.md contains checklist items (at least one checkbox or list item)" {
+  # AC: checklist ファイルにチェックリスト項目（チェックボックスまたはリスト）が含まれる
+  # RED: ファイルが存在しないため fail
+  run grep -qE '^\s*[-*]\s+\[[ xX]\]|^\s*[-*]\s+.+|^[0-9]+\.\s+' "${CHECKLIST_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1: observer-supervise-checklist.md has a markdown heading" {
+  # AC: checklist ファイルに Markdown 見出し（# で始まる行）が含まれる
+  # RED: ファイルが存在しないため fail
+  run grep -qE '^#+ ' "${CHECKLIST_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: SKILL.md Step 1 supervise loop から checklist への reference が追加されている
+# ===========================================================================
+
+@test "ac2: SKILL.md contains reference to observer-supervise-checklist" {
+  # AC: SKILL.md に observer-supervise-checklist への参照が含まれる
+  # RED: reference がまだ追加されていないため fail
+  run grep -qE 'observer-supervise-checklist' "${SKILL_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: SKILL.md reference to checklist is in Step 1 supervise loop section" {
+  # AC: checklist への参照が Step 1 supervise loop のセクション内に存在する
+  # RED: reference がまだ追加されていないため fail
+  run bash -c "
+    step1_line=\$(grep -n '^## Step 1' '${SKILL_MD}' | head -1 | cut -d: -f1)
+    [ -n \"\${step1_line}\" ] || exit 1
+    # Step 2 以降の行番号を取得
+    next_section_line=\$(awk -v s=\"\${step1_line}\" 'NR > s && /^## Step [2-9]/ {print NR; exit}' '${SKILL_MD}')
+    if [ -z \"\${next_section_line}\" ]; then
+      next_section_line=\$(wc -l < '${SKILL_MD}')
+    fi
+    # Step 1 セクション内に observer-supervise-checklist への参照がある
+    awk -v s=\"\${step1_line}\" -v e=\"\${next_section_line}\" \
+      'NR >= s && NR <= e && /observer-supervise-checklist/ {found=1; exit} END {exit !found}' \
+      '${SKILL_MD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: SKILL.md checklist reference uses Read directive or link format" {
+  # AC: checklist への参照が「Read」指示またはリンク形式で記述されている
+  # RED: reference がまだ追加されていないため fail
+  run bash -c "
+    # 'Read' + 'observer-supervise-checklist' が近接して存在する、またはリンク形式
+    grep -qE 'Read.*observer-supervise-checklist|observer-supervise-checklist.*Read|\[.*observer-supervise-checklist.*\]' '${SKILL_MD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: su-observer-supervise-channels.md から checklist への reference が追加されている
+# ===========================================================================
+
+@test "ac3: su-observer-supervise-channels.md contains reference to observer-supervise-checklist" {
+  # AC: su-observer-supervise-channels.md に observer-supervise-checklist への参照が含まれる
+  # RED: reference がまだ追加されていないため fail
+  run grep -qE 'observer-supervise-checklist' "${CHANNELS_MD}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: su-observer-supervise-channels.md checklist reference is not a comment-only line" {
+  # AC: checklist への参照がコメント行のみでなく、本文の指示・リンクとして存在する
+  # RED: reference がまだ追加されていないため fail
+  run bash -c "
+    grep -E 'observer-supervise-checklist' '${CHANNELS_MD}' | grep -qvE '^#'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: su-observer-supervise-channels.md checklist reference appears as Read directive or link" {
+  # AC: 参照が「Read」指示またはリンク形式（Markdown link or path形式）で記述されている
+  # RED: reference がまだ追加されていないため fail
+  run bash -c "
+    grep -qE 'Read.*observer-supervise-checklist|observer-supervise-checklist.*Read|\[.*observer-supervise-checklist.*\]|\`observer-supervise-checklist\`' '${CHANNELS_MD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: deps.yaml に observer-supervise-checklist エントリが登録されている（type=reference）
+# ===========================================================================
+
+@test "ac4: deps.yaml contains observer-supervise-checklist entry" {
+  # AC: deps.yaml に observer-supervise-checklist キーが存在する
+  # RED: エントリがまだ追加されていないため fail
+  run grep -qE '^  observer-supervise-checklist:' "${DEPS_YAML}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: deps.yaml observer-supervise-checklist entry has type: reference" {
+  # AC: エントリの type が reference である
+  # RED: エントリが存在しないため fail
+  run bash -c "
+    entry_line=\$(grep -n '^  observer-supervise-checklist:' '${DEPS_YAML}' | head -1 | cut -d: -f1)
+    [ -n \"\${entry_line}\" ] || exit 1
+    # エントリ直後 10 行以内に type: reference が存在する
+    awk -v s=\"\${entry_line}\" '
+      NR > s && NR < (s+10) && /^    type: reference/ {found=1; exit}
+      NR > s && /^  [a-zA-Z]/ {exit}
+      END {exit !found}
+    ' '${DEPS_YAML}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: deps.yaml observer-supervise-checklist entry has path pointing to checklist md" {
+  # AC: エントリの path が skills/su-observer/refs/observer-supervise-checklist.md を指している
+  # RED: エントリが存在しないため fail
+  run bash -c "
+    entry_line=\$(grep -n '^  observer-supervise-checklist:' '${DEPS_YAML}' | head -1 | cut -d: -f1)
+    [ -n \"\${entry_line}\" ] || exit 1
+    # エントリ直後 10 行以内に path: skills/su-observer/refs/observer-supervise-checklist.md が存在する
+    awk -v s=\"\${entry_line}\" '
+      NR > s && NR < (s+10) && /path:.*observer-supervise-checklist\.md/ {found=1; exit}
+      NR > s && /^  [a-zA-Z]/ {exit}
+      END {exit !found}
+    ' '${DEPS_YAML}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: deps.yaml observer-supervise-checklist entry has description field" {
+  # AC: エントリに description フィールドが存在する（空でない）
+  # RED: エントリが存在しないため fail
+  run bash -c "
+    entry_line=\$(grep -n '^  observer-supervise-checklist:' '${DEPS_YAML}' | head -1 | cut -d: -f1)
+    [ -n \"\${entry_line}\" ] || exit 1
+    # エントリ直後 15 行以内に description: が存在する
+    awk -v s=\"\${entry_line}\" '
+      NR > s && NR < (s+15) && /description:.*[^[:space:]]/ {found=1; exit}
+      NR > s && /^  [a-zA-Z]/ {exit}
+      END {exit !found}
+    ' '${DEPS_YAML}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: deps.yaml observer-supervise-checklist is placed in su-observer split refs section" {
+  # AC: エントリが su-observer split refs セクション（またはその近傍）に配置されている
+  # RED: エントリが存在しないため fail
+  run bash -c "
+    entry_line=\$(grep -n '^  observer-supervise-checklist:' '${DEPS_YAML}' | head -1 | cut -d: -f1)
+    [ -n \"\${entry_line}\" ] || exit 1
+    # エントリ前 30 行以内に su-observer の関連コメントまたはキーが存在する
+    awk -v s=\"\${entry_line}\" '
+      NR >= (s-30) && NR < s && /su-observer/ {found=1}
+      END {exit !found}
+    ' '${DEPS_YAML}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC5: bats テスト自身が存在し、5 件以上のテストを含む（self-referential）
+#
+# 注記: このテストは self-referential である。本ファイル自体が存在し、
+#       かつ 5 件以上の @test ブロックを含むことを検証する。
+#       このファイルが書き出された時点で GREEN になる（他の AC と異なる）。
+# ===========================================================================
+
+@test "ac5: this bats test file exists at expected path" {
+  # AC: bats ファイルが plugins/twl/tests/bats/issue-1245-observer-checklist.bats として存在する
+  # GREEN: このファイル自体が存在するため、実行時点では pass する
+  [ -f "${THIS_BATS}" ]
+}
+
+@test "ac5: this bats test file contains at least 5 test blocks" {
+  # AC: 本ファイルに 5 件以上の @test ブロックが含まれる
+  # GREEN: このファイルが書き出された時点で pass する
+  local count
+  count="$(grep -c '^@test ' "${THIS_BATS}")"
+  [ "${count}" -ge 5 ]
+}


### PR DESCRIPTION
## 概要

#1245 observer-supervise-checklist.md 新設（#1189 AC9 implementation gap）

## 変更内容

- `plugins/twl/skills/su-observer/refs/observer-supervise-checklist.md` 新規作成
  - #1189 AC9.2 の 7 項目（MUST/SHOULD/MAY レベル付き）
  - controller type 別 primary signal mapping 参照項目含む
- `plugins/twl/skills/su-observer/SKILL.md` Step 1 supervise loop に checklist Read 参照追加
- `plugins/twl/skills/su-observer/refs/su-observer-supervise-channels.md` に checklist Read 参照追加
- `plugins/twl/deps.yaml` に `observer-supervise-checklist` エントリ登録（type=reference）

## テスト

`plugins/twl/tests/bats/issue-1245-observer-checklist.bats` 17/17 PASS

Closes #1245