### PR TITLE
test(bats): SHADOW_LOG を /tmp 固定 → $SANDBOX ベースに隔離 (#1286)

### DIFF
--- a/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow-path-isolation.bats
+++ b/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow-path-isolation.bats
@@ -1,14 +1,14 @@
 #!/usr/bin/env bats
 # commit-validate-mcp-shadow-path-isolation.bats
 #
-# RED テストスタブ (Issue #1286)
+# SHADOW_LOG パス隔離検証 (Issue #1286)
 #
 # AC-1: commit-validate-mcp-shadow.bats 内の SHADOW_LOG が /tmp 固定パスを使用していない
 #        （$SANDBOX ベースであること）
 # AC-2: bats teardown 後、/tmp/mcp-shadow-commit-validate.log に残留しない
 #
-# 全テストは実装前に fail (RED) する。
-# 実装後: L20 の SHADOW_LOG="/tmp/..." を SHADOW_LOG="$SANDBOX/..." に変更すれば GREEN になる。
+# 実装: SHADOW_LOG を setup() 内で "$SANDBOX/mcp-shadow-commit-validate.log" に設定済み。
+# 全テストは GREEN で通過する。
 #
 
 load '../helpers/common'
@@ -37,7 +37,7 @@ teardown() {
 # ---------------------------------------------------------------------------
 
 @test "ac1: SHADOW_LOG のグローバル代入が /tmp 固定パスを使用していない" {
-  # RED: L20 が SHADOW_LOG="/tmp/..." のためこの grep が一致し fail する
+  # setup() 内で $SANDBOX ベースに設定されているため /tmp 固定パスが存在しないことを検証
   [ -f "$BATS_FILE" ] || {
     echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
     false
@@ -52,7 +52,7 @@ teardown() {
 }
 
 @test "ac1: SHADOW_LOG が SANDBOX ベースのパスで設定されている" {
-  # RED: L20 で /tmp/... が設定されており $SANDBOX/... が存在しないため fail する
+  # setup() 内で SHADOW_LOG="$SANDBOX/mcp-shadow-commit-validate.log" が設定されていることを検証
   [ -f "$BATS_FILE" ] || {
     echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
     false
@@ -68,8 +68,7 @@ teardown() {
 }
 
 @test "ac1: SHADOW_LOG のグローバルスコープ代入が setup() 内または setup() 後に限定されている" {
-  # RED: L20 がグローバルスコープ（setup() 外）で /tmp/... を代入しているため fail する
-  # 実装後は setup() 内で SANDBOX を参照する形になる（テスト間分離が保証される）
+  # setup() 内で SANDBOX を参照することでテスト間分離が保証されていることを検証
   [ -f "$BATS_FILE" ] || {
     echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
     false
@@ -93,14 +92,11 @@ teardown() {
 # AC-2: teardown 後、/tmp/mcp-shadow-commit-validate.log が残留しない
 #
 # WHEN commit-validate-mcp-shadow.bats の teardown を確認する
-# THEN /tmp/mcp-shadow-commit-validate.log が cleanup される仕組みがある
-#      または SHADOW_LOG が $SANDBOX/ ベースであり common_teardown で自動削除される
-# RED: SHADOW_LOG が /tmp 固定パスのため common_teardown では削除されず残留する
+# THEN SHADOW_LOG が $SANDBOX/ ベースであり common_teardown で自動削除される
 # ---------------------------------------------------------------------------
 
 @test "ac2: teardown が /tmp/mcp-shadow-commit-validate.log を明示的に削除するか SANDBOX ベースである" {
-  # RED: SHADOW_LOG が /tmp/... のため common_teardown では削除されず、
-  #      かつ teardown() 内に rm -f /tmp/... が存在しないため fail する
+  # SHADOW_LOG が $SANDBOX/ ベースのため common_teardown で自動クリーンアップされることを検証
   [ -f "$BATS_FILE" ] || {
     echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
     false
@@ -133,14 +129,8 @@ teardown() {
   fi
 }
 
-@test "ac2: /tmp/mcp-shadow-commit-validate.log が現在のテスト実行後に残留しない（実地検証）" {
-  # RED: SHADOW_LOG="/tmp/..." のため、テスト実行後に /tmp ファイルが残留するリスクがある
-  # このテストは実地で /tmp への書き込みが発生しないことを検証する
-
-  # 事前に /tmp の当該ファイルを削除（前回実行残留を排除）
-  rm -f /tmp/mcp-shadow-commit-validate.log
-
-  # SHADOW_LOG のパスを直接チェック: /tmp/... を使用していれば危険状態
+@test "ac2: /tmp/mcp-shadow-commit-validate.log が現在のテスト実行後に残留しない（静的検証）" {
+  # SHADOW_LOG が /tmp/... を使用していないことを静的に検証する（副作用なし）
   [ -f "$BATS_FILE" ] || {
     echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
     false

--- a/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow-path-isolation.bats
+++ b/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow-path-isolation.bats
@@ -1,0 +1,157 @@
+#!/usr/bin/env bats
+# commit-validate-mcp-shadow-path-isolation.bats
+#
+# RED テストスタブ (Issue #1286)
+#
+# AC-1: commit-validate-mcp-shadow.bats 内の SHADOW_LOG が /tmp 固定パスを使用していない
+#        （$SANDBOX ベースであること）
+# AC-2: bats teardown 後、/tmp/mcp-shadow-commit-validate.log に残留しない
+#
+# 全テストは実装前に fail (RED) する。
+# 実装後: L20 の SHADOW_LOG="/tmp/..." を SHADOW_LOG="$SANDBOX/..." に変更すれば GREEN になる。
+#
+
+load '../helpers/common'
+
+BATS_FILE=""
+
+setup() {
+  common_setup
+
+  local git_root
+  git_root="$(cd "$REPO_ROOT" && git rev-parse --show-toplevel 2>/dev/null)"
+
+  BATS_FILE="${git_root}/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow.bats"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC-1: SHADOW_LOG が /tmp 固定パスを使用していない（$SANDBOX ベースであること）
+#
+# WHEN commit-validate-mcp-shadow.bats を grep する
+# THEN SHADOW_LOG のデフォルト値が /tmp/... ではなく $SANDBOX/... であること
+# RED: 現状 L20 が SHADOW_LOG="/tmp/mcp-shadow-commit-validate.log" のため fail する
+# ---------------------------------------------------------------------------
+
+@test "ac1: SHADOW_LOG のグローバル代入が /tmp 固定パスを使用していない" {
+  # RED: L20 が SHADOW_LOG="/tmp/..." のためこの grep が一致し fail する
+  [ -f "$BATS_FILE" ] || {
+    echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
+    false
+  }
+  local tmp_assignments
+  tmp_assignments=$(grep -n 'SHADOW_LOG=.*"/tmp/' "$BATS_FILE" || true)
+  if [ -n "$tmp_assignments" ]; then
+    echo "SHADOW_LOG が /tmp 固定パスで設定されています（\$SANDBOX ベースに変更が必要）:" >&2
+    echo "$tmp_assignments" >&2
+    false
+  fi
+}
+
+@test "ac1: SHADOW_LOG が SANDBOX ベースのパスで設定されている" {
+  # RED: L20 で /tmp/... が設定されており $SANDBOX/... が存在しないため fail する
+  [ -f "$BATS_FILE" ] || {
+    echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
+    false
+  }
+  local sandbox_assignments
+  sandbox_assignments=$(grep -n 'SHADOW_LOG=.*"\$SANDBOX/' "$BATS_FILE" || true)
+  if [ -z "$sandbox_assignments" ]; then
+    echo "SHADOW_LOG が \$SANDBOX ベースのパスで設定されていません" >&2
+    echo "現在の SHADOW_LOG 設定:" >&2
+    grep -n 'SHADOW_LOG=' "$BATS_FILE" >&2 || echo "(SHADOW_LOG 設定なし)" >&2
+    false
+  fi
+}
+
+@test "ac1: SHADOW_LOG のグローバルスコープ代入が setup() 内または setup() 後に限定されている" {
+  # RED: L20 がグローバルスコープ（setup() 外）で /tmp/... を代入しているため fail する
+  # 実装後は setup() 内で SANDBOX を参照する形になる（テスト間分離が保証される）
+  [ -f "$BATS_FILE" ] || {
+    echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
+    false
+  }
+  # グローバルスコープ（関数外）での SHADOW_LOG="/tmp/... 代入を検出
+  # awk で関数ブロック外の代入行を抽出する
+  local global_tmp_assign
+  global_tmp_assign=$(awk '
+    /^[[:space:]]*(setup|teardown|@test|function)[[:space:]]*\(/ { in_func=1 }
+    /^}/ { in_func=0 }
+    !in_func && /SHADOW_LOG=.*\/tmp\// { print NR": "$0 }
+  ' "$BATS_FILE" || true)
+  if [ -n "$global_tmp_assign" ]; then
+    echo "SHADOW_LOG が グローバルスコープ（関数外）で /tmp/... に設定されています:" >&2
+    echo "$global_tmp_assign" >&2
+    false
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: teardown 後、/tmp/mcp-shadow-commit-validate.log が残留しない
+#
+# WHEN commit-validate-mcp-shadow.bats の teardown を確認する
+# THEN /tmp/mcp-shadow-commit-validate.log が cleanup される仕組みがある
+#      または SHADOW_LOG が $SANDBOX/ ベースであり common_teardown で自動削除される
+# RED: SHADOW_LOG が /tmp 固定パスのため common_teardown では削除されず残留する
+# ---------------------------------------------------------------------------
+
+@test "ac2: teardown が /tmp/mcp-shadow-commit-validate.log を明示的に削除するか SANDBOX ベースである" {
+  # RED: SHADOW_LOG が /tmp/... のため common_teardown では削除されず、
+  #      かつ teardown() 内に rm -f /tmp/... が存在しないため fail する
+  [ -f "$BATS_FILE" ] || {
+    echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
+    false
+  }
+
+  # 条件 A: SHADOW_LOG が $SANDBOX/ ベース（common_teardown で自動削除される）
+  # grep -c はマッチなしで exit 1 + stdout "0" を返す。|| true で exit code を吸収し値のみ取る
+  local has_sandbox_shadow_log
+  if grep -q 'SHADOW_LOG=.*"\$SANDBOX/' "$BATS_FILE" 2>/dev/null; then
+    has_sandbox_shadow_log=1
+  else
+    has_sandbox_shadow_log=0
+  fi
+
+  # 条件 B: teardown() 内で rm -f /tmp/mcp-shadow-commit-validate.log が存在する
+  local has_explicit_cleanup
+  has_explicit_cleanup=$(awk '
+    /teardown[[:space:]]*\(\)/ { in_teardown=1 }
+    in_teardown && /rm.*\/tmp\/mcp-shadow-commit-validate\.log/ { found=1 }
+    in_teardown && /^}/ { in_teardown=0 }
+    END { print (found ? "1" : "0") }
+  ' "$BATS_FILE")
+
+  if [ "$has_sandbox_shadow_log" -eq 0 ] && [ "$has_explicit_cleanup" -eq 0 ]; then
+    echo "/tmp/mcp-shadow-commit-validate.log が teardown でクリーンアップされません:" >&2
+    echo "  - SHADOW_LOG が \$SANDBOX/ ベースでない" >&2
+    echo "  - teardown() 内に rm -f /tmp/mcp-shadow-commit-validate.log がない" >&2
+    echo "いずれかの対策が必要です（推奨: SHADOW_LOG を \$SANDBOX/ ベースに変更）" >&2
+    false
+  fi
+}
+
+@test "ac2: /tmp/mcp-shadow-commit-validate.log が現在のテスト実行後に残留しない（実地検証）" {
+  # RED: SHADOW_LOG="/tmp/..." のため、テスト実行後に /tmp ファイルが残留するリスクがある
+  # このテストは実地で /tmp への書き込みが発生しないことを検証する
+
+  # 事前に /tmp の当該ファイルを削除（前回実行残留を排除）
+  rm -f /tmp/mcp-shadow-commit-validate.log
+
+  # SHADOW_LOG のパスを直接チェック: /tmp/... を使用していれば危険状態
+  [ -f "$BATS_FILE" ] || {
+    echo "テスト対象ファイルが存在しない: $BATS_FILE" >&2
+    false
+  }
+
+  local uses_tmp_path
+  uses_tmp_path=$(grep -c 'SHADOW_LOG=.*/tmp/' "$BATS_FILE" 2>/dev/null || echo "0")
+
+  if [ "$uses_tmp_path" -gt 0 ]; then
+    echo "SHADOW_LOG が /tmp/... を使用しています。並列テスト時に残留リスクがあります。" >&2
+    echo "SHADOW_LOG を \"\$SANDBOX/mcp-shadow-commit-validate.log\" に変更してください。" >&2
+    false
+  fi
+}

--- a/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow.bats
+++ b/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow.bats
@@ -253,21 +253,21 @@ _run_compare_commit() {
 }
 
 # ---------------------------------------------------------------------------
-# AC-5: mcp-shadow-compare.sh 互換ログを /tmp/mcp-shadow-commit-validate.log に追記
+# AC-5: mcp-shadow-compare.sh 互換ログを $SHADOW_LOG に追記
 # WHEN commit-validate の bash hook または mcp_tool hook が実行される
-# THEN /tmp/mcp-shadow-commit-validate.log に JSONL 形式でエントリが追記されること
+# THEN $SHADOW_LOG（$SANDBOX/mcp-shadow-commit-validate.log）に JSONL 形式でエントリが追記されること
 # RED: shadow log 書き込みロジック未実装のため fail する
 # ---------------------------------------------------------------------------
 
-@test "AC5: /tmp/mcp-shadow-commit-validate.log に JSONL エントリが書き込まれる" {
+@test "AC5: shadow log に JSONL エントリが書き込まれる" {
   # RED: shadow log 書き込みロジックが未実装のため、ログファイルが存在しないか空のため fail する
   # 実装後は pre-bash-commit-validate.sh または別の shadow hook がこのファイルに書き込む
   [ -f "$SHADOW_LOG" ] || {
-    echo "/tmp/mcp-shadow-commit-validate.log が存在しない（shadow log 書き込み未実装）" >&2
+    echo "$SHADOW_LOG が存在しない（shadow log 書き込み未実装）" >&2
     false
   }
   [ -s "$SHADOW_LOG" ] || {
-    echo "/tmp/mcp-shadow-commit-validate.log が空（shadow log 書き込み未実装）" >&2
+    echo "$SHADOW_LOG が空（shadow log 書き込み未実装）" >&2
     false
   }
 }
@@ -275,7 +275,7 @@ _run_compare_commit() {
 @test "AC5: shadow log エントリに source フィールド（bash または mcp_tool）が存在する" {
   # RED: shadow log 書き込みロジックが未実装のため fail する
   [ -f "$SHADOW_LOG" ] || {
-    echo "/tmp/mcp-shadow-commit-validate.log が存在しない" >&2
+    echo "$SHADOW_LOG が存在しない" >&2
     false
   }
   local has_bash has_mcp
@@ -287,11 +287,11 @@ _run_compare_commit() {
 @test "AC5: shadow log エントリに command フィールドが存在する" {
   # RED: shadow log 書き込みロジックが未実装のため fail する
   [ -f "$SHADOW_LOG" ] || {
-    echo "/tmp/mcp-shadow-commit-validate.log が存在しない" >&2
+    echo "$SHADOW_LOG が存在しない" >&2
     false
   }
   grep -q '"command"' "$SHADOW_LOG" || {
-    echo "shadow log に command フィールドが存在しない" >&2
+    echo "$SHADOW_LOG に command フィールドが存在しない" >&2
     false
   }
 }
@@ -303,7 +303,7 @@ _run_compare_commit() {
     false
   }
   [ -f "$SHADOW_LOG" ] || {
-    echo "/tmp/mcp-shadow-commit-validate.log が存在しない" >&2
+    echo "$SHADOW_LOG が存在しない" >&2
     false
   }
   run bash "$COMPARE_SH" --log-file "$SHADOW_LOG"

--- a/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow.bats
+++ b/plugins/twl/tests/bats/scripts/commit-validate-mcp-shadow.bats
@@ -17,7 +17,7 @@ load '../helpers/common'
 
 SETTINGS_JSON=""
 COMPARE_SH=""
-SHADOW_LOG="/tmp/mcp-shadow-commit-validate.log"
+SHADOW_LOG=""
 
 setup() {
   common_setup
@@ -27,6 +27,7 @@ setup() {
 
   SETTINGS_JSON="${git_root}/.claude/settings.json"
   COMPARE_SH="${git_root}/plugins/twl/scripts/mcp-shadow-compare.sh"
+  SHADOW_LOG="$SANDBOX/mcp-shadow-commit-validate.log"
 }
 
 teardown() {


### PR DESCRIPTION
## 概要

Issue #1286 の対応。

`commit-validate-mcp-shadow.bats` L20 の `SHADOW_LOG` グローバル代入（`/tmp/mcp-shadow-commit-validate.log`）を `setup()` 内へ移動し `"$SANDBOX/mcp-shadow-commit-validate.log"` に変更。

## 変更内容

- `commit-validate-mcp-shadow.bats`: `SHADOW_LOG` を `setup()` 内で `$SANDBOX` ベースに設定
- `commit-validate-mcp-shadow-path-isolation.bats`: パス隔離を検証する新規テスト（5件）を追加

## テスト結果

path-isolation テスト 5/5 GREEN。

Closes #1286