### PR TITLE
feat(orchestrator): #1246 STATE-aware auto-inject（reviewing/fixing）

### DIFF
--- a/plugins/twl/architecture/domain/contexts/autopilot.md
+++ b/plugins/twl/architecture/domain/contexts/autopilot.md
@@ -481,9 +481,19 @@ tmux send-keys -t "<WORKER_WINDOW>" "/twl:workflow-test-ready" Enter
 | #722 | #733 | inject が input-waiting を見逃す問題修正（`USE_SESSION_STATE=true` ブランチの backoff 改善） |
 | #752 | #760 | SESSION_STATE_CMD デフォルトパス (`$HOME/ubuntu-note-system/...`) が fresh clone 環境で不在 → 全 3 スクリプトで `USE_SESSION_STATE=false` に silent fallback。wrapper 参照に変更して解決 |
 | #1087 | TBD | co-issue v2 orchestrator の `DEBOUNCE_TRANSIENT_SEC` 30s → 120s 延長 + thinking indicator 検出によるリセット（Sonnet 4.6 max effort thinking time 対応） |
+| #1246 | #1255 | STATE-aware next-step auto-inject（reviewing → issue-review-aggregate / fixing → resume-from-fixing）を unclassified debounce 確認後に追加 |
 
 **再発防止**: `autopilot-session-state-cmd.bats` の AC-6 tests が `ubuntu-note-system` ハードコードの
 再導入を CI で検知する。
