### PR TITLE
tech-debt(hooks-mcp): twl_validate_commit を shadow mode として明示 (#1335)

### DIFF
--- a/cli/twl/architecture/decisions/ADR-0007-mcp-shadow-hook-separation.md
+++ b/cli/twl/architecture/decisions/ADR-0007-mcp-shadow-hook-separation.md
@@ -1,0 +1,36 @@
+# ADR-0007: MCP Shadow Hook と Bash Hook の責務分離
+
+**ステータス**: Accepted  
+**日付**: 2026-05-03  
+**関連 Issue**: #1335 (#1288 follow-up)
+
+## 背景
+
+`.claude/settings.json` の `PreToolUse:Bash` hook に `twl_validate_commit` MCP ツールを登録している。
+このツールは `files` パラメータに渡された deps.yaml ファイルを検証することが意図されているが、
+Claude Code の hook 仕様上の制約により、`tool_input` から staged files リストを取得する手段がない。
+そのため `files` は常に空リスト `[]` で呼び出され、ループがスキップされて常に `ok=true` を返す。
+
+## 決定
+
+MCP hook（`twl_validate_commit`）と bash hook（`pre-bash-commit-validate.sh`）の責務を明確に分離する:
+
+| Hook 種別 | 実装 | 責務 |
+|-----------|------|------|
+| bash hook | `pre-bash-commit-validate.sh` | **block 専用**: deps.yaml validation を行い、違反時に exit non-zero でコミットをブロック |
+| MCP hook | `twl_validate_commit` | **記録専用 (shadow mode)**: 将来の hook 仕様拡張に備えた登録・ログ記録のみ。現状は no-op |
+
+## 理由
+
+- Claude Code の `PreToolUse` hook では `tool_input` からファイルリストを取得できない（仕様制約）
+- `pre-bash-commit-validate.sh` が同等の検証を提供しており、実際の防衛線として機能している
+- MCP hook を削除するより「shadow mode として意図を明示した上で存在させる」ことで、
+  将来の hook 仕様拡張時に容易に有効化できる
+- `outputType: "log"` の設定により、MCP hook の失敗がユーザー体験に影響しない
+
+## 将来の変更
+
+Claude Code の hook 仕様が拡張されて `tool_input` から staged files が取得可能になった場合:
+1. `twl_validate_commit_handler` の `files` パラメータを実際に活用するよう更新
+2. `settings.json` の `files: []` を動的なファイルリストに変更
+3. 本 ADR のステータスを Superseded に更新し、新 ADR を作成すること

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -967,7 +967,17 @@ def twl_validate_commit_handler(
     files: list[str],
     timeout_sec: int | None = 300,
 ) -> dict:
-    """validation module: commit message and file deps validation (in-process, no subprocess)."""
+    """validation module: commit message and file deps validation (in-process, no subprocess).
+
+    現状: Claude Code の PreToolUse hook では tool_input から staged files リストを取得する
+    仕組みがない（hook 仕様制約）。そのため settings.json の files フィールドは常に空リスト
+    で呼び出され、このハンドラは files 空リストにより実質 no-op となる。
+    deps.yaml validation の実体は pre-bash-commit-validate.sh (bash hook) が担当する。
+    代替: pre-bash-commit-validate.sh (bash hook) が deps.yaml validation を担当。
+    MCP hook は記録専用（shadow mode）として位置づける。
+    # TODO: Claude Code hook 仕様拡張時に再検討 — staged files が取得可能になった場合に
+    #       files パラメータを実活用できる。Issue #1335 参照（self-deferred）。
+    """
     if timeout_sec is not None and timeout_sec <= 0:
         return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
 

--- a/cli/twl/tests/mcp_server/test_1335_validate_commit_files_empty.bats
+++ b/cli/twl/tests/mcp_server/test_1335_validate_commit_files_empty.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# test_1335_validate_commit_files_empty.bats
+#
+# RED テストスタブ (Issue #1335)
+#
+# AC-5: regression bats で「files=[] 入力で常に ok=true」を契約として固定（spec lock）
+#
+# このテストは spec lock として機能する:
+# - files=[] のとき twl_validate_commit_handler は常に ok=true を返さなければならない
+# - この挙動は Claude Code hook 仕様制約（staged files が取得不可）による意図的な設計
+# - 将来 hook 仕様が拡張された場合にこのテストを更新すること
+#
+
+GIT_ROOT=""
+TOOLS_PY=""
+
+setup() {
+  GIT_ROOT="$(git -C "$(dirname "${BATS_TEST_FILENAME}")" rev-parse --show-toplevel 2>/dev/null)"
+  TOOLS_PY="${GIT_ROOT}/cli/twl/src/twl/mcp_server/tools.py"
+}
+
+# ---------------------------------------------------------------------------
+# AC-5: files=[] 入力で常に ok=true (spec lock)
+# ---------------------------------------------------------------------------
+
+@test "ac5: files=[] で twl_validate_commit_handler は ok=true を返す (spec lock)" {
+  # AC: regression bats で「files=[] 入力で常に ok=true」を契約として固定
+  # この挙動は意図的設計: Claude Code hook 仕様制約で staged files が取得不可
+  # RED: handler 未実装または挙動変更時に fail する
+
+  run python3 -c "
+import sys
+sys.path.insert(0, '${GIT_ROOT}/cli/twl/src')
+from twl.mcp_server.tools import twl_validate_commit_handler
+result = twl_validate_commit_handler(message='test: commit message', files=[])
+assert result.get('ok') == True, f'expected ok=True, got {result}'
+print('ok=True confirmed for files=[]')
+"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok=True confirmed"* ]]
+}
+
+@test "ac5: files=[] で items リストは空 (no violations)" {
+  # AC: files=[] のとき violations リストが空であること
+  # RED: handler が files=[] 時に unexpected violation を返す場合 fail
+
+  run python3 -c "
+import sys
+sys.path.insert(0, '${GIT_ROOT}/cli/twl/src')
+from twl.mcp_server.tools import twl_validate_commit_handler
+result = twl_validate_commit_handler(message='feat: empty files list', files=[])
+items = result.get('items', [])
+assert items == [], f'expected items=[], got {items}'
+print('items=[] confirmed')
+"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"items=[] confirmed"* ]]
+}
+
+@test "ac5: files=[] で exit_code=0 (spec lock)" {
+  # AC: files=[] のとき exit_code=0 であること
+  # RED: exit_code が 0 以外の場合 fail
+
+  run python3 -c "
+import sys
+sys.path.insert(0, '${GIT_ROOT}/cli/twl/src')
+from twl.mcp_server.tools import twl_validate_commit_handler
+result = twl_validate_commit_handler(message='chore: no staged files', files=[])
+assert result.get('exit_code') == 0, f'expected exit_code=0, got {result}'
+print('exit_code=0 confirmed')
+"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"exit_code=0 confirmed"* ]]
+}

