### PR TITLE
fix: mcp-shadow-compare.sh の set -uo pipefail を set -euo pipefail に修正

### DIFF
--- a/plugins/twl/scripts/mcp-shadow-compare.sh
+++ b/plugins/twl/scripts/mcp-shadow-compare.sh
@@ -11,7 +11,7 @@
 #   mismatch がない場合: exit 0 (出力なし)
 #   mismatch がある場合: exit 1、stderr に MISMATCH エントリを出力
 
-set -uo pipefail
+set -euo pipefail
 
 LOG_FILE=""
 

--- a/plugins/twl/tests/bats/scripts/mcp-shadow-compare.bats
+++ b/plugins/twl/tests/bats/scripts/mcp-shadow-compare.bats
@@ -155,3 +155,13 @@ _run_compare_with_log() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"MISMATCH"* ]] || [[ "$stderr" == *"MISMATCH"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# Issue #1285: set -euo pipefail への統一（-e 欠如修正）
+# ---------------------------------------------------------------------------
+
+@test "ac1 (Issue #1285): mcp-shadow-compare.sh が set -euo pipefail を使用している" {
+  # AC: set -uo pipefail → set -euo pipefail に変更（-e 欠如修正）
+  # RED: 実装前は fail する（現在 set -uo pipefail で -e が欠如）
+  grep -q "^set -euo pipefail" "$COMPARE_SH"
+}


### PR DESCRIPTION
## 概要

Issue #1285 で検出された tech-debt を修正。

plugins/twl/scripts/mcp-shadow-compare.sh L14 の set -uo pipefail に -e が欠如していた。
JSONL パース中の予期しないコマンド失敗がサイレントに無視され、誤った mismatch=0 判定が返される可能性があったため修正。

## 変更内容

- set -uo pipefail を set -euo pipefail に変更（1行変更）
- bats テスト追加（Issue #1285 AC 検証）

## 検出元

PR #1284 (Issue #1277) のコードレビュー

Closes #1285