+
+### STATE-aware auto-inject（#1246）
+
+`issue-lifecycle-orchestrator.sh` の wait loop で unclassified debounce が確認された後、Worker の STATE を確認して次ステップへの自動 inject を行う（INFO レベル）。
+
+- **AC4 配置順序**: `AskUserQuestion` パターン検出 → `Waiting for user input` Pattern 4 → unclassified debounce 確認（`DEBOUNCE_UNCLASSIFIED_CONFIRM_SEC` 経過後）→ STATE チェック
+- **STATE=reviewing + findings.yaml 存在**: `/twl:issue-review-aggregate <findings_path>` を inject
+- **STATE=fixing**: `/twl:workflow-issue-lifecycle <subdir> --resume-from-fixing` を inject
+- **inject_count 5 回到達 + reviewing/fixing**: `inject_exhausted_state_aware` reason で `_generate_fallback_report` に移行（既存 `inject_exhausted_*` 系列と整合）
 
 ## Dependencies
 

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -675,15 +675,52 @@ wait_for_batch() {
                   all_done=false
                 else
                   rm -f "$_unclassified_debounce_ts_file"
-                  echo "[issue-lifecycle-orchestrator] ${subdir##*/}: unclassified input-waiting confirmed ($((current_ts - _unclassified_prev_ts))s elapsed) — failed" >&2
-                  mkdir -p "${subdir}/OUT"
-                  _generate_fallback_report "$subdir" "unclassified_input_waiting_confirmed"
-                  tmux kill-window -t "$window_name" 2>/dev/null || true
+                  echo "[issue-lifecycle-orchestrator] ${subdir##*/}: unclassified input-waiting confirmed ($((current_ts - _unclassified_prev_ts))s elapsed) — STATE チェック" >&2
+                  # #1246 STATE-aware inject: debounce 確認後に STATE チェック（AC1/AC2/AC4）
+                  # AC4: unclassified debounce 確認後に STATE チェックを実行（Pattern 4 より後）
+                  local _round_num=""
+                  _round_num=$(ls -d "${subdir}/rounds"/[0-9]* 2>/dev/null \
+                    | sort -n -t'/' -k7 2>/dev/null | tail -1 | xargs -I{} basename {} 2>/dev/null || echo "")
+                  local _findings_path="${subdir}/rounds/${_round_num:-0}/findings.yaml"
+                  if [[ "$current_state" == "reviewing" && -n "$_round_num" && -f "$_findings_path" ]]; then
+                    # AC1: STATE=reviewing + findings.yaml 存在 → issue-review-aggregate inject
+                    inject_count=$((inject_count + 1))
+                    echo "$inject_count" > "$inject_count_file"
+                    echo "$current_ts" > "$last_inject_ts_file"
+                    rm -f "$debounce_ts_file"
+                    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=reviewing → issue-review-aggregate inject ($inject_count/5)" >&2
+                    "${SCRIPTS_ROOT}/../../session/scripts/session-comm.sh" inject "$window_name" \
+                      "/twl:issue-review-aggregate ${_findings_path}" \
+                      2>/dev/null || true
+                    all_done=false
+                  elif [[ "$current_state" == "fixing" ]]; then
+                    # AC2: STATE=fixing → 次 round 開始 prompt inject
+                    inject_count=$((inject_count + 1))
+                    echo "$inject_count" > "$inject_count_file"
+                    echo "$current_ts" > "$last_inject_ts_file"
+                    rm -f "$debounce_ts_file"
+                    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: STATE=fixing → resume-from-fixing inject ($inject_count/5)" >&2
+                    "${SCRIPTS_ROOT}/../../session/scripts/session-comm.sh" inject "$window_name" \
+                      "/twl:workflow-issue-lifecycle ${subdir} --resume-from-fixing" \
+                      2>/dev/null || true
+                    all_done=false
+                  else
+                    echo "[issue-lifecycle-orchestrator] ${subdir##*/}: unclassified input-waiting confirmed — failed" >&2
+                    mkdir -p "${subdir}/OUT"
+                    _generate_fallback_report "$subdir" "unclassified_input_waiting_confirmed"
+                    tmux kill-window -t "$window_name" 2>/dev/null || true
+                  fi
                 fi
               fi
             else
               # inject 5 回失敗 → fallback (#647, #709)
-              local reason="inject_exhausted_${inject_count}"
+              # AC3: STATE-aware path の場合は inject_exhausted_state_aware reason を使用
+              local reason
+              if [[ "$current_state" == "reviewing" || "$current_state" == "fixing" ]]; then
+                reason="inject_exhausted_state_aware"
+              else
+                reason="inject_exhausted_${inject_count}"
+              fi
               echo "[issue-lifecycle-orchestrator] ${subdir##*/}: inject exhausted (STATE=$current_state, inject=$inject_count) — フォールバック生成" >&2
               mkdir -p "${subdir}/OUT"
               _generate_fallback_report "$subdir" "$reason"

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -680,7 +680,8 @@ wait_for_batch() {
                   # AC4: unclassified debounce 確認後に STATE チェックを実行（Pattern 4 より後）
                   local _round_num=""
                   _round_num=$(ls -d "${subdir}/rounds"/[0-9]* 2>/dev/null \
-                    | sort -n -t'/' -k7 2>/dev/null | tail -1 | xargs -I{} basename {} 2>/dev/null || echo "")
+                    | xargs -I{} basename {} 2>/dev/null \
+                    | sort -n | tail -1 || echo "")
                   local _findings_path="${subdir}/rounds/${_round_num:-0}/findings.yaml"
                   if [[ "$current_state" == "reviewing" && -n "$_round_num" && -f "$_findings_path" ]]; then
                     # AC1: STATE=reviewing + findings.yaml 存在 → issue-review-aggregate inject

--- a/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
+++ b/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
@@ -50,7 +50,7 @@ teardown() {
   # AC1: findings.yaml 存在チェックと reviewing inject が同一ブロックに存在する
   # RED: 実装前はパターンが存在しないため fail する
   local reviewing_line findings_line
-  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^[0-9]*:#" | head -1 | cut -d: -f1)
   findings_line=$(grep -n 'findings\.yaml.*reviewing\|reviewing.*findings\.yaml\|_findings_path.*findings\.yaml' "$SCRIPT_SRC" | head -1 | cut -d: -f1)
 
   [[ -n "$reviewing_line" ]] \

--- a/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
+++ b/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+# issue-lifecycle-orchestrator-state-aware-inject.bats
+# Issue #1246: feat(orchestrator): co-issue Worker の stop 検知と STATE-aware auto-inject
+#
+# TDD RED フェーズ — 全テストは実装前に fail し、実装後に PASS する。
+#
+# AC coverage:
+#   AC1 - STATE=reviewing + findings.yaml 存在 → session-comm.sh inject /twl:issue-review-aggregate
+#   AC2 - STATE=fixing → session-comm.sh inject 次 round prompt (resume-from-fixing 相当)
+#   AC3 - inject_count==5 → inject_exhausted_state_aware（または同等 reason）fallback
+#   AC4 - STATE-aware inject elif は AskUserQuestion パターン後 + unclassified debounce 確認後に配置
+#
+# 実装ファイル: plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+# （wait_for_batch 内 if/elif チェーンに新 elif を追加）
+
+load '../helpers/common'
+
+SCRIPT_SRC=""
+
+setup() {
+  common_setup
+  SCRIPT_SRC="$REPO_ROOT/scripts/issue-lifecycle-orchestrator.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: STATE=reviewing → issue-review-aggregate inject ロジック
+# ===========================================================================
+
+@test "ac1: script contains STATE=reviewing check in wait loop" {
+  # AC1: wait loop 内に STATE=reviewing の条件分岐が存在する
+  # RED: 実装前はパターンが存在しないため fail する
+  run grep -nE '"reviewing"|\breviewing\b' "$SCRIPT_SRC"
+  [ "$status" -eq 0 ] \
+    || fail "AC1: STATE=reviewing チェックがスクリプトに存在しない"
+}
+
+@test "ac1: reviewing inject includes issue-review-aggregate command" {
+  # AC1: reviewing 時の inject テキストに issue-review-aggregate が含まれる
+  # RED: 実装前は存在しないため fail する
+  run grep -qE 'issue-review-aggregate' "$SCRIPT_SRC"
+  [ "$status" -eq 0 ] \
+    || fail "AC1: inject テキストに issue-review-aggregate が含まれていない"
+}
+
+@test "ac1: reviewing inject is conditioned on findings.yaml existence" {
+  # AC1: findings.yaml 存在チェックと reviewing inject が同一ブロックに存在する
+  # RED: 実装前はパターンが存在しないため fail する
+  local reviewing_line findings_line
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  findings_line=$(grep -n 'findings\.yaml.*reviewing\|reviewing.*findings\.yaml\|_findings_path.*findings\.yaml' "$SCRIPT_SRC" | head -1 | cut -d: -f1)
+
+  [[ -n "$reviewing_line" ]] \
+    || fail "AC1: reviewing 条件チェックがスクリプトに存在しない"
+  [[ -n "$findings_line" ]] \
+    || fail "AC1: findings.yaml 存在チェック (_findings_path) がスクリプトに存在しない"
+}
+
+@test "ac1: session-comm.sh inject is called in reviewing state path" {
+  # AC1: reviewing パスで session-comm.sh inject が呼ばれる
+  # RED: 実装前は存在しないため fail する
+  local reviewing_line comm_after_reviewing
+
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  [[ -n "$reviewing_line" ]] \
+    || fail "AC1: reviewing 条件がスクリプトに存在しない"
+
+  # reviewing ブロック直後（50行以内）に session-comm.sh inject があること
+  comm_after_reviewing=$(awk "NR>=$reviewing_line && NR<=$((reviewing_line + 50)) && /session-comm\.sh.*inject/" "$SCRIPT_SRC" | head -1)
+  [[ -n "$comm_after_reviewing" ]] \
+    || fail "AC1: reviewing ブロック内に session-comm.sh inject 呼び出しが存在しない"
+}
+
+# ===========================================================================
+# AC2: STATE=fixing → 次 round prompt inject ロジック
+# ===========================================================================
+
+@test "ac2: script contains STATE=fixing check in wait loop" {
+  # AC2: wait loop 内に STATE=fixing の条件分岐が存在する
+  # RED: 実装前はパターンが存在しないため fail する
+  run grep -nE '"fixing"|\bfixing\b' "$SCRIPT_SRC"
+  [ "$status" -eq 0 ] \
+    || fail "AC2: STATE=fixing チェックがスクリプトに存在しない"
+}
+
+@test "ac2: fixing inject includes resume-from-fixing in inject command string" {
+  # AC2: fixing inject の session-comm.sh inject 呼び出しに resume-from-fixing が含まれる
+  # RED: 実装前は session-comm.sh inject と resume-from-fixing が同行/隣接して存在しないため fail する
+  run grep -qE 'resume-from-fixing' "$SCRIPT_SRC"
+  [ "$status" -eq 0 ] \
+    || fail "AC2: inject コマンド文字列に resume-from-fixing が含まれていない"
+}
+
+@test "ac2: session-comm.sh inject is called in fixing state path" {
+  # AC2: fixing パスで session-comm.sh inject が呼ばれる
+  # RED: 実装前は存在しないため fail する
+  local fixing_line comm_after_fixing
+
+  fixing_line=$(grep -n '"fixing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  [[ -n "$fixing_line" ]] \
+    || fail "AC2: fixing 条件がスクリプトに存在しない"
+
+  comm_after_fixing=$(awk "NR>=$fixing_line && NR<=$((fixing_line + 30)) && /session-comm\.sh.*inject/" "$SCRIPT_SRC" | head -1)
+  [[ -n "$comm_after_fixing" ]] \
+    || fail "AC2: fixing ブロック内に session-comm.sh inject 呼び出しが存在しない"
+}
+
+# ===========================================================================
+# AC3: inject_count=5 → inject_exhausted_state_aware fallback
+# ===========================================================================
+
+@test "ac3: script contains inject_exhausted_state_aware or state-aware exhausted pattern" {
+  # AC3: inject 5 回上限到達時に inject_exhausted_state_aware（または同等 reason）で fallback する
+  # RED: 実装前はパターンが存在しないため fail する
+  run grep -qE 'inject_exhausted_state_aware|state_aware.*exhausted|exhausted.*state_aware' "$SCRIPT_SRC"
+  [ "$status" -eq 0 ] \
+    || fail "AC3: inject_exhausted_state_aware / 同等パターンがスクリプトに存在しない"
+}
+
+# ===========================================================================
+# AC4: 配置順序 — AskUserQuestion → unclassified debounce → STATE-aware inject
+# ===========================================================================
+
+@test "ac4: STATE=reviewing elif appears AFTER unclassified debounce confirmation" {
+  # AC4: STATE=reviewing の elif は unclassified debounce 確認 (DEBOUNCE_UNCLASSIFIED_CONFIRM_SEC) より後の行に配置
+  # RED: reviewing パターンが存在しない or 順序が逆の場合 fail する
+  local debounce_line reviewing_line
+
+  debounce_line=$(grep -n 'DEBOUNCE_UNCLASSIFIED_CONFIRM_SEC\|unclassified_debounce_ts_file' "$SCRIPT_SRC" \
+    | grep -v '^[0-9]*:[[:space:]]*#' | head -1 | cut -d: -f1)
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+
+  [[ -n "$debounce_line" ]] \
+    || fail "AC4: unclassified debounce ロジックがスクリプトに存在しない (DEBOUNCE_UNCLASSIFIED_CONFIRM_SEC)"
+  [[ -n "$reviewing_line" ]] \
+    || fail "AC4: reviewing 条件がスクリプトに存在しない"
+  [[ "$reviewing_line" -gt "$debounce_line" ]] \
+    || fail "AC4: reviewing inject (L$reviewing_line) が unclassified debounce (L$debounce_line) より前に配置されている — 配置順序違反"
+}
+
+@test "ac4: AskUserQuestion check appears BEFORE STATE=reviewing check (priority)" {
+  # AC4: AskUserQuestion パターン検出は STATE=reviewing より手前に配置（AskUserQuestion が優先）
+  # RED: reviewing パターンが存在しない場合 fail する
+  local askuserquestion_line reviewing_line
+
+  askuserquestion_line=$(grep -n 'AskUserQuestion' "$SCRIPT_SRC" | grep -v "^#" | head -1 | cut -d: -f1)
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+
+  [[ -n "$askuserquestion_line" ]] \
+    || fail "AC4: AskUserQuestion パターンチェックがスクリプトに存在しない"
+  [[ -n "$reviewing_line" ]] \
+    || fail "AC4: reviewing 条件がスクリプトに存在しない"
+  [[ "$askuserquestion_line" -lt "$reviewing_line" ]] \
+    || fail "AC4: AskUserQuestion check (L$askuserquestion_line) が reviewing check (L$reviewing_line) より後に配置されている — AskUserQuestion 優先順序違反"
+}

--- a/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
+++ b/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
@@ -64,7 +64,9 @@ teardown() {
   # RED: 実装前は存在しないため fail する
   local reviewing_line comm_after_reviewing
 
-  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  # "reviewing" と "session-comm.sh" + "issue-review-aggregate" が同一ブロック内に存在する
+  # reviewing inject ブロックの先頭行（inject_exhausted ブロック手前 = 最初の reviewing）
+  reviewing_line=$(grep -n '"reviewing"' "$SCRIPT_SRC" | grep -v "^[0-9]*:#" | head -1 | cut -d: -f1)
   [[ -n "$reviewing_line" ]] \
     || fail "AC1: reviewing 条件がスクリプトに存在しない"
 
@@ -99,7 +101,8 @@ teardown() {
   # RED: 実装前は存在しないため fail する
   local fixing_line comm_after_fixing
 
-  fixing_line=$(grep -n '"fixing"' "$SCRIPT_SRC" | grep -v "^#" | tail -1 | cut -d: -f1)
+  # fixing inject ブロックの先頭行（inject_exhausted ブロック手前 = 最初の fixing）
+  fixing_line=$(grep -n '"fixing"' "$SCRIPT_SRC" | grep -v "^[0-9]*:#" | head -1 | cut -d: -f1)
   [[ -n "$fixing_line" ]] \
     || fail "AC2: fixing 条件がスクリプトに存在しない"
 


### PR DESCRIPTION
## 概要

Issue #1246: `issue-lifecycle-orchestrator.sh` の wait loop で Worker が stop した際の STATE-aware auto-inject を実装。

## 変更内容

### `plugins/twl/scripts/issue-lifecycle-orchestrator.sh`
- unclassified debounce 確認後に STATE チェックを追加（AC4 配置順序維持）
- AC1: STATE=reviewing + findings.yaml 存在 → `/twl:issue-review-aggregate <path>` inject
- AC2: STATE=fixing → `/twl:workflow-issue-lifecycle <subdir> --resume-from-fixing` inject  
- AC3: inject 5 回到達 + STATE=reviewing/fixing → `inject_exhausted_state_aware` fallback

### `plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats`
- AC1-AC4 を構造チェック（grep）で検証する 10 ケースを追加（全 PASS）

## テスト

```
bats plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-state-aware-inject.bats
→ 10/10 PASS
```

Closes #1246