### PR TITLE
feat(co-explore): summary-gate CO_EXPLORE_AUTOSAVE=1 env 対応 (#1321)

### DIFF
--- a/plugins/twl/skills/co-explore/SKILL.md
+++ b/plugins/twl/skills/co-explore/SKILL.md
@@ -37,6 +37,7 @@ spawnable_by:
 - **`#N` パターン検出時**: 既存 Issue `#N` に紐づく探索。`gh issue view N --json number,title,body` で取得し `ISSUE_NUMBER=N` に設定
 - **`#N` なし + テキストあり**: 新規問題の探索。Step 1 で Issue draft を起票
 - **引数なし**: 「何を探索しますか？」と AskUserQuestion で確認
+- **`refine` モード検出** (AC-4): `$ARGUMENTS` に `refine` または `--refine` が含まれる場合、`REFINE_MODE=true` に設定し `CO_EXPLORE_AUTOSAVE=1` を自動 enable する
 
 ## Step 1: Issue 確保
 
@@ -105,6 +106,16 @@ rationale: DDD は過剰、軽量 spec で十分なため
 - `rationale:` — この構造を選んだ理由（任意）
 
 **不在の場合**: co-architect は `--type=ddd` default で動作する。
+
+### CO_EXPLORE_AUTOSAVE 判定（summary-gate env check）
+
+summary を提示した後、AskUserQuestion を呼ぶ前に以下を判定する（AC-1）:
+
+1. **大規模変更 safety override** (AC-3): explore-summary の行数が 500 を超える場合は `CO_EXPLORE_AUTOSAVE=1` 設定を無視してメニューを表示する（以下の自動選択をスキップ）
+2. **自動選択** (AC-2): `CO_EXPLORE_AUTOSAVE=1` が設定されている（または REFINE_MODE=true で自動 enable された）場合は `[A]` を自動選択し、以下をログ出力して Step 4 へ進む:
+   ```
+   [auto-confirm] CO_EXPLORE_AUTOSAVE=1: summary-gate [A] を自動選択しました
+   ```
 
 AskUserQuestion で 3 択を提示:
 - `[A] この summary で確定`

--- a/plugins/twl/tests/bats/ac-test-mapping-1321.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1321.yaml
@@ -1,0 +1,35 @@
+mappings:
+  - ac_index: 1
+    ac_text: "co-explore/SKILL.md L88 summary-gate に env 判定追加"
+    test_file: "tests/bats/issue-1321-co-explore-autosave.bats"
+    test_name: "ac1: SKILL.md summary-gate section contains CO_EXPLORE_AUTOSAVE env judgment"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+
+  - ac_index: 2
+    ac_text: "CO_EXPLORE_AUTOSAVE=1 で [A]確定 自動選択 + log"
+    test_file: "tests/bats/issue-1321-co-explore-autosave.bats"
+    test_name: "ac2: SKILL.md describes auto-select [A] when CO_EXPLORE_AUTOSAVE=1"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+
+  - ac_index: 3
+    ac_text: "大規模変更 (>500 行) は env 無視で menu 表示 (safety)"
+    test_file: "tests/bats/issue-1321-co-explore-autosave.bats"
+    test_name: "ac3: SKILL.md describes large-change safety override (>500 lines)"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+
+  - ac_index: 4
+    ac_text: "refine mode 時は env 自動 enable"
+    test_file: "tests/bats/issue-1321-co-explore-autosave.bats"
+    test_name: "ac4: SKILL.md describes refine mode auto-enabling CO_EXPLORE_AUTOSAVE"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+
+  - ac_index: 5
+    ac_text: "regression bats: env 経路で auto-confirm 確認"
+    test_file: "tests/bats/issue-1321-co-explore-autosave.bats"
+    test_name: "ac5: SKILL.md autosave env path covers all 3 required behaviors (auto-select, large-change-guard, refine-mode)"
+    impl_files:
+      - "skills/co-explore/SKILL.md"

--- a/plugins/twl/tests/bats/issue-1321-co-explore-autosave.bats
+++ b/plugins/twl/tests/bats/issue-1321-co-explore-autosave.bats
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+# issue-1321-co-explore-autosave.bats
+#
+# RED-phase tests for Issue #1321:
+#   feat(co-explore): summary-gate CO_EXPLORE_AUTOSAVE=1 環境変数対応 (Wave 26 sub-5, Tier B)
+#
+# AC coverage:
+#   AC1 - co-explore/SKILL.md の summary-gate セクションに CO_EXPLORE_AUTOSAVE env 判定が追加されている
+#   AC2 - CO_EXPLORE_AUTOSAVE=1 で [A]確定 自動選択 + log の記述がある
+#   AC3 - 大規模変更 (>500 行) は env 無視で menu 表示 (safety) の記述がある
+#   AC4 - refine mode 時は env を自動 enable する記述がある
+#   AC5 - regression bats: env 経路で auto-confirm 確認 (bats ファイル自身の存在 + AC1-4 が全 PASS)
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  SKILL_FILE="${REPO_ROOT}/skills/co-explore/SKILL.md"
+  export SKILL_FILE
+}
+
+# ===========================================================================
+# AC1: co-explore/SKILL.md の summary-gate に CO_EXPLORE_AUTOSAVE env 判定追加
+# ===========================================================================
+
+@test "ac1: SKILL.md summary-gate section contains CO_EXPLORE_AUTOSAVE env judgment" {
+  # AC: co-explore/SKILL.md の summary-gate セクションに CO_EXPLORE_AUTOSAVE 環境変数判定が追加されている
+  # RED: 現在 env 判定が存在しないため fail する
+  run grep -c "CO_EXPLORE_AUTOSAVE" "${SKILL_FILE}"
+  [ "${output}" -gt 0 ]
+}
+
+# ===========================================================================
+# AC2: CO_EXPLORE_AUTOSAVE=1 で [A]確定 自動選択 + log
+# ===========================================================================
+
+@test "ac2: SKILL.md describes auto-select [A] when CO_EXPLORE_AUTOSAVE=1" {
+  # AC: CO_EXPLORE_AUTOSAVE=1 設定時に [A] を自動選択する旨の記述が SKILL.md にある
+  # RED: 実装前は fail する
+  run grep -c "CO_EXPLORE_AUTOSAVE=1" "${SKILL_FILE}"
+  [ "${output}" -gt 0 ]
+}
+
+@test "ac2: SKILL.md describes logging of auto-confirm action" {
+  # AC: CO_EXPLORE_AUTOSAVE=1 による自動選択時にログ出力する旨の記述がある
+  # RED: 実装前は fail する
+  # "自動" or "auto" と "log" or "出力" の組み合わせを確認
+  run grep -iE "(自動.*log|auto.*log|log.*auto|自動.*出力)" "${SKILL_FILE}"
+  [ "${#lines[@]}" -gt 0 ]
+}
+
+# ===========================================================================
+# AC3: 大規模変更 (>500 行) は env 無視で menu 表示 (safety)
+# ===========================================================================
+
+@test "ac3: SKILL.md describes large-change safety override (>500 lines)" {
+  # AC: 大規模変更 (>500 行) の場合は CO_EXPLORE_AUTOSAVE env を無視してメニュー表示する安全動作の記述がある
+  # RED: 実装前は fail する
+  run grep -c "500" "${SKILL_FILE}"
+  [ "${output}" -gt 0 ]
+}
+
+@test "ac3: SKILL.md safety clause overrides env for large changes" {
+  # AC: env 設定があっても大規模変更時はメニューを強制表示する記述がある
+  # RED: 実装前は fail する
+  # "safety" or "安全" or "env 無視" or "override" の表現を確認
+  run grep -iE "(safety|安全|env.*無視|override|強制.*menu|menu.*強制)" "${SKILL_FILE}"
+  [ "${#lines[@]}" -gt 0 ]
+}
+
+# ===========================================================================
+# AC4: refine mode 時は env を自動 enable
+# ===========================================================================
+
+@test "ac4: SKILL.md describes refine mode auto-enabling CO_EXPLORE_AUTOSAVE" {
+  # AC: refine mode（引数に refine が含まれる場合）は CO_EXPLORE_AUTOSAVE を自動 enable する記述がある
+  # RED: 実装前は fail する
+  run grep -iE "(refine.*auto|auto.*refine|refine.*CO_EXPLORE_AUTOSAVE|CO_EXPLORE_AUTOSAVE.*refine)" "${SKILL_FILE}"
+  [ "${#lines[@]}" -gt 0 ]
+}
+
+@test "ac4: SKILL.md refine mode section mentions autosave behavior" {
+  # AC: refine mode 専用の autosave 自動有効化ロジックの記述が存在する
+  # RED: 実装前は fail する
+  # "refine" キーワード近傍で "enable" または "有効" が言及されているか確認
+  run grep -iE "(refine.*enable|refine.*有効|enable.*refine|有効.*refine)" "${SKILL_FILE}"
+  [ "${#lines[@]}" -gt 0 ]
+}
+
+# ===========================================================================
+# AC5: regression bats ファイル存在 + env 経路で auto-confirm 確認
+# ===========================================================================
+
+@test "ac5: this bats file itself exists as regression test for env auto-confirm path" {
+  # AC: CO_EXPLORE_AUTOSAVE=1 環境変数経路の auto-confirm を検証する regression bats が存在する
+  # このテスト自身が存在することを確認（常に PASS するが、ファイル存在の証明）
+  local this_bats_file="${REPO_ROOT}/tests/bats/issue-1321-co-explore-autosave.bats"
+  [ -f "${this_bats_file}" ]
+}
+
+@test "ac5: SKILL.md autosave env path covers all 3 required behaviors (auto-select, large-change-guard, refine-mode)" {
+  # AC: env 経路の 3 つの動作（自動選択、大規模変更ガード、refine 自動有効化）が
+  #     すべて SKILL.md に記述されていることを一括確認する regression テスト
+  # RED: 実装前は fail する（いずれかの記述が欠如）
+  local autosave_count
+  autosave_count=$(grep -c "CO_EXPLORE_AUTOSAVE" "${SKILL_FILE}" || true)
+  [ "${autosave_count}" -ge 3 ]
+}


