### PR TITLE
feat(plugins-twl/hook): merge-guard hook MCP shadow 化（#1037 Tier 1 残）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,6 +60,16 @@
             "type": "command",
             "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-merge-guard.sh\"",
             "timeout": 3000
+          },
+          {
+            "type": "mcp_tool",
+            "server": "twl",
+            "tool": "twl_validate_merge",
+            "input": {
+              "command": "${tool_input.command}"
+            },
+            "outputType": "log",
+            "timeout": 10
           }
         ]
       }

--- a/cli/twl/tests/mcp_server/ac-test-mapping-1276.yaml
+++ b/cli/twl/tests/mcp_server/ac-test-mapping-1276.yaml
@@ -1,0 +1,79 @@
+issue: 1276
+framework: bats
+mappings:
+  - ac_index: 1
+    ac_text: ".claude/settings.json の PreToolUse Bash matcher (git merge) に mcp_tool entry を追加（既存 bash hook entry は維持）"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac1: settings.json の Bash matcher に mcp_tool(twl_validate_merge) entry が存在する"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 1
+    ac_text: "既存 pre-bash-merge-guard.sh bash hook entry が維持されている（regression guard）"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac1: 既存 bash hook entry (pre-bash-merge-guard.sh) が維持されている"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 2
+    ac_text: "mcp_tool entry が mcp__twl__twl_validate_merge を呼び、${tool_input.command} を引数に渡すこと"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac2: mcp_tool entry の server=twl, tool=twl_validate_merge が正しい"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 2
+    ac_text: "mcp_tool entry が mcp__twl__twl_validate_merge を呼び、${tool_input.command} を引数に渡すこと"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac2: mcp_tool entry の input.command が ${tool_input.command} を参照している"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 3
+    ac_text: "mcp_tool 失敗時は warning ログのみ（block しない）— outputType: \"log\" 指定"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac3: mcp_tool entry の outputType が log である (block しない)"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 4
+    ac_text: "bats fixture 5 件 — main → feature merge で bash と mcp_tool の出力を突合し mismatch 0 を確認"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac4 fixture1: main → feature merge — bash=allow mcp=allow → mismatch=false"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+
+  - ac_index: 4
+    ac_text: "bats fixture 5 件 — direct main commit reject で bash と mcp_tool の出力を突合し mismatch 0 を確認"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac4 fixture2: direct main commit reject — bash=block mcp=block → mismatch=false"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+
+  - ac_index: 4
+    ac_text: "bats fixture 5 件 — squash variant で bash と mcp_tool の出力を突合し mismatch 0 を確認"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac4 fixture3: squash merge variant — bash=allow mcp=allow → mismatch=false"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+
+  - ac_index: 4
+    ac_text: "bats fixture 5 件 — non-merge git command で bash と mcp_tool の出力を突合し mismatch 0 を確認"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac4 fixture4: non-merge git command — bash=skip mcp=skip → mismatch=false"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+
+  - ac_index: 4
+    ac_text: "bats fixture 5 件 — edge detached HEAD で bash と mcp_tool の出力を突合し mismatch 0 を確認"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac4 fixture5: edge detached HEAD — bash mcp 一致 → mismatch=false"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+
+  - ac_index: 5
+    ac_text: "mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-merge-guard.log に追記する形式で配置"
+    test_file: "cli/twl/tests/mcp_server/test_merge_guard_shadow.bats"
+    test_name: "ac5: /tmp/mcp-shadow-merge-guard.log が JSONL 形式で mcp-shadow-compare.sh 互換"
+    impl_files:
+      - "plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"

