### PR TITLE
fix(hooks/mcp): twl_validate_commit command-based invocation (#1334)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,7 +69,7 @@
             "server": "twl",
             "tool": "twl_validate_commit",
             "input": {
-              "message": "${tool_input.command}",
+              "command": "${tool_input.command}",
               "files": []
             },
             "outputType": "log",

--- a/architecture/decisions/ADR-0011-mcp-shadow-hook-responsibility-separation.md
+++ b/architecture/decisions/ADR-0011-mcp-shadow-hook-responsibility-separation.md
@@ -39,6 +39,20 @@ handler 内部でコマンド文字列を解析してメッセージを抽出す
 hook 設定を単純化し（`tool_input.command` をそのまま渡す）、
 将来的な `-m`/`--message` 以外のオプション対応も handler 内に集約できる。
 
+## Alternatives Considered
+
+### Option 1: `message: str` パラメータを維持し hook 側でメッセージ抽出
+
+hook 設定で `"message": "$(echo '${tool_input.command}' | sed 's/.*-m //')"` 等のシェル展開でメッセージを抽出する案。
+
+**却下理由**: Claude Code の settings.json は変数展開に対応しているが、シェルコマンドの埋め込みは非サポート。また hook 側に解析ロジックを置くと責務が分散し、将来の `-m`/`--message`/`-F` 拡張が困難になる。
+
+### Option 2: MCP shadow hook の廃止
+
+`twl_validate_commit` MCP hook 自体を削除し、bash hook のみでバリデーションを行う案。
+
+**却下理由**: MCP shadow hook は記録・監視（将来的なメトリクス収集）の用途を持つ。また PR #1332 / Issue #1288 のレビューで shadow hook パターンが設計として確立されており、廃止は過剰な変更となる。
+
 ## Consequences
 
 - `twl_validate_commit` の `command` パラメータは full git command 文字列を受け取る

--- a/architecture/decisions/ADR-0011-mcp-shadow-hook-responsibility-separation.md
+++ b/architecture/decisions/ADR-0011-mcp-shadow-hook-responsibility-separation.md
@@ -1,0 +1,47 @@
+# ADR-0011: MCP Shadow Hook と Bash Hook の責務分離
+
+**Status**: Accepted
+**Date**: 2026-05-03
+**Issue**: #1334
+
+## Context
+
+`PreToolUse:Bash` hook には 2 種類の実装が共存している:
+
+1. **Bash hook** (`pre-bash-commit-validate.sh` 等): 実行前にブロック/中断を行う
+2. **MCP shadow hook** (`twl_validate_commit` 等): MCP tool として副作用なしに記録・検査する
+
+Issue #1288 で MCP shadow hook が追加された際、`twl_validate_commit` の入力スキーマと
+`settings.json` の hook 設定が整合しておらず、`message` パラメータに full git command 文字列が
+渡されるという不整合が発生していた（Issue #1334 で検出）。
+
+## Decision
+
+### 責務分離の原則
+
+| 層 | 実装 | 役割 |
+|---|---|---|
+| **ブロック層** | Bash hook (`pre-bash-commit-validate.sh`) | コミットを実際に止める (exit code != 0 で中断) |
+| **記録層** | MCP shadow hook (`twl_validate_commit`) | コマンドを記録・検査する (outputType=log、ブロックしない) |
+
+### `twl_validate_commit` の修正方針 (Issue #1334)
+
+- パラメータを `message: str` → `command: str` に変更し、full git command 文字列を受け取る
+- 内部で `extract_commit_message_from_command()` によりメッセージ本文を抽出する
+- `settings.json` の hook input を `"command": "${tool_input.command}"` に統一する
+- MCP shadow は記録専用 (`outputType: "log"`) — ブロックは Bash hook が担当
+
+### なぜ `command: str` か
+
+PreToolUse:Bash hook の `tool_input.command` は Bash コマンド全体
+（例: `git commit -m "feat: add X"`）を渡す。
+handler 内部でコマンド文字列を解析してメッセージを抽出することで、
+hook 設定を単純化し（`tool_input.command` をそのまま渡す）、
+将来的な `-m`/`--message` 以外のオプション対応も handler 内に集約できる。
+
+## Consequences
+
+- `twl_validate_commit` の `command` パラメータは full git command 文字列を受け取る
+- `-F`（ファイルから読む）形式は `extract_commit_message_from_command` が `""` を返す (no-op)
+- MCP shadow hook は記録専用であり、検証ブロックは bash hook 側で行う
+- 既存 `pre-bash-commit-validate.sh` は変更不要（責務変更なし）

--- a/cli/twl/architecture/domain/glossary.md
+++ b/cli/twl/architecture/domain/glossary.md
@@ -92,3 +92,6 @@
 | SSOT | Single Source of Truth。唯一の正しい情報源 | (cross-cutting) |
 | orphan | どのコンポーネントからも参照されない孤立ノード | Refactoring |
 | dead component | entry_points から到達不能なコンポーネント | Refactoring |
+| MCP shadow hook | ブロックせずに記録・検査のみを行う MCP tool 型 hook（outputType=log）。ADR-0011 参照 | Hook Integration |
+| pre-bash-commit-validate.sh | PreToolUse:Bash hook として git commit コマンドを検証し必要に応じてブロックする bash スクリプト | Hook Integration |
+| outputType | Claude Code hook 設定のフィールド。"log" を指定すると hook の出力が stderr のみに限定される | Hook Integration |

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -962,8 +962,32 @@ def twl_validate_merge_handler(
             return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
 
 
+def extract_commit_message_from_command(command: str) -> str:
+    """Extract commit message body from a git commit command string.
+
+    Handles -m/--message flags; returns "" for -F (file-based) or unrecognized forms.
+    """
+    import shlex
+
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return ""
+
+    i = 0
+    while i < len(parts):
+        token = parts[i]
+        if token in ("-m", "--message") and i + 1 < len(parts):
+            return parts[i + 1]
+        # -m"message" without space (e.g. -m"feat: X")
+        if token.startswith("-m") and len(token) > 2:
+            return token[2:]
+        i += 1
+    return ""
+
+
 def twl_validate_commit_handler(
-    message: str,
+    command: str,
     files: list[str],
     timeout_sec: int | None = 300,
 ) -> dict:
@@ -1271,9 +1295,9 @@ try:
         return json.dumps(twl_validate_merge_handler(branch=branch, base=base, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
-    def twl_validate_commit(message: str, files: list[str], timeout_sec: int | None = 300) -> str:
+    def twl_validate_commit(command: str, files: list[str], timeout_sec: int | None = 300) -> str:
         """validation module: commit message and file deps validation (in-process, no subprocess)."""
-        return json.dumps(twl_validate_commit_handler(message=message, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
+        return json.dumps(twl_validate_commit_handler(command=command, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
     def twl_check_completeness(manifest_context: str) -> str:
@@ -1405,9 +1429,9 @@ except ImportError:
         """validation module: merge pre-flight guard (2-guard scope only)."""
         return json.dumps(twl_validate_merge_handler(branch=branch, base=base, timeout_sec=timeout_sec), ensure_ascii=False)
 
-    def twl_validate_commit(message: str, files: list[str], timeout_sec: int | None = 300) -> str:  # type: ignore[misc]
+    def twl_validate_commit(command: str, files: list[str], timeout_sec: int | None = 300) -> str:  # type: ignore[misc]
         """validation module: commit message and file deps validation (in-process, no subprocess)."""
-        return json.dumps(twl_validate_commit_handler(message=message, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
+        return json.dumps(twl_validate_commit_handler(command=command, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
 
     def twl_check_completeness(manifest_context: str) -> str:  # type: ignore[misc]
         """validation module: specialist completeness check via flock-guarded manifest files."""

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -965,7 +965,7 @@ def twl_validate_merge_handler(
 def extract_commit_message_from_command(command: str) -> str:
     """Extract commit message body from a git commit command string.
 
-    Handles -m/--message flags; returns "" for -F (file-based) or unrecognized forms.
+    Handles -m/--message flags (with and without =); returns "" for -F (file-based) or unrecognized forms.
     """
     import shlex
 
@@ -979,6 +979,9 @@ def extract_commit_message_from_command(command: str) -> str:
         token = parts[i]
         if token in ("-m", "--message") and i + 1 < len(parts):
             return parts[i + 1]
+        # --message=value form
+        if token.startswith("--message="):
+            return token[len("--message="):]
         # -m"message" without space (e.g. -m"feat: X")
         if token.startswith("-m") and len(token) > 2:
             return token[2:]
@@ -994,6 +997,8 @@ def twl_validate_commit_handler(
     """validation module: commit message and file deps validation (in-process, no subprocess)."""
     if timeout_sec is not None and timeout_sec <= 0:
         return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
+
+    _message = extract_commit_message_from_command(command)
 
     def _inner() -> dict:
         from twl.validation.validate import validate_v3_schema
@@ -1016,6 +1021,7 @@ def twl_validate_commit_handler(
             "items": all_violations,
             "exit_code": 0 if ok else 1,
             "summary": f"{len(all_violations)} violation(s) found",
+            "commit_message": _message,
         }
 
     if timeout_sec is None:

--- a/cli/twl/tests/test_issue_1334_validate_commit_command.py
+++ b/cli/twl/tests/test_issue_1334_validate_commit_command.py
@@ -1,0 +1,292 @@
+"""Tests for Issue #1334: fix(hooks/mcp): twl_validate_commit command-based invocation.
+
+TDD RED phase test stubs.
+All tests FAIL before implementation (intentional RED).
+
+AC list:
+  AC-1: twl_validate_commit_handler の引数を command: str に変更し、
+        内部で git commit -m "..." または --message 引数から commit message 本文を抽出する
+        ロジックを追加（実装 option 2）
+  AC-2: 引数変更に伴い cli/twl/src/twl/mcp_server/tools.py の inputSchema 更新
+        （properties.command の type/required）
+  AC-3: .claude/settings.json の hook 設定を "command": "${tool_input.command}" に同期更新
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+WORKTREE_ROOT = Path(__file__).resolve().parent.parent
+TOOLS_PY = WORKTREE_ROOT / "src" / "twl" / "mcp_server" / "tools.py"
+SETTINGS_JSON = WORKTREE_ROOT.parent.parent / ".claude" / "settings.json"
+
+
+# ---------------------------------------------------------------------------
+# AC-1: twl_validate_commit_handler が command: str パラメータを受け付けること
+# ---------------------------------------------------------------------------
+
+
+class TestAC1ValidateCommitHandlerCommandParam:
+    """AC-1: twl_validate_commit_handler の引数が command: str に変更されていること."""
+
+    def test_ac1_handler_accepts_command_param(self):
+        # AC: twl_validate_commit_handler が command キーワード引数を受け付けること
+        # RED: 現在の signature は message: str なので TypeError が発生する
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        sig = inspect.signature(twl_validate_commit_handler)
+        assert "command" in sig.parameters, (
+            "AC-1 未実装: twl_validate_commit_handler シグネチャに 'command' 引数が存在しない。"
+            f"現在のパラメータ: {list(sig.parameters.keys())}"
+        )
+
+    def test_ac1_handler_does_not_have_message_param(self):
+        # AC: 変更後、message 引数が削除されていること（command に置き換え）
+        # RED: 現在の signature に message が存在するため FAIL する
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        sig = inspect.signature(twl_validate_commit_handler)
+        assert "message" not in sig.parameters, (
+            "AC-1 未実装: twl_validate_commit_handler シグネチャにまだ 'message' 引数が存在する。"
+            "command に置き換える必要がある。"
+        )
+
+    def test_ac1_handler_extracts_message_from_git_commit_m(self):
+        # AC: "git commit -m 'feat: X'" を command に渡すと message="feat: X" を内部抽出すること
+        # RED: handler が command パラメータを受け付けないため TypeError または AssertionError で FAIL
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        result = twl_validate_commit_handler(
+            command='git commit -m "feat: add new feature"',
+            files=[],
+        )
+        # ok=True（バリデーション対象なし）かつエラーなく実行できること
+        assert isinstance(result, dict), (
+            f"AC-1 未実装: 戻り値が dict でない。got={result!r}"
+        )
+        assert "ok" in result, (
+            f"AC-1 未実装: 戻り値に 'ok' キーが存在しない。got={result}"
+        )
+
+    def test_ac1_handler_extracts_message_from_git_commit_long_message(self):
+        # AC: "git commit --message 'fix: Y'" を command に渡して動作すること
+        # RED: handler が command パラメータを受け付けないため FAIL
+        from twl.mcp_server.tools import twl_validate_commit_handler
+
+        result = twl_validate_commit_handler(
+            command='git commit --message "fix: resolve bug"',
+            files=[],
+        )
+        assert isinstance(result, dict), (
+            f"AC-1 未実装: --message 形式で戻り値が dict でない。got={result!r}"
+        )
+
+    def test_ac1_source_has_extract_commit_message_logic(self):
+        # AC: tools.py に extract_commit_message_from_command 関数または同等の抽出ロジックが存在すること
+        # RED: 現在は message パラメータを直接使用するため抽出ロジックが存在しない
+        source = TOOLS_PY.read_text(encoding="utf-8")
+        has_extract_function = "extract_commit_message_from_command" in source
+        has_inline_extraction = (
+            "-m " in source
+            and "command" in source
+            and "def twl_validate_commit_handler" in source
+        )
+        # extract 関数存在 or handler 内に -m/--message 抽出ロジックがあること
+        assert has_extract_function or (
+            "twl_validate_commit_handler" in source
+            and any(pat in source for pat in [
+                'shlex.split',
+                'argparse',
+                'r"(-m|--message)"',
+                "'-m'",
+                '"-m"',
+                '"--message"',
+            ])
+        ), (
+            "AC-1 未実装: tools.py に commit message 抽出ロジック（extract 関数 or "
+            "-m/--message パース）が存在しない"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-2: MCP tool twl_validate_commit の signature が command パラメータを持つこと
+# ---------------------------------------------------------------------------
+
+
+class TestAC2ValidateCommitMCPToolSignature:
+    """AC-2: MCP wrapper の twl_validate_commit 関数シグネチャが command: str に変更されていること."""
+
+    def test_ac2_try_branch_validate_commit_has_command_param(self):
+        # AC: try branch (L1274 周辺) の twl_validate_commit 関数シグネチャに command があること
+        # RED: 現在のシグネチャは message: str なので FAIL する
+        source = TOOLS_PY.read_text(encoding="utf-8")
+
+        # try branch は except ImportError より前
+        except_import_pos = source.find("except ImportError:")
+        try_branch_source = source[:except_import_pos]
+
+        validate_commit_pos = try_branch_source.rfind("def twl_validate_commit(")
+        assert validate_commit_pos != -1, (
+            "AC-2 未実装: try branch に twl_validate_commit 定義が見つからない"
+        )
+
+        def_line_end = try_branch_source.find("\n", validate_commit_pos)
+        def_line = try_branch_source[validate_commit_pos:def_line_end]
+
+        assert "command" in def_line, (
+            f"AC-2 未実装: try branch の twl_validate_commit シグネチャに 'command' が存在しない。"
+            f"got={def_line}"
+        )
+
+    def test_ac2_try_branch_validate_commit_does_not_have_message_param(self):
+        # AC: try branch の twl_validate_commit シグネチャから message が除去されていること
+        # RED: 現在の def 行に message が存在するため FAIL する
+        source = TOOLS_PY.read_text(encoding="utf-8")
+
+        except_import_pos = source.find("except ImportError:")
+        try_branch_source = source[:except_import_pos]
+
+        validate_commit_pos = try_branch_source.rfind("def twl_validate_commit(")
+        assert validate_commit_pos != -1, (
+            "AC-2 未実装: try branch に twl_validate_commit 定義が見つからない"
+        )
+
+        def_line_end = try_branch_source.find("\n", validate_commit_pos)
+        def_line = try_branch_source[validate_commit_pos:def_line_end]
+
+        assert "message" not in def_line, (
+            f"AC-2 未実装: try branch の twl_validate_commit シグネチャにまだ 'message' が存在する。"
+            f"got={def_line}"
+        )
+
+    def test_ac2_except_importerror_branch_validate_commit_has_command_param(self):
+        # AC: except-ImportError branch (L1408 周辺) の twl_validate_commit にも command があること
+        # RED: 現在の except-ImportError branch シグネチャも message: str なので FAIL する
+        source = TOOLS_PY.read_text(encoding="utf-8")
+
+        except_import_pos = source.find("except ImportError:")
+        except_branch_source = source[except_import_pos:]
+
+        validate_commit_pos = except_branch_source.find("def twl_validate_commit(")
+        assert validate_commit_pos != -1, (
+            "AC-2 未実装: except-ImportError branch に twl_validate_commit 定義が見つからない"
+        )
+
+        def_line_end = except_branch_source.find("\n", validate_commit_pos)
+        def_line = except_branch_source[validate_commit_pos:def_line_end]
+
+        assert "command" in def_line, (
+            f"AC-2 未実装: except-ImportError branch の twl_validate_commit シグネチャに "
+            f"'command' が存在しない。got={def_line}"
+        )
+
+    def test_ac2_try_branch_handler_call_passes_command(self):
+        # AC: try branch の handler 呼び出しに command=command が渡されていること
+        # RED: 現在は message=message を渡しているため FAIL する
+        source = TOOLS_PY.read_text(encoding="utf-8")
+
+        except_import_pos = source.find("except ImportError:")
+        try_branch_source = source[:except_import_pos]
+
+        validate_commit_pos = try_branch_source.rfind("def twl_validate_commit(")
+        next_def_pos = try_branch_source.find("\n    @mcp.tool()", validate_commit_pos + 1)
+        if next_def_pos == -1:
+            next_def_pos = len(try_branch_source)
+        body_source = try_branch_source[validate_commit_pos:next_def_pos]
+
+        assert "command=command" in body_source, (
+            "AC-2 未実装: try branch の twl_validate_commit_handler 呼び出しに "
+            "'command=command' が含まれていない"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC-3: .claude/settings.json の hook が "command" キーを持つこと
+# ---------------------------------------------------------------------------
+
+
+class TestAC3SettingsJsonHookCommand:
+    """AC-3: .claude/settings.json の twl_validate_commit hook input が command キーを持つこと."""
+
+    def test_ac3_settings_json_exists(self):
+        # 前提: settings.json が存在すること
+        assert SETTINGS_JSON.exists(), (
+            f"settings.json が存在しない: {SETTINGS_JSON}"
+        )
+
+    def test_ac3_validate_commit_hook_has_command_key(self):
+        # AC: twl_validate_commit hook の input に "command" キーが存在すること
+        # RED: 現在の hook input は {"message": ..., "files": []} なので FAIL する
+        data = json.loads(SETTINGS_JSON.read_text(encoding="utf-8"))
+
+        pretooluse_hooks = data.get("hooks", {}).get("PreToolUse", [])
+        validate_commit_input = None
+        for hook_group in pretooluse_hooks:
+            for hook in hook_group.get("hooks", []):
+                if (
+                    hook.get("type") == "mcp_tool"
+                    and hook.get("tool") == "twl_validate_commit"
+                ):
+                    validate_commit_input = hook.get("input", {})
+                    break
+
+        assert validate_commit_input is not None, (
+            "AC-3 未実装: settings.json に twl_validate_commit の mcp_tool hook が見つからない"
+        )
+        assert "command" in validate_commit_input, (
+            f"AC-3 未実装: twl_validate_commit hook の input に 'command' キーが存在しない。"
+            f"現在の input={validate_commit_input}"
+        )
+
+    def test_ac3_validate_commit_hook_does_not_have_message_key(self):
+        # AC: 変更後、hook input から "message" キーが除去されていること
+        # RED: 現在の hook input に "message" が存在するため FAIL する
+        data = json.loads(SETTINGS_JSON.read_text(encoding="utf-8"))
+
+        pretooluse_hooks = data.get("hooks", {}).get("PreToolUse", [])
+        validate_commit_input = None
+        for hook_group in pretooluse_hooks:
+            for hook in hook_group.get("hooks", []):
+                if (
+                    hook.get("type") == "mcp_tool"
+                    and hook.get("tool") == "twl_validate_commit"
+                ):
+                    validate_commit_input = hook.get("input", {})
+                    break
+
+        assert validate_commit_input is not None, (
+            "AC-3 未実装: settings.json に twl_validate_commit の mcp_tool hook が見つからない"
+        )
+        assert "message" not in validate_commit_input, (
+            f"AC-3 未実装: twl_validate_commit hook の input にまだ 'message' キーが存在する。"
+            f"'command' キーに置き換える必要がある。現在の input={validate_commit_input}"
+        )
+
+    def test_ac3_validate_commit_hook_command_value_references_tool_input(self):
+        # AC: command の値が "${tool_input.command}" であること
+        # RED: 現在の値は "${tool_input.command}" (message キーの値) なので FAIL する（keyが変わるだけ）
+        data = json.loads(SETTINGS_JSON.read_text(encoding="utf-8"))
+
+        pretooluse_hooks = data.get("hooks", {}).get("PreToolUse", [])
+        validate_commit_input = None
+        for hook_group in pretooluse_hooks:
+            for hook in hook_group.get("hooks", []):
+                if (
+                    hook.get("type") == "mcp_tool"
+                    and hook.get("tool") == "twl_validate_commit"
+                ):
+                    validate_commit_input = hook.get("input", {})
+                    break
+
+        assert validate_commit_input is not None, (
+            "AC-3 未実装: settings.json に twl_validate_commit の mcp_tool hook が見つからない"
+        )
+        command_value = validate_commit_input.get("command")
+        assert command_value == "${tool_input.command}", (
+            f"AC-3 未実装: twl_validate_commit hook の command 値が '{{tool_input.command}}' でない。"
+            f"got={command_value!r}"
+        )

--- a/cli/twl/tests/test_mcp_validation.py
+++ b/cli/twl/tests/test_mcp_validation.py
@@ -367,18 +367,21 @@ class TestAC21bValidateMergeSignature:
 # ---------------------------------------------------------------------------
 
 class TestAC21cValidateCommitSignature:
-    """AC2-1c: twl_validate_commit_handler(message: str, files: list[str], timeout_sec: int | None = 300) -> dict."""
+    """AC2-1c: twl_validate_commit_handler(command: str, files: list[str], timeout_sec: int | None = 300) -> dict.
+
+    Updated in Issue #1334: message → command (handler now accepts full git command string).
+    """
 
     def test_ac2_1c_validate_commit_handler_signature(self):
-        # AC: twl_validate_commit_handler(message: str, files: list[str], timeout_sec: int | None = 300) -> dict
-        # RED: 未実装のため ImportError
+        # AC: twl_validate_commit_handler(command: str, files: list[str], timeout_sec: int | None = 300) -> dict
+        # Updated by Issue #1334: message param renamed to command
         from twl.mcp_server.tools import twl_validate_commit_handler
 
         sig = inspect.signature(twl_validate_commit_handler)
         params = sig.parameters
 
-        assert "message" in params, (
-            "twl_validate_commit_handler に message 引数がない (AC2-1c 未実装)"
+        assert "command" in params, (
+            "twl_validate_commit_handler に command 引数がない (Issue #1334 で message → command に変更)"
         )
         assert "files" in params, (
             "twl_validate_commit_handler に files 引数がない (AC2-1c 未実装)"
@@ -629,15 +632,18 @@ class TestAC25aValidateMergeTimeout:
 # ---------------------------------------------------------------------------
 
 class TestAC25bValidateCommitTimeout:
-    """AC2-5b: twl_validate_commit_handler(message="test", files=[], timeout_sec=0) がタイムアウト応答を返すこと."""
+    """AC2-5b: twl_validate_commit_handler(command="git commit -m test", files=[], timeout_sec=0) がタイムアウト応答を返すこと.
+
+    Updated in Issue #1334: message → command parameter.
+    """
 
     def test_ac2_5b_validate_commit_timeout_response(self):
-        # AC: twl_validate_commit_handler(message="test", files=[], timeout_sec=0) が
+        # AC: twl_validate_commit_handler(command="...", files=[], timeout_sec=0) が
         #     {ok: False, error_type: "timeout", exit_code: 124} を返すこと
-        # RED: 未実装のため ImportError
+        # Updated by Issue #1334: message param renamed to command
         from twl.mcp_server.tools import twl_validate_commit_handler
 
-        result = twl_validate_commit_handler(message="test", files=[], timeout_sec=0)
+        result = twl_validate_commit_handler(command='git commit -m "test"', files=[], timeout_sec=0)
 
         assert isinstance(result, dict), (
             f"twl_validate_commit_handler の戻り値が dict でない: {type(result)} (AC2-5b 未実装)"

--- a/plugins/twl/docs/mcp-tools-inventory.md
+++ b/plugins/twl/docs/mcp-tools-inventory.md
@@ -217,7 +217,7 @@ ADR-029 (twl-mcp-integration-strategy) Decision 2 準拠。
 由来: #1037 Tier 0「検証系 tool 追加」、既存 Bash hook の MCP 化前提。
 effort: 2-3 日。依存: 子 1 完了。
 
-- [ ] **AC2-1**: 5 tool 追加 — `twl_validate_deps(plugin_root) / twl_validate_merge(branch, base, timeout_sec?) / twl_validate_commit(message, files, timeout_sec?) / twl_check_completeness(spec_path, context?) / twl_check_specialist(spec_path)`
+- [ ] **AC2-1**: 5 tool 追加 — `twl_validate_deps(plugin_root) / twl_validate_merge(branch, base, timeout_sec?) / twl_validate_commit(command, files, timeout_sec?) / twl_check_completeness(spec_path, context?) / twl_check_specialist(spec_path)`
 - [ ] **AC2-2**: 各 handler は pure Python (in-process testable)、Hybrid Path 5 原則準拠
 - [ ] **AC2-3**: pytest 5 件 (各 tool)、fastmcp 経由 + 直接呼出 2 経路で PASS
 - [ ] **AC2-4**: 既存 Bash hook (`pre-tool-use-deps-yaml-guard.sh` / `pre-bash-merge-guard.sh` / `pre-bash-commit-validate.sh` / `check-specialist-completeness.sh`) は維持

--- a/plugins/twl/docs/mcp-tools-inventory.md
+++ b/plugins/twl/docs/mcp-tools-inventory.md
@@ -128,7 +128,7 @@ ADR-029 (twl-mcp-integration-strategy) Decision 2 準拠。
 |---|---|---|
 | `twl_validate_deps(plugin_root)` | `pre-tool-use-deps-yaml-guard.sh` | deps.yaml YAML syntax + integrity 検証 |
 | `twl_validate_merge(branch, base, timeout_sec?)` | `pre-bash-merge-guard.sh` | merge 前の不変条件 (worktree, worker_window, status) 検証 |
-| `twl_validate_commit(message, files, timeout_sec?)` | `pre-bash-commit-validate.sh` | commit 前の `twl --validate` 実行 |
+| `twl_validate_commit(command, files, timeout_sec?)` | `pre-bash-commit-validate.sh` | commit コマンド文字列の記録 (MCP shadow = 記録専用; ブロックは bash 側が担当) |
 | `twl_check_completeness(spec_path, context?)` | `check-specialist-completeness.sh` | specialist spawn manifest との突合 |
 | `twl_check_specialist(spec_path)` | (新規) | specialist 設計の整合性検証 |
 

--- a/plugins/twl/tests/bats/hooks/twl-validate-commit-message-extract.bats
+++ b/plugins/twl/tests/bats/hooks/twl-validate-commit-message-extract.bats
@@ -1,0 +1,190 @@
+#!/usr/bin/env bats
+# twl-validate-commit-message-extract.bats - Issue #1334: commit message extraction regression tests
+#
+# AC-4: extract_commit_message_from_command の抽出ロジック検証
+#
+# 検証 fixture:
+#   - git commit -m "feat: X"        -> message="feat: X"
+#   - git commit --message "fix: Y"  -> message="fix: Y"
+#   - git commit -F /path/to/file    -> message="" (no-op / ファイルパスなので抽出対象外)
+#
+# RED: 実装前（extract_commit_message_from_command 未定義）は全テストが FAIL する。
+#
+# bats baseline §9 注意: このファイルはヒアドキュメントを使用しないため
+# heredoc 変数展開の警告は適用しない。
+#
+# bats baseline §10 注意: python3 -c で直接インポートするため
+# source guard パターンの適用は不要。
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+  # REPO_ROOT は common_setup で REPO_ROOT 変数が設定される
+  # helpers/common.bash より: REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+  REPO_GIT_ROOT="$(cd "${BATS_TEST_FILENAME%/*/*/*/*}" 2>/dev/null && git rev-parse --show-toplevel 2>/dev/null || echo "")"
+  if [[ -z "${REPO_GIT_ROOT}" ]]; then
+    REPO_GIT_ROOT="$(cd "$(dirname "${BATS_TEST_FILENAME}")/../../../../.." && pwd)"
+  fi
+  TWILL_SRC="${REPO_GIT_ROOT}/cli/twl/src"
+  export TWILL_SRC REPO_GIT_ROOT
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Helper: extract_commit_message_from_command を python3 で呼び出す
+# ---------------------------------------------------------------------------
+_extract_msg() {
+  local cmd="$1"
+  python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except (ImportError, AttributeError) as e:
+    print(f"IMPORT_ERROR: {e}", file=sys.stderr)
+    sys.exit(1)
+result = extract_commit_message_from_command('${cmd}')
+print(result)
+PYEOF
+}
+
+# ===========================================================================
+# AC-4: git commit -m "feat: X" -> message="feat: X"
+# ===========================================================================
+
+@test "ac4: extract_commit_message_from_command is importable from tools" {
+  # AC: extract_commit_message_from_command が tools モジュールからインポートできること
+  # RED: 実装前は ImportError または AttributeError で fail する
+  python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except ImportError as e:
+    print(f"ImportError: {e}", file=sys.stderr)
+    sys.exit(1)
+except AttributeError as e:
+    print(f"AttributeError (function not defined): {e}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+}
+
+@test "ac4: git commit -m extracts message (short flag)" {
+  # AC: "git commit -m 'feat: X'" から message="feat: X" が抽出されること
+  # RED: 関数未定義のため ImportError または AssertionError で fail する
+  run python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except (ImportError, AttributeError) as e:
+    print(f"EXTRACT_FUNC_MISSING: {e}", file=sys.stderr)
+    sys.exit(1)
+result = extract_commit_message_from_command('git commit -m "feat: X"')
+expected = "feat: X"
+if result != expected:
+    print(f"FAIL: expected={expected!r}, got={result!r}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+  [ "$status" -eq 0 ]
+}
+
+@test "ac4: git commit --message extracts message (long flag)" {
+  # AC: "git commit --message 'fix: Y'" から message="fix: Y" が抽出されること
+  # RED: 関数未定義のため ImportError または AssertionError で fail する
+  run python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except (ImportError, AttributeError) as e:
+    print(f"EXTRACT_FUNC_MISSING: {e}", file=sys.stderr)
+    sys.exit(1)
+result = extract_commit_message_from_command('git commit --message "fix: Y"')
+expected = "fix: Y"
+if result != expected:
+    print(f"FAIL: expected={expected!r}, got={result!r}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+  [ "$status" -eq 0 ]
+}
+
+@test "ac4: git commit -F returns empty string (no-op, file-based commit)" {
+  # AC: "git commit -F /path/to/file" の場合 message="" が返ること
+  #     (ファイルから読む形式は MCP shadow では抽出対象外として no-op 扱い)
+  # RED: 関数未定義のため ImportError で fail する
+  run python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except (ImportError, AttributeError) as e:
+    print(f"EXTRACT_FUNC_MISSING: {e}", file=sys.stderr)
+    sys.exit(1)
+result = extract_commit_message_from_command('git commit -F /path/to/file')
+# -F はファイル読み込みなので抽出不可 -> 空文字列を期待
+if result != "":
+    print(f"FAIL: expected empty string for -F form, got={result!r}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+  [ "$status" -eq 0 ]
+}
+
+@test "ac4: twl_validate_commit_handler accepts command param (integration)" {
+  # AC: twl_validate_commit_handler が command キーワード引数を受け付け、正常に動作すること
+  # RED: 現在のシグネチャは message: str なので TypeError で fail する
+  run python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import twl_validate_commit_handler
+except ImportError as e:
+    print(f"ImportError: {e}", file=sys.stderr)
+    sys.exit(1)
+try:
+    result = twl_validate_commit_handler(
+        command='git commit -m "feat: test command param"',
+        files=[],
+    )
+except TypeError as e:
+    print(f"TypeError (signature not updated): {e}", file=sys.stderr)
+    sys.exit(1)
+if not isinstance(result, dict):
+    print(f"FAIL: result is not dict, got={result!r}", file=sys.stderr)
+    sys.exit(1)
+if "ok" not in result:
+    print(f"FAIL: 'ok' key missing from result, got={result}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+  [ "$status" -eq 0 ]
+}
+
+@test "ac4: git commit -m with single quotes extracts message" {
+  # AC: "git commit -m 'chore: update'" のシングルクォート形式も抽出できること
+  # RED: 関数未定義のため fail する
+  run python3 - <<PYEOF
+import sys
+sys.path.insert(0, '${TWILL_SRC}')
+try:
+    from twl.mcp_server.tools import extract_commit_message_from_command
+except (ImportError, AttributeError) as e:
+    print(f"EXTRACT_FUNC_MISSING: {e}", file=sys.stderr)
+    sys.exit(1)
+result = extract_commit_message_from_command("git commit -m 'chore: update'")
+expected = "chore: update"
+if result != expected:
+    print(f"FAIL: expected={expected!r}, got={result!r}", file=sys.stderr)
+    sys.exit(1)
+print("OK")
+PYEOF
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Issue #1334 の修正。MCP shadow hook `twl_validate_commit` が `message: str` パラメータに full git command 文字列を渡していた問題を解消。

## Changes

- **AC-1**: `twl_validate_commit_handler` の引数を `message: str` → `command: str` に変更し、`extract_commit_message_from_command()` で本文抽出
- **AC-2**: `tools.py` の `twl_validate_commit` MCP tool signature を `command: str` に更新（try/except 両ブランチ）
- **AC-3**: `.claude/settings.json` hook input を `"message"` → `"command"` に更新
- **AC-4**: `twl-validate-commit-message-extract.bats` 新規作成（-m / --message / -F fixture 検証）
- **AC-5**: `ADR-0011` 新規作成 — MCP shadow（記録専用）vs bash hook（ブロック専用）責務分離を明記

## Responsibility Separation

| 層 | 実装 | 役割 |
|---|---|---|
| ブロック層 | `pre-bash-commit-validate.sh` | コミットを実際に止める |
| 記録層 | `twl_validate_commit` (MCP shadow) | コマンドを記録・検査（ブロックしない） |

Closes #1334