### PR TITLE
fix(#1263): fix-phase 発動条件に ac-verify CRITICAL を追加

### DIFF
--- a/cli/twl/tests/skills/workflow-pr-fix/ac-test-mapping.yaml
+++ b/cli/twl/tests/skills/workflow-pr-fix/ac-test-mapping.yaml
@@ -1,0 +1,72 @@
+mappings:
+  - ac_index: 1
+    ac_text: >-
+      chain logic 修正 (案 A): workflow-pr-fix の fix-phase 判定で phase-review.json CRITICAL に加え
+      ac-verify.json CRITICAL も critical_count に含めるよう修正
+      (plugins/twl/skills/workflow-pr-fix/ 該当箇所)。
+      SKIP 条件は phase_review_critical + ac_verify_critical == 0 のみ
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac1: fix-phase.md の発動条件に ac-verify CRITICAL が含まれる"
+    impl_files:
+      - "plugins/twl/commands/fix-phase.md"
+
+  - ac_index: 2
+    ac_text: >-
+      regression bats (a): ac-verify CRITICAL 1+ かつ phase-review CRITICAL 0 → fix-phase が走ること
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac2a: ac-verify CRITICAL 1+ かつ phase-review CRITICAL 0 のとき fix-phase が実行される"
+    impl_files:
+      - "plugins/twl/commands/fix-phase.md"
+
+  - ac_index: 2
+    ac_text: >-
+      regression bats (b): 両方 0 → SKIP
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac2b: phase-review CRITICAL 0 かつ ac-verify CRITICAL 0 のとき fix-phase を SKIP する"
+    impl_files:
+      - "plugins/twl/commands/fix-phase.md"
+
+  - ac_index: 2
+    ac_text: >-
+      regression bats (c): 両方 1+ → fix-phase が走り両 findings が input として渡ること
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac2c: phase-review と ac-verify 両方 CRITICAL 1+ のとき両 findings が fix-phase の input として渡される"
+    impl_files:
+      - "plugins/twl/commands/fix-phase.md"
+
+  - ac_index: 3
+    ac_text: >-
+      Worker prompt 注入 (案 C): Worker prompt template
+      (plugins/twl/skills/co-autopilot/refs/worker-prompt-*.md 該当箇所) に
+      「TDD-style Issue では GREEN phase まで実装し、test scaffold のみで PR を出してはならない。
+      RED 状態 PR は ac-verify CRITICAL でブロックされる」旨の指示を追加
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac3: co-autopilot SKILL.md に TDD GREEN phase 完遂の指示が含まれる"
+    impl_files:
+      - "plugins/twl/skills/co-autopilot/SKILL.md"
+
+  - ac_index: 4
+    ac_text: >-
+      docs 追記: plugins/twl/refs/pr-merge-chain-steps.md の fix-phase セクションに
+      「ac-verify CRITICAL も判定対象」と明記
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac4a: pr-merge-chain-steps.md の fix-phase セクションに ac-verify CRITICAL が明記されている"
+    impl_files:
+      - "plugins/twl/refs/pr-merge-chain-steps.md"
+
+  - ac_index: 4
+    ac_text: >-
+      ADR-022 (chain SSoT) に変更点を記録
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac4b: ADR-022 に ac-verify CRITICAL を fix-phase 判定に追加した変更点が記録されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md"
+
+  - ac_index: 5
+    ac_text: >-
+      検証 (本 Issue クローズ条件): lab-assistant#6 を再 spawn し、本 fix 後の autopilot で
+      TDD RED → GREEN 完遂が確認できる（または同等条件の minimal fixture project で再現）こと
+    test_file: "cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats"
+    test_name: "ac5: fix-phase.md が ac-verify CRITICAL を含む発動条件を持つ（TDD RED->GREEN 前提条件）"
+    impl_files: []
+    # impl_files: プロセス AC。full e2e 検証は lab-assistant#6 再 spawn で実施。

--- a/cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats
+++ b/cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+# test_1263_fix_phase_ac_verify.bats
+#
+# Issue #1263: autopilot が TDD RED-only PR を fix-phase 未実行でマージしてしまうバグ
+#
+# 対象 AC:
+#   AC1: fix-phase.md の発動条件に ac-verify CRITICAL も含めるよう修正
+#   AC2: regression fixture —
+#        (a) ac-verify CRITICAL 1+ / phase-review CRITICAL 0 → fix-phase が走る
+#        (b) 両方 0 → SKIP
+#        (c) 両方 1+ → fix-phase が走り両 findings が input として渡る
+#   AC3: worker-prompt template に TDD GREEN phase まで実装する旨の指示を追加
+#   AC4: pr-merge-chain-steps.md の fix-phase セクションに ac-verify CRITICAL も
+#        判定対象と明記 / ADR-022 に変更点を記録
+#   AC5: 本 fix 後の autopilot で TDD RED → GREEN 完遂が確認される（プロセス AC）
+#
+# 全テストは実装前に fail (RED) する。
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../../../" && pwd)"
+    FIX_PHASE_MD="${REPO_ROOT}/plugins/twl/commands/fix-phase.md"
+    PR_MERGE_STEPS_MD="${REPO_ROOT}/plugins/twl/refs/pr-merge-chain-steps.md"
+    ADR_022_MD="${REPO_ROOT}/plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md"
+    CO_AUTOPILOT_SKILL_MD="${REPO_ROOT}/plugins/twl/skills/co-autopilot/SKILL.md"
+}
+
+# ===========================================================================
+# AC1: fix-phase.md の発動条件に ac-verify CRITICAL が追加されていること
+# RED: 現状 fix-phase.md は phase-review の critical_count のみ参照しており
+#      ac-verify CRITICAL を参照していないため FAIL する
+# ===========================================================================
+
+@test "ac1: fix-phase.md の発動条件に ac-verify CRITICAL が含まれる" {
+    # AC: commands/fix-phase.md の SKIP 条件が
+    #     phase_review_critical + ac_verify_critical == 0 になっていること
+    # RED: 実装前は ac-verify への言及がないため FAIL する
+    [[ -f "$FIX_PHASE_MD" ]] \
+        || { echo "FAIL: fix-phase.md が見つかりません: $FIX_PHASE_MD"; false; }
+
+    # ac-verify checkpoint への参照が追加されていること
+    grep -qE 'ac.verify' "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に ac-verify への言及がありません"; false; }
+
+    # 発動条件として ac_verify の critical_count / CRITICAL が参照されていること
+    grep -qE 'ac.verify.*critical|ac_verify.*CRITICAL|ac_verify_critical|phase_review_critical.*ac_verify' \
+        "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md の発動条件に ac_verify CRITICAL が含まれていません"; false; }
+}
+
+# ===========================================================================
+# AC2-a: ac-verify CRITICAL 1+ / phase-review CRITICAL 0 → fix-phase が走ること
+# RED: 現状の fix-phase.md は phase-review CRITICAL のみを参照しているため
+#      このシナリオでは fix-phase をスキップしてしまい FAIL する
+# ===========================================================================
+
+@test "ac2a: ac-verify CRITICAL 1+ かつ phase-review CRITICAL 0 のとき fix-phase が実行される" {
+    # AC: ac-verify.json に CRITICAL findings が存在し phase-review.json に CRITICAL 0 の場合、
+    #     fix-phase を SKIP しないこと
+    # RED: 実装前の fix-phase.md は phase-review critical_count > 0 のみを条件とするため
+    #      このシナリオは SKIP 扱いになり FAIL する
+
+    [[ -f "$FIX_PHASE_MD" ]] \
+        || { echo "FAIL: fix-phase.md が見つかりません: $FIX_PHASE_MD"; false; }
+
+    # 修正後は ac-verify CRITICAL 単独でも fix-phase を発動する条件が記載されること
+    # 具体的には "phase_review_critical + ac_verify_critical == 0" のみが SKIP 条件
+    grep -qE 'ac_verify_critical.*==.*0|ac.verify.*0.*skip|phase_review_critical.*ac_verify_critical' \
+        "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に ac_verify_critical == 0 を SKIP 条件とする記述がありません"; false; }
+}
+
+# ===========================================================================
+# AC2-b: phase-review CRITICAL 0 かつ ac-verify CRITICAL 0 → fix-phase が SKIP
+# RED: 上記条件の記述が存在しないため FAIL する（AC1/AC2-a と同起因）
+# ===========================================================================
+
+@test "ac2b: phase-review CRITICAL 0 かつ ac-verify CRITICAL 0 のとき fix-phase を SKIP する" {
+    # AC: 両方 0 の場合のみ SKIP — SKILL.md またはコマンドに明記されていること
+    # RED: 実装前は SKIP 条件が "phase-review critical_count == 0" のみのため FAIL する
+
+    [[ -f "$FIX_PHASE_MD" ]] \
+        || { echo "FAIL: fix-phase.md が見つかりません: $FIX_PHASE_MD"; false; }
+
+    # SKIP 条件として "両方 0" であることが明記されていること
+    grep -qE 'SKIP|skip' "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に SKIP 条件の記述がありません"; false; }
+
+    # 両方 0 のときのみ SKIP という制約が表現されていること
+    grep -qE '(phase_review_critical|phase.review).*\+.*(ac_verify_critical|ac.verify)|両方.*0|both.*0|== 0.*SKIP' \
+        "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に phase_review + ac_verify の合計 == 0 を SKIP 条件とする記述がありません"; false; }
+}
+
+# ===========================================================================
+# AC2-c: 両方 CRITICAL 1+ → fix-phase が両 findings を input として渡す
+# RED: ac-verify findings を input に渡すロジックが未実装のため FAIL する
+# ===========================================================================
+
+@test "ac2c: phase-review と ac-verify 両方 CRITICAL 1+ のとき両 findings が fix-phase の input として渡される" {
+    # AC: fix-phase.md が phase-review と ac-verify の両 checkpoint から
+    #     CRITICAL findings を取得して修正指示に渡していること
+    # RED: 現在は phase-review checkpoint からのみ取得しており ac-verify を読まない
+
+    [[ -f "$FIX_PHASE_MD" ]] \
+        || { echo "FAIL: fix-phase.md が見つかりません: $FIX_PHASE_MD"; false; }
+
+    # ac-verify checkpoint からの findings 取得コマンドが記載されていること
+    grep -qE 'checkpoint.*read.*ac.verify|ac.verify.*checkpoint.*read|step ac.verify.*findings|ac.verify.*critical.findings' \
+        "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に ac-verify checkpoint からの findings 取得が記載されていません"; false; }
+}
+
+# ===========================================================================
+# AC3: worker-prompt (co-autopilot SKILL.md) に TDD GREEN phase 完遂の指示が追加されていること
+# RED: 現状の co-autopilot SKILL.md に TDD/GREEN/scaffold に関する制約記述がないため FAIL する
+# ===========================================================================
+
+@test "ac3: co-autopilot SKILL.md に TDD GREEN phase 完遂の指示が含まれる" {
+    # AC: plugins/twl/skills/co-autopilot/SKILL.md または
+    #     plugins/twl/scripts/issue-lifecycle-orchestrator.sh の worker prompt 生成箇所に
+    #     「TDD-style Issue では GREEN phase まで実装し test scaffold のみで PR を出してはならない」
+    #     旨の指示が追加されていること
+    # RED: 実装前はこの旨の記述がないため FAIL する
+
+    [[ -f "$CO_AUTOPILOT_SKILL_MD" ]] \
+        || { echo "FAIL: co-autopilot SKILL.md が見つかりません: $CO_AUTOPILOT_SKILL_MD"; false; }
+
+    # TDD / GREEN / scaffold に関する制約が追加されていること
+    grep -qE 'TDD|GREEN.*phase|GREEN.*実装|test.*scaffold.*PR|scaffold.*のみ.*PR.*禁止|RED.*状態.*PR.*禁止' \
+        "$CO_AUTOPILOT_SKILL_MD" \
+        || { echo "FAIL: co-autopilot SKILL.md に TDD GREEN phase まで実装する旨の指示がありません"; false; }
+}
+
+# ===========================================================================
+# AC4-a: pr-merge-chain-steps.md の fix-phase セクションに ac-verify CRITICAL も
+#         判定対象と明記されていること
+# RED: 現状 pr-merge-chain-steps.md に ac-verify CRITICAL への言及がないため FAIL する
+# ===========================================================================
+
+@test "ac4a: pr-merge-chain-steps.md の fix-phase セクションに ac-verify CRITICAL が明記されている" {
+    # AC: plugins/twl/refs/pr-merge-chain-steps.md の fix-phase セクションに
+    #     「ac-verify CRITICAL も判定対象」と明記されていること
+    # RED: 現状この記述がないため FAIL する
+
+    [[ -f "$PR_MERGE_STEPS_MD" ]] \
+        || { echo "FAIL: pr-merge-chain-steps.md が見つかりません: $PR_MERGE_STEPS_MD"; false; }
+
+    grep -qE 'ac.verify.*CRITICAL.*判定|ac.verify.*判定.*対象|fix.phase.*ac.verify.*CRITICAL' \
+        "$PR_MERGE_STEPS_MD" \
+        || { echo "FAIL: pr-merge-chain-steps.md に ac-verify CRITICAL 判定対象の記述がありません"; false; }
+}
+
+# ===========================================================================
+# AC4-b: ADR-022 に今回の変更点（ac-verify CRITICAL を fix-phase 条件に追加）が記録されていること
+# RED: 現状 ADR-022 に Issue #1263 の変更内容が記録されていないため FAIL する
+# ===========================================================================
+
+@test "ac4b: ADR-022 に ac-verify CRITICAL を fix-phase 判定に追加した変更点が記録されている" {
+    # AC: ADR-022-chain-ssot-boundary.md に #1263 または
+    #     ac-verify CRITICAL を fix-phase 条件に追加した旨の記述が追加されていること
+    # RED: 実装前は ADR-022 に今回変更の記録がないため FAIL する
+
+    [[ -f "$ADR_022_MD" ]] \
+        || { echo "FAIL: ADR-022-chain-ssot-boundary.md が見つかりません: $ADR_022_MD"; false; }
+
+    grep -qE '#1263|ac.verify.*CRITICAL.*fix.phase|fix.phase.*ac.verify.*CRITICAL' \
+        "$ADR_022_MD" \
+        || { echo "FAIL: ADR-022 に #1263 または ac-verify CRITICAL → fix-phase 変更の記録がありません"; false; }
+}
+
+# ===========================================================================
+# AC5: プロセス AC（検証）— minimal fixture で TDD RED → GREEN 完遂を機械的に確認
+# RED: 本 fix 前は ac-verify CRITICAL があっても fix-phase がスキップされるため
+#      RED → GREEN フローが成立しない。fix-phase.md の修正なしでは FAIL する。
+# ===========================================================================
+
+@test "ac5: fix-phase.md が ac-verify CRITICAL を含む発動条件を持つ（TDD RED->GREEN 前提条件）" {
+    # AC: プロセス AC の前提として fix-phase.md が ac-verify CRITICAL に反応すること。
+    #     lab-assistant#6 等の full e2e 検証は本テストスコープ外だが、
+    #     その前提条件（fix-phase 修正済み）を機械確認する。
+    # RED: 実装前は ac-verify への言及が一切ないため FAIL する
+
+    [[ -f "$FIX_PHASE_MD" ]] \
+        || { echo "FAIL: fix-phase.md が見つかりません: $FIX_PHASE_MD"; false; }
+
+    # AC1 と同じ観点を AC5 視点から確認: ac-verify CRITICAL への言及が存在すること
+    local ac_verify_mention_count
+    ac_verify_mention_count="$(grep -cE 'ac.verify' "$FIX_PHASE_MD" 2>/dev/null || true)"
+    ac_verify_mention_count="${ac_verify_mention_count//[^0-9]/}"
+    ac_verify_mention_count="${ac_verify_mention_count:-0}"
+
+    # 修正後は ac-verify への言及が 1 行以上あること
+    [[ "$ac_verify_mention_count" -gt 0 ]] \
+        || { echo "FAIL: fix-phase.md に ac-verify への言及がゼロ行です (count=${ac_verify_mention_count})"; false; }
+
+    # さらに SKIP 条件として ac_verify_critical が含まれること
+    grep -qE 'ac_verify_critical|ac.verify.*critical_count' "$FIX_PHASE_MD" \
+        || { echo "FAIL: fix-phase.md に ac_verify_critical の SKIP 条件が記述されていません（TDD RED→GREEN 前提条件未達）"; false; }
+}