--- a/cli/twl/tests/test_issue_1335_validate_commit_no_op.py
+++ b/cli/twl/tests/test_issue_1335_validate_commit_no_op.py
@@ -1,0 +1,178 @@
+"""Tests for Issue #1335: twl_validate_commit hook が files=[] 固定で実質 no-op (RED フェーズ).
+
+TDD RED フェーズ用テストスタブ。実装前は全テストが FAIL する（意図的 RED）。
+
+AC 一覧:
+- AC-1: twl_validate_commit_handler docstring に「files 空リストにより実質 no-op」を明記
+- AC-2: tools.py コメントに Claude Code hook 仕様制約と pre-bash-commit-validate.sh 代替を明示
+- AC-3: ADR/architecture/ に MCP shadow hook 責務分離を記録
+- AC-4: TODO/コメントに「Claude Code hook 仕様拡張時に再検討」を記録
+"""
+
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+WORKTREE_ROOT = TWL_DIR.parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+ARCH_DIR = TWL_DIR / "architecture"
+
+
+# ---------------------------------------------------------------------------
+# AC-1: twl_validate_commit_handler docstring に「files 空リストにより実質 no-op」
+# ---------------------------------------------------------------------------
+
+
+class TestAC1ValidateCommitHandlerDocstring:
+    """AC-1: twl_validate_commit_handler の docstring に no-op 旨を明記."""
+
+    def test_ac1_docstring_contains_files_empty_no_op(self):
+        # AC: twl_validate_commit_handler の docstring に
+        #     「files 空リストにより実質 no-op」を明記（現状を spec として記録）
+        # RED: docstring 未更新のため fail する
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        doc = inspect.getdoc(twl_validate_commit_handler) or ""
+        assert "no-op" in doc or "no_op" in doc, (
+            f"docstring に 'no-op' が見つかりません: {doc!r}"
+        )
+
+    def test_ac1_docstring_mentions_files_empty_list(self):
+        # AC: docstring が files=[] / 空リストについて言及していること
+        # RED: docstring 未更新のため fail する
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        doc = inspect.getdoc(twl_validate_commit_handler) or ""
+        has_empty_list = (
+            "files" in doc.lower()
+            and ("空" in doc or "empty" in doc.lower() or "[]" in doc)
+        )
+        assert has_empty_list, (
+            f"docstring に 'files 空リスト' に関する記述が見つかりません: {doc!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: tools.py コメントに Claude Code hook 仕様制約を明示
+# ---------------------------------------------------------------------------
+
+
+class TestAC2ToolsPyComment:
+    """AC-2: tools.py に hook 仕様制約と代替 bash hook を明示するコメント."""
+
+    def test_ac2_comment_mentions_tool_input_limitation(self):
+        # AC: Claude Code hook 仕様で tool_input から staged files が取得不可を明示
+        # RED: コメント未追加のため fail する
+        assert TOOLS_PY.exists(), f"tools.py not found: {TOOLS_PY}"
+        content = TOOLS_PY.read_text(encoding="utf-8")
+        has_limitation = (
+            "tool_input" in content and "staged" in content
+        ) or "hook 仕様" in content or "hook specification" in content.lower()
+        assert has_limitation, (
+            "tools.py に Claude Code hook 仕様制約（tool_input / staged files 不可）の"
+            "コメントが見つかりません"
+        )
+
+    def test_ac2_comment_mentions_pre_bash_commit_validate(self):
+        # AC: 代替として pre-bash-commit-validate.sh (bash hook) に言及
+        # RED: コメント未追加のため fail する
+        assert TOOLS_PY.exists(), f"tools.py not found: {TOOLS_PY}"
+        content = TOOLS_PY.read_text(encoding="utf-8")
+        assert "pre-bash-commit-validate.sh" in content, (
+            "tools.py に pre-bash-commit-validate.sh への言及がありません"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: ADR/architecture/ に MCP shadow hook 責務分離を記録
+# ---------------------------------------------------------------------------
+
+
+class TestAC3ArchitectureDocument:
+    """AC-3: ADR または architecture/ に MCP shadow hook 責務分離を記録."""
+
+    def test_ac3_architecture_doc_exists_with_shadow_hook_separation(self):
+        # AC: MCP=記録専用、bash=block 専用の責務分離を記録したドキュメントが存在
+        # RED: ドキュメント未作成のため fail する
+        assert ARCH_DIR.exists(), f"architecture/ not found: {ARCH_DIR}"
+
+        # ADR または context doc で shadow hook 責務分離を検索
+        candidates = list(ARCH_DIR.rglob("*.md"))
+        assert candidates, "architecture/ に markdown ファイルが存在しません"
+
+        keyword_patterns = [
+            r"shadow",
+            r"MCP.*記録専用|記録専用.*MCP",
+            r"bash.*block専用|block専用.*bash",
+            r"責務分離",
+            r"twl_validate_commit",
+        ]
+        matched_files = []
+        for md_file in candidates:
+            text = md_file.read_text(encoding="utf-8")
+            if any(re.search(p, text) for p in keyword_patterns):
+                matched_files.append(md_file)
+
+        assert matched_files, (
+            "architecture/ に MCP shadow hook 責務分離を記録したドキュメントが見つかりません。"
+            f"検索対象: {[str(f.relative_to(TWL_DIR)) for f in candidates[:5]]}"
+        )
+
+    def test_ac3_shadow_doc_mentions_mcp_record_only(self):
+        # AC: MCP=記録専用 の役割が明示されていること
+        # RED: ドキュメント未作成のため fail する
+        found_text = ""
+        if ARCH_DIR.exists():
+            for md_file in ARCH_DIR.rglob("*.md"):
+                text = md_file.read_text(encoding="utf-8")
+                if "twl_validate_commit" in text or "shadow" in text.lower():
+                    found_text += text + "\n"
+
+        assert found_text, "twl_validate_commit / shadow に関する architecture doc が見つかりません"
+        has_record_role = (
+            "記録" in found_text
+            or "record" in found_text.lower()
+            or "log" in found_text.lower()
+        )
+        assert has_record_role, (
+            "MCP hook の記録専用ロールが architecture doc に明示されていません"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-4: TODO/コメントに「Claude Code hook 仕様拡張時に再検討」を記録
+# ---------------------------------------------------------------------------
+
+
+class TestAC4FutureConsiderationTodo:
+    """AC-4: 将来対応 TODO or コメントに hook 仕様拡張時再検討を記録."""
+
+    def test_ac4_todo_comment_exists_in_tools_py(self):
+        # AC: tools.py に「Claude Code hook 仕様拡張時に再検討」または同等の TODO を記録
+        # RED: TODO 未追加のため fail する
+        # 注意: concurrent.futures の "future" にマッチしないよう、
+        #       コメント行（#で始まる行）の中に仕様拡張・再検討の意図を確認する
+        assert TOOLS_PY.exists(), f"tools.py not found: {TOOLS_PY}"
+        content = TOOLS_PY.read_text(encoding="utf-8")
+
+        comment_lines = [
+            line.strip()
+            for line in content.splitlines()
+            if line.strip().startswith("#")
+        ]
+        comment_text = "\n".join(comment_lines)
+
+        has_todo = (
+            "再検討" in comment_text
+            or "revisit" in comment_text.lower()
+            or ("hook" in comment_text.lower() and "将来" in comment_text)
+            or ("TODO" in comment_text and "hook" in comment_text.lower())
+        )
+
+        assert has_todo, (
+            "tools.py のコメント行に Claude Code hook 仕様拡張時の再検討 TODO が見つかりません。"
+            f"コメント行数: {len(comment_lines)}"
+        )


### PR DESCRIPTION
## 概要

Issue #1335 対応。`twl_validate_commit` MCP hook が `files=[]` 固定で実質 no-op となっている状況を spec として明示し、責務分離を記録する。

## 変更内容

- **AC-1**: `twl_validate_commit_handler` docstring に files 空リストによる no-op を明記
- **AC-2**: `tools.py` に Claude Code hook 仕様制約コメントと `pre-bash-commit-validate.sh` 代替への言及を追加
- **AC-3**: ADR-0007 を新規作成 — MCP shadow hook と bash hook の責務分離を記録（MCP=記録専用、bash=block 専用）
- **AC-4**: TODO コメントで hook 仕様拡張時の再検討を記録（self-deferred）
- **AC-5**: regression bats で `files=[]` 入力で常に `ok=true` の spec lock を追加

## テスト

- `pytest tests/test_issue_1335_validate_commit_no_op.py` — 7件 PASS
- `bats tests/mcp_server/test_1335_validate_commit_files_empty.bats` — 3件 PASS

Closes #1335