### PR TITLE
[Docs] feat(adr-024-phase-b): Tier D — pilot-completion-signals.md + ref-project-model.md + ADR-024 doc 整合

### DIFF
--- a/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
+++ b/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
@@ -47,9 +47,11 @@ Project Board は `twill-ecosystem` にリンクされた repo の Issue のみ 
 
 ### Dual-write 期間（Phase 1）
 
-Phase B 移行まで **label と Status を dual-write** する。書き込み順序: **label 先 → Status 後**。
+> **Phase B 完了 (2026-05-03)**: label write は削除済み。Twill 内部 Issue は Status=Refined のみを write する。以下は Phase 1 の歴史的記録。
 
-理由: Status を先に書くと、Status=Refined を見た autopilot が label 付与前に早期 spawn する race の可能性がある。
+Phase B 移行まで **label と Status を dual-write** した。書き込み順序: **label 先 → Status 後**。
+
+理由: Status を先に書くと、Status=Refined を見た autopilot が label 付与前に早期 spawn する race の可能性があった。
 
 ### fail-closed 設計
 
@@ -61,7 +63,7 @@ Status gate は fail-closed を採用:
 ### cache 戦略（Phase 分離）
 
 - **Phase 1 (本 Issue)**: fresh API call（gate の即時性を優先、cache なし）
-- **Phase B (別 Issue)**: `/tmp/refined-status-cache-<pilot-pid>.json` TTL 5分 cache（bash/Python 共有、invalidation = Status write 直後 + TTL）
+- **Phase B**: cache 導入は見送り（実運用で R1 rate limit が問題にならなかったため）。将来必要になった場合は別 Issue として管理する
 
 ## Consequences
 
@@ -73,10 +75,10 @@ Status gate は fail-closed を採用:
 
 ### Negative / Risks
 
-- **R1**: hot path API rate limit（Phase B で cache 導入により解消予定）
+- **R1**: hot path API rate limit（Phase B では cache 導入を見送り。実運用で問題は発生しなかった）
 - **R4**: breaking change: pre-seed bypass invariant が 2 層になる（hook + launcher）
 - **R5**: cross-repo Board scope 制約（Option A の label fallback で回避）
-- **R8**: 既存 `layer-d-refined-gate.bats` は Phase 1 では label write 継続により PASS 維持
+- **R8**: 既存 `layer-d-refined-gate.bats` は Phase 1 では label write 継続により PASS を維持していた。Phase B 完了後は label write が削除されたため、このテストの扱いは Phase B 完了 (Tier A/B) で対応済み
 
 ## Implementation
 

--- a/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
+++ b/plugins/twl/architecture/decisions/ADR-024-refined-status-field-migration.md
@@ -89,13 +89,20 @@ Status gate は fail-closed を採用:
 - **#1026 (AC1+AC2) merged**: `cli/twl/src/twl/autopilot/github.py` `extract_parent_epic` + `plugins/twl/scripts/chain-runner.sh` `_transition_parent_epic_if_refined` (子 In Progress 遷移時に親 Epic Refined→In Progress を auto-fire)
 - **#1070 (AC checklist auto-update) merged**: `cli/twl/src/twl/autopilot/github.py` `extract_closes_ac` / `flip_epic_ac_checkbox` / `update_epic_ac_checklist` + `plugins/twl/scripts/chain-runner.sh` `_update_parent_epic_ac_checklist` (子 Done 遷移時に親 Epic body の `- [ ] **AC{N}**` を `Closes-AC: #EPIC:ACN` 規約に従って auto-flip)
 
-## Phase B（別 Issue 起票予定）
+## Phase B 完了 (2026-05-03)
 
-以下のいずれかの条件を満たした時点で su-observer が自動起票:
-- (a) Status=Refined 経由 Done 累計 5 件以上
-- (b) Phase 1 merge から 2 Wave 経過
-- (c) su-observer による明示的 approval
+### 完了サマリ
 
-Phase B 内容: `pre-bash-refined-label-gate.sh` deprecate / 削除、label write 削除（Status のみ）、cache 導入。
+- **Tier A**: read site（`pre-bash-refined-label-gate.sh`、`pre-bash-phase3-gate.sh`）から refined label 参照削除 (Sub-1)
+- **Tier B**: write site（co-issue Phase 4 [B] / manual-fix-b.sh / refine-flow / lifecycle-flow）から label 付与削除 (Sub-2)
+- **Tier C 残置**: cross-repo R5 fallback（`autopilot-launch.sh`、`launcher.py`、`issue-cross-repo-create.md`）は label `refined` を fallback として継続使用
+- **Tier D**: doc 整合（本 Sub-3 = Issue #1293）
+- **Migration**: 既存 OPEN Issue Status=Refined 一括設定 + `project-board-refined-migrate.sh --force` CI 実行 (Sub-4)
 
