### PR TITLE
docs(tests): Issue #1218 AC5「空 dir」定義を smoke テストに明記 (#1230)

### DIFF
--- a/plugins/twl/tests/bats/scripts/ac-test-mapping-1230.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping-1230.yaml
@@ -1,0 +1,9 @@
+mappings:
+  - ac_index: 1
+    ac_text: "smoke テストのコメントに Issue #1218 AC5「空 dir」の定義が明示されている（done 済み subdir を含む dir = exit 0、truly 空 dir = exit 1 の区別）"
+    test_file: "plugins/twl/tests/bats/scripts/smoke-ac5-dir-clarification-1230.bats"
+    test_name: "@test AC1: smoke テストに「空 dir」の定義コメントがある（Issue #1218 AC5 との対応明示）"
+    status: RED
+    red_mechanism: "smoke bats に「空 dir」（Issue body 表記）がなく grep -qE が fail する"
+    impl_files:
+      - "plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-smoke.bats"

--- a/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-smoke.bats
+++ b/plugins/twl/tests/bats/scripts/issue-lifecycle-orchestrator-smoke.bats
@@ -20,6 +20,13 @@
 #     を使うようにリファクタされる
 #   - set-option callsite (L368) も同様にリファクタされる
 #   - それらの変更後も orchestrator が exit 0 で完了すること
+#
+# 「空 dir」の定義（Issue #1230: tech-debt clarification）:
+#   Issue #1218 AC5「空 dir で起動して exit 0 確認」の「空 dir」は
+#   literally 空ディレクトリ（IN/draft.md なし）を意味しない。
+#   正確な定義: 有効な per-issue-dir（done 済み subdir を少なくとも 1 つ含む dir）
+#   - 空 dir = done 済み subdir 1 件含む dir → spawn_session スキップ → exit 0
+#   - truly 空 dir（IN/draft.md なし）→ バリデーション失敗 → exit 1（AC5-smoke-empty-dir-exit1 参照）
 
 load '../../bats/helpers/common'
 

--- a/plugins/twl/tests/bats/scripts/smoke-ac5-dir-clarification-1230.bats
+++ b/plugins/twl/tests/bats/scripts/smoke-ac5-dir-clarification-1230.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+# smoke-ac5-dir-clarification-1230.bats
+# Issue #1230: tech-debt: AC5 smoke テストと Issue body の「空 dir」定義を明確化
+#
+# Issue #1218 AC5 は「空 dir で起動して exit 0 確認」と記述しているが、
+# smoke テストは「done 済み subdir 1 件 → exit 0」かつ「truly 空 → exit 1」を検証する。
+# 「空 dir」の定義が曖昧なため、smoke テストのコメントに明示的な定義が必要。
+#
+# AC1:
+#   issue-lifecycle-orchestrator-smoke.bats のコメントに
+#   Issue #1218 AC5「空 dir」の定義（done 済み subdir を含む dir であること）が記載されている
+#
+# RED → GREEN 条件:
+#   smoke bats に「空 dir」（Issue body・AC5 由来の表記）を使った定義コメントが追加されること
+
+load '../../bats/helpers/common'
+
+SMOKE_BATS=""
+
+setup() {
+    common_setup
+    SMOKE_BATS="$REPO_ROOT/tests/bats/scripts/issue-lifecycle-orchestrator-smoke.bats"
+}
+
+# ---------------------------------------------------------------------------
+# AC1: smoke テストに「空 dir」の定義コメントがある（Issue #1218 AC5 との対応明示）
+# RED:  現状は「空ディレクトリ」（日本語）のみで「空 dir」表記がない
+#       → Issue #1218 AC5 が言う「空 dir」と smoke テストのテストケースの対応が不明確
+# GREEN: smoke bats に「空 dir」を使った定義コメントが追加され
+#        「done 済み subdir 含む dir = exit 0」「truly 空 dir = exit 1」の区別が明示された時
+# ---------------------------------------------------------------------------
+@test "AC1: smoke テストに「空 dir」の定義コメントがある（Issue #1218 AC5 との対応明示）" {
+    # RED: 「空 dir」（スペース含む Issue body 表記）が存在しない → 定義コメント未追加
+    [ -f "$SMOKE_BATS" ]
+    grep -qE "空 dir" "$SMOKE_BATS"
+}


### PR DESCRIPTION
## 概要

Issue #1230 の tech-debt: Issue #1218 AC5「空 dir」定義と smoke テストの乖離を解消。

## 変更内容

### `issue-lifecycle-orchestrator-smoke.bats` ヘッダーコメント追記

Issue #1218 AC5「空 dir で起動して exit 0 確認」の「空 dir」定義を明記:

```
「空 dir」の定義（Issue #1230: tech-debt clarification）:
  Issue #1218 AC5「空 dir で起動して exit 0 確認」の「空 dir」は
  literally 空ディレクトリ（IN/draft.md なし）を意味しない。
  正確な定義: 有効な per-issue-dir（done 済み subdir を少なくとも 1 つ含む dir）
  - 空 dir = done 済み subdir 1 件含む dir → spawn_session スキップ → exit 0
  - truly 空 dir（IN/draft.md なし）→ バリデーション失敗 → exit 1（AC5-smoke-empty-dir-exit1 参照）
```

### テスト

- `smoke-ac5-dir-clarification-1230.bats`: AC1「空 dir 定義コメントの存在確認」GREEN 確認済み
- `ac-test-mapping-1230.yaml`: AC→テストマッピング記録

## 関連 Issue

Closes #1230