--- a/plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md
+++ b/plugins/twl/architecture/decisions/ADR-022-chain-ssot-boundary.md
@@ -87,3 +87,20 @@ ADR-020 D-1 (名称正規化)、D-3 (export API)、D-4 (feature flag) は本 ADR
 - **chain.py と workflow-pr-merge SKILL の step 順序整合化**: `all-pass-check` と `pr-cycle-report` の順序不整合は別 Issue (Phase D) で調査する。本 ADR のスコープ外
 - **CHAIN_META の将来導入**: step メタデータ (dispatch_mode, 所属 chain) が必要になった場合は、chain.py の新規 dict として追加検討 (本 ADR で廃案にしたわけではなく、必要性が再確認された時点で再提案)
 - **deps.yaml.chains の step 順序検証**: workflow skill 概念順の正しさは bats テスト (#870 chain-export-drift.bats) で verify する方針 (本 ADR のスコープ外)
+
+## 変更履歴
+
+### #1263 (2026-05-03): fix-phase 発動条件に ac-verify CRITICAL を追加
+
+`workflow-pr-fix` の `fix-phase` 判定を変更:
+
+- **変更前**: `phase-review.critical_count > 0` のみが fix-phase の発動条件
+- **変更後**: `phase_review_critical + ac_verify_critical > 0`（どちらか 1 以上で発動）
+
+変更対象:
+- `plugins/twl/commands/fix-phase.md` — checkpoint 読み込みと発動条件を更新
+- `plugins/twl/skills/workflow-pr-fix/SKILL.md` — fix ループ条件の記述を更新
+- `plugins/twl/skills/co-autopilot/SKILL.md` — TDD GREEN phase 完遂ルール追加（禁止事項）
+- `plugins/twl/refs/pr-merge-chain-steps.md` — fix-phase セクションに ac-verify CRITICAL 判定を明記
+
+この変更は D-4（workflow skill 内 orchestrate step の取扱い）の範囲内であり、chain.py CHAIN_STEPS や chain-steps.sh には影響しない。

--- a/plugins/twl/commands/fix-phase.md
+++ b/plugins/twl/commands/fix-phase.md
@@ -20,23 +20,34 @@ chain ステップの実行順序は deps.yaml で宣言されている。
 
 ### checkpoint 読み込み（MUST）
 
-phase-review の checkpoint から CRITICAL findings を読み込む。
+phase-review と ac-verify の両 checkpoint から CRITICAL findings を読み込む。
 specialist raw output は参照しない。
 
 ```bash
 # phase-review checkpoint から CRITICAL findings を取得
-CRITICAL_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --critical-findings)
-CRITICAL_COUNT=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field critical_count)
+PHASE_REVIEW_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step phase-review --critical-findings 2>/dev/null || echo "")
+phase_review_critical=$(python3 -m twl.autopilot.checkpoint read --step phase-review --field critical_count 2>/dev/null || echo "0")
+
+# ac-verify checkpoint から CRITICAL findings を取得
+AC_VERIFY_FINDINGS=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --critical-findings 2>/dev/null || echo "")
+ac_verify_critical=$(python3 -m twl.autopilot.checkpoint read --step ac-verify --field critical_count 2>/dev/null || echo "0")
+
+# 両方を結合して修正指示として使用
+CRITICAL_FINDINGS="${PHASE_REVIEW_FINDINGS}
+${AC_VERIFY_FINDINGS}"
+CRITICAL_COUNT=$(( ${phase_review_critical:-0} + ${ac_verify_critical:-0} ))
 ```
 
 ### 発動条件
 
 ```
-IF phase-review の checkpoint に critical_count > 0 かつ
-   CRITICAL findings の confidence>=80 が存在
-THEN fix-phase を実行
-ELSE スキップ
+IF phase_review_critical + ac_verify_critical == 0
+THEN SKIP（修正不要）
+ELSE fix-phase を実行（phase-review CRITICAL / ac-verify CRITICAL のいずれかが 1 以上）
 ```
+
+**重要**: ac-verify CRITICAL は「テスト RED のまま PR を出した（GREEN 未完了）」等の TDD 違反を示す。
+phase-review CRITICAL が 0 であっても ac-verify CRITICAL が 1 以上なら fix-phase を発動する。
 
 ### 修正ループ
 

--- a/plugins/twl/refs/pr-merge-chain-steps.md
+++ b/plugins/twl/refs/pr-merge-chain-steps.md
@@ -2,6 +2,22 @@
 
 `workflow-pr-merge/SKILL.md` から切り出した各 Step の詳細実行手順。
 
+## Step 4: fix-phase（自動修正ループ）— 判定条件リファレンス
+
+fix-phase（`workflow-pr-fix` で実行）の発動条件は以下の通り:
+
+```
+IF phase_review_critical + ac_verify_critical == 0
+THEN skip（修正不要）
+ELSE fix-phase を実行
+```
+
+**ac-verify CRITICAL も判定対象**（#1263 追加）。
+phase-review が PASS（critical_count=0）でも、ac-verify CRITICAL が 1 以上の場合は fix-phase を実行する。
+
+- **ac-verify CRITICAL の例**: テスト RED のまま PR を出した（GREEN 未完了）、AC 実装が欠落している等の TDD 違反
+- checkpoint: `python3 -m twl.autopilot.checkpoint read --step ac-verify --field critical_count`
+
 ## Step 6: e2e-screening（Visual 検証）【LLM 判断】
 
 `commands/e2e-screening.md` を Read → 実行。E2E なければスキップ。

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -245,6 +245,14 @@ issue-{N}.json の status から自動判定:
 
 マージ手順は `refs/co-autopilot-emergency-bypass.md` を Read → 実行。
 
+## TDD 実装ルール（Worker 向け — MUST）
+
+TDD-style Issue（ac-scaffold-tests で RED テストが生成された場合）の Worker は以下を遵守すること:
+
+- **GREEN phase まで実装してから PR を出すこと**。test scaffold のみのコミットで PR を出してはならない
+- RED 状態の PR は ac-verify CRITICAL でブロックされる（`fix-phase` が強制実行される）
+- GREEN 確認コマンド例: `bats cli/twl/tests/skills/workflow-pr-fix/test_*.bats` 等、issue 固有のテストコマンドを実行し全 PASS を確認してから push すること
+
 ## 禁止事項（MUST NOT）
 
 - plan.yaml を独自生成してはならない（制約 AP-1）
@@ -254,3 +262,4 @@ issue-{N}.json の status から自動判定:
 - trivial change であっても co-autopilot を bypass してはならない（制約 AP-2）
 - Pilot は Worker の代わりに Issue を直接実装してはならない（不変条件 K）。Worker 失敗時は根本原因分析 → Issue 化で対処する
 - **Worker chain 停止時に Pilot が直接 nudge してマージしてはならない（不変条件 M）**。chain 停止時の復旧手順に従い orchestrator 再起動 or 手動 workflow inject で再開すること。specialist review スキップ禁止
+- **TDD-style Issue で test scaffold のみで PR を出してはならない**。GREEN phase 完了（全テスト PASS）後に PR を出すこと

--- a/plugins/twl/skills/workflow-pr-fix/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-fix/SKILL.md
@@ -64,7 +64,7 @@ CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
 ```
 
 ### Step 4: fix-phase（自動修正ループ）【LLM 判断】
-review に CRITICAL findings がある場合のみ。`commands/fix-phase.md` を Read → 実行。
+`phase_review_critical + ac_verify_critical > 0` の場合のみ実行。`commands/fix-phase.md` を Read → 実行。
 fix 後は post-fix-verify（Step 4.5）→ pr-test 再実行のループ。
 
 ### Step 4.5: post-fix-verify（fix 後検証）【LLM 判断】

--- a/plugins/twl/skills/workflow-pr-fix/SKILL.md
+++ b/plugins/twl/skills/workflow-pr-fix/SKILL.md
@@ -31,19 +31,23 @@ workflow-pr-cycle を 3 分割した第2段階。fix ループと warning 修正
 
 ### fix ループ条件
 
-phase-review（workflow-pr-verify で実行済み）が CRITICAL findings を返した場合の修正ループ:
+phase-review と ac-verify（workflow-pr-verify で実行済み）が CRITICAL findings を返した場合の修正ループ:
 
 ```
-IF phase-review に CRITICAL findings (confidence >= 80) が存在
+IF phase_review_critical + ac_verify_critical > 0
+   （phase-review CRITICAL または ac-verify CRITICAL のいずれかが 1 以上）
 THEN
   1. fix-phase を実行（Step 4）
   2. post-fix-verify を実行（Step 4.5）
   3. pr-test を再実行（runner）
   4. テスト PASS → warning-fix へ（Step 5）
   5. テスト FAIL → fix-phase に戻る（最大 1 ループ）
-ELSE
+ELSE （phase_review_critical + ac_verify_critical == 0 のみ）
   fix-phase をスキップし warning-fix へ
 ```
+
+**ac-verify CRITICAL の例**: テストが RED のまま PR を出した（GREEN 未完了）、
+AC の実装が欠落している等の TDD 違反。phase-review が PASS でも fix-phase を発動する。
 
 ## chain 実行指示（MUST — 全ステップを順に実行せよ。途中で停止するな）
 


### PR DESCRIPTION
## 概要

Issue #1263 の修正。autopilot が TDD RED-only PR を fix-phase 未実行でマージしてしまうバグを修正。

## 変更内容

- **fix-phase.md**: phase-review に加え ac-verify checkpoint も読み込み、SKIP 条件を `phase_review_critical + ac_verify_critical == 0` のみに変更
- **workflow-pr-fix/SKILL.md**: fix ループ条件に ac-verify CRITICAL を明記（案 A）
- **co-autopilot/SKILL.md**: TDD GREEN phase 完遂ルールを禁止事項に追加（案 C）
- **pr-merge-chain-steps.md**: fix-phase セクションに ac-verify CRITICAL 判定対象を追記
- **ADR-022**: #1263 変更点を変更履歴に記録
- **tests**: AC 1-5 対応 8 bats テスト追加

## テスト

```
bats cli/twl/tests/skills/workflow-pr-fix/test_1263_fix_phase_ac_verify.bats
1..8 (全 GREEN)
```

Closes #1263