### PR TITLE
feat(provenance): origin:* label 体系定義 + 既存 Issue 遡及付与 (cross-origin Phase A) (#1273)

### DIFF
--- a/plugins/twl/scripts/onboarding/setup-origin-labels.sh
+++ b/plugins/twl/scripts/onboarding/setup-origin-labels.sh
@@ -1,0 +1,269 @@
+#!/usr/bin/env bash
+# setup-origin-labels.sh - cross-origin Phase A: origin:* label 体系定義 + 既存 Issue 遡及付与
+#
+# 使用方法:
+#   bash plugins/twl/scripts/onboarding/setup-origin-labels.sh [--dry-run]
+#
+# 機能:
+#   1. origin:host:* / origin:repo:* ラベルを GitHub に作成（冪等）
+#   2. 既存 OPEN/CLOSED Issue を多段階検索で分類し cross-repo 起源を確定
+#   3. 確定 Issue に --add-label で一括付与（既付与は skip）
+#   4. AC2 確定件数をユーザーに報告（3 件超の場合は差分を明示）
+#
+# doobidoo memory: 3c47c84a (soap-copilot-mock observer-lesson, cross-reference 情報)
+# 参考: .explore/wave19-cross-origin-tracking/summary.md §7 Phase A
+
+set -euo pipefail
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] || return 0
+
+REPO="shuu5/twill"
+DRY_RUN=false
+VERBOSE=false
+HOST_ALIASES_FILE="${HOME}/.config/twl/host-aliases.json"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --verbose) VERBOSE=true ;;
+  esac
+done
+
+log() { echo "[setup-origin-labels] $*"; }
+log_dry() { echo "[DRY-RUN] $*"; }
+
+# ---------------------------------------------------------------------------
+# Phase 1: ラベル作成
+# ---------------------------------------------------------------------------
+
+create_labels() {
+  log "Phase 1: origin:* ラベル作成"
+
+  local host_color="fef2c0"
+  local repo_color="bfd4f2"
+
+  local host_labels=(
+    "origin:host:ipatho-1"
+    "origin:host:ipatho2"
+    "origin:host:thinkpad"
+  )
+  local repo_labels=(
+    "origin:repo:soap-copilot-mock"
+    "origin:repo:twill"
+  )
+
+  for label in "${host_labels[@]}"; do
+    if gh label list --repo "$REPO" | grep -qF "$label"; then
+      log "  skip (already exists): $label"
+    else
+      if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "gh label create \"$label\" --repo $REPO --color $host_color"
+      else
+        gh label create "$label" --repo "$REPO" --color "$host_color" --description "起票元 host: ${label#origin:host:}"
+        log "  created: $label"
+      fi
+    fi
+  done
+
+  for label in "${repo_labels[@]}"; do
+    if gh label list --repo "$REPO" | grep -qF "$label"; then
+      log "  skip (already exists): $label"
+    else
+      if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "gh label create \"$label\" --repo $REPO --color $repo_color"
+      else
+        gh label create "$label" --repo "$REPO" --color "$repo_color" --description "起源 repo: ${label#origin:repo:}"
+        log "  created: $label"
+      fi
+    fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Phase 2: 既存 Issue の多段階分類
+# ---------------------------------------------------------------------------
+
+# doobidoo memory hash 3c47c84a の cross-reference 情報から確認済み Issue
+KNOWN_CROSS_ORIGIN=(1242 1244 1231)
+
+classify_issues() {
+  log "Phase 2: 既存 Issue の多段階分類 (--state all --limit 500)"
+
+  # host-aliases.json から hostname → alias の対応を取得
+  local current_host
+  current_host="$(hostname)"
+  local current_alias="unknown"
+  if [[ -f "$HOST_ALIASES_FILE" ]]; then
+    current_alias=$(python3 -c "
+import json, sys
+with open('${HOST_ALIASES_FILE}') as f:
+    d = json.load(f)
+alias = d.get('${current_host}', 'unknown')
+print(alias)
+" 2>/dev/null || echo "unknown")
+  fi
+  log "  current host: $current_host → alias: $current_alias"
+
+  # Step 1: キーワード grep で候補 Issue を列挙
+  local search_query="検出元 OR soap-copilot OR ipatho OR thinkpad OR 起源 OR observer"
+  local candidates
+  candidates=$(gh issue list --repo "$REPO" --state all --limit 500 \
+    --search "$search_query" \
+    --json number,title,labels 2>/dev/null || echo "[]")
+
+  local candidate_numbers
+  candidate_numbers=$(echo "$candidates" | python3 -c "
+import json, sys
+items = json.load(sys.stdin)
+nums = [str(i['number']) for i in items]
+print(' '.join(nums))
+" 2>/dev/null || echo "")
+
+  # Step 2 (本文確認): 候補 Issue の body を gh issue view --json body で取得し cross-repo 起源を確認
+  local verified_numbers=()
+  for n in $candidate_numbers; do
+    local body
+    body=$(gh issue view "$n" --repo "$REPO" --json body -q '.body' 2>/dev/null || echo "")
+    if echo "$body" | grep -qiE "検出元|soap-copilot|cross-repo|起票.*cross|observer.*wave|ipatho"; then
+      verified_numbers+=("$n")
+    fi
+  done
+  candidate_numbers="${verified_numbers[*]:-}"
+
+  # Step 3: doobidoo memory hash 3c47c84a の cross-reference で既知 Issue を補完
+  local all_targets=()
+  for n in "${KNOWN_CROSS_ORIGIN[@]}"; do
+    all_targets+=("$n")
+  done
+  for n in $candidate_numbers; do
+    # 重複排除
+    local found=false
+    for existing in "${all_targets[@]:-}"; do
+      [[ "$existing" == "$n" ]] && found=true && break
+    done
+    [[ "$found" == "false" ]] && all_targets+=("$n")
+  done
+
+  log "  候補 Issue 総数: ${#all_targets[@]} 件"
+  echo "${all_targets[*]:-}"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 3: ラベル付与（べき等）
+# ---------------------------------------------------------------------------
+
+assign_labels() {
+  local issue_numbers=("$@")
+  local assigned=0
+  local skipped=0
+
+  log "Phase 3: ラベル付与（べき等、${#issue_numbers[@]} 件対象）"
+
+  # host-aliases.json から current host の alias を取得
+  local current_host
+  current_host="$(hostname)"
+  local host_alias="unknown"
+  if [[ -f "$HOST_ALIASES_FILE" ]]; then
+    host_alias=$(python3 -c "
+import json
+with open('${HOST_ALIASES_FILE}') as f:
+    d = json.load(f)
+print(d.get('${current_host}', 'unknown'))
+" 2>/dev/null || echo "unknown")
+  fi
+
+  for num in "${issue_numbers[@]}"; do
+    # 既存ラベルを確認（べき等チェック）
+    local existing_labels
+    existing_labels=$(gh issue view "$num" --repo "$REPO" --json labels -q '.labels[].name' 2>/dev/null || echo "")
+
+    local host_label="origin:host:${host_alias}"
+    local repo_label="origin:repo:soap-copilot-mock"
+
+    # origin:host:* が既に付与済みかチェック
+    local has_host_label=false
+    if echo "$existing_labels" | grep -qF "origin:host:"; then
+      has_host_label=true
+    fi
+
+    if [[ "$has_host_label" == "true" ]]; then
+      [[ "$VERBOSE" == "true" ]] && log "  skip (already labeled): #$num"
+      ((skipped++)) || true
+    else
+      if [[ "$DRY_RUN" == "true" ]]; then
+        log_dry "gh issue edit $num --repo $REPO --add-label \"$host_label\" --add-label \"$repo_label\""
+      else
+        gh issue edit "$num" --repo "$REPO" \
+          --add-label "$host_label" \
+          --add-label "$repo_label"
+        log "  labeled: #$num (+$host_label, +$repo_label)"
+      fi
+      ((assigned++)) || true
+    fi
+  done
+
+  log "  付与: $assigned 件 / skip: $skipped 件"
+  echo "$assigned"
+}
+
+# ---------------------------------------------------------------------------
+# Phase 4: 件数報告（AC7）
+# ---------------------------------------------------------------------------
+
+report_results() {
+  local total="$1"
+  local confirmed_nums=("${@:2}")
+
+  log "Phase 4: 結果報告"
+  echo ""
+  echo "=== origin:* ラベル付与 完了 ==="
+  echo "確定件数: $total 件"
+
+  if [[ "$total" -gt 3 ]]; then
+    echo "（3 件超のため差分を明示）"
+    echo "確定 Issue 一覧:"
+    for n in "${confirmed_nums[@]}"; do
+      echo "  #$n"
+    done
+  else
+    echo "確定 Issue: ${confirmed_nums[*]:-（なし）}"
+  fi
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    echo ""
+    echo "注: --dry-run モードで実行されました。実際の変更は行われていません。"
+  fi
+
+  # Project Board #6 (shuu5/twill-ecosystem) view filter 追加について:
+  # 以下のフィルターを手動で追加してください（GitHub Project Board は API 経由の追加が制限されています）:
+  #   - Cross-repo:          label:origin:repo:soap-copilot-mock
+  #   - ipatho2 host 起票:   label:origin:host:ipatho2
+  #   - ipatho-1 host 起票:  label:origin:host:ipatho-1
+  #   - thinkpad host 起票:  label:origin:host:thinkpad
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+main() {
+  log "=== setup-origin-labels.sh 開始 ==="
+  [[ "$DRY_RUN" == "true" ]] && log "DRY-RUN モード有効"
+
+  create_labels
+
+  local issue_numbers_str
+  issue_numbers_str=$(classify_issues)
+  IFS=' ' read -r -a issue_numbers <<< "$issue_numbers_str"
+
+  local assigned_count=0
+  if [[ "${#issue_numbers[@]}" -gt 0 && -n "${issue_numbers[0]:-}" ]]; then
+    assigned_count=$(assign_labels "${issue_numbers[@]}")
+  else
+    log "対象 Issue なし"
+  fi
+
+  report_results "${#issue_numbers[@]}" "${issue_numbers[@]:-}"
+}
+
+main "$@"

--- a/plugins/twl/scripts/onboarding/setup-origin-labels.sh
+++ b/plugins/twl/scripts/onboarding/setup-origin-labels.sh
@@ -184,9 +184,6 @@ assign_labels() {
     echo "$existing_labels" | grep -qF "origin:host:" && has_host_label=true
     echo "$existing_labels" | grep -qF "origin:repo:" && has_repo_label=true
 
-    local need_host=[[ "$has_host_label" == "false" ]] && echo true || echo false
-    local need_repo=[[ "$has_repo_label" == "false" ]] && echo true || echo false
-
     if [[ "$has_host_label" == "true" && "$has_repo_label" == "true" ]]; then
       [[ "$VERBOSE" == "true" ]] && log "  skip (already labeled): #$num"
       ((skipped++)) || true

--- a/plugins/twl/scripts/onboarding/setup-origin-labels.sh
+++ b/plugins/twl/scripts/onboarding/setup-origin-labels.sh
@@ -29,8 +29,8 @@ for arg in "$@"; do
   esac
 done
 
-log() { echo "[setup-origin-labels] $*"; }
-log_dry() { echo "[DRY-RUN] $*"; }
+log() { echo "[setup-origin-labels] $*" >&2; }
+log_dry() { echo "[DRY-RUN] $*" >&2; }
 
 # ---------------------------------------------------------------------------
 # Phase 1: ラベル作成
@@ -86,22 +86,28 @@ create_labels() {
 # doobidoo memory hash 3c47c84a の cross-reference 情報から確認済み Issue
 KNOWN_CROSS_ORIGIN=(1242 1244 1231)
 
+_resolve_host_alias() {
+  local host="$1"
+  if [[ ! -f "$HOST_ALIASES_FILE" ]]; then
+    echo "unknown"
+    return
+  fi
+  # 環境変数経由で渡しインジェクションを防ぐ
+  TWL_HOST="$host" TWL_ALIASES_FILE="$HOST_ALIASES_FILE" python3 -c '
+import json, os
+with open(os.environ["TWL_ALIASES_FILE"]) as f:
+    d = json.load(f)
+print(d.get(os.environ["TWL_HOST"], "unknown"))
+' 2>/dev/null || echo "unknown"
+}
+
 classify_issues() {
   log "Phase 2: 既存 Issue の多段階分類 (--state all --limit 500)"
 
-  # host-aliases.json から hostname → alias の対応を取得
   local current_host
   current_host="$(hostname)"
-  local current_alias="unknown"
-  if [[ -f "$HOST_ALIASES_FILE" ]]; then
-    current_alias=$(python3 -c "
-import json, sys
-with open('${HOST_ALIASES_FILE}') as f:
-    d = json.load(f)
-alias = d.get('${current_host}', 'unknown')
-print(alias)
-" 2>/dev/null || echo "unknown")
-  fi
+  local current_alias
+  current_alias="$(_resolve_host_alias "$current_host")"
   log "  current host: $current_host → alias: $current_alias"
 
   # Step 1: キーワード grep で候補 Issue を列挙
@@ -111,41 +117,42 @@ print(alias)
     --search "$search_query" \
     --json number,title,labels 2>/dev/null || echo "[]")
 
-  local candidate_numbers
-  candidate_numbers=$(echo "$candidates" | python3 -c "
+  local candidate_numbers=()
+  while IFS= read -r n; do
+    [[ -n "$n" ]] && candidate_numbers+=("$n")
+  done < <(echo "$candidates" | python3 -c '
 import json, sys
 items = json.load(sys.stdin)
-nums = [str(i['number']) for i in items]
-print(' '.join(nums))
-" 2>/dev/null || echo "")
+for i in items:
+    print(i["number"])
+' 2>/dev/null || true)
 
   # Step 2 (本文確認): 候補 Issue の body を gh issue view --json body で取得し cross-repo 起源を確認
   local verified_numbers=()
-  for n in $candidate_numbers; do
+  for n in "${candidate_numbers[@]+"${candidate_numbers[@]}"}"; do
     local body
     body=$(gh issue view "$n" --repo "$REPO" --json body -q '.body' 2>/dev/null || echo "")
     if echo "$body" | grep -qiE "検出元|soap-copilot|cross-repo|起票.*cross|observer.*wave|ipatho"; then
       verified_numbers+=("$n")
     fi
   done
-  candidate_numbers="${verified_numbers[*]:-}"
 
-  # Step 3: doobidoo memory hash 3c47c84a の cross-reference で既知 Issue を補完
+  # Step 3: doobidoo memory hash 3c47c84a の cross-reference で既知 Issue を補完（重複排除）
   local all_targets=()
   for n in "${KNOWN_CROSS_ORIGIN[@]}"; do
     all_targets+=("$n")
   done
-  for n in $candidate_numbers; do
-    # 重複排除
+  for n in "${verified_numbers[@]+"${verified_numbers[@]}"}"; do
     local found=false
-    for existing in "${all_targets[@]:-}"; do
+    for existing in "${all_targets[@]}"; do
       [[ "$existing" == "$n" ]] && found=true && break
     done
     [[ "$found" == "false" ]] && all_targets+=("$n")
   done
 
   log "  候補 Issue 総数: ${#all_targets[@]} 件"
-  echo "${all_targets[*]:-}"
+  # stdout に Issue 番号のみを出力（log は stderr 済み）
+  printf '%s\n' "${all_targets[@]+"${all_targets[@]}"}"
 }
 
 # ---------------------------------------------------------------------------
@@ -159,44 +166,45 @@ assign_labels() {
 
   log "Phase 3: ラベル付与（べき等、${#issue_numbers[@]} 件対象）"
 
-  # host-aliases.json から current host の alias を取得
   local current_host
   current_host="$(hostname)"
-  local host_alias="unknown"
-  if [[ -f "$HOST_ALIASES_FILE" ]]; then
-    host_alias=$(python3 -c "
-import json
-with open('${HOST_ALIASES_FILE}') as f:
-    d = json.load(f)
-print(d.get('${current_host}', 'unknown'))
-" 2>/dev/null || echo "unknown")
-  fi
+  local host_alias
+  host_alias="$(_resolve_host_alias "$current_host")"
 
   for num in "${issue_numbers[@]}"; do
-    # 既存ラベルを確認（べき等チェック）
     local existing_labels
     existing_labels=$(gh issue view "$num" --repo "$REPO" --json labels -q '.labels[].name' 2>/dev/null || echo "")
 
     local host_label="origin:host:${host_alias}"
     local repo_label="origin:repo:soap-copilot-mock"
 
-    # origin:host:* が既に付与済みかチェック
+    # host / repo それぞれ独立にべき等チェック
     local has_host_label=false
-    if echo "$existing_labels" | grep -qF "origin:host:"; then
-      has_host_label=true
-    fi
+    local has_repo_label=false
+    echo "$existing_labels" | grep -qF "origin:host:" && has_host_label=true
+    echo "$existing_labels" | grep -qF "origin:repo:" && has_repo_label=true
 
-    if [[ "$has_host_label" == "true" ]]; then
+    local need_host=[[ "$has_host_label" == "false" ]] && echo true || echo false
+    local need_repo=[[ "$has_repo_label" == "false" ]] && echo true || echo false
+
+    if [[ "$has_host_label" == "true" && "$has_repo_label" == "true" ]]; then
       [[ "$VERBOSE" == "true" ]] && log "  skip (already labeled): #$num"
       ((skipped++)) || true
     else
       if [[ "$DRY_RUN" == "true" ]]; then
-        log_dry "gh issue edit $num --repo $REPO --add-label \"$host_label\" --add-label \"$repo_label\""
+        log_dry "gh issue edit $num --repo $REPO --add-label <labels>"
       else
-        gh issue edit "$num" --repo "$REPO" \
-          --add-label "$host_label" \
-          --add-label "$repo_label"
-        log "  labeled: #$num (+$host_label, +$repo_label)"
+        # 未付与ラベルのみ --add-label で付与（べき等）
+        if [[ "$has_host_label" == "false" && "$has_repo_label" == "false" ]]; then
+          gh issue edit "$num" --repo "$REPO" --add-label "$host_label" --add-label "$repo_label"
+          log "  labeled: #$num (+$host_label +$repo_label)"
+        elif [[ "$has_host_label" == "false" ]]; then
+          gh issue edit "$num" --repo "$REPO" --add-label "$host_label"
+          log "  labeled: #$num (+$host_label)"
+        else
+          gh issue edit "$num" --repo "$REPO" --add-label "$repo_label"
+          log "  labeled: #$num (+$repo_label)"
+        fi
       fi
       ((assigned++)) || true
     fi
@@ -211,22 +219,22 @@ print(d.get('${current_host}', 'unknown'))
 # ---------------------------------------------------------------------------
 
 report_results() {
-  local total="$1"
-  local confirmed_nums=("${@:2}")
+  local assigned_count="$1"
+  local total="$2"
+  local confirmed_nums=("${@:3}")
 
-  log "Phase 4: 結果報告"
   echo ""
   echo "=== origin:* ラベル付与 完了 ==="
-  echo "確定件数: $total 件"
+  echo "分類件数: $total 件 / 付与件数: $assigned_count 件"
 
   if [[ "$total" -gt 3 ]]; then
     echo "（3 件超のため差分を明示）"
-    echo "確定 Issue 一覧:"
-    for n in "${confirmed_nums[@]}"; do
+    echo "対象 Issue 一覧:"
+    for n in "${confirmed_nums[@]+"${confirmed_nums[@]}"}"; do
       echo "  #$n"
     done
   else
-    echo "確定 Issue: ${confirmed_nums[*]:-（なし）}"
+    echo "対象 Issue: ${confirmed_nums[*]+"${confirmed_nums[*]}"}"
   fi
 
   if [[ "$DRY_RUN" == "true" ]]; then
@@ -252,18 +260,19 @@ main() {
 
   create_labels
 
-  local issue_numbers_str
-  issue_numbers_str=$(classify_issues)
-  IFS=' ' read -r -a issue_numbers <<< "$issue_numbers_str"
+  local issue_numbers=()
+  while IFS= read -r n; do
+    [[ -n "$n" ]] && issue_numbers+=("$n")
+  done < <(classify_issues)
 
   local assigned_count=0
-  if [[ "${#issue_numbers[@]}" -gt 0 && -n "${issue_numbers[0]:-}" ]]; then
+  if [[ "${#issue_numbers[@]}" -gt 0 ]]; then
     assigned_count=$(assign_labels "${issue_numbers[@]}")
   else
     log "対象 Issue なし"
   fi
 
-  report_results "${#issue_numbers[@]}" "${issue_numbers[@]:-}"
+  report_results "$assigned_count" "${#issue_numbers[@]}" "${issue_numbers[@]+"${issue_numbers[@]}"}"
 }
 
 main "$@"

--- a/plugins/twl/tests/bats/ac-test-mapping-1273.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1273.yaml
@@ -1,0 +1,186 @@
+mappings:
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh exists at expected path"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh contains origin:host:ipatho-1 label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh contains origin:host:ipatho2 label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh contains origin:host:thinkpad label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh contains origin:repo:soap-copilot-mock label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh contains origin:repo:twill label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh references host label color fef2c0"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh references repo label color bfd4f2"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 1
+    ac_text: "以下の label が gh label create (または GraphQL mutation) で作成される: origin:host:ipatho-1 / origin:host:ipatho2 / origin:host:thinkpad (色: #fef2c0) / origin:repo:soap-copilot-mock / origin:repo:twill (色: #bfd4f2)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac1: setup-origin-labels.sh uses gh label create or GraphQL mutation"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 2
+    ac_text: "既存 OPEN/CLOSED Issue を多段階検索 (--state all --limit 500) で全数分類し、cross-repo 起源を確定する"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac2: setup-origin-labels.sh contains --state all flag"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 2
+    ac_text: "既存 OPEN/CLOSED Issue を多段階検索 (--state all --limit 500) で全数分類し、cross-repo 起源を確定する"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac2: setup-origin-labels.sh contains --limit 500 flag"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 2
+    ac_text: "既存 OPEN/CLOSED Issue を多段階検索 (--state all --limit 500) で全数分類し、cross-repo 起源を確定する"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac2: setup-origin-labels.sh contains cross-repo origin search keywords"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 2
+    ac_text: "既存 OPEN/CLOSED Issue を多段階検索 (--state all --limit 500) で全数分類し、cross-repo 起源を確定する"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac2: setup-origin-labels.sh contains gh issue view for body retrieval"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 3
+    ac_text: "AC2 で確定した Issue に対し gh issue edit <N> --repo shuu5/twill --add-label で一括付与（べき等性: 既付与は skip）"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac3: setup-origin-labels.sh contains idempotency check (skip if already labeled)"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 3
+    ac_text: "AC2 で確定した Issue に対し gh issue edit <N> --repo shuu5/twill --add-label で一括付与（べき等性: 既付与は skip）"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac3: setup-origin-labels.sh uses gh issue edit with --add-label"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 3
+    ac_text: "AC2 で確定した Issue に対し gh issue edit <N> --repo shuu5/twill --add-label で一括付与（べき等性: 既付与は skip）"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac3: setup-origin-labels.sh references shuu5/twill repo for label assignment"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json exists at ~/.config/twl/host-aliases.json"
+    impl_files: []
+    # impl_files 推定失敗: ~/.config/twl/host-aliases.json はローカル設定ファイル（リポジトリ外）のため手動確認が必要
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json is valid JSON"
+    impl_files: []
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json contains ipatho-server-2 -> ipatho2 mapping"
+    impl_files: []
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json contains ipatho-server-1 -> ipatho-1 mapping"
+    impl_files: []
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json contains shuu5-thinkpad -> thinkpad mapping"
+    impl_files: []
+  - ac_index: 4
+    ac_text: "hostname -> 通称 mapping を ~/.config/twl/host-aliases.json に新規定義 (ipatho-server-2->ipatho2, ipatho-server-1->ipatho-1, shuu5-thinkpad->thinkpad)"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac4: host-aliases.json has exactly 3 entries"
+    impl_files: []
+  - ac_index: 5
+    ac_text: "[WARNING] Project Board #6 (shuu5/twill-ecosystem) に Cross-repo / ipatho2 host 起票 / ipatho-1 host 起票 / thinkpad host 起票 の view filter を追加"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac5: setup-origin-labels.sh contains Project Board or project-board reference"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+    # NOTE: Project Board view filter 自体はプロセス AC（GitHub UI 操作）。script への言及有無のみ検証
+  - ac_index: 6
+    ac_text: "[WARNING] 遡及付与 script を plugins/twl/scripts/onboarding/setup-origin-labels.sh に保存。--state all --limit 500 フラグを含み、べき等実行可能であること"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac6: setup-origin-labels.sh is executable"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 6
+    ac_text: "[WARNING] 遡及付与 script を plugins/twl/scripts/onboarding/setup-origin-labels.sh に保存。--state all --limit 500 フラグを含み、べき等実行可能であること"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac6: setup-origin-labels.sh has bash shebang"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 6
+    ac_text: "[WARNING] 遡及付与 script を plugins/twl/scripts/onboarding/setup-origin-labels.sh に保存。--state all --limit 500 フラグを含み、べき等実行可能であること"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac6: setup-origin-labels.sh contains --state all --limit 500 as documented in AC6"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 6
+    ac_text: "[WARNING] 遡及付与 script を plugins/twl/scripts/onboarding/setup-origin-labels.sh に保存。--state all --limit 500 フラグを含み、べき等実行可能であること"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac6: setup-origin-labels.sh is idempotent (no duplicate label assignment on re-run)"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 6
+    ac_text: "[WARNING] 遡及付与 script を plugins/twl/scripts/onboarding/setup-origin-labels.sh に保存。--state all --limit 500 フラグを含み、べき等実行可能であること"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac6: setup-origin-labels.sh has source guard (BASH_SOURCE check - baseline-bash.md §10)"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+    # NOTE: source guard なしで set -euo pipefail 環境で source すると main 到達前に exit する（baseline-bash §10）
+    # 実装者は [[ "${BASH_SOURCE[0]}" == "${0}" ]] guard を追加すること
+  - ac_index: 7
+    ac_text: "[INFO] AC2 の確定件数をユーザーに報告し、3 件超の場合は差分を明示"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac7: setup-origin-labels.sh reports classified issue count"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 7
+    ac_text: "[INFO] AC2 の確定件数をユーザーに報告し、3 件超の場合は差分を明示"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac7: setup-origin-labels.sh has branch for count > 3"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+  - ac_index: 8
+    ac_text: "[INFO] doobidoo memory (hash 3c47c84a) の cross-reference 情報を遡及解析の補助情報として活用"
+    test_file: "tests/bats/issue-1273-origin-labels.bats"
+    test_name: "ac8: setup-origin-labels.sh mentions doobidoo memory hash 3c47c84a"
+    impl_files:
+      - "plugins/twl/scripts/onboarding/setup-origin-labels.sh"
+    # NOTE: AC8 は INFO レベル。script 内コメントとして言及されることを期待

--- a/plugins/twl/tests/bats/issue-1273-origin-labels.bats
+++ b/plugins/twl/tests/bats/issue-1273-origin-labels.bats
@@ -1,0 +1,300 @@
+#!/usr/bin/env bats
+# issue-1273-origin-labels.bats
+#
+# RED-phase tests for Issue #1273:
+#   feat(provenance): origin:* label 体系定義 + 既存 Issue 遡及付与 (cross-origin Phase A)
+#
+# AC coverage:
+#   AC1 - origin:host:* / origin:repo:* ラベルが定義済みである（setup-origin-labels.sh が作成コマンドを含む）
+#   AC2 - 多段階検索フラグ（--state all --limit 500）が setup-origin-labels.sh に含まれる
+#   AC3 - べき等付与（既付与 skip）ロジックが setup-origin-labels.sh に含まれる
+#   AC4 - host-aliases.json が ~/.config/twl/ に存在し、3 ホストエントリを含む
+#   AC5 - setup-origin-labels.sh が Project Board view filter に関するコメントまたは参照を含む
+#   AC6 - setup-origin-labels.sh が plugins/twl/scripts/onboarding/ に存在し、基本要件を満たす
+#   AC7 - setup-origin-labels.sh が Issue 件数報告ロジック（3 件超分岐）を含む
+#   AC8 - setup-origin-labels.sh が doobidoo memory hash 3c47c84a への言及を含む（INFO）
+#
+# 全テストは実装前（RED）状態で fail する。
+#
+# NOTE: setup-origin-labels.sh は source guard
+#   ([[ "${BASH_SOURCE[0]}" == "${0}" ]] guard) の存在を確認することを推奨する（baseline-bash.md §10）。
+#   本スクリプトは新規作成のため、実装者は guard を追加すること。
+
+load 'helpers/common'
+
+setup() {
+  common_setup
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+
+  SETUP_SCRIPT="${REPO_ROOT}/scripts/onboarding/setup-origin-labels.sh"
+  HOST_ALIASES_JSON="${HOME}/.config/twl/host-aliases.json"
+  THIS_BATS="${REPO_ROOT}/tests/bats/issue-1273-origin-labels.bats"
+
+  export REPO_ROOT SETUP_SCRIPT HOST_ALIASES_JSON THIS_BATS
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: origin:host:* / origin:repo:* ラベルが setup-origin-labels.sh に定義されている
+# ===========================================================================
+
+@test "ac1: setup-origin-labels.sh exists at expected path" {
+  # AC: plugins/twl/scripts/onboarding/setup-origin-labels.sh が存在する
+  # RED: ファイルがまだ作成されていないため fail
+  [ -f "${SETUP_SCRIPT}" ]
+}
+
+@test "ac1: setup-origin-labels.sh contains origin:host:ipatho-1 label" {
+  # AC: origin:host:ipatho-1 ラベル作成コマンドが含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF 'origin:host:ipatho-1' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh contains origin:host:ipatho2 label" {
+  # AC: origin:host:ipatho2 ラベル作成コマンドが含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF 'origin:host:ipatho2' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh contains origin:host:thinkpad label" {
+  # AC: origin:host:thinkpad ラベル作成コマンドが含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF 'origin:host:thinkpad' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh contains origin:repo:soap-copilot-mock label" {
+  # AC: origin:repo:soap-copilot-mock ラベル作成コマンドが含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF 'origin:repo:soap-copilot-mock' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh contains origin:repo:twill label" {
+  # AC: origin:repo:twill ラベル作成コマンドが含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF 'origin:repo:twill' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh references host label color fef2c0" {
+  # AC: origin:host:* ラベルに色 #fef2c0 が指定されている
+  # RED: ファイルが存在しないため fail
+  grep -qF 'fef2c0' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh references repo label color bfd4f2" {
+  # AC: origin:repo:* ラベルに色 #bfd4f2 が指定されている
+  # RED: ファイルが存在しないため fail
+  grep -qF 'bfd4f2' "${SETUP_SCRIPT}"
+}
+
+@test "ac1: setup-origin-labels.sh uses gh label create or GraphQL mutation" {
+  # AC: gh label create コマンドまたは GraphQL mutation でラベルを作成する
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'gh label create|gh api graphql|api\.github\.com.*labels' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: 多段階検索フラグが setup-origin-labels.sh に含まれる
+# ===========================================================================
+
+@test "ac2: setup-origin-labels.sh contains --state all flag" {
+  # AC: gh issue list に --state all フラグが含まれる（全数分類のため）
+  # RED: ファイルが存在しないため fail
+  grep -qF -- '--state all' "${SETUP_SCRIPT}"
+}
+
+@test "ac2: setup-origin-labels.sh contains --limit 500 flag" {
+  # AC: gh issue list に --limit 500 フラグが含まれる（全数分類のため）
+  # RED: ファイルが存在しないため fail
+  grep -qF -- '--limit 500' "${SETUP_SCRIPT}"
+}
+
+@test "ac2: setup-origin-labels.sh contains cross-repo origin search keywords" {
+  # AC: 検索キーワードに soap-copilot / ipatho / thinkpad / observer のいずれかが含まれる
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'soap-copilot|ipatho|thinkpad|observer|検出元|起源' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: setup-origin-labels.sh contains gh issue view for body retrieval" {
+  # AC: 候補 Issue の body を gh issue view --json body で取得するロジックが含まれる（Step 2）
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'gh issue view.*--json.*body|gh issue view.*body' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: べき等付与ロジックが setup-origin-labels.sh に含まれる
+# ===========================================================================
+
+@test "ac3: setup-origin-labels.sh contains idempotency check (skip if already labeled)" {
+  # AC: 既付与ラベルを skip するロジックが含まれる（re-run safe）
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'skip|already|既付与|idempotent|grep.*label|label.*grep' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: setup-origin-labels.sh uses gh issue edit with --add-label" {
+  # AC: gh issue edit --add-label でラベルを付与する
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'gh issue edit.*--add-label|--add-label.*origin:' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: setup-origin-labels.sh references shuu5/twill repo for label assignment" {
+  # AC: --repo shuu5/twill が指定されている
+  # RED: ファイルが存在しないため fail
+  grep -qF 'shuu5/twill' "${SETUP_SCRIPT}"
+}
+
+# ===========================================================================
+# AC4: host-aliases.json が ~/.config/twl/ に存在し、3 ホストエントリを含む
+# ===========================================================================
+
+@test "ac4: host-aliases.json exists at ~/.config/twl/host-aliases.json" {
+  # AC: ~/.config/twl/host-aliases.json が存在する
+  # RED: ファイルがまだ作成されていないため fail
+  [ -f "${HOST_ALIASES_JSON}" ]
+}
+
+@test "ac4: host-aliases.json is valid JSON" {
+  # AC: host-aliases.json が有効な JSON である
+  # RED: ファイルが存在しないため fail
+  run jq '.' "${HOST_ALIASES_JSON}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: host-aliases.json contains ipatho-server-2 -> ipatho2 mapping" {
+  # AC: "ipatho-server-2": "ipatho2" エントリが含まれる
+  # RED: ファイルが存在しないため fail
+  run jq -e '."ipatho-server-2" == "ipatho2"' "${HOST_ALIASES_JSON}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: host-aliases.json contains ipatho-server-1 -> ipatho-1 mapping" {
+  # AC: "ipatho-server-1": "ipatho-1" エントリが含まれる
+  # RED: ファイルが存在しないため fail
+  run jq -e '."ipatho-server-1" == "ipatho-1"' "${HOST_ALIASES_JSON}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: host-aliases.json contains shuu5-thinkpad -> thinkpad mapping" {
+  # AC: "shuu5-thinkpad": "thinkpad" エントリが含まれる
+  # RED: ファイルが存在しないため fail
+  run jq -e '."shuu5-thinkpad" == "thinkpad"' "${HOST_ALIASES_JSON}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4: host-aliases.json has exactly 3 entries" {
+  # AC: エントリが 3 件（ipatho-server-2, ipatho-server-1, shuu5-thinkpad）
+  # RED: ファイルが存在しないため fail
+  local count
+  count="$(jq 'keys | length' "${HOST_ALIASES_JSON}")"
+  [ "${count}" -eq 3 ]
+}
+
+# ===========================================================================
+# AC5: setup-origin-labels.sh が Project Board view filter に関する言及を含む [WARNING]
+# ===========================================================================
+
+@test "ac5: setup-origin-labels.sh contains Project Board or project-board reference" {
+  # AC: Project Board #6 への言及またはコメントが含まれる（Cross-repo view filter）
+  # RED: ファイルが存在しないため fail
+  run grep -qiE 'project.?board|project #6|twill-ecosystem|view filter|Cross-repo|ipatho2 host|ipatho-1 host|thinkpad host' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC6: setup-origin-labels.sh が plugins/twl/scripts/onboarding/ に存在し基本要件を満たす [WARNING]
+# ===========================================================================
+
+@test "ac6: setup-origin-labels.sh is executable" {
+  # AC: setup-origin-labels.sh が実行可能（chmod +x 済み）
+  # RED: ファイルが存在しないため fail
+  [ -x "${SETUP_SCRIPT}" ]
+}
+
+@test "ac6: setup-origin-labels.sh has bash shebang" {
+  # AC: #!/usr/bin/env bash または #!/bin/bash shebang が存在する
+  # RED: ファイルが存在しないため fail
+  run head -1 "${SETUP_SCRIPT}"
+  echo "${output}" | grep -qE '^#!/(usr/bin/env bash|bin/bash)'
+}
+
+@test "ac6: setup-origin-labels.sh contains --state all --limit 500 as documented in AC6" {
+  # AC: AC6 要件として --state all --limit 500 フラグを含むこと
+  # RED: ファイルが存在しないため fail
+  run grep -qF -- '--state all' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+  run grep -qF -- '--limit 500' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6: setup-origin-labels.sh is idempotent (no duplicate label assignment on re-run)" {
+  # AC: べき等実行可能 - 重複付与ロジックが実装されている
+  # RED: ファイルが存在しないため fail
+  # 実装者は「既付与 skip」ロジックの存在を確認すること
+  run grep -qE 'skip|already.*label|label.*already|existing.*label|label.*exist|gh issue view.*json.*labels' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6: setup-origin-labels.sh has source guard (BASH_SOURCE check - baseline-bash.md §10)" {
+  # AC: source guard [[ "${BASH_SOURCE[0]}" == "${0}" ]] が存在する
+  # RED: ファイルが存在しないため fail
+  # NOTE: source guard なしで set -euo pipefail 環境で source すると main 到達前に exit する（baseline-bash §10）
+  run grep -qE 'BASH_SOURCE\[0\].*==.*\$\{?0\}?|\$\{BASH_SOURCE\[0\]\}.*\$0' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC7: setup-origin-labels.sh が Issue 件数報告ロジック（3 件超分岐）を含む [INFO]
+# ===========================================================================
+
+@test "ac7: setup-origin-labels.sh reports classified issue count" {
+  # AC: AC2 で確定した件数をユーザーに報告するロジックが含まれる
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'echo|printf|report|count|件数|classified|found' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac7: setup-origin-labels.sh has branch for count > 3" {
+  # AC: 3 件超の場合に差分を明示する分岐が含まれる
+  # RED: ファイルが存在しないため fail
+  run grep -qE 'if.*-gt 3|count.*>.*3|\[ .* -gt 3 \]|gt 3' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC8: setup-origin-labels.sh が doobidoo memory hash 3c47c84a への言及を含む [INFO]
+# ===========================================================================
+
+@test "ac8: setup-origin-labels.sh mentions doobidoo memory hash 3c47c84a" {
+  # AC: doobidoo memory hash 3c47c84a への言及（コメントとして可）が含まれる
+  # RED: ファイルが存在しないため fail
+  grep -qF '3c47c84a' "${SETUP_SCRIPT}"
+}
+
+# ===========================================================================
+# self-referential: このテストファイル自体の存在確認
+# ===========================================================================
+
+@test "self: this bats test file exists at expected path" {
+  # AC: bats ファイルが plugins/twl/tests/bats/issue-1273-origin-labels.bats として存在する
+  # GREEN: このファイル自体が存在するため、実行時点では pass する
+  [ -f "${THIS_BATS}" ]
+}
+
+@test "self: this bats test file contains at least 10 test blocks" {
+  # AC: 本ファイルに 10 件以上の @test ブロックが含まれる
+  # GREEN: このファイルが書き出された時点で pass する
+  local count
+  count="$(grep -c '^@test ' "${THIS_BATS}")"
+  [ "${count}" -ge 10 ]
+}

--- a/plugins/twl/tests/bats/issue-1273-origin-labels.bats
+++ b/plugins/twl/tests/bats/issue-1273-origin-labels.bats
@@ -206,8 +206,31 @@ teardown() {
 
 @test "ac5: setup-origin-labels.sh contains Project Board or project-board reference" {
   # AC: Project Board #6 への言及またはコメントが含まれる（Cross-repo view filter）
-  # RED: ファイルが存在しないため fail
   run grep -qiE 'project.?board|project #6|twill-ecosystem|view filter|Cross-repo|ipatho2 host|ipatho-1 host|thinkpad host' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: setup-origin-labels.sh references Cross-repo filter (label:origin:repo:soap-copilot-mock)" {
+  # AC5 view filter 個別確認: Cross-repo フィルター
+  run grep -qF 'label:origin:repo:soap-copilot-mock' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: setup-origin-labels.sh references ipatho2 host filter (label:origin:host:ipatho2)" {
+  # AC5 view filter 個別確認: ipatho2 host 起票フィルター
+  run grep -qF 'label:origin:host:ipatho2' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: setup-origin-labels.sh references ipatho-1 host filter (label:origin:host:ipatho-1)" {
+  # AC5 view filter 個別確認: ipatho-1 host 起票フィルター
+  run grep -qF 'label:origin:host:ipatho-1' "${SETUP_SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5: setup-origin-labels.sh references thinkpad host filter (label:origin:host:thinkpad)" {
+  # AC5 view filter 個別確認: thinkpad host 起票フィルター
+  run grep -qF 'label:origin:host:thinkpad' "${SETUP_SCRIPT}"
   [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## 概要

cross-origin Issue tracking 機構統合 epic (#1267) の Phase A。`origin:host:*` / `origin:repo:*` label 体系を新規定義し、既存 Issue に遡及付与することで、twill リポジトリで cross-repo 起源の Issue をフィルタ可能にする最小コアを構築する。

## 変更内容

- `plugins/twl/tests/bats/issue-1273-origin-labels.bats`: AC1-AC8 の RED bats テスト（33テスト、31 RED）
- `plugins/twl/tests/bats/ac-test-mapping-1273.yaml`: AC↔test マッピング

## 関連

- Closes #1273
- 親 epic: #1267