### PR TITLE
feat(plugins-twl/architect): co-architect --type 引数と DDD skip 対応 (#1266)

### DIFF
--- a/plugins/twl/commands/architect-completeness-check.md
+++ b/plugins/twl/commands/architect-completeness-check.md
@@ -11,26 +11,50 @@ architecture/ ディレクトリの完全性を検証し、不足ファイル・
 ## 入力
 
 - `architecture-dir-path`（省略時: `$(git rev-parse --show-toplevel)/architecture`）
+- `--type=<value>`（省略時: type 解決ロジックで決定）
+
+## type 解決ロジック（`--type` 未指定時）
+
+後方互換のため、`--type` 未指定時は以下の順序で type を解決する:
+
+1. `.architecture-type` ファイル（プロジェクトルートまたは architecture-dir-path の親に存在する場合）の内容を読む
+2. `vision.md` frontmatter の `type:` フィールドを読む
+3. いずれも存在しない場合はデフォルト `ddd` を使用
+
+解決した type は後続ステップで使用する。既存 `architecture/` を持つプロジェクトは `.architecture-type` も `vision.md` frontmatter も持たないため、デフォルト `ddd` が適用され、影響なし（後方互換保証）。
+
+## type 検証
+
+有効な type 値: `ddd` | `generic`（`lib` は将来実装予定のため現時点では未対応）
+
+未知の type（例: `--type=foo`）を受け取った場合は明示エラーで停止する:
+```
+ERROR: 未知の type 値 'foo'。有効な type: ddd | generic
+```
 
 ## 手順
 
+### 0. type 決定
+
+上記「type 解決ロジック」に従い type を決定する。`ref-architecture-spec.md` の `## Project Type` セクションを Read し、有効な type 値を確認する。未知の type はエラーで停止。
+
 ### 1. 必須ファイル存在チェック
 
-**Step 1 冒頭**: `ref-architecture-spec.md` を Read し、`## 必須ファイル` セクションの必須テーブルから各パスの `Severity` 列を動的に読み出す。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。
+**Step 1 冒頭**: `ref-architecture-spec.md` を Read し、`## 必須ファイル` セクションの必須テーブルから各パスの `Severity (<TYPE>)` 列を動的に読み出す（type に対応する列を選択）。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。
 
-テーブル形式（`ref-architecture-spec.md` の `## 必須ファイル` テーブルを参照）:
+テーブル参照例（`ref-architecture-spec.md` の `## 必須ファイル` テーブルを参照）:
 
-| パス | 必須 | Severity（ref-architecture-spec.md から読み出し） |
-|------|------|------------------------------------------------|
+| パス | 必須 | Severity（ref-architecture-spec.md から type 対応列を動的読み出し） |
+|------|------|---------------------------------------------------------------------|
 | `vision.md` | YES | 動的読み出し |
-| `domain/model.md` | YES | 動的読み出し |
-| `domain/glossary.md` | YES | 動的読み出し |
-| `domain/contexts/*.md` | 1つ以上 | 動的読み出し |
+| `domain/model.md` | YES | 動的読み出し（type=generic では RECOMMENDED → INFO） |
+| `domain/glossary.md` | YES | 動的読み出し（type=generic では RECOMMENDED → INFO） |
+| `domain/contexts/*.md` | 1つ以上 | 動的読み出し（type=generic では RECOMMENDED → INFO） |
 | `phases/*.md` | 1つ以上 | 動的読み出し |
 | `decisions/*.md` | NO | 動的読み出し |
 | `contracts/*.md` | NO | 動的読み出し |
 
-各パスを Glob で確認し、不在時は `ref-architecture-spec.md` テーブルの `Severity` 値に従ってレベルを決定する:
+各パスを Glob で確認し、不在時は `ref-architecture-spec.md` テーブルの type 対応 `Severity` 値に従ってレベルを決定する:
 - `Severity=WARNING` → `[WARNING]`
 - `Severity=RECOMMENDED` → `[INFO]`（RECOMMENDED 不在は WARNING より低い INFO レベル）
 
@@ -69,9 +93,10 @@ architecture/ ディレクトリの完全性を検証し、不足ファイル・
 ### 指摘一覧
 - [WARNING] vision.md: Non-Goals セクションが未定義
 - [INFO] decisions/: ディレクトリ未作成（任意）
+- [INFO] domain/model.md: 未作成（generic type では任意）
 ```
 
 ## 禁止事項
 
 - ファイルの作成・修正を行わない（報告のみ）
-- ERROR レベルは使用しない（ユーザー判断に委ねる）
+- ERROR レベルは使用しない（ユーザー判断に委ねる）ただし未知の type は ERROR で停止

--- a/plugins/twl/refs/ref-architecture-spec.md
+++ b/plugins/twl/refs/ref-architecture-spec.md
@@ -11,6 +11,18 @@ disable-model-invocation: true
 
 プロジェクトレベルの設計意図（前方参照）を管理するディレクトリ構造。
 
+## Project Type
+
+プロジェクトの種別（`type`）に応じて、必須ファイルと Severity が異なる。`architect-completeness-check` は `--type` 引数または type 解決ロジック（`.architecture-type` ファイル → `vision.md` frontmatter → デフォルト `ddd`）で type を決定し、対応する Severity 列を動的に参照する（テーブル駆動）。
+
+有効な type 値: `ddd` | `generic` | `lib`（`lib` は将来実装予定、定義のみ）
+
+| type | 説明 |
+|------|------|
+| `ddd` | Domain-Driven Design。Bounded Context / ユビキタス言語を中心に設計（デフォルト） |
+| `generic` | 汎用プロジェクト。`vision.md` + `phases/*.md` 中心の軽量設計フロー |
+| `lib` | ライブラリ。将来実装予定（TBD）、現時点では未実装・予約済み |
+
 ## ディレクトリ構造
 
 ```
@@ -27,17 +39,17 @@ architecture/
 
 ## 必須ファイル
 
-アーキテクチャ完全性チェックで検証される必須ファイル。`Severity` 列は不在時の報告レベルを定義する（`WARNING` または `RECOMMENDED`）。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。テーブル変更のみで `Severity` 値を切替可能な設計とする（テーブル駆動）。
+アーキテクチャ完全性チェックで検証される必須ファイル。`Severity` 列は type 別に定義し、不在時の報告レベルを決定する（`WARNING` または `RECOMMENDED`）。`RECOMMENDED` 不在は `INFO` レベルで報告する（`WARNING` より低い）。テーブル変更のみで `Severity` 値を切替可能な設計とする（テーブル駆動）。
 
-| ファイル | 必須 | Severity | 説明 |
-|---------|------|----------|------|
-| vision.md | YES | WARNING | プロジェクトの目的・制約・非目標 |
-| domain/model.md | YES | WARNING | コアドメインモデル |
-| domain/glossary.md | YES | WARNING | ユビキタス言語定義 |
-| domain/contexts/*.md | 1つ以上 | WARNING | Bounded Context 定義 |
-| phases/*.md | 1つ以上 | WARNING | Phase 計画 |
-| decisions/*.md | NO | RECOMMENDED | ADR（任意） |
-| contracts/*.md | NO | RECOMMENDED | API 境界（任意） |
+| ファイル | 必須 | Severity (DDD) | Severity (Generic) | 説明 |
+|---------|------|----------------|--------------------|------|
+| vision.md | YES | WARNING | WARNING | プロジェクトの目的・制約・非目標 |
+| domain/model.md | YES | WARNING | RECOMMENDED | コアドメインモデル（generic では任意） |
+| domain/glossary.md | YES | WARNING | RECOMMENDED | ユビキタス言語定義（generic では任意） |
+| domain/contexts/*.md | 1つ以上 | WARNING | RECOMMENDED | Bounded Context 定義（generic では任意） |
+| phases/*.md | 1つ以上 | WARNING | WARNING | Phase 計画 |
+| decisions/*.md | NO | RECOMMENDED | RECOMMENDED | ADR（任意） |
+| contracts/*.md | NO | RECOMMENDED | RECOMMENDED | API 境界（任意） |
 
 ## ファイルフォーマット
 

--- a/plugins/twl/refs/ref-architecture-spec.md
+++ b/plugins/twl/refs/ref-architecture-spec.md
@@ -15,13 +15,14 @@ disable-model-invocation: true
 
 プロジェクトの種別（`type`）に応じて、必須ファイルと Severity が異なる。`architect-completeness-check` は `--type` 引数または type 解決ロジック（`.architecture-type` ファイル → `vision.md` frontmatter → デフォルト `ddd`）で type を決定し、対応する Severity 列を動的に参照する（テーブル駆動）。
 
-有効な type 値: `ddd` | `generic` | `lib`（`lib` は将来実装予定、定義のみ）
+実装済み type 値: `ddd` | `generic`
+予約済み（未実装）type 値: `lib`（将来実装予定、現時点では `architect-completeness-check` で `--type=lib` 指定時はエラーになる）
 
-| type | 説明 |
-|------|------|
-| `ddd` | Domain-Driven Design。Bounded Context / ユビキタス言語を中心に設計（デフォルト） |
-| `generic` | 汎用プロジェクト。`vision.md` + `phases/*.md` 中心の軽量設計フロー |
-| `lib` | ライブラリ。将来実装予定（TBD）、現時点では未実装・予約済み |
+| type | 説明 | 実装状態 |
+|------|------|----------|
+| `ddd` | Domain-Driven Design。Bounded Context / ユビキタス言語を中心に設計（デフォルト） | 実装済み |
+| `generic` | 汎用プロジェクト。`vision.md` + `phases/*.md` 中心の軽量設計フロー | 実装済み |
+| `lib` | ライブラリ。将来実装予定（TBD）、現時点では未実装・予約済み | 未実装（予約） |
 
 ## ディレクトリ構造
 

--- a/plugins/twl/skills/co-architect/SKILL.md
+++ b/plugins/twl/skills/co-architect/SKILL.md
@@ -22,10 +22,15 @@ maxTurns: 60
 
 対話的アーキテクチャ構築 → branch/PR + workflow-arch-review 経由マージ。Issue 化は co-issue に委譲。explore-summary リンク付き Issue を入力として開始。Non-implementation controller（chain-driven 不要）。
 
-## Step 0: 引数解析 + --group 分岐
+## Step 0: 引数解析 + type 検証 + --group 分岐
 
 引数から `--type=<value>` と `--group <context-name>` を解析する。
 有効な type 値: `ddd` | `generic`（デフォルト: `ddd`、未指定時のデフォルト）
+
+`--type` が指定されており、値が `ddd` / `generic` のいずれでもない場合は明示エラーで停止:
+```
+ERROR: 未知の type 値 '<value>'。有効な type: ddd | generic
+```
 
 `--group <context-name>` が含まれる場合:
 → `--type` が指定されていれば `--type` を `architect-group-refine` に引き継ぐ: `/twl:architect-group-refine <context-name> --type=<value>`
@@ -97,7 +102,7 @@ TaskUpdate → completed
 
 TaskCreate 「Architecture: 完全性チェック」(status: in_progress)
 
-`/twl:architect-completeness-check` を実行。
+Step 0 で決定した type を渡して `/twl:architect-completeness-check --type=<type>` を実行（type 別 Severity テーブルが正しく適用される）。
 
 WARNING がある場合 → ユーザーに不足箇所を提示し補完するか確認。
 補完する場合 → Step 2 の探索ループに戻る。

--- a/plugins/twl/skills/co-architect/SKILL.md
+++ b/plugins/twl/skills/co-architect/SKILL.md
@@ -22,10 +22,15 @@ maxTurns: 60
 
 対話的アーキテクチャ構築 → branch/PR + workflow-arch-review 経由マージ。Issue 化は co-issue に委譲。explore-summary リンク付き Issue を入力として開始。Non-implementation controller（chain-driven 不要）。
 
-## Step 0: --group 分岐
+## Step 0: 引数解析 + --group 分岐
+
+引数から `--type=<value>` と `--group <context-name>` を解析する。
+有効な type 値: `ddd` | `generic`（デフォルト: `ddd`、未指定時のデフォルト）
 
 `--group <context-name>` が含まれる場合:
-→ `/twl:architect-group-refine <context-name>` を実行して終了（Step 1〜7 スキップ）。
+→ `--type` が指定されていれば `--type` を `architect-group-refine` に引き継ぐ: `/twl:architect-group-refine <context-name> --type=<value>`
+→ `--type` 未指定の場合: `/twl:architect-group-refine <context-name>`
+→ Step 1〜7 スキップ。`--group` と `--type` 同時指定時は `--group` 優先で動作し、`--type` は `--group` 処理内に引き継がれる。
 
 `--group` なし → Step 1 へ。
 
@@ -54,21 +59,37 @@ python3 -m twl.autopilot.worktree create "${BRANCH}"
 
 作成した worktree ディレクトリに移動する。
 
+**type 表示:**
+
+選択された type 名をユーザーに表示する（type 名: `ddd` または `generic`）:
+```
+アーキテクチャ設計を開始します（type: <type名>）
+```
+
 **explore-summary 読み込み:**
 
 入力 Issue に explore-summary がリンクされている場合、`twl explore-link read <N>` で読み込み、探索の出発点として活用する。リンクがない場合は Issue body から直接コンテキストを取得する。
 
-**対話的アーキテクチャ探索（worktree 上）:**
+**対話的アーキテクチャ探索（worktree 上）— type による分岐:**
 
+type=ddd（デフォルト）:
 explore-summary（または Issue body）を基に、ユーザーと対話しながらアーキテクチャ設計を構造化する。DDD の Bounded Context、ユビキタス言語、Context Map を使い設計を構造化。
 
 確定した設計事項は architecture/ の対応ファイルに Write:
 - ビジョン → `architecture/vision.md`
 - ドメインモデル → `architecture/domain/model.md`
 - 用語定義 → `architecture/domain/glossary.md`
-- Bounded Context → `architecture/domain/contexts/<name>.md`
+- Bounded Context → `architecture/domain/contexts/<name>.md`（generic では不要・省略可）
 - 設計判断 → `architecture/decisions/<NNNN>-<title>.md`
 - API 境界 → `architecture/contracts/<name>.md`
+
+type=generic（Bounded Context / ユビキタス言語は不要・省略）— generic フロー:
+explore-summary（または Issue body）を基に、ユーザーと対話しながらアーキテクチャ設計を構造化する。generic vision.md + phases/*.md 設計フロー中心で、DDD 特有の Bounded Context / ユビキタス言語の設計は行わない。
+
+確定した設計事項は architecture/ の対応ファイルに Write:
+- ビジョン → `architecture/vision.md`
+- Phase 計画 → `architecture/phases/<N>.md`
+- 設計判断 → `architecture/decisions/<NNNN>-<title>.md`（任意）
 
 TaskUpdate → completed
 

--- a/plugins/twl/tests/bats/ac-scaffold-tests-1266.bats
+++ b/plugins/twl/tests/bats/ac-scaffold-tests-1266.bats
@@ -1,0 +1,265 @@
+#!/usr/bin/env bats
+# ac-scaffold-tests-1266.bats
+#
+# Issue #1266: co-architect --type=value / DDD skip 対応
+#
+# AC coverage:
+#   AC1  - --type=generic 起動時 domain/* 不在で WARNING 出さない (INFO 降格)
+#   AC2  - ref-architecture-spec.md に Project Type 概念と type 別必須テーブル (DDD/Generic 列)
+#   AC3  - --type 未指定時デフォルト ddd、既存 architecture/ は影響なし (後方互換)
+#   AC4  - architect-completeness-check が --type=<value> を受け取り動的選択
+#   AC5  - --type 未指定時 .architecture-type → vision.md frontmatter → ddd の解決順序
+#   AC6  - 未知 type は明示エラーで停止
+#   AC7  - co-architect Step 2 メッセージに選択 type 名を表示
+#   AC8  - --type=generic 時 Step 2 が DDD フローではなく vision.md + phases/*.md フローに切り替わる
+#   AC9  - --group と --type 同時指定時 --group 優先、--type は --group 処理内に引き継がれる
+#   AC10 - lib type の予約（実装は将来、定義のみ）
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  COMPLETENESS_CHECK_CMD="${REPO_ROOT}/commands/architect-completeness-check.md"
+  CO_ARCHITECT_SKILL="${REPO_ROOT}/skills/co-architect/SKILL.md"
+  REF_ARCH_SPEC="${REPO_ROOT}/refs/ref-architecture-spec.md"
+  export COMPLETENESS_CHECK_CMD CO_ARCHITECT_SKILL REF_ARCH_SPEC
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC1: --type=generic 時 domain/* 不在で WARNING が出ない (INFO 降格)
+# ===========================================================================
+
+@test "ac1-generic-domain-no-warning: architect-completeness-check.md が generic type 時 domain/* を WARNING しない旨を記述している" {
+  # AC: co-architect --type=generic 起動時、domain/model.md / domain/glossary.md /
+  #     domain/contexts/*.md 不在で architect-completeness-check が WARNING を出さない (INFO 降格)
+  # RED: 現在 architect-completeness-check.md に --type=generic の分岐が存在しないため fail
+  run bash -c "
+    grep -qE 'generic.*INFO|INFO.*generic|type.*generic.*domain|generic.*domain.*INFO' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: ref-architecture-spec.md に Project Type 概念と type 別必須テーブル (DDD/Generic 列)
+# ===========================================================================
+
+@test "ac2-project-type-concept: ref-architecture-spec.md に Project Type または type 概念の定義がある" {
+  # AC: ref-architecture-spec.md に Project Type 概念が定義されている
+  # RED: 現在 ref-architecture-spec.md に Project Type 概念が存在しないため fail
+  run bash -c "
+    grep -qE 'Project Type|project.type|プロジェクト.*タイプ|ProjectType' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2-type-table-ddd-col: ref-architecture-spec.md の必須テーブルに DDD 列がある" {
+  # AC: ref-architecture-spec.md の必須テーブルに DDD 列が含まれる
+  # RED: 現在必須テーブルに DDD 列が存在しないため fail
+  run bash -c "
+    grep -qE '^\|.*DDD' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2-type-table-generic-col: ref-architecture-spec.md の必須テーブルに Generic 列がある" {
+  # AC: ref-architecture-spec.md の必須テーブルに Generic 列が含まれる
+  # RED: 現在必須テーブルに Generic 列が存在しないため fail
+  run bash -c "
+    grep -qE '^\|.*Generic|^\|.*GENERIC' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: --type 未指定時デフォルト ddd、後方互換
+# ===========================================================================
+
+@test "ac3-default-type-ddd: co-architect SKILL.md に --type 未指定時のデフォルトが ddd である旨が記述されている" {
+  # AC: --type 未指定時のデフォルトが ddd で既存 architecture/ を持つプロジェクトは影響なし
+  # RED: 現在 SKILL.md に --type デフォルト値の記述が存在しないため fail
+  run bash -c "
+    grep -qE 'default.*ddd|ddd.*default|未指定.*ddd|ddd.*未指定' '${CO_ARCHITECT_SKILL}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3-backward-compat: architect-completeness-check.md に --type 未指定時の後方互換動作が記述されている" {
+  # AC: --type 未指定時は ddd として動作し、既存プロジェクトに影響しない
+  # RED: 現在 architect-completeness-check.md に後方互換の記述が存在しないため fail
+  run bash -c "
+    grep -qE '後方互換|backward.compat|backward_compat|既存.*影響なし|影響なし.*既存' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: architect-completeness-check が --type=<value> を受け取り動的列選択
+# ===========================================================================
+
+@test "ac4-type-argument: architect-completeness-check.md に --type 引数の記述がある" {
+  # AC: architect-completeness-check が --type=<value> 引数を受け取り、
+  #     ref-architecture-spec.md の対応列を動的に選択する
+  # RED: 現在 architect-completeness-check.md に --type 引数の記述が存在しないため fail
+  run bash -c "
+    grep -qE '\-\-type|--type=|type.*引数|type.*argument' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4-dynamic-column-selection: architect-completeness-check.md が type に応じて ref-architecture-spec.md の列を動的選択する記述がある" {
+  # AC: ADR-032 のテーブル駆動拡張として type 対応列を動的に選択する
+  # RED: 現在動的列選択の記述が存在しないため fail
+  run bash -c "
+    grep -qE '動的.*選択|select.*column|column.*select|type.*列|列.*type|対応列' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC5: --type 未指定時 .architecture-type → vision.md frontmatter → ddd の解決順序
+# ===========================================================================
+
+@test "ac5-resolution-architecture-type-file: architect-completeness-check.md に .architecture-type ファイル参照が記述されている" {
+  # AC: --type 未指定時 .architecture-type ファイルから type を解決する (第1優先)
+  # RED: 現在 .architecture-type ファイル参照の記述が存在しないため fail
+  run bash -c "
+    grep -qE '\.architecture-type|architecture.type.*ファイル|architecture-type' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-resolution-frontmatter: architect-completeness-check.md に vision.md frontmatter 参照が記述されている" {
+  # AC: --type 未指定時 vision.md frontmatter から type を解決する (第2優先)
+  # RED: 現在 vision.md frontmatter 参照の記述が存在しないため fail
+  run bash -c "
+    grep -qE 'frontmatter|vision\.md.*type|front.matter' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5-resolution-order: architect-completeness-check.md の type 解決順序が .architecture-type → frontmatter → ddd になっている" {
+  # AC: 解決優先順位 .architecture-type > vision.md frontmatter > ddd が明記されている
+  # RED: 現在解決順序の記述が存在しないため fail
+  run bash -c "
+    grep -qE '1.*\.architecture-type|第1.*\.architecture-type|\.architecture-type.*第1|architecture-type.*→|architecture-type.*first' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC6: 未知 type は明示エラーで停止
+# ===========================================================================
+
+@test "ac6-unknown-type-error: architect-completeness-check.md に未知 type のエラー停止が記述されている" {
+  # AC: 未知の type (--type=foo) は明示エラーで停止する
+  # RED: 現在未知 type のエラー処理記述が存在しないため fail
+  run bash -c "
+    grep -qE '未知.*type|unknown.*type|type.*unknown|invalid.*type|type.*invalid|エラー.*停止|停止.*エラー' '${COMPLETENESS_CHECK_CMD}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6-valid-type-values: ref-architecture-spec.md に有効な type 値の定義がある" {
+  # AC: 有効な type 値 (ddd, generic 等) が ref-architecture-spec.md で定義されている
+  # RED: 現在有効 type 値の定義が存在しないため fail
+  run bash -c "
+    grep -qE 'ddd.*generic|generic.*ddd|有効.*type|type.*値域|valid.*type' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC7: co-architect Step 2 メッセージに選択 type 名を表示
+# ===========================================================================
+
+@test "ac7-step2-type-display: co-architect SKILL.md の Step 2 に type 名表示の記述がある" {
+  # AC: co-architect Step 2 のメッセージに選択された type 名を表示する
+  # RED: 現在 SKILL.md の Step 2 に type 名表示の記述が存在しないため fail
+  run bash -c "
+    awk '/## Step 2:/{found=1} found && /## Step 3:/{exit} found{print}' '${CO_ARCHITECT_SKILL}' \
+      | grep -qE 'type.*名|type.*name|選択.*type|type.*表示|display.*type'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC8: --type=generic 時 Step 2 が DDD フローではなく vision.md + phases フローに切り替わる
+# ===========================================================================
+
+@test "ac8-generic-flow-switch: co-architect SKILL.md に --type=generic 時の Step 2 フロー切り替えが記述されている" {
+  # AC: --type=generic 時 Step 2 の対話プロンプトが Bounded Context / ユビキタス言語ではなく
+  #     vision.md + phases/*.md 設計フローに切り替わる
+  # RED: 現在 SKILL.md に generic type の分岐が存在しないため fail
+  run bash -c "
+    grep -qE 'generic.*phases|phases.*generic|type.*generic.*flow|generic.*フロー|generic.*vision' '${CO_ARCHITECT_SKILL}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac8-generic-no-bounded-context: co-architect SKILL.md に --type=generic 時は Bounded Context を省略する記述がある" {
+  # AC: generic type では Bounded Context / ユビキタス言語の対話が行われない
+  # RED: 現在 SKILL.md に generic フローの Bounded Context スキップ記述が存在しないため fail
+  run bash -c "
+    grep -qE 'generic.*Bounded Context.*省略|generic.*skip.*Bounded|Bounded.*generic.*not required|generic.*不要.*Bounded' '${CO_ARCHITECT_SKILL}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC9: --group と --type 同時指定時 --group 優先、--type は --group 処理に引き継がれる
+# ===========================================================================
+
+@test "ac9-group-takes-precedence: co-architect SKILL.md に --group と --type 同時指定時 --group 優先の記述がある" {
+  # AC: --group と --type 同時指定時は --group 優先で動作し、--type は --group 処理内に引き継がれる
+  # RED: 現在 SKILL.md の Step 0 に --group + --type の優先順位記述が存在しないため fail
+  run bash -c "
+    grep -qE '\-\-group.*\-\-type|\-\-type.*\-\-group|group.*優先|group.*priority|group.*type.*引き継' '${CO_ARCHITECT_SKILL}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac9-type-passed-to-group: co-architect SKILL.md の --group 呼び出しに --type を引き継ぐ記述がある" {
+  # AC: architect-group-refine 呼び出し時に --type が引き継がれる
+  # RED: 現在 architect-group-refine 呼び出しに --type の引き渡し記述が存在しないため fail
+  run bash -c "
+    # Step 0 の group-refine 呼び出し行に --type の引き継ぎが含まれること
+    awk '/## Step 0/{found=1} found && /## Step 1/{exit} found{print}' '${CO_ARCHITECT_SKILL}' \
+      | grep -qE 'type.*引き継|--type.*group.refine|group.refine.*--type|pass.*type'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC10: lib type の予約（実装は将来、定義のみ）
+# ===========================================================================
+
+@test "ac10-lib-type-reserved: ref-architecture-spec.md に lib type が予約済みとして定義されている" {
+  # AC: lib type の予約 (実装は将来、定義のみ)
+  # RED: 現在 ref-architecture-spec.md に lib type の予約定義が存在しないため fail
+  run bash -c "
+    grep -qE 'lib.*予約|lib.*reserved|reserved.*lib|type.*lib' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10-lib-type-not-implemented: ref-architecture-spec.md の lib type が「将来実装」または未実装として明記されている" {
+  # AC: lib type は将来の実装予定として定義されており、現時点では動作しない
+  # RED: 現在 lib type の予約定義が存在しないため fail
+  run bash -c "
+    grep -qE 'lib.*将来|lib.*future|future.*lib|lib.*TBD|TBD.*lib|lib.*未実装|lib.*not.yet' '${REF_ARCH_SPEC}'
+  "
+  [ "${status}" -eq 0 ]
+}

--- a/plugins/twl/tests/bats/ac-test-mapping-1266.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1266.yaml
@@ -1,0 +1,80 @@
+---
+# ac-test-mapping-1266.yaml
+# Issue #1266: co-architect --type=value / DDD skip 対応
+# 生成日: 2026-05-03
+# テストファイル: plugins/twl/tests/bats/ac-scaffold-tests-1266.bats
+# フェーズ: TDD RED（全テストが実装前に fail することを確認済み）
+
+mappings:
+  - ac_index: 1
+    ac_text: "co-architect --type=generic 起動時、domain/model.md / domain/glossary.md / domain/contexts/*.md 不在で architect-completeness-check が WARNING を出さない (INFO 降格)"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac1-generic-domain-no-warning: architect-completeness-check.md が generic type 時 domain/* を WARNING しない旨を記述している"
+    impl_files:
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 2
+    ac_text: "ref-architecture-spec.md に Project Type 概念と type 別必須テーブル (DDD / Generic 列) が定義されている"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac2-project-type-concept / ac2-type-table-ddd-col / ac2-type-table-generic-col"
+    impl_files:
+      - "plugins/twl/refs/ref-architecture-spec.md"
+
+  - ac_index: 3
+    ac_text: "--type 未指定時のデフォルトが ddd で、既存 architecture/ を持つプロジェクトは影響なし (後方互換)"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac3-default-type-ddd / ac3-backward-compat"
+    impl_files:
+      - "plugins/twl/skills/co-architect/SKILL.md"
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 4
+    ac_text: "architect-completeness-check が --type=<value> 引数を受け取り、ref-architecture-spec.md の対応列を動的に選択する (ADR-032 のテーブル駆動拡張)"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac4-type-argument / ac4-dynamic-column-selection"
+    impl_files:
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 5
+    ac_text: "architect-completeness-check の --type 未指定時は .architecture-type → vision.md frontmatter → ddd の順で type を解決する"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac5-resolution-architecture-type-file / ac5-resolution-frontmatter / ac5-resolution-order"
+    impl_files:
+      - "plugins/twl/commands/architect-completeness-check.md"
+
+  - ac_index: 6
+    ac_text: "type 値の検証 — 未知の type (--type=foo) は明示エラーで停止"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac6-unknown-type-error / ac6-valid-type-values"
+    impl_files:
+      - "plugins/twl/commands/architect-completeness-check.md"
+      - "plugins/twl/refs/ref-architecture-spec.md"
+
+  - ac_index: 7
+    ac_text: "co-architect Step 2 のメッセージに選択された type 名を表示"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac7-step2-type-display"
+    impl_files:
+      - "plugins/twl/skills/co-architect/SKILL.md"
+
+  - ac_index: 8
+    ac_text: "--type=generic 時、Step 2 の対話プロンプトが DDD 特有の設計（Bounded Context / ユビキタス言語等）ではなく、vision.md + phases/*.md 設計フローに切り替わる"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac8-generic-flow-switch / ac8-generic-no-bounded-context"
+    impl_files:
+      - "plugins/twl/skills/co-architect/SKILL.md"
+
+  - ac_index: 9
+    ac_text: "--group と --type 同時指定時は --group 優先で動作し、--type は --group 処理内に引き継がれる"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac9-group-takes-precedence / ac9-type-passed-to-group"
+    impl_files:
+      - "plugins/twl/skills/co-architect/SKILL.md"
+      - "plugins/twl/commands/architect-group-refine.md"
+
+  - ac_index: 10
+    ac_text: "lib type の予約 (実装は将来、定義のみ)"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1266.bats"
+    test_name: "ac10-lib-type-reserved / ac10-lib-type-not-implemented"
+    impl_files:
+      - "plugins/twl/refs/ref-architecture-spec.md"


### PR DESCRIPTION
## 概要

Issue #1266 の実装。co-architect に `--type` 引数を追加し、DDD 以外のプロジェクト（generic）では domain/* ファイルが WARNING にならないよう対応。

## 変更内容

- `ref-architecture-spec.md`: Project Type 概念と DDD/Generic 別必須テーブルを追加。`lib` type を将来予約定義
- `architect-completeness-check.md`: `--type` 引数・type 解決ロジック（.architecture-type → vision.md frontmatter → ddd）・型検証を追加。generic type 時は domain/* を INFO 降格
- `co-architect/SKILL.md`: type 名表示（Step 2）、generic フロー分岐、`--group` + `--type` 同時指定時の引き継ぎを追加

## テスト

- `ac-scaffold-tests-1266.bats`: 全 20 件 PASS（GREEN）

Closes #1266