### PR TITLE
feat(adr-024-phase-b): Tier B — co-issue Phase 4 [B] path + manual-fix-b.sh + refine/lifecycle-flow から label add 削除

### DIFF
--- a/plugins/twl/refs/lifecycle-processing-flow.md
+++ b/plugins/twl/refs/lifecycle-processing-flow.md
@@ -132,78 +132,40 @@ if round == policies.max_rounds and CRITICAL findings あり:
   exit 0
 ```
 
-### Step 4.5: refined ラベル判定
-
-round loop が正常完了した場合（STATE が `circuit_broken` でない場合）、`labels_hint` に `"refined"` を追加する:
-
-```
-if STATE != circuit_broken:
-  policies.labels_hint ← policies.labels_hint + ["refined"]
-```
-
-- `STATE == circuit_broken` の場合: スキップ（round loop が正常完了していないため）
-- `STATE == failed` の場合: Step 4c の `exit 0` で制御フローが終了するため Step 4.5 に到達しない（条件式の対象外）
-
 ### Step 5: arch-drift
 
 `/twl:issue-arch-drift` を Skill tool で呼び出す:
 - 入力: 最終 body（最後の body-fixed.md または rounds/0/body.md）
 
-### Step 6: issue 作成 + Status 書き込み（dual-write: label 先 → Status 後）
+### Step 6: issue 作成 + Status 書き込み（ADR-024 Phase B: Status=Refined SSoT）
 
 `/twl:issue-create` を Skill tool で呼び出す:
 - タイトルと本文は最終 body から抽出
-- labels: policies.labels_hint（Step 4.5 で追加された "refined" ラベルを含む）
+- labels: policies.labels_hint（refined を除く）
 - `--repo policies.target_repo`（null の場合は省略）
 
-issue 作成後、labels_hint のラベルを付与する際は以下の dual-write パターンを適用する（AC1+AC2 と同等、#1209 準拠）:
+issue 作成後、labels_hint のラベルを付与し、Status=Refined を設定する:
 
 ```bash
 # ISSUE_NUMBER: issue_url（/twl:issue-create 出力）の末尾パスセグメントから抽出
 # TARGET_REPO: policies.target_repo（null の場合は既定リポジトリ）
-# LABELS_HINT: jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json" で取得
 
