### PR TITLE
fix(tests): fix pre-existing failures in reference-migration.test.sh (#1221)

### DIFF
--- a/plugins/twl/tests/scenarios/reference-migration-ac-verify.test.sh
+++ b/plugins/twl/tests/scenarios/reference-migration-ac-verify.test.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# =============================================================================
+# AC Verification Tests: Issue #1221
+# reference-migration.test.sh pre-existing failures
+# =============================================================================
+set -uo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PASS=0
+FAIL=0
+ERRORS=()
+
+run_test() {
+  local name="$1"
+  local func="$2"
+  local result=0
+  $func || result=$?
+  if [[ $result -eq 0 ]]; then
+    echo "  PASS: ${name}"
+    ((PASS++)) || true
+  else
+    echo "  FAIL: ${name}"
+    ((FAIL++)) || true
+    ERRORS+=("${name}")
+  fi
+}
+
+# --- AC-1: 対象 file/script の修正実施 ---
+# RED: reference-migration.test.sh に誤ったサブコマンド構文 "twl validate" が残っている間は FAIL
+test_ac1_wrong_subcommand_syntax_removed() {
+  local test_file="${PROJECT_ROOT}/tests/scenarios/reference-migration.test.sh"
+  [[ -f "$test_file" ]] || return 1
+  # コメント行を除いて "twl validate" (without --) が残っていないことを確認
+  if grep -v '^\s*#' "$test_file" | grep -q 'twl validate\b' 2>/dev/null; then
+    echo "ERROR: 'twl validate' (wrong syntax, should be 'twl --validate') found in non-comment line" >&2
+    return 1
+  fi
+  # コメント行を除いて "twl sync-docs --check" が残っていないことを確認
+  if grep -v '^\s*#' "$test_file" | grep -q 'twl sync-docs --check' 2>/dev/null; then
+    echo "ERROR: 'twl sync-docs --check' found in non-comment line (should be 'twl --check')" >&2
+    return 1
+  fi
+  return 0
+}
+echo ""
+echo "--- AC-1: 対象 file/script の修正実施 ---"
+run_test "AC-1: reference-migration.test.sh に誤ったサブコマンド構文が残っていない" test_ac1_wrong_subcommand_syntax_removed
+
+# --- AC-2: 該当 bats / pytest test の green 化 ---
+# RED: reference-migration.test.sh が現在 4 failures を持つ間は FAIL
+test_ac2_reference_migration_all_pass() {
+  local test_file="${PROJECT_ROOT}/tests/scenarios/reference-migration.test.sh"
+  [[ -f "$test_file" ]] || return 1
+  local output exit_code
+  output=$(cd "${PROJECT_ROOT}" && bash "$test_file" 2>&1)
+  exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo "$output" | grep "FAIL:" >&2
+    echo "reference-migration.test.sh exited with $exit_code" >&2
+    return 1
+  fi
+  return 0
+}
+echo ""
+echo "--- AC-2: 該当テストの green 化 ---"
+run_test "AC-2: reference-migration.test.sh が 0 failures で通過" test_ac2_reference_migration_all_pass
+
+# --- AC-3: 修正後 twl validate で WARNING 解消確認 ---
+# RED: twl がサブコマンド "validate" を認識しない間（または --validate が失敗する間）は FAIL
+test_ac3_twl_validate_passes() {
+  if ! command -v twl &>/dev/null; then
+    echo "ERROR: twl command not found" >&2
+    return 1
+  fi
+  local output exit_code
+  output=$(cd "${PROJECT_ROOT}" && twl --validate 2>&1)
+  exit_code=$?
+  if [[ $exit_code -ne 0 ]]; then
+    echo "$output" >&2
+    return 1
+  fi
+  # validate 出力に Violations があれば失敗
+  if echo "$output" | grep -q 'Violations: [^0]'; then
+    echo "Type constraint violations found:" >&2
+    echo "$output" >&2
+    return 1
+  fi
+  return 0
+}
+echo ""
+echo "--- AC-3: twl --validate で WARNING 解消 ---"
+run_test "AC-3: twl --validate がエラー・Violations なしで通過" test_ac3_twl_validate_passes
+
+# --- AC-4: regression test で修正の persistence 確認 ---
+# RED: deps.yaml の refs path 整合性が修正されるまで FAIL
+test_ac4_deps_refs_path_consistency() {
+  local deps_yaml="${PROJECT_ROOT}/deps.yaml"
+  [[ -f "$deps_yaml" ]] || return 1
+  local errors
+  errors=$(python3 -c "
+import yaml, sys
+with open('${deps_yaml}') as f:
+    data = yaml.safe_load(f)
+refs = data.get('refs', {})
+errors = []
+for name, entry in refs.items():
+    if not isinstance(entry, dict):
+        continue
+    path = entry.get('path', '')
+    # 許容パターン: refs/<name>.md OR skills/**/refs/<name>.md
+    expected_flat = f'refs/{name}.md'
+    import re
+    if path != expected_flat and not re.match(r'^skills/[^/]+/refs/' + re.escape(name) + r'\.md\$', path):
+        errors.append(f'{name}: path={path}, expected refs/{name}.md or skills/*/refs/{name}.md')
+if errors:
+    for e in errors:
+        print(e, file=sys.stderr)
+    sys.exit(1)
+sys.exit(0)
+" 2>&1)
+  local ec=$?
+  if [[ $ec -ne 0 ]]; then
+    echo "$errors" >&2
+    return 1
+  fi
+  return 0
+}
+test_ac4_reference_migration_idempotent() {
+  local test_file="${PROJECT_ROOT}/tests/scenarios/reference-migration.test.sh"
+  [[ -f "$test_file" ]] || return 1
+  # 2回実行してどちらも 0 failures
+  local exit1 exit2
+  cd "${PROJECT_ROOT}" && bash "$test_file" &>/dev/null; exit1=$?
+  cd "${PROJECT_ROOT}" && bash "$test_file" &>/dev/null; exit2=$?
+  if [[ $exit1 -ne 0 || $exit2 -ne 0 ]]; then
+    echo "Test not idempotent: first=$exit1, second=$exit2" >&2
+    return 1
+  fi
+  return 0
+}
+echo ""
+echo "--- AC-4: regression test で persistence 確認 ---"
+run_test "AC-4a: deps.yaml refs の path 整合性（refs/ or skills/*/refs/ パターン）" test_ac4_deps_refs_path_consistency
+run_test "AC-4b: reference-migration.test.sh が 2 回連続で 0 failures（冪等性）" test_ac4_reference_migration_idempotent
+
+# =============================================================================
+echo ""
+echo "==========================================="
+echo "AC Results: ${PASS} passed, ${FAIL} failed"
+echo "==========================================="
+if [[ ${#ERRORS[@]} -gt 0 ]]; then
+  echo ""
+  echo "Failed ACs:"
+  for err in "${ERRORS[@]}"; do
+    echo "  - ${err}"
+  done
+fi
+exit $FAIL

--- a/plugins/twl/tests/scenarios/reference-migration-ac-verify.test.sh
+++ b/plugins/twl/tests/scenarios/reference-migration-ac-verify.test.sh
@@ -79,8 +79,8 @@ test_ac3_twl_validate_passes() {
     echo "$output" >&2
     return 1
   fi
-  # validate 出力に Violations があれば失敗
-  if echo "$output" | grep -q 'Violations: [^0]'; then
+  # validate 出力に Violations があれば失敗（0 以外の数値を検出）
+  if echo "$output" | grep -qP 'Violations:\s*[1-9]'; then
     echo "Type constraint violations found:" >&2
     echo "$output" >&2
     return 1
@@ -96,10 +96,12 @@ run_test "AC-3: twl --validate がエラー・Violations なしで通過" test_a
 test_ac4_deps_refs_path_consistency() {
   local deps_yaml="${PROJECT_ROOT}/deps.yaml"
   [[ -f "$deps_yaml" ]] || return 1
-  local errors
-  errors=$(python3 -c "
-import yaml, sys
-with open('${deps_yaml}') as f:
+  local errors ec
+  # シングルクォートで python3 を呼び出し、シェル展開を避ける
+  errors=$(python3 - "$deps_yaml" <<'PYEOF'
+import yaml, sys, re
+deps_yaml = sys.argv[1]
+with open(deps_yaml) as f:
     data = yaml.safe_load(f)
 refs = data.get('refs', {})
 errors = []
@@ -107,18 +109,18 @@ for name, entry in refs.items():
     if not isinstance(entry, dict):
         continue
     path = entry.get('path', '')
-    # 許容パターン: refs/<name>.md OR skills/**/refs/<name>.md
-    expected_flat = f'refs/{name}.md'
-    import re
-    if path != expected_flat and not re.match(r'^skills/[^/]+/refs/' + re.escape(name) + r'\.md\$', path):
+    flat_path = f'refs/{name}.md'
+    skill_pattern = re.compile(r'^skills/[^/]+/refs/' + re.escape(name) + r'\.md$')
+    if path != flat_path and not skill_pattern.match(path):
         errors.append(f'{name}: path={path}, expected refs/{name}.md or skills/*/refs/{name}.md')
 if errors:
     for e in errors:
         print(e, file=sys.stderr)
     sys.exit(1)
 sys.exit(0)
-" 2>&1)
-  local ec=$?
+PYEOF
+  )
+  ec=$?
   if [[ $ec -ne 0 ]]; then
     echo "$errors" >&2
     return 1
@@ -129,7 +131,7 @@ test_ac4_reference_migration_idempotent() {
   local test_file="${PROJECT_ROOT}/tests/scenarios/reference-migration.test.sh"
   [[ -f "$test_file" ]] || return 1
   # 2回実行してどちらも 0 failures
-  local exit1 exit2
+  local exit1=0 exit2=0
   cd "${PROJECT_ROOT}" && bash "$test_file" &>/dev/null; exit1=$?
   cd "${PROJECT_ROOT}" && bash "$test_file" &>/dev/null; exit2=$?
   if [[ $exit1 -ne 0 || $exit2 -ne 0 ]]; then

--- a/plugins/twl/tests/scenarios/reference-migration.test.sh
+++ b/plugins/twl/tests/scenarios/reference-migration.test.sh
@@ -239,13 +239,14 @@ test_non_sync_refs_no_marker() {
 }
 run_test "sync 対象外ファイルに同期マーカーがない [edge]" test_non_sync_refs_no_marker
 
-# Scenario: twl sync-docs --check の通過 (line 11)
-test_twl_sync_docs_check() {
+# Scenario: twl --check の通過（ファイル存在検証）
+# twl sync-docs はフラグ形式 (--sync-docs TARGET_DIR)。--check で全依存ファイル存在を検証
+test_twl_check_passes() {
   if ! command -v twl &>/dev/null; then
     return 1
   fi
   local output exit_code
-  output=$(cd "${PROJECT_ROOT}" && twl sync-docs --check 2>&1)
+  output=$(cd "${PROJECT_ROOT}" && twl --check 2>&1)
   exit_code=$?
   if [[ $exit_code -ne 0 ]]; then
     echo "$output" >&2
@@ -255,14 +256,9 @@ test_twl_sync_docs_check() {
 }
 
 if command -v twl &>/dev/null; then
-  # twl sync-docs may not be available yet
-  if cd "${PROJECT_ROOT}" && twl sync-docs --help &>/dev/null 2>&1; then
-    run_test "twl sync-docs --check がエラーなしで通過" test_twl_sync_docs_check
-  else
-    run_test_skip "twl sync-docs --check がエラーなしで通過" "twl sync-docs subcommand not available"
-  fi
+  run_test "twl --check がエラーなしで通過（refs ファイル存在検証）" test_twl_check_passes
 else
-  run_test_skip "twl sync-docs --check がエラーなしで通過" "twl command not found"
+  run_test_skip "twl --check がエラーなしで通過" "twl command not found"
 fi
 
 # =============================================================================
@@ -447,20 +443,20 @@ run_test "全 12 new reference に type: reference frontmatter" test_all_refs_ha
 
 # Scenario: reference の deps.yaml 登録 (line 44)
 # WHEN: 全 12 references の deps.yaml 登録が完了した
-# THEN: refs セクションに 16 エントリが存在する（既存 4 + 新規 12）
-test_deps_refs_count_15() {
+# THEN: refs セクションに 16 以上のエントリが存在する（既存 4 + 新規 12 が最小セット、その後の migration で追加あり）
+test_deps_refs_count_at_least_16() {
   assert_file_exists "$DEPS_YAML" || return 1
   assert_valid_yaml "$DEPS_YAML" || return 1
   yaml_get "$DEPS_YAML" "
 refs = data.get('refs', {})
 count = len(refs)
-if count != 16:
-    print(f'Expected 16 refs, got {count}', file=sys.stderr)
+if count < 16:
+    print(f'Expected at least 16 refs, got {count}', file=sys.stderr)
     sys.exit(1)
 sys.exit(0)
 "
 }
-run_test "deps.yaml refs セクションに 16 エントリ (既存 4 + 新規 12)" test_deps_refs_count_15
+run_test "deps.yaml refs セクションに 16 以上のエントリ (既存 4 + 新規 12 が最小セット)" test_deps_refs_count_at_least_16
 
 # 全 12 new refs が deps.yaml に登録されている
 test_deps_all_new_refs_registered() {
@@ -539,19 +535,22 @@ sys.exit(0)
 }
 run_test "deps.yaml 全 refs の type が reference [edge]" test_deps_refs_type_all_reference
 
-# Edge case: 全 refs の path が refs/<name>.md と一致
+# Edge case: 全 refs の path が refs/<name>.md または skills/*/refs/<name>.md と一致
+# su-observer / co-autopilot などスキル固有 refs は skills/<skill>/refs/<name>.md パスを使用
 test_deps_refs_path_consistency() {
   assert_file_exists "$DEPS_YAML" || return 1
   yaml_get "$DEPS_YAML" "
+import re
 refs = data.get('refs', {})
 errors = []
 for name, entry in refs.items():
     if not isinstance(entry, dict):
         continue
-    expected_path = f'refs/{name}.md'
     actual_path = entry.get('path', '')
-    if actual_path != expected_path:
-        errors.append(f'{name}: path={actual_path}, expected {expected_path}')
+    flat_path = f'refs/{name}.md'
+    skill_pattern = re.compile(r'^skills/[^/]+/refs/' + re.escape(name) + r'\.md$')
+    if actual_path != flat_path and not skill_pattern.match(actual_path):
+        errors.append(f'{name}: path={actual_path}, expected refs/{name}.md or skills/*/refs/{name}.md')
 if errors:
     for e in errors:
         print(e, file=sys.stderr)
@@ -559,15 +558,15 @@ if errors:
 sys.exit(0)
 "
 }
-run_test "deps.yaml 全 refs の path が refs/<name>.md [edge: パス整合性]" test_deps_refs_path_consistency
+run_test "deps.yaml 全 refs の path が refs/<name>.md または skills/*/refs/<name>.md [edge: パス整合性]" test_deps_refs_path_consistency
 
-# Scenario: twl validate が通過 (line 48)
+# Scenario: twl --validate が通過 (line 48)
 test_twl_validate_refs() {
   if ! command -v twl &>/dev/null; then
     return 1
   fi
   local output exit_code
-  output=$(cd "${PROJECT_ROOT}" && twl validate 2>&1)
+  output=$(cd "${PROJECT_ROOT}" && twl --validate 2>&1)
   exit_code=$?
   if [[ $exit_code -ne 0 ]]; then
     echo "$output" >&2
@@ -577,9 +576,9 @@ test_twl_validate_refs() {
 }
 
 if command -v twl &>/dev/null; then
-  run_test "twl validate がエラーなしで通過する (refs)" test_twl_validate_refs
+  run_test "twl --validate がエラーなしで通過する (refs)" test_twl_validate_refs
 else
-  run_test_skip "twl validate がエラーなしで通過する (refs)" "twl command not found"
+  run_test_skip "twl --validate がエラーなしで通過する (refs)" "twl command not found"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## 概要

Issue #1221 で検出された `reference-migration.test.sh` の 4 つの pre-existing failures を修正。

## 変更内容

### 1. `twl sync-docs --check` → `twl --check`
`twl sync-docs --check` は存在しないサブコマンド構文。guard の `twl sync-docs --help` が `--help` フラグ優先で exit 0 になるため誤ってテストが実行されていた。`twl --check`（ファイル存在検証）に置き換え。

### 2. `twl validate` → `twl --validate`
`validate` はサブコマンドではなくフラグ。正しい構文 `twl --validate` に修正。

### 3. refs count: 正確な 16 → 16 以上
migration 後の追加 refs により現状 43 エントリ。テスト期待値を `>= 16`（最小セット）に変更。

### 4. path 整合性: `refs/<name>.md` のみ → `refs/<name>.md` または `skills/*/refs/<name>.md` を許容
su-observer 11件・co-autopilot 1件 がスキル固有パス（`skills/<skill>/refs/<name>.md`）を意図的に使用。

### 追加: reference-migration-ac-verify.test.sh
AC ベースの regression チェックテストを追加。

## テスト結果

`reference-migration.test.sh`: 23 passed, 0 failed ✓
`reference-migration-ac-verify.test.sh`: 5 passed, 0 failed ✓

Closes #1221