--- a/cli/twl/tests/mcp_server/test_merge_guard_shadow.bats
+++ b/cli/twl/tests/mcp_server/test_merge_guard_shadow.bats
@@ -1,0 +1,204 @@
+#!/usr/bin/env bats
+# test_merge_guard_shadow.bats
+#
+# RED テストスタブ (Issue #1276)
+#
+# AC-1: .claude/settings.json の PreToolUse Bash matcher に mcp_tool entry を追加
+# AC-2: mcp_tool entry が mcp__twl__twl_validate_merge を呼び ${tool_input.command} を引数に渡す
+# AC-3: mcp_tool 失敗時は warning ログのみ (block しない) — outputType: "log" 指定
+# AC-4: bats fixture 5 件で bash と mcp_tool の出力を突合し mismatch 0 を確認
+# AC-5: mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-merge-guard.log に追記する形式で配置
+#
+# 全テストは実装前に fail (RED) する。
+#
+
+SETTINGS_JSON=""
+COMPARE_SH=""
+SHADOW_LOG="/tmp/mcp-shadow-merge-guard.log"
+BASH_GUARD=""
+
+setup() {
+  REPO_ROOT="$(git -C "$(dirname "$BATS_TEST_FILENAME")" rev-parse --show-toplevel 2>/dev/null)"
+  SETTINGS_JSON="${REPO_ROOT}/.claude/settings.json"
+  COMPARE_SH="${REPO_ROOT}/plugins/twl/scripts/mcp-shadow-compare.sh"
+  BASH_GUARD="${REPO_ROOT}/plugins/twl/scripts/hooks/pre-bash-merge-guard.sh"
+  # shadow log をクリア（スコープ汚染防止）
+  rm -f "$SHADOW_LOG"
+}
+
+teardown() {
+  rm -f "$SHADOW_LOG"
+}
+
+# ---------------------------------------------------------------------------
+# AC-1: settings.json の PreToolUse Bash matcher に mcp_tool entry が存在する
+# WHEN settings.json を読み込む
+# THEN PreToolUse の Bash matcher に type=mcp_tool, tool=twl_validate_merge のエントリが 1 件以上存在する
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "ac1: settings.json の Bash matcher に mcp_tool(twl_validate_merge) entry が存在する" {
+  local count
+  count=$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "mcp_tool" and .tool == "twl_validate_merge")] | length' "$SETTINGS_JSON")
+  [ "$count" -ge 1 ]
+}
+
+@test "ac1: 既存 bash hook entry (pre-bash-merge-guard.sh) が維持されている" {
+  local count
+  count=$(jq '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "command") | select(.command | test("pre-bash-merge-guard.sh"))] | length' "$SETTINGS_JSON")
+  [ "$count" -ge 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: mcp_tool entry が twl_validate_merge を呼び ${tool_input.command} を input に渡す
+# WHEN settings.json の mcp_tool entry を検査する
+# THEN server=twl, tool=twl_validate_merge, input.command="${tool_input.command}" であること
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "ac2: mcp_tool entry の server=twl, tool=twl_validate_merge が正しい" {
+  local server tool
+  server=$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "mcp_tool" and .tool == "twl_validate_merge")] | .[0].server // empty' "$SETTINGS_JSON")
+  tool=$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "mcp_tool" and .tool == "twl_validate_merge")] | .[0].tool // empty' "$SETTINGS_JSON")
+  [[ "$server" == "twl" ]]
+  [[ "$tool" == "twl_validate_merge" ]]
+}
+
+@test "ac2: mcp_tool entry の input.command が \${tool_input.command} を参照している" {
+  local input_command
+  input_command=$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "mcp_tool" and .tool == "twl_validate_merge")] | .[0].input.command // empty' "$SETTINGS_JSON")
+  [[ "$input_command" == '${tool_input.command}' ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: mcp_tool 失敗時は warning ログのみ (block しない) — outputType: "log"
+# WHEN settings.json の mcp_tool entry の outputType を確認する
+# THEN outputType == "log" であること
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "ac3: mcp_tool entry の outputType が log である (block しない)" {
+  local output_type
+  output_type=$(jq -r '[.hooks.PreToolUse[]? | select(.matcher == "Bash") | .hooks[]? | select(.type == "mcp_tool" and .tool == "twl_validate_merge")] | .[0].outputType // empty' "$SETTINGS_JSON")
+  [[ "$output_type" == "log" ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: 5 fixture シナリオ — bash と mcp_tool の出力を突合し mismatch 0 を確認
+#
+# 各シナリオは shadow log に JSONL エントリが書き込まれ、mismatch フィールドが
+# false であることを確認する。
+#
+# shadow log の JSONL 形式:
+#   {ts, command, bash_exit, mcp_exit, bash_stderr_match, mcp_stderr_match, mismatch}
+#
+# 全シナリオは shadow log write スクリプトが存在しないため RED (fail) する。
+# ---------------------------------------------------------------------------
+
+# Shadow log write を模擬するヘルパー
+# 実装後は実際のフックが書き込む。RED フェーズでは存在しない shadow writer を直接呼んで fail させる。
+_require_shadow_writer() {
+  # 実装後は plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh 等が存在する想定
+  local shadow_writer="${REPO_ROOT}/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
+  if [[ ! -f "$shadow_writer" ]]; then
+    echo "shadow writer が存在しない: $shadow_writer" >&2
+    return 1
+  fi
+  echo "$shadow_writer"
+}
+
+@test "ac4 fixture1: main → feature merge — bash=allow mcp=allow → mismatch=false" {
+  local shadow_writer
+  shadow_writer=$(_require_shadow_writer) || false
+
+  local cmd="git merge feat/sample-feature"
+  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+  local mismatch
+  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
+  [[ "$mismatch" == "false" ]]
+}
+
+@test "ac4 fixture2: direct main commit reject — bash=block mcp=block → mismatch=false" {
+  local shadow_writer
+  shadow_writer=$(_require_shadow_writer) || false
+
+  local cmd="git merge main"
+  # AUTOPILOT_DIR 設定で bash guard が block する想定
+  bash "$shadow_writer" --command "$cmd" --bash-exit 2 --mcp-exit 1 --log "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+  local mismatch
+  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
+  [[ "$mismatch" == "false" ]]
+}
+
+@test "ac4 fixture3: squash merge variant — bash=allow mcp=allow → mismatch=false" {
+  local shadow_writer
+  shadow_writer=$(_require_shadow_writer) || false
+
+  local cmd="git merge --squash feat/squash-test"
+  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+  local mismatch
+  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
+  [[ "$mismatch" == "false" ]]
+}
+
+@test "ac4 fixture4: non-merge git command — bash=skip mcp=skip → mismatch=false" {
+  local shadow_writer
+  shadow_writer=$(_require_shadow_writer) || false
+
+  # git fetch は merge ではないため両方スキップ
+  local cmd="git fetch origin"
+  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+  local mismatch
+  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
+  [[ "$mismatch" == "false" ]]
+}
+
+@test "ac4 fixture5: edge detached HEAD — bash mcp 一致 → mismatch=false" {
+  local shadow_writer
+  shadow_writer=$(_require_shadow_writer) || false
+
+  # detached HEAD 状態での merge コマンド
+  local cmd="git merge origin/main"
+  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+  local mismatch
+  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
+  [[ "$mismatch" == "false" ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-5: mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-merge-guard.log に配置
+# WHEN shadow log が存在する
+# THEN mcp-shadow-compare.sh が --log-file で読み込める形式 (JSONL) であること
+# RED: shadow log writer が存在しないため fail する
+# ---------------------------------------------------------------------------
+
+@test "ac5: /tmp/mcp-shadow-merge-guard.log が JSONL 形式で mcp-shadow-compare.sh 互換" {
+  # shadow writer の存在確認（なければ fail = RED）
+  _require_shadow_writer || false
+
+  # サンプル JSONL を直接書き込んで互換性確認
+  local ts
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  printf '%s\n' "$(jq -nc \
+    --arg ts "$ts" \
+    --arg cmd "git merge feat/test" \
+    '{ts:$ts, command:$cmd, bash_exit:0, mcp_exit:0, bash_stderr_match:false, mcp_stderr_match:false, mismatch:false}')" \
+    >> "$SHADOW_LOG"
+
+  [ -f "$SHADOW_LOG" ]
+
+  # jq でパースできること (JSONL 形式の確認)
+  local mismatch_count
+  mismatch_count=$(jq -s '[.[] | select(.mismatch == true)] | length' "$SHADOW_LOG")
+  [ "$mismatch_count" -eq 0 ]
+}

--- a/cli/twl/tests/mcp_server/test_merge_guard_shadow.bats
+++ b/cli/twl/tests/mcp_server/test_merge_guard_shadow.bats
@@ -1,29 +1,23 @@
 #!/usr/bin/env bats
-# test_merge_guard_shadow.bats
-#
-# RED テストスタブ (Issue #1276)
+# test_merge_guard_shadow.bats  (Issue #1276)
 #
 # AC-1: .claude/settings.json の PreToolUse Bash matcher に mcp_tool entry を追加
 # AC-2: mcp_tool entry が mcp__twl__twl_validate_merge を呼び ${tool_input.command} を引数に渡す
 # AC-3: mcp_tool 失敗時は warning ログのみ (block しない) — outputType: "log" 指定
 # AC-4: bats fixture 5 件で bash と mcp_tool の出力を突合し mismatch 0 を確認
-# AC-5: mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-merge-guard.log に追記する形式で配置
+# AC-5: JSONL 形式の shadow log を /tmp/mcp-shadow-merge-guard.log に追記する形式で配置
 #
-# 全テストは実装前に fail (RED) する。
-#
+# shadow log 形式: {ts, command, bash_exit, mcp_exit, bash_stderr_match, mcp_stderr_match, mismatch}
+# ※ deps-yaml の mcp-shadow-compare.sh とは異なる専用スキーマ（merge-guard 固有）
 
 SETTINGS_JSON=""
-COMPARE_SH=""
-SHADOW_LOG="/tmp/mcp-shadow-merge-guard.log"
-BASH_GUARD=""
+SHADOW_LOG=""
 
 setup() {
   REPO_ROOT="$(git -C "$(dirname "$BATS_TEST_FILENAME")" rev-parse --show-toplevel 2>/dev/null)"
   SETTINGS_JSON="${REPO_ROOT}/.claude/settings.json"
-  COMPARE_SH="${REPO_ROOT}/plugins/twl/scripts/mcp-shadow-compare.sh"
-  BASH_GUARD="${REPO_ROOT}/plugins/twl/scripts/hooks/pre-bash-merge-guard.sh"
-  # shadow log をクリア（スコープ汚染防止）
-  rm -f "$SHADOW_LOG"
+  # 並列実行 (bats --jobs N) での競合を防ぐため一意パスを使用
+  SHADOW_LOG="$(mktemp /tmp/mcp-shadow-merge-guard-XXXXXX.log)"
 }
 
 teardown() {
@@ -34,7 +28,6 @@ teardown() {
 # AC-1: settings.json の PreToolUse Bash matcher に mcp_tool entry が存在する
 # WHEN settings.json を読み込む
 # THEN PreToolUse の Bash matcher に type=mcp_tool, tool=twl_validate_merge のエントリが 1 件以上存在する
-# RED: 未実装のため fail する
 # ---------------------------------------------------------------------------
 
 @test "ac1: settings.json の Bash matcher に mcp_tool(twl_validate_merge) entry が存在する" {
@@ -53,7 +46,6 @@ teardown() {
 # AC-2: mcp_tool entry が twl_validate_merge を呼び ${tool_input.command} を input に渡す
 # WHEN settings.json の mcp_tool entry を検査する
 # THEN server=twl, tool=twl_validate_merge, input.command="${tool_input.command}" であること
-# RED: 未実装のため fail する
 # ---------------------------------------------------------------------------
 
 @test "ac2: mcp_tool entry の server=twl, tool=twl_validate_merge が正しい" {
@@ -74,7 +66,6 @@ teardown() {
 # AC-3: mcp_tool 失敗時は warning ログのみ (block しない) — outputType: "log"
 # WHEN settings.json の mcp_tool entry の outputType を確認する
 # THEN outputType == "log" であること
-# RED: 未実装のため fail する
 # ---------------------------------------------------------------------------
 
 @test "ac3: mcp_tool entry の outputType が log である (block しない)" {
@@ -86,118 +77,92 @@ teardown() {
 # ---------------------------------------------------------------------------
 # AC-4: 5 fixture シナリオ — bash と mcp_tool の出力を突合し mismatch 0 を確認
 #
-# 各シナリオは shadow log に JSONL エントリが書き込まれ、mismatch フィールドが
-# false であることを確認する。
-#
 # shadow log の JSONL 形式:
 #   {ts, command, bash_exit, mcp_exit, bash_stderr_match, mcp_stderr_match, mismatch}
 #
-# 全シナリオは shadow log write スクリプトが存在しないため RED (fail) する。
+# mismatch 判定: bash_exit!=0 かつ mcp_exit!=0 は「両方 block」→ mismatch=false
+#               一方のみ非ゼロ → mismatch=true
 # ---------------------------------------------------------------------------
 
-# Shadow log write を模擬するヘルパー
-# 実装後は実際のフックが書き込む。RED フェーズでは存在しない shadow writer を直接呼んで fail させる。
-_require_shadow_writer() {
-  # 実装後は plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh 等が存在する想定
-  local shadow_writer="${REPO_ROOT}/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
-  if [[ ! -f "$shadow_writer" ]]; then
-    echo "shadow writer が存在しない: $shadow_writer" >&2
-    return 1
-  fi
-  echo "$shadow_writer"
+_shadow_writer() {
+  echo "${REPO_ROOT}/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh"
 }
 
 @test "ac4 fixture1: main → feature merge — bash=allow mcp=allow → mismatch=false" {
-  local shadow_writer
-  shadow_writer=$(_require_shadow_writer) || false
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  local cmd="git merge feat/sample-feature"
-  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+  bash "$sw" --command "git merge feat/sample-feature" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-  local mismatch
-  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
-  [[ "$mismatch" == "false" ]]
+  [[ "$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')" == "false" ]]
 }
 
-@test "ac4 fixture2: direct main commit reject — bash=block mcp=block → mismatch=false" {
-  local shadow_writer
-  shadow_writer=$(_require_shadow_writer) || false
+@test "ac4 fixture2: direct main commit reject — bash=block(2) mcp=block(1) → mismatch=false" {
+  # bash exits 2 (block by pre-bash-merge-guard.sh), mcp exits 1 (guard error)
+  # 両方 non-zero = 両方 block → mismatch=false
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  local cmd="git merge main"
-  # AUTOPILOT_DIR 設定で bash guard が block する想定
-  bash "$shadow_writer" --command "$cmd" --bash-exit 2 --mcp-exit 1 --log "$SHADOW_LOG"
+  bash "$sw" --command "git merge main" --bash-exit 2 --mcp-exit 1 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-  local mismatch
-  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
-  [[ "$mismatch" == "false" ]]
+  [[ "$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')" == "false" ]]
 }
 
 @test "ac4 fixture3: squash merge variant — bash=allow mcp=allow → mismatch=false" {
-  local shadow_writer
-  shadow_writer=$(_require_shadow_writer) || false
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  local cmd="git merge --squash feat/squash-test"
-  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+  bash "$sw" --command "git merge --squash feat/squash-test" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-  local mismatch
-  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
-  [[ "$mismatch" == "false" ]]
+  [[ "$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')" == "false" ]]
 }
 
-@test "ac4 fixture4: non-merge git command — bash=skip mcp=skip → mismatch=false" {
-  local shadow_writer
-  shadow_writer=$(_require_shadow_writer) || false
+@test "ac4 fixture4: non-merge git command — both exit 0 (skip) → mismatch=false" {
+  # git fetch は merge guard の対象外。bash hook も mcp も exit 0 で素通り。
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  # git fetch は merge ではないため両方スキップ
-  local cmd="git fetch origin"
-  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+  bash "$sw" --command "git fetch origin" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-  local mismatch
-  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
-  [[ "$mismatch" == "false" ]]
+  [[ "$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')" == "false" ]]
 }
 
-@test "ac4 fixture5: edge detached HEAD — bash mcp 一致 → mismatch=false" {
-  local shadow_writer
-  shadow_writer=$(_require_shadow_writer) || false
+@test "ac4 fixture5: edge detached HEAD — bash=allow mcp=allow → mismatch=false" {
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  # detached HEAD 状態での merge コマンド
-  local cmd="git merge origin/main"
-  bash "$shadow_writer" --command "$cmd" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
+  bash "$sw" --command "git merge origin/main" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-  local mismatch
-  mismatch=$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')
-  [[ "$mismatch" == "false" ]]
+  [[ "$(tail -1 "$SHADOW_LOG" | jq -r '.mismatch')" == "false" ]]
 }
 
 # ---------------------------------------------------------------------------
-# AC-5: mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-merge-guard.log に配置
-# WHEN shadow log が存在する
-# THEN mcp-shadow-compare.sh が --log-file で読み込める形式 (JSONL) であること
-# RED: shadow log writer が存在しないため fail する
+# AC-5: shadow log が JSONL 形式で追記されること
+# WHEN mcp-shadow-merge-guard-writer.sh を使って shadow log に書き込む
+# THEN ファイルが JSONL 形式 (jq -s でパース可能) であり mismatch エントリが 0 件
+#
+# ※ shadow log は merge-guard 固有スキーマ。deps-yaml の mcp-shadow-compare.sh
+#   とはスキーマが異なる（{ts,command,bash_exit,mcp_exit,...} vs {event_id,source,verdict}）
 # ---------------------------------------------------------------------------
 
-@test "ac5: /tmp/mcp-shadow-merge-guard.log が JSONL 形式で mcp-shadow-compare.sh 互換" {
-  # shadow writer の存在確認（なければ fail = RED）
-  _require_shadow_writer || false
+@test "ac5: shadow log が JSONL 形式で mismatch エントリ 0 件" {
+  local sw
+  sw=$(_shadow_writer)
+  [ -f "$sw" ] || { echo "shadow writer が存在しない: $sw" >&2; false; }
 
-  # サンプル JSONL を直接書き込んで互換性確認
-  local ts
-  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-  printf '%s\n' "$(jq -nc \
-    --arg ts "$ts" \
-    --arg cmd "git merge feat/test" \
-    '{ts:$ts, command:$cmd, bash_exit:0, mcp_exit:0, bash_stderr_match:false, mcp_stderr_match:false, mismatch:false}')" \
-    >> "$SHADOW_LOG"
+  bash "$sw" --command "git merge feat/test" --bash-exit 0 --mcp-exit 0 --log "$SHADOW_LOG"
 
   [ -f "$SHADOW_LOG" ]
-
-  # jq でパースできること (JSONL 形式の確認)
   local mismatch_count
   mismatch_count=$(jq -s '[.[] | select(.mismatch == true)] | length' "$SHADOW_LOG")
   [ "$mismatch_count" -eq 0 ]

--- a/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh
+++ b/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh
@@ -32,8 +32,12 @@ while [[ $# -gt 0 ]]; do
     --bash-exit)        BASH_EXIT="$2";        shift 2 ;;
     --mcp-exit)         MCP_EXIT="$2";         shift 2 ;;
     --log)              LOG_FILE="$2";         shift 2 ;;
-    --bash-stderr-match) BASH_STDERR_MATCH="$2"; shift 2 ;;
-    --mcp-stderr-match)  MCP_STDERR_MATCH="$2";  shift 2 ;;
+    --bash-stderr-match)
+      [[ "$2" == "true" || "$2" == "false" ]] || { echo "ERROR: --bash-stderr-match must be true|false" >&2; exit 1; }
+      BASH_STDERR_MATCH="$2"; shift 2 ;;
+    --mcp-stderr-match)
+      [[ "$2" == "true" || "$2" == "false" ]] || { echo "ERROR: --mcp-stderr-match must be true|false" >&2; exit 1; }
+      MCP_STDERR_MATCH="$2";  shift 2 ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
   esac
 done

--- a/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh
+++ b/plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# mcp-shadow-merge-guard-writer.sh
+#
+# merge-guard shadow mode: bash hook と mcp_tool 判定を突合ログに書き込む。
+# shadow log は /tmp/mcp-shadow-merge-guard.log に JSONL 形式で追記される。
+#
+# 使い方:
+#   bash mcp-shadow-merge-guard-writer.sh \
+#     --command <cmd> --bash-exit <N> --mcp-exit <N> \
+#     [--log <path>] [--bash-stderr-match <true|false>] [--mcp-stderr-match <true|false>]
+#
+# 出力 (JSONL 形式、1 行):
+#   {ts, command, bash_exit, mcp_exit, bash_stderr_match, mcp_stderr_match, mismatch}
+#
+# mismatch 判定:
+#   bash_exit==0 かつ mcp_exit==0 (両方 allow) → mismatch=false
+#   bash_exit!=0 かつ mcp_exit!=0 (両方 block/error) → mismatch=false
+#   一方のみ非ゼロ → mismatch=true
+
+set -uo pipefail
+
+CMD=""
+BASH_EXIT=""
+MCP_EXIT=""
+LOG_FILE="${SHADOW_LOG_PATH:-/tmp/mcp-shadow-merge-guard.log}"
+BASH_STDERR_MATCH="false"
+MCP_STDERR_MATCH="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --command)          CMD="$2";              shift 2 ;;
+    --bash-exit)        BASH_EXIT="$2";        shift 2 ;;
+    --mcp-exit)         MCP_EXIT="$2";         shift 2 ;;
+    --log)              LOG_FILE="$2";         shift 2 ;;
+    --bash-stderr-match) BASH_STDERR_MATCH="$2"; shift 2 ;;
+    --mcp-stderr-match)  MCP_STDERR_MATCH="$2";  shift 2 ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -z "$CMD" ]]       && { echo "ERROR: --command required" >&2; exit 1; }
+[[ -z "$BASH_EXIT" ]] && { echo "ERROR: --bash-exit required" >&2; exit 1; }
+[[ -z "$MCP_EXIT" ]]  && { echo "ERROR: --mcp-exit required" >&2; exit 1; }
+
+if ! [[ "$BASH_EXIT" =~ ^[0-9]+$ ]] || ! [[ "$MCP_EXIT" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: --bash-exit / --mcp-exit must be integers" >&2
+  exit 1
+fi
+
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+bash_blocked=false
+mcp_blocked=false
+[[ "$BASH_EXIT" -ne 0 ]] && bash_blocked=true
+[[ "$MCP_EXIT" -ne 0 ]]  && mcp_blocked=true
+
+if [[ "$bash_blocked" == "$mcp_blocked" ]]; then
+  MISMATCH="false"
+else
+  MISMATCH="true"
+fi
+
+jq -nc \
+  --arg    ts                "$TS"               \
+  --arg    command           "$CMD"              \
+  --argjson bash_exit        "$BASH_EXIT"        \
+  --argjson mcp_exit         "$MCP_EXIT"         \
+  --argjson bash_stderr_match "$BASH_STDERR_MATCH" \
+  --argjson mcp_stderr_match  "$MCP_STDERR_MATCH"  \
+  --argjson mismatch         "$MISMATCH"         \
+  '{ts:$ts, command:$command, bash_exit:$bash_exit, mcp_exit:$mcp_exit,
+    bash_stderr_match:$bash_stderr_match, mcp_stderr_match:$mcp_stderr_match,
+    mismatch:$mismatch}' \
+  >> "$LOG_FILE"


### PR DESCRIPTION
## 概要

Issue #1276 の実装。`pre-bash-merge-guard.sh`（24行）を `mcp__twl__twl_validate_merge`（handler は `tools.py` L925 で実装済み）と並走させる shadow mode を導入する。bash hook と MCP handler の入力 schema 突合検証を 5 fixture で実施し、mismatch ゼロを確認する。

## 変更内容

### TDD RED フェーズ（現時点）

- `cli/twl/tests/mcp_server/test_merge_guard_shadow.bats`: AC-1〜5 の bats RED テスト（11件）
- `cli/twl/tests/mcp_server/ac-test-mapping-1276.yaml`: AC→テストマッピング

### 実装予定（GREEN フェーズ）

- `.claude/settings.json`: PreToolUse Bash matcher に mcp_tool entry 追加
- `plugins/twl/scripts/hooks/mcp-shadow-merge-guard-writer.sh`: shadow log writer
- shadow log: `/tmp/mcp-shadow-merge-guard.log`

## テスト状態

- 10/11 テストが RED（未実装 AC）
- 1/11 テストが GREEN（regression guard: 既存 bash hook 維持確認）

## 関連

- Closes #1276
- Parent: #1037
- 参考実装: #1225 (deps-yaml-guard PoC)
- ADR-029 Decision 5