### PR DESCRIPTION
## Summary
Closes #1321

summary-gate (Step 3) に `CO_EXPLORE_AUTOSAVE=1` 環境変数対応を追加。refine mode 時の手間削減。

## Changes
- **AC-1**: `co-explore/SKILL.md` summary-gate に env 判定ブロックを追加
- **AC-2**: `CO_EXPLORE_AUTOSAVE=1` 設定時に `[A]` を自動選択 + `[auto-confirm]` ログ出力
- **AC-3**: explore-summary >500 行の場合は env を無視してメニュー表示 (safety override)
- **AC-4**: `refine` モード検出時に `CO_EXPLORE_AUTOSAVE=1` を自動 enable
- **AC-5**: regression bats `issue-1321-co-explore-autosave.bats` (9/9 PASS)

## Test Results
```
1..9
ok 1 ac1: SKILL.md summary-gate section contains CO_EXPLORE_AUTOSAVE env judgment
ok 2 ac2: SKILL.md describes auto-select [A] when CO_EXPLORE_AUTOSAVE=1
ok 3 ac2: SKILL.md describes logging of auto-confirm action
ok 4 ac3: SKILL.md describes large-change safety override (>500 lines)
ok 5 ac3: SKILL.md safety clause overrides env for large changes
ok 6 ac4: SKILL.md describes refine mode auto-enabling CO_EXPLORE_AUTOSAVE
ok 7 ac4: SKILL.md refine mode section mentions autosave behavior
ok 8 ac5: this bats file itself exists as regression test for env auto-confirm path
ok 9 ac5: SKILL.md autosave env path covers all 3 required behaviors
```