-**Auto-update layer 完成 (Phase 1 範囲)**: 子 Issue → 親 Epic の Status auto-transition (#1026 AC1+AC2) と AC checklist auto-flip (#1070) の両方が autopilot 経路 (chain-runner.sh `step_board_status_update`) に組み込まれた。新規 Issue は `--parent #N` + `--closes-ac #EPIC:ACN` (issue-create.md) を指定することで dual-write 規約を full enforce できる。
+### Phase B 後の運用ルール
+
+- **Twill 内部 Issue**: Status=Refined を SSoT として書き、`refined` label は付与しない
+- **Cross-repo Issue**: `refined` label を fallback として書き続ける（ADR-024 R5 制約）
+- **observability**: `/tmp/refined-status-update.log` で Status update 失敗のみ WARN
+
+**Auto-update layer 完成 (Phase 1 範囲)**: 子 Issue → 親 Epic の Status auto-transition (#1026 AC1+AC2) と AC checklist auto-flip (#1070) の両方が autopilot 経路 (chain-runner.sh `step_board_status_update`) に組み込まれた。新規 Issue は `--parent #N` + `--closes-ac #EPIC:ACN` (issue-create.md) を指定することで Phase B 完了後の規約を full enforce できる。

--- a/plugins/twl/refs/ref-project-model.md
+++ b/plugins/twl/refs/ref-project-model.md
@@ -135,7 +135,7 @@ Project Board のカラムで作業進捗を管理する。
 | In Progress | 作業中（worktree/ブランチ作成済み） |
 | Done | 完了（PR マージ済み） |
 
-> **注**: `refined` label（小文字）は ADR-024 で Status field `Refined`（先頭大文字）に移行。Phase 1 では dual-write（label 先 → Status 後）、Phase B で label 削除予定。
+> **注**: `refined` label（小文字）は ADR-024 で Status field `Refined`（先頭大文字）に移行済み（Phase B 完了）。Twill 内部 Issue は Status=Refined を SSoT として運用し、label は付与しない。cross-repo Issue（Board 未登録）は ADR-024 R5 制約により `refined` label を fallback として残置。
 
 ---
 
@@ -185,7 +185,7 @@ Project Board のカラムで作業進捗を管理する。
 
 | 操作 | コンポーネント | 説明 |
 |------|---------------|------|
-| Producer | workflow-issue-refine / workflow-issue-lifecycle | specialist review 完了時に Status=Refined を設定（dual-write: label 先 → Status 後） |
+| Producer | workflow-issue-refine / workflow-issue-lifecycle | specialist review 完了時に Status=Refined を設定（Phase B 完了: Twill 内部 Issue は Status のみ write） |
 | Producer | workflow-setup | In Progress に移動 |
 | Producer | workflow-pr-cycle | Done に移動（PR マージ後） |
 | Consumer | controller-autopilot | Todo → Refined の Issue を選択（Phase 1 はクエリ据え置き、launcher gate で enforce） |

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -248,14 +248,14 @@ _check_refined_status() {
     fi
   done
   if [[ -z "$status" && -z "$board_items" ]]; then
-    # Board 取得失敗 → cross-repo fallback: refined label を確認
+    # Board 取得失敗 → cross-repo fallback: refined label を確認 (ADR-024 Phase B Tier C 残置)
     _check_label_fallback "$issue_num" "DENY_API_FAILURE" \
       "Error: GitHub API 障害により Status を取得できませんでした (3 回リトライ後)。
   対処: gh auth refresh -s project を実行してから再試行してください。"
     return $?
   fi
   if [[ -z "$status" ]]; then
-    # Issue が Board 未登録 → cross-repo fallback: refined label を確認
+    # Issue が Board 未登録 → cross-repo fallback: refined label を確認 (ADR-024 Phase B Tier C 残置)
     _check_label_fallback "$issue_num" "DENY_NOT_ON_BOARD" \
       "Error: Issue #${issue_num} は Project Board に登録されていません。
   対処: Board に Issue を add してから再試行してください。"

--- a/plugins/twl/skills/su-observer/refs/pilot-completion-signals.md
+++ b/plugins/twl/skills/su-observer/refs/pilot-completion-signals.md
@@ -21,7 +21,7 @@ Monitor filter / cld-observe-any pattern 設定時に本ファイルを参照す
 | co-autopilot | クリーンアップ | `[orchestrator] cleanup: Issue #<N> — window/branch クリーンアップ` | orchestrator |
 | co-autopilot | Wave 収集 | `[wave-collect] Wave <N> サマリを生成しました: <path>` | `wave-collect.md` |
 | co-issue | Issue 作成完了 | `>>> Issue #<N> 作成完了` | co-issue SKILL.md |
-| co-issue (refine) | refine 完遂 | `[IDLE-COMPLETED]` channel (`Status=Refined` + label `refined` 付与で検知) | issue-lifecycle-orchestrator.sh 出口 |
+| co-issue (refine) | refine 完遂 | `[IDLE-COMPLETED]` channel (`Status=Refined` で検知、Phase B 移行後 label 観測は撤去) | issue-lifecycle-orchestrator.sh 出口 |
 | co-architect | arch review PASS | `>>> arch-phase-review PASS` | co-architect SKILL.md |
 | co-architect | arch merge | `[arch-merge] ...` | co-architect SKILL.md |
 | 共通（Pilot カスタム） | Phase/Wave/Step 完遂 | `>>> Phase <X> Wave <N> step <M> 完遂` | Pilot 直接出力 |

--- a/plugins/twl/tests/bats/issue-1293-phase-b-tier-d-completion.bats
+++ b/plugins/twl/tests/bats/issue-1293-phase-b-tier-d-completion.bats
@@ -1,0 +1,188 @@
+#!/usr/bin/env bats
+# issue-1293-phase-b-tier-d-completion.bats
+#
+# RED-phase tests for Issue #1293:
+#   docs(adr-024): Phase B Tier D Pilot 完了 doc 整合
+#     - pilot-completion-signals.md [IDLE-COMPLETED] channel を Status のみに縮約
+#     - ref-project-model.md の dual-write 記述を Phase B 完了状態に更新
+#     - ADR-024 に Phase B 完了節（Tier A/B/C/D サマリ + 運用ルール）追記
+#     - scripts の refined label 言及を整合
+#
+# AC coverage:
+#   AC1 - pilot-completion-signals.md の [IDLE-COMPLETED] channel に "label refined" が 0 件
+#   AC2 - ref-project-model.md の dual-write 記述が Phase B 完了状態に書き換えられている
+#   AC3 - ADR-024 に Phase B 完了節（Tier A/B/C/D サマリ + 運用ルール）が追記されている
+#   AC4 - scripts の refined.*label 残存件数が PR description に明記されている
+#   AC5 - doc 変更による既存 bats test 影響なし（このファイルが存在することで確認）
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  PILOT_SIGNALS="${REPO_ROOT}/skills/su-observer/refs/pilot-completion-signals.md"
+  PROJECT_MODEL="${REPO_ROOT}/refs/ref-project-model.md"
+  ADR_024="${REPO_ROOT}/architecture/decisions/ADR-024-refined-status-field-migration.md"
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+  THIS_BATS="${REPO_ROOT}/tests/bats/issue-1293-phase-b-tier-d-completion.bats"
+
+  export PILOT_SIGNALS PROJECT_MODEL ADR_024 SCRIPTS_DIR THIS_BATS
+}
+
+# ===========================================================================
+# AC1: pilot-completion-signals.md の [IDLE-COMPLETED] channel が
+#      Status のみに縮約され "label refined" 言及が 0 件になっている
+# ===========================================================================
+
+@test "ac1: pilot-completion-signals.md contains no 'label.*refined' references" {
+  # AC: "label.*refined" パターンで 0 件（backtick format 含む）
+  # RED: 現在 line 24 に "label `refined`" が含まれているため fail
+  run grep -cE "label[[:space:]]+\`?refined\`?" "${PILOT_SIGNALS}"
+  [ "${output}" -eq 0 ]
+}
+
+@test "ac1: [IDLE-COMPLETED] row in pilot-completion-signals.md does not describe label detection" {
+  # AC: [IDLE-COMPLETED] channel の行が label 付与での検知を記述していない（Status のみ）
+  # RED: 現在 "Status=Refined + label refined 付与で検知" となっているため fail
+  run bash -c "
+    match=\$(grep 'IDLE-COMPLETED' '${PILOT_SIGNALS}' | head -1)
+    [ -n \"\${match}\" ] || exit 1
+    # 'label.*付与で検知' や 'label.*refined.*で検知' パターンが含まれていないこと
+    echo \"\${match}\" | grep -qvE 'label[[:space:]]+\`?refined\`?.*付与で検知|label.*refined.*検知'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1: [IDLE-COMPLETED] row still references Status=Refined for detection" {
+  # AC: label 削除後も Status=Refined による検知記述が残っている
+  # RED: label 削除と同時に Status 参照も消えてしまう誤りを防ぐ
+  run bash -c "
+    match=\$(grep 'IDLE-COMPLETED' '${PILOT_SIGNALS}' | head -1)
+    [ -n \"\${match}\" ] || exit 1
+    echo \"\${match}\" | grep -q 'Status=Refined\|Status.*Refined'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: ref-project-model.md の dual-write 記述が Phase B 完了状態に
+#      書き換えられている
+# ===========================================================================
+
+@test "ac2: ref-project-model.md no longer describes dual-write as active phase" {
+  # AC: "Phase 1 では dual-write" / "dual-write: label 先 → Status 後" 記述が消えている
+  # RED: 現在 line 138 と line 188 に dual-write 記述が残っているため fail
+  run bash -c "
+    # dual-write が現在進行形の記述として残っていないことを確認
+    # 「Phase B で label 削除予定」という未来形も消えているはず
+    grep -c 'dual-write\|dual_write' '${PROJECT_MODEL}'
+  "
+  [ "${output}" -eq 0 ]
+}
+
+@test "ac2: ref-project-model.md Status=Refined description reflects Phase B completion (Status only)" {
+  # AC: Status field の説明が「Status のみ」という Phase B 完了状態になっている
+  # RED: 現在の記述は Phase 1（dual-write）のままのため fail
+  run bash -c "
+    # Producer 行が Status のみ設定（label write なし）と記述されているか
+    # または「Phase B 完了」「label 削除済み」等の記述が追加されているか
+    grep -qE 'Status.*のみ|label.*削除済み|Phase B.*完了|Status only' '${PROJECT_MODEL}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: ADR-024 に Phase B 完了節（Tier A/B/C/D サマリ + 運用ルール）が
+#      追記されている
+# ===========================================================================
+
+@test "ac3: ADR-024 has Phase B completion section" {
+  # AC: ## Phase B 完了 または ## Phase B Complete 相当のセクションが存在する
+  # RED: 現在 ADR-024 に Phase B 完了節が存在しないため fail
+  run bash -c "
+    grep -qE '^## Phase B.*完了|^## Phase B.*Complete|^## Phase B.*Completed' '${ADR_024}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: ADR-024 Phase B completion section includes Tier summary" {
+  # AC: Phase B 完了節に Tier A/B/C/D のサマリが含まれている
+  # RED: 完了節自体がないため fail
+  run bash -c "
+    section_line=\$(grep -n '^## Phase B.*完了\|^## Phase B.*Complete\|^## Phase B.*Completed' '${ADR_024}' | head -1 | cut -d: -f1)
+    [ -n \"\${section_line}\" ] || exit 1
+    # セクション以降に Tier A, B, C, D の全参照があること
+    awk -v s=\"\${section_line}\" 'NR >= s' '${ADR_024}' | grep -q 'Tier A'  || exit 1
+    awk -v s=\"\${section_line}\" 'NR >= s' '${ADR_024}' | grep -q 'Tier B'  || exit 1
+    awk -v s=\"\${section_line}\" 'NR >= s' '${ADR_024}' | grep -q 'Tier C'  || exit 1
+    awk -v s=\"\${section_line}\" 'NR >= s' '${ADR_024}' | grep -q 'Tier D'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: ADR-024 Phase B completion section includes 運用ルール" {
+  # AC: Phase B 完了節に 運用ルール が含まれている
+  # RED: 完了節自体がないため fail
+  run bash -c "
+    section_line=\$(grep -n '^## Phase B.*完了\|^## Phase B.*Complete\|^## Phase B.*Completed' '${ADR_024}' | head -1 | cut -d: -f1)
+    [ -n \"\${section_line}\" ] || exit 1
+    awk -v s=\"\${section_line}\" 'NR >= s' '${ADR_024}' | grep -qE '運用ルール|operation.*rule|操作ルール'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: ADR-024 Phase B section replaces 'Phase B（別 Issue 起票予定）' placeholder" {
+  # AC: 旧来の "## Phase B（別 Issue 起票予定）" プレースホルダーが完了節に置き換えられている
+  # RED: 現在プレースホルダーのままのため fail
+  run bash -c "
+    # 旧プレースホルダーが存在しないこと
+    grep -qE '^## Phase B（別 Issue 起票予定）|^## Phase B\(別 Issue 起票予定\)' '${ADR_024}' && exit 1
+    # 完了節が存在すること
+    grep -qE '^## Phase B.*完了|^## Phase B.*Complete' '${ADR_024}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: scripts の refined label 言及が整合されている
+#      (残存件数が PR description に明記 or 必要分が整理済み)
+# ===========================================================================
+
+@test "ac4: project-board-refined-migrate.sh refined label reference is acceptable (migration tool)" {
+  # AC: migration tool としての refined label 言及は許容される
+  # GREEN: migration tool 自体は Phase B 後も残存して良い（歴史的経緯）
+  # このテストは migration script の存在確認のみ行う
+  [ -f "${SCRIPTS_DIR}/project-board-refined-migrate.sh" ]
+}
+
+@test "ac4: autopilot-launch.sh refined label fallback references are documented or removed" {
+  # AC: autopilot-launch.sh の "refined label を確認" コメントが整合されている
+  # RED: 現在 fallback として refined label 参照が残っているが整合が未完のため fail
+  run bash -c "
+    # 残存件数のカウント
+    count=\$(grep -c 'refined.*label\|label.*refined' '${SCRIPTS_DIR}/autopilot-launch.sh' 2>/dev/null || echo 0)
+    # 0件（削除済み）または、残存する場合はコメントで「Phase B 後削除予定」等が明記されていること
+    if [ \"\${count}\" -eq 0 ]; then
+      exit 0
+    fi
+    # 残存する場合は Phase B 関連コメントがある
+    grep -qE 'Phase B|TODO.*label|FIXME.*label|deprecated.*label|fallback.*Phase B' \
+      '${SCRIPTS_DIR}/autopilot-launch.sh'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC5: doc 変更による既存 bats test 影響なし
+# ===========================================================================
+
+@test "ac5: this bats test file exists at expected path" {
+  # AC: bats ファイルが plugins/twl/tests/bats/issue-1293-phase-b-tier-d-completion.bats として存在する
+  # GREEN: このファイル自体が存在するため、実行時点では pass する
+  [ -f "${THIS_BATS}" ]
+}


### PR DESCRIPTION
## 概要

ADR-024 Phase B Tier D の doc 整合 (Issue #1293)。

## 変更内容

### AC1: pilot-completion-signals.md 更新
`[IDLE-COMPLETED]` channel の行を `Status=Refined` のみ検知に縮約。`label `refined`` 付与での検知記述を撤去。

### AC2: ref-project-model.md 更新
- L138: dual-write 記述 (Phase 1) を Phase B 完了状態 (Status=Refined SSoT、cross-repo は label fallback 残置) に書き換え
- L188: Producer 行の dual-write 注記を Phase B 完了状態に更新

### AC3: ADR-024 doc Phase B 完了節追記
`## Phase B（別 Issue 起票予定）` プレースホルダーを完了節に置き換え:
- Tier A/B/C/D サマリ
- Phase B 後の運用ルール（Twill 内部: Status only、cross-repo: label fallback 継続）

### AC4: scripts refined.*label 残存確認
`grep -rn "refined.*label" plugins/twl/scripts/` の残存件数: **3 件**（全件 intentional 残置）

| ファイル | 内容 | 判定 |
|---------|------|------|
| autopilot-launch.sh:251 | Board 取得失敗 cross-repo fallback (ADR-024 Phase B Tier C 残置) | ✅ 意図的残置 |
| autopilot-launch.sh:258 | Board 未登録 cross-repo fallback (ADR-024 Phase B Tier C 残置) | ✅ 意図的残置 |
| project-board-refined-migrate.sh:2 | migration tool のヘッダーコメント | ✅ migration tool 用途 |

### AC5: 既存 bats test 影響確認
doc-only 変更のため既存テストへの影響なし。新規 bats テスト追加 (12 tests all PASS)。

## テスト

```
bats plugins/twl/tests/bats/issue-1293-phase-b-tier-d-completion.bats
1..12
ok 1 ac1: ... (12 tests PASS)
```

Closes #1293