### PR TITLE
fix(autopilot-launch): gh 完全不可用時に status gate を non-fatal 化

### DIFF
--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -222,8 +222,8 @@ _check_label_fallback() {
   fi
   # gh 完全不可用（exit≠0）→ non-fatal（graceful fallback、#1241）
   if [[ "$gh_exit" -ne 0 ]]; then
-    echo "[$(date -Iseconds)] ALLOW_GH_UNAVAILABLE issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
-    echo "WARN: gh API 障害のため status gate をスキップします (issue=#${issue_num})" >&2
+    echo "[$(date -Iseconds)] ALLOW_GH_UNAVAILABLE(exit=${gh_exit}) issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
+    echo "WARN: gh API 障害のため status gate をスキップします (issue=#${issue_num}, exit=${gh_exit})" >&2
     return 0
   fi
   echo "[$(date -Iseconds)] ${deny_log_token} issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -211,13 +211,19 @@ _check_label_fallback() {
   local deny_log_token="$2"
   local deny_msg="$3"
   # Option 1: 事前 capture → 文字列検索（pipefail 下の SIGPIPE false-negative を回避 #960）
-  local labels has_label=0
-  labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null || true)
+  local labels has_label=0 gh_exit=0
+  labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null) || gh_exit=$?
   if printf '%s\n' "$labels" | grep -Fxq 'refined'; then
     has_label=1
   fi
   if [[ "$has_label" -eq 1 ]]; then
     echo "[$(date -Iseconds)] ALLOW_LABEL_FALLBACK issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
+    return 0
+  fi
+  # gh 完全不可用（exit≠0）→ non-fatal（graceful fallback、#1241）
+  if [[ "$gh_exit" -ne 0 ]]; then
+    echo "[$(date -Iseconds)] ALLOW_GH_UNAVAILABLE issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true
+    echo "WARN: gh API 障害のため status gate をスキップします (issue=#${issue_num})" >&2
     return 0
   fi
   echo "[$(date -Iseconds)] ${deny_log_token} issue=#${issue_num}" >> "$_STATUS_GATE_LOG" 2>/dev/null || true


### PR DESCRIPTION
## 概要

Issue #1241 の修正。

`autopilot-launch.sh` の `_check_label_fallback` で `|| true` を使用していたため、`gh` の exit code が隠蔽され、`gh` が完全に失敗した場合でも deny 扱いとなっていた。

## 根本原因

```bash
# 修正前: || true で exit code を隠蔽
labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null || true)
```

## 修正内容

`gh_exit` を別途捕捉し、exit≠0（gh 完全不可用）の場合は `ALLOW_GH_UNAVAILABLE` として non-fatal に変更。

```bash
local labels has_label=0 gh_exit=0
labels=$(gh issue view "$issue_num" --json labels -q '.labels[].name' 2>/dev/null) || gh_exit=$?
# ...
if [[ "$gh_exit" -ne 0 ]]; then
  # gh 完全不可用 → non-fatal
  return 0
fi
```

## テスト結果

`autopilot-launch-merge-context.bats` 全 10 テスト PASS（test 10 が RED → GREEN）。

Closes #1241