-# idempotent auto-create pre-step（ADR-024 Phase 1; Phase B 移行で削除予定）
-# label 不在時に --add-label が失敗して Status=Refined 移行が skip される連鎖を断つ
-# 例: gh label create refined --color "8B5CF6" --description "auto-created" --repo "$TARGET_REPO" 2>/dev/null || true
-while IFS= read -r label; do
-  [[ -n "$label" ]] && gh label create "$label" --color "8B5CF6" --description "auto-created by workflow-issue-lifecycle" --repo "$TARGET_REPO" 2>/dev/null || true
-done < <(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json")
-
-# シェルレベル || true guard — loop が abort せず次 label に継続することを保証する
+# labels_hint のラベルを付与（refined を除く）
 while IFS= read -r label; do
   [[ -n "$label" ]] && gh issue edit "$ISSUE_NUMBER" --repo "$TARGET_REPO" --add-label "$label" 2>/dev/null || true
 done < <(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json")
 
-# Status update 独立性保証 — label 付与 loop の結果（成功/失敗/部分失敗）と無関係に実行される。
-# label 付与で発生した失敗は Status update を block しない（ADR-024 dual-write 独立性保証）。
-bash "${SCRIPTS_ROOT:-plugins/twl/scripts}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined \
-  2>/dev/null || echo "⚠️ Status=Refined への Board 更新失敗（label は付与済み）"
+# Status=Refined を設定（Phase B 移行後: Status only SSoT）
+bash "${SCRIPTS_ROOT:-plugins/twl/scripts}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined
+_status_exit=$?
+if [[ "$_status_exit" -ne 0 ]]; then
+  printf '[%s] WARN status_update_failed issue=#%s exit_code=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" "$_status_exit" \
+    >> /tmp/refined-status-update.log 2>/dev/null || true
+fi
 ```
-
-labels_hint に "refined" が含まれていれば Status=Todo を初期値として Board に登録する（project-board-sync で対応）。
 
 責任境界: #943 gate は Status=Refined の有無のみ確認。phase-review の内容は #940 の責務。
-
-**dual-write observability（Issue #1212）**: `/twl:issue-create` 完了後かつ Step 6.5 の前に、labels_hint に "refined" が含まれる場合は以下を実行する:
-
-```bash
-# refined-dual-write-log.sh を source（CLAUDE_PLUGIN_ROOT 不確定時の fallback あり）
-source "${CLAUDE_PLUGIN_ROOT}/scripts/refined-dual-write-log.sh" 2>/dev/null || true
-
-# /twl:issue-create は Skill tool 呼び出しのため exit code は直接取得できない。
-# Skill 実行後の labels_hint 付与を gh issue edit で行う場合は以下のパターンを使用する:
-#   gh issue edit "${ISSUE_NUMBER}" --repo "${TARGET_REPO}" --add-label refined
-#   _label_exit=$?
-#   if [[ "$_label_exit" -ne 0 ]]; then
-#     dual_write_log WARN label_add_failed "${ISSUE_NUMBER}" "label=refined repo=${TARGET_REPO} exit_code=${_label_exit}"
-#   else
-#     dual_write_log OK dual_write "${ISSUE_NUMBER}" "label_ok=Y"
-#   fi
-# Skill 内部での label 付与の場合は、Skill 完了後の issue label 状態を gh issue view で確認して記録する。
-```
-
-CLAUDE_PLUGIN_ROOT が不確定の場合の fallback: `bash -c 'source "${CLAUDE_PLUGIN_ROOT}/scripts/refined-dual-write-log.sh" && dual_write_log ...'` またはインライン `printf '[%s] WARN label_add_failed issue=#%s ...\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "${ISSUE_NUMBER}" >> /tmp/refined-dual-write.log` を使用する。
 
 ### Step 6.5: project-board-sync
 

--- a/plugins/twl/refs/refine-processing-flow.md
+++ b/plugins/twl/refs/refine-processing-flow.md
@@ -145,28 +145,12 @@ if round == policies.max_rounds and CRITICAL findings あり:
   exit 0
 ```
 
-### Step 4.5: refined ラベル判定
-
-round loop が正常完了した場合（STATE が `circuit_broken` でない場合）、`labels_hint` に `"refined"` を追加する:
-
-```bash
-if [[ "$(cat "$PER_ISSUE_DIR/STATE")" != "circuit_broken" ]]; then
-  # policies.json に "refined" ラベルを追加して永続化（Step 6' が jq で読み取るため）
-  jq '.labels_hint += ["refined"] | .labels_hint |= unique' \
-    "$PER_ISSUE_DIR/IN/policies.json" > "$PER_ISSUE_DIR/IN/policies.json.tmp" \
-    && mv "$PER_ISSUE_DIR/IN/policies.json.tmp" "$PER_ISSUE_DIR/IN/policies.json"
-fi
-```
-
-- `STATE == circuit_broken` の場合: スキップ（round loop が正常完了していないため）
-- `STATE == failed` の場合: Step 4c の `exit 0` で制御フローが終了するため Step 4.5 に到達しない（条件式の対象外）
-
 ### Step 5: arch-drift
 
 `/twl:issue-arch-drift` を Skill tool で呼び出す:
 - 入力: 最終 body（最後の body-fixed.md または rounds/0/body.md）
 
-### Step 6': body 更新 + ラベル付与 + Status 書き込み（dual-write: label 先 → Status 後）
+### Step 6': body 更新 + Status 書き込み（ADR-024 Phase B: Status=Refined SSoT）
 
 `existing-issue.json` から `number` と `repo` を取得し、既存 Issue の body を更新する。
 
@@ -185,59 +169,28 @@ for f in "$PER_ISSUE_DIR"/rounds/*/body-fixed.md; do
   [[ -f "$f" ]] && FINAL_BODY="$f"
 done
 
-# body 更新
+# body 更新（既存ラベル・title は変更しない）
 gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --body-file "$FINAL_BODY"
 
-# labels_hint のラベルを付与（既存ラベル・title は変更しない）
-# Step 4.5 で追加された "refined" ラベルも含む
-# dual-write 順序: label 先（ここまで）→ Status 後（下記）
-# 理由: Status を先に書くと autopilot が label 付与前に early spawn する race の可能性がある
-
-# dual-write observability ロガーを source（Issue #1212）— 後続 loop で dual_write_log を使用するため先に読み込む
-source "${CLAUDE_PLUGIN_ROOT:-$(dirname "$0")/..}/scripts/refined-dual-write-log.sh" 2>/dev/null || true
-
-# AC1(1): idempotent auto-create pre-step（ADR-024 Phase 1; Phase B 移行で削除予定、#1209）
-# label 不在時に --add-label が失敗して Status=Refined 移行が skip される連鎖を断つため、
-# 付与前に label を事前作成する。|| true で「既存 label でも abort しない」を保証する。
+# labels_hint のラベルを付与（refined を除く labels_hint のみ）
 while IFS= read -r label; do
-  [[ -n "$label" ]] && gh label create "$label" --color "8B5CF6" \
-    --description "auto-created by workflow-issue-refine" \
-    --repo "$ISSUE_REPO" 2>/dev/null || true
+  [[ -n "$label" ]] && gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label "$label" 2>/dev/null || true
 done < <(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json")
 
-# AC1(2): label 付与 + dual-write observability（#1209 のシェルレベル || true 分離 + Issue #1212 の logging）
-# 各 label の add 結果を dual_write_log で記録する。loop 内エラーは次 label に継続する。
-while IFS= read -r label; do
-  if [[ -n "$label" ]]; then
-    gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label "$label"
-    _label_exit=$?
-    if [[ "$_label_exit" -ne 0 ]]; then
-      dual_write_log WARN label_add_failed "$ISSUE_NUMBER" "label=$label repo=$ISSUE_REPO exit_code=$_label_exit"
-    else
-      dual_write_log OK dual_write "$ISSUE_NUMBER" "label_ok=Y"
-    fi
-  fi
-done < <(jq -r '.labels_hint[]' "$PER_ISSUE_DIR/IN/policies.json")
-
-# AC2: Status update 独立性保証 — label 付与 loop の結果（成功/失敗/部分失敗）と無関係に実行される。
-# label 付与で発生した失敗は Status update を block しない。
-# これは ADR-024 dual-write 順序遵守の元、label 付与失敗で Status=Todo のまま残ることを防ぐ独立性保証である。
-# 責任境界: #943 gate は Status=Refined の有無のみ確認、phase-review の内容は検証しない（#940 の責務）
-# dual-write observability (Issue #1212): Status update 失敗時も dual_write_log WARN status_update_failed を呼び出す
+# Status=Refined を設定（Phase B 移行後: Status only SSoT）
 if [[ "$(cat "$PER_ISSUE_DIR/STATE")" != "circuit_broken" ]]; then
   bash "${SCRIPTS_ROOT:-$(dirname "$0")/../../scripts}/chain-runner.sh" \
     board-status-update "$ISSUE_NUMBER" "Refined" 2>/dev/null
   _status_exit=$?
   if [[ "$_status_exit" -ne 0 ]]; then
-    echo "⚠️  Status=Refined への Board 更新失敗（label は付与済み）"
-    dual_write_log WARN status_update_failed "$ISSUE_NUMBER" "status=Refined chain_runner_exit=$_status_exit"
-  else
-    dual_write_log OK dual_write "$ISSUE_NUMBER" "label_ok=Y status_ok=Y"
+    printf '[%s] WARN status_update_failed issue=#%s exit_code=%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" "$_status_exit" \
+      >> /tmp/refined-status-update.log 2>/dev/null || true
   fi
 fi
 ```
 
-**制約**: 既存ラベル・title は変更しない（body のみ更新 + ラベル追加）。dual-write は label 先・Status 後の順序を厳守。Status 書き込み失敗時は label 付与済み状態で継続（ワークフロー停止しない）。
+**制約**: 既存ラベル・title は変更しない（body のみ更新）。Status=Refined は circuit_broken でない場合のみ設定。
 
 ### Step 7: 完了
 

--- a/plugins/twl/scripts/co-issue-manual-fix-b.sh
+++ b/plugins/twl/scripts/co-issue-manual-fix-b.sh
@@ -33,8 +33,9 @@ SCRIPTS_ROOT="$(cd "${SCRIPTS_ROOT}" && pwd 2>/dev/null)" || {
 }
 
 # Status=Refined を設定（Phase B 移行後: Status only SSoT）
-bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined
-_status_exit=$?
+# || _status_exit=$? で set -euo pipefail 下でも失敗終了コードを捕捉できる
+_status_exit=0
+bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined || _status_exit=$?
 # observability: status update 失敗時のみ WARN
 if [[ "$_status_exit" -ne 0 ]]; then
   printf '[%s] WARN status_update_failed issue=#%s exit_code=%s\n' \

--- a/plugins/twl/scripts/co-issue-manual-fix-b.sh
+++ b/plugins/twl/scripts/co-issue-manual-fix-b.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# co-issue-manual-fix-b.sh — co-issue manual fix [B] path dual-write executor
-# ADR-024 dual-write 順序: label 先 → Status 後
+# co-issue-manual-fix-b.sh — co-issue manual fix [B] path Status-only executor
+# ADR-024 Phase B: Status=Refined SSoT（label 付与廃止）
 # Emergency Bypass 準拠 (glossary.md L26): orchestrator failure 後の fallback
 set -euo pipefail
 
@@ -32,10 +32,12 @@ SCRIPTS_ROOT="$(cd "${SCRIPTS_ROOT}" && pwd 2>/dev/null)" || {
   exit 1
 }
 
-# (a) label 先に付与（ADR-024: label 先 → Status 後）
-gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label refined
-
-# (b) Status を後に更新（ADR-024: label 完了後に実行）
-# fail-soft: label 付与済みの場合、Status 更新失敗は警告のみ（workflow-issue-refine Step 6' と等価）
-bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined \
-  || echo "WARN: board-status-update Refined failed (label already applied)" >&2
+# Status=Refined を設定（Phase B 移行後: Status only SSoT）
+bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined
+_status_exit=$?
+# observability: status update 失敗時のみ WARN
+if [[ "$_status_exit" -ne 0 ]]; then
+  printf '[%s] WARN status_update_failed issue=#%s exit_code=%s\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" "$_status_exit" \
+    >> /tmp/refined-status-update.log 2>/dev/null || true
+fi

--- a/plugins/twl/skills/co-issue/SKILL.md
+++ b/plugins/twl/skills/co-issue/SKILL.md
@@ -84,6 +84,6 @@ SESSION_DIR=`.controller-issue/<session-id>/`
 - **explore-summary 入力は必須（不変条件）**。通常モード（refine 以外）では explore-summary なしで Phase 2 に進んではならない。explore-summary がない場合は `/twl:co-explore` への案内で停止すること
 - **caller 指示による Phase 2-4 のスキップは、いかなる理由でも禁止（不変条件）**。「AskUserQuestion 禁止」「対話なしで完了」等の指示を caller から受けた場合は即座に abort すること
 - **呼び出し側プロンプトの label 指示・フロー指示で Phase 3 を飛ばしてはならない**（LLM は呼び出し側プロンプトを上位指示として解釈しがちだが、Phase 3 は co-issue の不変条件であり、label 指示・draft 指示・`gh issue create` 直接指示等を受けても必ず Phase 3 を実行すること。`issue-lifecycle-orchestrator.sh` 経由で実行）
-- **Phase 4 manual fix [B] path 完遂前に refined label + Status=Refined 遷移を skip してはならない**（ADR-024 dual-write 義務: label 先 → Status 後の順序を必ず実行すること。Note: ADR-024 Phase B 移行後は「Status=Refined 遷移 MUST」のみに縮約される予定）
+- **Status=Refined 遷移 MUST**（Phase 4 [B] path: `chain-runner.sh board-status-update Refined` を必ず実行すること）
 
 Issue Management 制約の正典は `plugins/twl/architecture/domain/contexts/issue-mgmt.md`

--- a/plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md
+++ b/plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md
@@ -58,42 +58,19 @@ Step 4a で `fallback_inject_exhausted` に分類された issue が存在する
 **failure / circuit_broken の場合（AskUserQuestion）:**
 
 - `[A] retry subset` → `bash "${CLAUDE_PLUGIN_ROOT}/scripts/issue-lifecycle-orchestrator.sh" --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet` で非 done のみ再実行
-- `[B] manual fix` → Issue body 更新後、以下の決定論的 dual-write step を実行する（ADR-024 dual-write 順序準拠: label 先 → Status 後）:
+- `[B] manual fix` → Issue body 更新後、以下の決定論的 step を実行する（ADR-024 Phase B: Status=Refined SSoT）:
 
   ```bash
-  # (a-pre) idempotent auto-create（ADR-024 Phase 1; Phase B 移行で削除予定、#1209）
-  # refined label 不在時に --add-label が失敗して Status=Refined 移行が skip される連鎖を断つ
-  gh label create refined --color "C2E0C6" --description "auto-created by co-issue manual fix [B]" --repo "$ISSUE_REPO" 2>/dev/null || true
-
-  # (a) label 先に付与（ADR-024: label 先 → Status 後）。exit code を _label_exit に記録（Issue #1212 の dual-write log で使用）
-  gh issue edit "$ISSUE_NUMBER" --repo "$ISSUE_REPO" --add-label refined
-  _label_exit=$?
-
-  # (b) dual-write observability (Issue #1212): label 付与 exit code に応じて記録
-  # 失敗時（_label_exit != 0）: WARN label_add_failed を記録
-  # 成功時（_label_exit == 0）: OK dual_write を記録
-  # Pilot LLM は Bash tool で直接実行する（shell helper を source できない場合に備えた fallback 付き）
-  if [[ "$_label_exit" -ne 0 ]]; then
-    bash -c 'source "${CLAUDE_PLUGIN_ROOT}/scripts/refined-dual-write-log.sh" 2>/dev/null \
-      && dual_write_log WARN label_add_failed "'"$ISSUE_NUMBER"'" "label=refined repo='"$ISSUE_REPO"' exit_code='"$_label_exit"'"' \
-      2>/dev/null || \
-      printf '[%s] WARN label_add_failed issue=#%s label=refined repo=%s exit_code=%s\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" "$ISSUE_REPO" "$_label_exit" \
-        >> /tmp/refined-dual-write.log 2>/dev/null || true
-  else
-    bash -c 'source "${CLAUDE_PLUGIN_ROOT}/scripts/refined-dual-write-log.sh" 2>/dev/null \
-      && dual_write_log OK dual_write "'"$ISSUE_NUMBER"'" "label_ok=Y"' \
-      2>/dev/null || \
-      printf '[%s] OK dual_write issue=#%s label_ok=Y\n' \
-        "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" \
-        >> /tmp/refined-dual-write.log 2>/dev/null || true
-  fi
-  # CLAUDE_PLUGIN_ROOT 不確定時: inline printf で直接書き込む（上記 fallback）
-  # ISSUE_NUMBER は [B] path で Pilot が確認した Issue 番号（数字文字列）
-
-  # (c) Status を後に更新（ADR-024: label 完了後に実行）
+  # Status=Refined を設定（Phase B 移行後: Status only SSoT）
   bash "${SCRIPTS_ROOT:-plugins/twl/scripts}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined
+  _status_exit=$?
+  # observability: status update 失敗時のみ WARN
+  if [[ "$_status_exit" -ne 0 ]]; then
+    printf '[%s] WARN status_update_failed issue=#%s exit_code=%s\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$ISSUE_NUMBER" "$_status_exit" \
+      >> /tmp/refined-status-update.log 2>/dev/null || true
+  fi
   ```
 
-  dual-write 完了後、ユーザーに修正箇所と完了を案内する。
+  Status 更新完了後、ユーザーに修正箇所と完了を案内する。
 - `[C] accept partial` → このまま完了（**ユーザーの明示的承認を確認してから実行すること**。デフォルト選択禁止）

--- a/plugins/twl/tests/bats/ac-test-mapping-1292.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1292.yaml
@@ -1,0 +1,49 @@
+mappings:
+  - ac_index: 1
+    ac_text: "co-issue-phase4-aggregate.md から gh label create refined / gh issue edit --add-label refined 行が消えている (grep -nE 'gh (label create|issue edit.*refined)' ... で 0 件)"
+    test_file: "plugins/twl/tests/bats/co-issue-status-only-flow.bats"
+    test_name: "ac1: grep -nE 'gh (label create|issue edit.*refined)' が 0 件（RED: 現状は 2 件以上）"
+    impl_files:
+      - "plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md"
+  - ac_index: 2
+    ac_text: "co-issue-manual-fix-b.sh から label 付与 step が消えている (Status=Refined 設定 + observability の最小構成)"
+    test_file: "plugins/twl/tests/bats/co-issue-manual-fix-b.bats"
+    test_name: "ac2: 実行時に gh issue edit --add-label refined が呼ばれないこと（RED: 現状は呼ばれる）"
+    impl_files:
+      - "plugins/twl/scripts/co-issue-manual-fix-b.sh"
+  - ac_index: 3
+    ac_text: "refine-processing-flow.md から labels_hint += [\"refined\"] が消えている"
+    test_file: "plugins/twl/tests/bats/co-issue-status-only-flow.bats"
+    test_name: "ac3: refine-processing-flow.md に labels_hint += [\"refined\"] が存在しないこと（RED: 現状 L155 に存在する）"
+    impl_files:
+      - "plugins/twl/refs/refine-processing-flow.md"
+  - ac_index: 4
+    ac_text: "lifecycle-processing-flow.md から labels_hint += [\"refined\"] が消えている"
+    test_file: "plugins/twl/tests/bats/co-issue-status-only-flow.bats"
+    test_name: "ac4: lifecycle-processing-flow.md に policies.labels_hint + refined 追加コードが存在しないこと（RED: 現状 L141 に存在する）"
+    impl_files:
+      - "plugins/twl/refs/lifecycle-processing-flow.md"
+  - ac_index: 5
+    ac_text: "co-issue SKILL.md の MUST NOT 注意書きが「Status=Refined 遷移 MUST」に縮約されている"
+    test_file: "plugins/twl/tests/bats/co-issue-status-only-flow.bats"
+    test_name: "ac5: SKILL.md に縮約済み形式 'Status=Refined 遷移 MUST' が存在すること（RED: 現状は長い注意書き形式）"
+    impl_files:
+      - "plugins/twl/skills/co-issue/SKILL.md"
+  - ac_index: 6
+    ac_text: "bats test (co-issue-manual-fix-b.bats 等) が Status only 期待に書き換えられて全 PASS"
+    test_file: "plugins/twl/tests/bats/co-issue-manual-fix-b.bats"
+    test_name: "ac6: このテストファイルが Status only 期待のテストであること（meta: テスト名に add-label が存在しないこと）"
+    impl_files: []
+    # impl_files: co-issue-manual-fix-b.bats 自体がテスト対象（meta test）
+  - ac_index: 7
+    ac_text: "dual-write log event 整理 — WARN label_add_failed / OK dual_write が消え、WARN status_update_failed のみが残る"
+    test_file: "plugins/twl/tests/bats/co-issue-status-only-flow.bats"
+    test_name: "ac7: co-issue-phase4-aggregate.md に WARN label_add_failed が存在しないこと（RED: 現状 L73,L80 に存在する）"
+    impl_files:
+      - "plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md"
+  - ac_index: 8
+    ac_text: "新規起票 (本 PR の bats E2E) で Issue が Status=Refined のみ設定され、refined label が付与されないことを確認"
+    test_file: "plugins/twl/tests/bats/co-issue-manual-fix-b.bats"
+    test_name: "ac8: 実行後に refined label が付与されないこと（RED: 現状は付与される）"
+    impl_files:
+      - "plugins/twl/scripts/co-issue-manual-fix-b.sh"

--- a/plugins/twl/tests/bats/co-issue-manual-fix-b.bats
+++ b/plugins/twl/tests/bats/co-issue-manual-fix-b.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+# co-issue-manual-fix-b.bats
+#
+# RED-phase behavior tests for plugins/twl/scripts/co-issue-manual-fix-b.sh
+# Issue #1292: ADR-024 Phase B — co-issue-manual-fix-b.sh から label 付与 step 削除
+#
+# AC coverage:
+#   AC2 - co-issue-manual-fix-b.sh から label 付与 step が消えている (Status=Refined のみ)
+#   AC6 - bats test が Status only 期待に書き換えられて全 PASS
+#   AC7 - WARN label_add_failed / OK dual_write が消え WARN status_update_failed のみ残る
+#   AC8 - 実行時に Status=Refined のみ設定され、refined label が付与されないこと
+#
+# RED 状態の根拠:
+#   現在の co-issue-manual-fix-b.sh は `gh issue edit --add-label refined` を呼ぶため
+#   AC2/AC8 の "label 付与なし" アサーションが FAIL する。
+#   AC7 static: co-issue-manual-fix-b.sh に dual-write log コードが存在する（削除前）。
+
+load 'helpers/common'
+
+SCRIPT_SRC=""
+GH_CALLS_FILE=""
+CHAIN_RUNNER_CALLS_FILE=""
+
+setup() {
+  common_setup
+
+  # REPO_ROOT = plugins/twl (helpers/common.bash の定義)
+  SCRIPT_SRC="${REPO_ROOT}/scripts/co-issue-manual-fix-b.sh"
+  GH_CALLS_FILE="${SANDBOX}/gh-calls.log"
+  CHAIN_RUNNER_CALLS_FILE="${SANDBOX}/chain-runner-calls.log"
+
+  # gh stub: 全呼び出し引数を記録し常に exit 0 で返す
+  cat > "${STUB_BIN}/gh" <<GHEOF
+#!/usr/bin/env bash
+echo "gh \$*" >> "${GH_CALLS_FILE}"
+exit 0
+GHEOF
+  chmod +x "${STUB_BIN}/gh"
+
+  # chain-runner.sh stub: SCRIPTS_ROOT 配下に配置、呼び出し引数を記録し常に exit 0 で返す
+  # common_setup が $REPO_ROOT/scripts/*.sh を $SANDBOX/scripts/ にコピー済みのため上書き
+  cat > "${SANDBOX}/scripts/chain-runner.sh" <<CREOF
+#!/usr/bin/env bash
+echo "chain-runner.sh \$*" >> "${CHAIN_RUNNER_CALLS_FILE}"
+exit 0
+CREOF
+  chmod +x "${SANDBOX}/scripts/chain-runner.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# SCRIPTS_ROOT を sandbox に向けてスクリプトを実行するヘルパー
+_run_script() {
+  local issue_num="${1:-123}"
+  local repo="${2:-owner/repo}"
+  SCRIPTS_ROOT="${SANDBOX}/scripts" \
+    run bash "${SCRIPT_SRC}" "${issue_num}" "${repo}"
+}
+
+# ---------------------------------------------------------------------------
+# 前提確認
+# ---------------------------------------------------------------------------
+
+@test "前提: co-issue-manual-fix-b.sh が存在すること" {
+  [ -f "${SCRIPT_SRC}" ]
+}
+
+# ---------------------------------------------------------------------------
+# AC2: スクリプトから label 付与 step が消えていること（静的内容チェック）
+# RED: 現状 L34 に `gh issue edit --add-label refined` が存在するため FAIL
+# ---------------------------------------------------------------------------
+
+@test "ac2-static: co-issue-manual-fix-b.sh に --add-label refined が存在しないこと（RED: 現状は存在する）" {
+  # AC: Phase B 移行後、label 付与行が削除される
+  # RED: 現在 L34 に存在するため fail
+  run grep -n '\-\-add-label refined' "${SCRIPT_SRC}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-manual-fix-b.sh に --add-label refined が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac2-static: co-issue-manual-fix-b.sh に gh issue edit.*refined が存在しないこと（RED）" {
+  # AC: gh issue edit コマンドの refined label 付与が削除される
+  # RED: 現在存在するため fail
+  run grep -nE 'gh issue edit.*refined' "${SCRIPT_SRC}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-manual-fix-b.sh に gh issue edit refined 行が存在する:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac2-static: co-issue-manual-fix-b.sh に board-status-update.*Refined が存在すること（GREEN 保証）" {
+  # AC: Status=Refined 設定行は残る（label 付与のみ削除）
+  # GREEN: 現在の実装でも存在する → 実装前から PASS
+  run grep -c 'board-status-update.*Refined\|Refined.*board-status-update' "${SCRIPT_SRC}"
+  local count="${output:-0}"
+  if [ "${count}" -lt 1 ]; then
+    echo "FAIL: co-issue-manual-fix-b.sh に board-status-update Refined が存在しない" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC2/AC8: スクリプト実行時に gh issue edit --add-label refined が呼ばれないこと
+# RED: 現在の実装は呼ぶため FAIL
+# ---------------------------------------------------------------------------
+
+@test "ac2: 実行時に gh issue edit --add-label refined が呼ばれないこと（RED: 現状は呼ばれる）" {
+  # AC: Phase B 移行後、label 付与 step が削除される
+  # RED: 現在の実装は gh issue edit --add-label refined を呼ぶため fail
+  _run_script 123 "owner/repo"
+
+  if grep -qE 'gh issue edit.*--add-label refined|gh issue edit.*refined' "${GH_CALLS_FILE}" 2>/dev/null; then
+    echo "FAIL: gh issue edit --add-label refined が呼ばれた（Phase B では禁止）" >&2
+    cat "${GH_CALLS_FILE}" >&2
+    return 1
+  fi
+}
+
+@test "ac8: 実行後に refined label が付与されないこと（RED: 現状は付与される）" {
+  # AC: 実行後、gh で refined label が付与されない
+  # RED: 現在の実装は付与するため fail
+  _run_script 456 "test-owner/test-repo"
+
+  local gh_label_calls
+  gh_label_calls=$(grep -cE 'gh issue edit.*refined' "${GH_CALLS_FILE}" 2>/dev/null || echo "0")
+  gh_label_calls="${gh_label_calls// /}"
+
+  if [ "${gh_label_calls}" -gt 0 ]; then
+    echo "FAIL: refined label 付与が ${gh_label_calls} 件検出された（Phase B では 0 件必須）" >&2
+    grep -E 'gh issue edit.*refined' "${GH_CALLS_FILE}" >&2 || true
+    return 1
+  fi
+}
+
+@test "ac8: 実行時に gh が 0 回呼ばれること（label 付与なし）（RED: 現状は 1 回以上呼ばれる）" {
+  # AC: Phase B では gh issue edit が呼ばれない → 合計 gh 呼び出し = 0
+  # RED: 現在の実装は gh issue edit を呼ぶため fail
+  _run_script 789 "owner/repo"
+
+  local total_gh_calls
+  total_gh_calls=$(wc -l < "${GH_CALLS_FILE}" 2>/dev/null || echo "0")
+  total_gh_calls="${total_gh_calls// /}"
+
+  if [ "${total_gh_calls}" -gt 0 ]; then
+    echo "FAIL: gh が ${total_gh_calls} 回呼ばれた（Phase B では 0 回必須）" >&2
+    cat "${GH_CALLS_FILE}" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC8: Status=Refined が設定されること（GREEN 保証）
+# ---------------------------------------------------------------------------
+
+@test "ac8: chain-runner.sh board-status-update Refined が呼ばれること（GREEN 保証）" {
+  # AC: Status=Refined は維持される（label 付与のみ削除）
+  # GREEN: 現在の実装でも board-status-update は呼ばれる → 実装前から PASS
+  _run_script 123 "owner/repo"
+
+  if ! grep -qE 'chain-runner\.sh board-status-update 123 Refined' "${CHAIN_RUNNER_CALLS_FILE}" 2>/dev/null; then
+    echo "FAIL: chain-runner.sh board-status-update 123 Refined が呼ばれていない" >&2
+    cat "${CHAIN_RUNNER_CALLS_FILE}" >&2
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC7: dual-write log コードが削除されること（静的チェック）
+# RED: 現在 co-issue-manual-fix-b.sh には dual-write log コードはないが
+#      Issue #1292 スコープ内の co-issue-phase4-aggregate.md にはある（AC7 の主対象）
+# NOTE: co-issue-manual-fix-b.sh 自体に dual-write log コードがないことを確認
+# ---------------------------------------------------------------------------
+
+@test "ac7: co-issue-manual-fix-b.sh に dual-write log コードが存在しないこと（ADR-024 Phase B 整理）" {
+  # AC: dual-write log event（WARN label_add_failed / OK dual_write）が削除される
+  # NOTE: 現在の co-issue-manual-fix-b.sh は label_add_failed を書いていないが
+  #       「Phase B 整理後も残っていないこと」を保証するテスト
+  run grep -cE 'label_add_failed|dual_write_log|OK dual_write|refined-dual-write' "${SCRIPT_SRC}"
+  local count="${output:-0}"
+  count="${count// /}"
+  if [ "${count}" -gt 0 ]; then
+    echo "FAIL: co-issue-manual-fix-b.sh に dual-write log コードが ${count} 件存在する（Phase B では削除必須）" >&2
+    grep -nE 'label_add_failed|dual_write_log|OK dual_write|refined-dual-write' "${SCRIPT_SRC}" >&2 || true
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC6: このファイル自体が Status only 期待のテストとして機能すること（meta test）
+# ---------------------------------------------------------------------------
+
+@test "ac6: このテストファイルが Status only 期待のテストであること（meta: テスト名に add-label が存在しないこと）" {
+  # AC: co-issue-manual-fix-b.bats が Status only 期待に書き換えられている
+  # GREEN: このテスト自体が "label 付与なし" を期待しているため PASS
+  # このテストはテストファイルの内容を grep して、label 付与を期待するテスト名が残っていないことを検証
+  local self_file="${BATS_TEST_FILENAME}"
+  # "add-label refined を期待する（MUST）" といった肯定的な label 付与期待がないことを確認
+  run grep -n 'add-label refined.*呼ばれること\|add-label.*MUST\|label 付与.*MUST' "${self_file}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: テストファイルに label 付与を MUST とするテスト名が存在する（Status only 期待に書き換え必要）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}

--- a/plugins/twl/tests/bats/co-issue-status-only-flow.bats
+++ b/plugins/twl/tests/bats/co-issue-status-only-flow.bats
@@ -104,14 +104,15 @@ teardown() {
   fi
 }
 
-@test "ac3: refine-processing-flow.md に labels_hint.*refined の追加コードが存在しないこと（RED）" {
+@test "ac3: refine-processing-flow.md に labels_hint += [\"refined\"] の追加コードが存在しないこと（RED）" {
   # AC: Step 4.5 の refined ラベル追加ロジックが削除される
   # RED: 現在 L155-157 の jq コードブロックが存在するため fail
+  # 注: regex は追加演算子（+= または + ["refined"]）に限定してコメント行の偽陽性を除去
   local count
-  count=$(grep -cE 'labels_hint.*\+.*\[.*"refined".*\]|labels_hint.*refined' "${REFINE_FLOW}" 2>/dev/null || echo "0")
+  count=$(grep -cE 'labels_hint.*\+=.*"refined"|\.labels_hint.*\+.*\["refined"\]|\+ \["refined"\]' "${REFINE_FLOW}" 2>/dev/null || echo "0")
   if [ "${count}" -gt 0 ]; then
-    echo "FAIL: refine-processing-flow.md に labels_hint + refined 追加コードが ${count} 件存在する" >&2
-    grep -nE 'labels_hint.*\+.*\[.*"refined".*\]|labels_hint.*refined' "${REFINE_FLOW}" >&2 || true
+    echo "FAIL: refine-processing-flow.md に labels_hint += refined 追加コードが ${count} 件存在する" >&2
+    grep -nE 'labels_hint.*\+=.*"refined"|\.labels_hint.*\+.*\["refined"\]|\+ \["refined"\]' "${REFINE_FLOW}" >&2 || true
     return 1
   fi
 }
@@ -135,17 +136,15 @@ teardown() {
   fi
 }
 
-@test "ac4: lifecycle-processing-flow.md の Step 4.5 に refined ラベル判定コードが存在しないこと（RED）" {
+@test "ac4: lifecycle-processing-flow.md の Step 4.5 に refined ラベル追加コードが存在しないこと（RED）" {
   # AC: Step 4.5 refined ラベル判定セクション自体が削除される
   # RED: 現在 L135-145 のブロックが存在するため fail
+  # 注: regex は追加演算子（← または + ["refined"]）に限定してコメント行の偽陽性を除去
   local count
-  count=$(grep -cE 'labels_hint.*refined|refined.*labels_hint' "${LIFECYCLE_FLOW}" 2>/dev/null || echo "0")
-  # L156, L184, L188 は labels_hint に refined が含まれる場合の参照として残る可能性があるが
-  # L141 の追加コードは削除必須。2 件を超える場合は削除が不完全
-  # Phase B 移行後は labels_hint に refined が含まれないため、参照記述自体も 0 件を期待
+  count=$(grep -cE 'labels_hint.*←.*refined|\+ \["refined"\]|labels_hint.*\+=.*refined' "${LIFECYCLE_FLOW}" 2>/dev/null || echo "0")
   if [ "${count}" -gt 0 ]; then
-    echo "FAIL: lifecycle-processing-flow.md に labels_hint refined 参照が ${count} 件存在する" >&2
-    grep -nE 'labels_hint.*refined|refined.*labels_hint' "${LIFECYCLE_FLOW}" >&2 || true
+    echo "FAIL: lifecycle-processing-flow.md に labels_hint refined 追加コードが ${count} 件存在する" >&2
+    grep -nE 'labels_hint.*←.*refined|\+ \["refined"\]|labels_hint.*\+=.*refined' "${LIFECYCLE_FLOW}" >&2 || true
     return 1
   fi
 }

--- a/plugins/twl/tests/bats/co-issue-status-only-flow.bats
+++ b/plugins/twl/tests/bats/co-issue-status-only-flow.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+# co-issue-status-only-flow.bats
+#
+# RED-phase static content tests for Issue #1292: ADR-024 Phase B — refined label 廃止
+#
+# AC coverage:
+#   AC1 - co-issue-phase4-aggregate.md から gh label create refined / gh issue edit --add-label refined
+#          行が消えている（grep で 0 件）
+#   AC3 - refine-processing-flow.md から labels_hint += ["refined"] が消えている
+#   AC4 - lifecycle-processing-flow.md から labels_hint += ["refined"] が消えている
+#   AC5 - co-issue SKILL.md の MUST NOT 注意書きが「Status=Refined 遷移 MUST」に縮約されている
+#   AC7 - co-issue-phase4-aggregate.md に WARN label_add_failed / OK dual_write が存在しない
+#
+# RED 状態の根拠:
+#   AC1: co-issue-phase4-aggregate.md L66,L69 に gh label create refined / gh issue edit --add-label refined が存在する
+#   AC3: refine-processing-flow.md L155 に labels_hint += ["refined"] が存在する
+#   AC4: lifecycle-processing-flow.md L141 に policies.labels_hint ← policies.labels_hint + ["refined"] が存在する
+#   AC5: SKILL.md L87 に長い注意書き（"refined label + Status=Refined 遷移を skip してはならない"）が存在し
+#        縮約された形式（"Status=Refined 遷移 MUST"）になっていない
+#   AC7: co-issue-phase4-aggregate.md L73-87 に WARN label_add_failed / OK dual_write が存在する
+
+load 'helpers/common'
+
+PHASE4_AGGREGATE=""
+REFINE_FLOW=""
+LIFECYCLE_FLOW=""
+CO_ISSUE_SKILL=""
+
+setup() {
+  common_setup
+
+  # REPO_ROOT は plugins/twl/ を指す（helpers/common.bash の定義に準拠）
+  PHASE4_AGGREGATE="${REPO_ROOT}/skills/co-issue/refs/co-issue-phase4-aggregate.md"
+  REFINE_FLOW="${REPO_ROOT}/refs/refine-processing-flow.md"
+  LIFECYCLE_FLOW="${REPO_ROOT}/refs/lifecycle-processing-flow.md"
+  CO_ISSUE_SKILL="${REPO_ROOT}/skills/co-issue/SKILL.md"
+
+  export PHASE4_AGGREGATE REFINE_FLOW LIFECYCLE_FLOW CO_ISSUE_SKILL
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: co-issue-phase4-aggregate.md に gh label create refined / gh issue edit --add-label refined が存在しない
+# ===========================================================================
+
+@test "ac1: co-issue-phase4-aggregate.md が存在すること" {
+  # 前提確認: ファイルが存在する
+  [ -f "${PHASE4_AGGREGATE}" ]
+}
+
+@test "ac1: co-issue-phase4-aggregate.md に gh label create refined が存在しないこと（RED: 現状 L66 に存在する）" {
+  # AC: `grep -nE 'gh (label create|issue edit.*refined)' ...co-issue-phase4-aggregate.md` で 0 件
+  # RED: 現在 L66 に `gh label create refined` が存在するため fail
+  run grep -nE 'gh label create.*refined' "${PHASE4_AGGREGATE}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に以下の行が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac1: co-issue-phase4-aggregate.md に gh issue edit.*--add-label refined が存在しないこと（RED: 現状 L69 に存在する）" {
+  # AC: AC1 の一部 — gh issue edit --add-label refined 行が削除される
+  # RED: 現在 L69 に当該行が存在するため fail
+  run grep -nE 'gh issue edit.*--add-label refined|gh issue edit.*refined' "${PHASE4_AGGREGATE}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に以下の label 付与行が存在する:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac1: grep -nE 'gh (label create|issue edit.*refined)' が 0 件（RED: 現状は 2 件以上）" {
+  # AC: Issue body 記載の grep コマンドで 0 件
+  # RED: 現在は L66 + L69 で 2 件以上ヒットするため fail
+  local match_count
+  match_count=$(grep -cE 'gh (label create|issue edit.*refined)' "${PHASE4_AGGREGATE}" 2>/dev/null || echo "0")
+  if [ "${match_count}" -gt 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に ${match_count} 件の label 操作行が存在する" >&2
+    grep -nE 'gh (label create|issue edit.*refined)' "${PHASE4_AGGREGATE}" >&2 || true
+    return 1
+  fi
+}
+
+# ===========================================================================
+# AC3: refine-processing-flow.md から labels_hint += ["refined"] が消えている
+# ===========================================================================
+
+@test "ac3: refine-processing-flow.md が存在すること" {
+  [ -f "${REFINE_FLOW}" ]
+}
+
+@test "ac3: refine-processing-flow.md に labels_hint += [\"refined\"] が存在しないこと（RED: 現状 L155 に存在する）" {
+  # AC: jq '.labels_hint += ["refined"]' の行が削除される
+  # RED: 現在 L155 に存在するため fail
+  run grep -n 'labels_hint += \["refined"\]' "${REFINE_FLOW}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: refine-processing-flow.md に以下の行が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac3: refine-processing-flow.md に labels_hint.*refined の追加コードが存在しないこと（RED）" {
+  # AC: Step 4.5 の refined ラベル追加ロジックが削除される
+  # RED: 現在 L155-157 の jq コードブロックが存在するため fail
+  local count
+  count=$(grep -cE 'labels_hint.*\+.*\[.*"refined".*\]|labels_hint.*refined' "${REFINE_FLOW}" 2>/dev/null || echo "0")
+  if [ "${count}" -gt 0 ]; then
+    echo "FAIL: refine-processing-flow.md に labels_hint + refined 追加コードが ${count} 件存在する" >&2
+    grep -nE 'labels_hint.*\+.*\[.*"refined".*\]|labels_hint.*refined' "${REFINE_FLOW}" >&2 || true
+    return 1
+  fi
+}
+
+# ===========================================================================
+# AC4: lifecycle-processing-flow.md から labels_hint += ["refined"] が消えている
+# ===========================================================================
+
+@test "ac4: lifecycle-processing-flow.md が存在すること" {
+  [ -f "${LIFECYCLE_FLOW}" ]
+}
+
+@test "ac4: lifecycle-processing-flow.md に policies.labels_hint + refined 追加コードが存在しないこと（RED: 現状 L141 に存在する）" {
+  # AC: Step 4.5 の labels_hint ← labels_hint + ["refined"] が削除される
+  # RED: 現在 L141 に `policies.labels_hint ← policies.labels_hint + ["refined"]` が存在するため fail
+  run grep -n 'labels_hint.*\+.*\["refined"\]\|labels_hint.*+.*refined' "${LIFECYCLE_FLOW}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: lifecycle-processing-flow.md に以下の labels_hint 追加行が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac4: lifecycle-processing-flow.md の Step 4.5 に refined ラベル判定コードが存在しないこと（RED）" {
+  # AC: Step 4.5 refined ラベル判定セクション自体が削除される
+  # RED: 現在 L135-145 のブロックが存在するため fail
+  local count
+  count=$(grep -cE 'labels_hint.*refined|refined.*labels_hint' "${LIFECYCLE_FLOW}" 2>/dev/null || echo "0")
+  # L156, L184, L188 は labels_hint に refined が含まれる場合の参照として残る可能性があるが
+  # L141 の追加コードは削除必須。2 件を超える場合は削除が不完全
+  # Phase B 移行後は labels_hint に refined が含まれないため、参照記述自体も 0 件を期待
+  if [ "${count}" -gt 0 ]; then
+    echo "FAIL: lifecycle-processing-flow.md に labels_hint refined 参照が ${count} 件存在する" >&2
+    grep -nE 'labels_hint.*refined|refined.*labels_hint' "${LIFECYCLE_FLOW}" >&2 || true
+    return 1
+  fi
+}
+
+# ===========================================================================
+# AC5: co-issue SKILL.md の MUST NOT 注意書きが縮約されていること
+# ===========================================================================
+
+@test "ac5: co-issue SKILL.md が存在すること" {
+  [ -f "${CO_ISSUE_SKILL}" ]
+}
+
+@test "ac5: SKILL.md に縮約済み形式 'Status=Refined 遷移 MUST' が存在すること（RED: 現状は長い注意書き形式）" {
+  # AC: 長い注意書き（"refined label + Status=Refined 遷移を skip してはならない（ADR-024 dual-write 義務..."）
+  #     が「Status=Refined 遷移 MUST」のみに縮約される
+  # RED: 現在は縮約前の長い形式のため、縮約後のキーフレーズが存在せず fail
+  #      縮約後は独立した注意書きとして「Status=Refined 遷移 MUST」が存在することを検証
+  run grep -c 'Status=Refined 遷移 MUST' "${CO_ISSUE_SKILL}"
+  local count="${output:-0}"
+  if [ "${count}" -lt 1 ]; then
+    echo "FAIL: SKILL.md に縮約済みフレーズ 'Status=Refined 遷移 MUST' が存在しない" >&2
+    echo "  現状のL87: $(grep -n 'Phase 4 manual fix' "${CO_ISSUE_SKILL}" || echo '(見つからない)')" >&2
+    return 1
+  fi
+}
+
+@test "ac5: SKILL.md に旧 dual-write 義務の長い注意書きが存在しないこと（RED: 現状 L87 に存在する）" {
+  # AC: 旧形式 "dual-write 義務: label 先 → Status 後" の注意書きが削除される
+  # RED: 現在 L87 に旧形式が存在するため fail
+  run grep -n 'dual-write 義務.*label 先.*Status 後\|label 先 → Status 後' "${CO_ISSUE_SKILL}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: SKILL.md に旧 dual-write 義務の注意書きが残存している（Phase B では縮約必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac5: SKILL.md に 'ADR-024 Phase B 移行後は' 注記が存在しないこと（RED: 現状は存在する）" {
+  # AC: 「Note: ADR-024 Phase B 移行後は...縮約される予定」の注記が削除される（移行完了のため）
+  # RED: 現在 L87 に "Note: ADR-024 Phase B 移行後は" が存在するため fail
+  run grep -n 'ADR-024 Phase B 移行後は.*縮約される予定\|Phase B 移行後は.*縮約' "${CO_ISSUE_SKILL}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: SKILL.md に 'Phase B 移行後は縮約' 予定注記が残存している（移行完了後は削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+# ===========================================================================
+# AC7: co-issue-phase4-aggregate.md に WARN label_add_failed / OK dual_write が存在しない
+# ===========================================================================
+
+@test "ac7: co-issue-phase4-aggregate.md に WARN label_add_failed が存在しないこと（RED: 現状 L73,L80 に存在する）" {
+  # AC: Phase B 移行後、label_add_failed log event が削除される
+  # RED: 現在 L73,L80 に当該文字列が存在するため fail
+  run grep -n 'label_add_failed' "${PHASE4_AGGREGATE}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に以下の label_add_failed 行が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac7: co-issue-phase4-aggregate.md に OK dual_write が存在しないこと（RED: 現状 L85-87 に存在する）" {
+  # AC: Phase B 移行後、OK dual_write log event が削除される
+  # RED: 現在 L85-87 に当該文字列が存在するため fail
+  run grep -n 'OK dual_write\|dual_write_log OK' "${PHASE4_AGGREGATE}"
+  if [ "${status}" -eq 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に以下の dual_write 行が存在する（Phase B では削除必須）:" >&2
+    echo "${output}" >&2
+    return 1
+  fi
+}
+
+@test "ac7: co-issue-phase4-aggregate.md に dual-write observability コードブロックが存在しないこと（RED）" {
+  # AC: dual-write observability セクション（_label_exit 記録+分岐）が削除される
+  # RED: 現在 L70-90 のコードブロックが存在するため fail
+  local count
+  count=$(grep -cE '_label_exit|dual_write_log|refined-dual-write-log' "${PHASE4_AGGREGATE}" 2>/dev/null || echo "0")
+  if [ "${count}" -gt 0 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に dual-write observability コードが ${count} 件存在する" >&2
+    grep -nE '_label_exit|dual_write_log|refined-dual-write-log' "${PHASE4_AGGREGATE}" >&2 || true
+    return 1
+  fi
+}
+
+@test "ac7: co-issue-phase4-aggregate.md に WARN status_update_failed のみが残ること（実装後の最終形確認）" {
+  # AC: 整理後は WARN status_update_failed が残る（board-status-update 失敗時の警告）
+  # NOTE: このテストは実装後に GREEN になる。現状は WARN status_update_failed が存在しないため fail。
+  # RED: 現在のファイルに status_update_failed が存在しないため fail
+  run grep -c 'status_update_failed\|WARN.*status_update_failed' "${PHASE4_AGGREGATE}"
+  local count="${output:-0}"
+  if [ "${count}" -lt 1 ]; then
+    echo "FAIL: co-issue-phase4-aggregate.md に WARN status_update_failed が存在しない（Phase B では残存必須）" >&2
+    return 1
+  fi
+}


### PR DESCRIPTION
## 概要

ADR-024 Phase B Tier B の write site 撤去。

## 変更内容

- **W1** : dual-write ブロック縮約 (gh label create / gh issue edit --add-label refined 廃止)
- **W2** : label 付与 step 削除 → Status=Refined のみ
- **W3** : Step 4.5 削除 + Step 6' label 付与ロジック縮約
- **W4** : Step 4.5 削除 + Step 6 label 付与ロジック縮約
- **W5** co-issue `SKILL.md`: MUST NOT 注意書きを「Status=Refined 遷移 MUST」に縮約
- **AC7** observability 整理: `WARN label_add_failed` / `OK dual_write` → `WARN status_update_failed` のみ

## テスト

- `co-issue-manual-fix-b.bats` (AC2, AC6, AC7, AC8)
- `co-issue-status-only-flow.bats` (AC1, AC3, AC4, AC5, AC7)
- `ac-test-mapping-1292.yaml`

## 関連

- Closes #1292
- Closes #1212 (dual-write observability 整理)
- Parent: #1290 (epic adr-024-phase-b)
- 依存: #1291 (Sub-1 Tier A) 完了済