### PR TITLE
fix(session): remove dead run_observe_once helper and _mock_session_state export (#1197)

### DIFF
--- a/plugins/session/deps.yaml
+++ b/plugins/session/deps.yaml
@@ -152,4 +152,9 @@ tests:
   test-1167-ac-verify:
     type: test
     path: tests/test_1167_ac_verify.bats
-    description: "Issue #1167: cld-observe-any.bats L74 slash-in-function-name AC テスト（AC1-AC5: _mock_session_state rename 検証）"
+    description: "Issue #1167/#1197: cld-observe-any.bats _mock_session_state 削除完了の回帰ガード（AC1-AC5）"
+
+  test-1197-ac-verify:
+    type: test
+    path: tests/test_ac1197_mock_intercept.bats
+    description: "Issue #1197: run_observe_once dead mock 削除の regression guard（AC1-AC4）"

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -8,7 +8,6 @@ CLD_OBSERVE_LOOP="$SCRIPT_DIR/cld-observe-loop"
 
 setup() {
     TMPDIR_TEST="$(mktemp -d)"
-    FAKE_WIN="test-win-$$"
 }
 
 teardown() {

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -16,68 +16,6 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# ヘルパー: tmux/session-state.sh をモックして cld-observe-any --once を実行
-# ---------------------------------------------------------------------------
-# pane_info: "pane_dead pane_cmd"（例: "0 claude"）
-# capture_content: tmux capture-pane が返す scrollback テキスト
-# status_line: status line（budget パース対象、空可）
-run_observe_once() {
-    local win="$1"
-    local pane_info="${2:-0 claude}"
-    local capture_content="${3:-}"
-    local status_line="${4:-}"
-    local extra_args="${5:-}"
-
-    local pane_dead="${pane_info%% *}"
-    local pane_cmd="${pane_info#* }"
-
-    local capture_file="$TMPDIR_TEST/capture.txt"
-    printf '%s\n' "$capture_content" > "$capture_file"
-    local status_file="$TMPDIR_TEST/status.txt"
-    printf '%s\n' "$status_line" > "$status_file"
-    local list_file="$TMPDIR_TEST/list.txt"
-    printf 'test-session:0 %s\n' "$win" > "$list_file"
-
-    run bash <<EOF
-# tmux モック
-tmux() {
-    case "\$1" in
-        list-windows)
-            if [[ "\${2:-}" == "-a" ]]; then
-                # get_target_windows の呼び出し
-                printf 'test-session:0\n'
-                return
-            fi
-            cat "$list_file"
-            ;;
-        display-message)
-            # pane_dead + pane_current_command
-            echo "${pane_dead} ${pane_cmd}"
-            ;;
-        capture-pane)
-            # status line または scrollback
-            if [[ "\${*}" == *"-S -1"* ]]; then
-                cat "$status_file"
-            else
-                cat "$capture_file"
-            fi
-            ;;
-        *)
-            return 0 ;;
-    esac
-}
-export -f tmux
-
-# session-state.sh モック (関数名は slash-free)
-_mock_session_state() { echo "processing"; }
-export -f _mock_session_state
-
-_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$SCRIPT_DIR" \
-    bash "$CLD_OBSERVE_ANY" --window "$win" --once $extra_args
-EOF
-}
-
-# ---------------------------------------------------------------------------
 # Scenario 1: LLM indicator あり → event emit されないこと（false positive 再発防止）
 # ---------------------------------------------------------------------------
 @test "LLM indicator 'Brewing' あり → event emit なし" {

--- a/plugins/session/tests/test_1167_ac_verify.bats
+++ b/plugins/session/tests/test_1167_ac_verify.bats
@@ -1,38 +1,36 @@
 #!/usr/bin/env bats
 # test_1167_ac_verify.bats
 # Issue #1167: tech-debt: cld-observe-any.bats L74 slash-containing function name
-# RED フェーズ — 修正前の現状では全テストが FAIL する
-# 修正後（実装完了後）は全テストが PASS する
+# Issue #1197 により run_observe_once ヘルパーごと削除済み
+# AC1-3: _mock_session_state が存在しないことを確認（削除完了の回帰ガード）
 
 TARGET_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/cld-observe-any.bats"
 
 # ---------------------------------------------------------------------------
-# AC1: L74 の関数定義を _mock_session_state() に rename する（slash 除去）
-# RED: 修正前は "\"$SCRIPT_DIR/session-state.sh\"()" 形式が残っているため FAIL
+# AC1: _mock_session_state() 関数定義が存在しないこと
+# #1167 で rename 済み、#1197 で dead code 削除済み
 # ---------------------------------------------------------------------------
-@test "ac1: L74 の関数定義が _mock_session_state() { ... } 形式になっている" {
-    # 修正済みならこのパターンが存在する → PASS
-    grep -qE '^_mock_session_state\(\)[[:space:]]*\{' "$TARGET_FILE"
+@test "ac1: _mock_session_state() 関数定義が cld-observe-any.bats に存在しない（#1197 削除確認）" {
+    run grep -E '^_mock_session_state\(\)[[:space:]]*\{' "$TARGET_FILE"
+    [ "$status" -ne 0 ]
 }
 
 # ---------------------------------------------------------------------------
-# AC2: L75 の export 行が export -f _mock_session_state に置換されている
-# RED: 修正前は export -f "$SCRIPT_DIR/session-state.sh" 形式が残っているため FAIL
+# AC2: export -f _mock_session_state が存在しないこと
+# #1167 で rename 済み、#1197 で dead code 削除済み
 # ---------------------------------------------------------------------------
-@test "ac2: L75 の export 行が export -f _mock_session_state になっている" {
-    # 修正済みならこのパターンが存在する → PASS
-    grep -qE '^export -f _mock_session_state[[:space:]]*$' "$TARGET_FILE"
+@test "ac2: export -f _mock_session_state が cld-observe-any.bats に存在しない（#1197 削除確認）" {
+    run grep -E '^export -f _mock_session_state[[:space:]]*$' "$TARGET_FILE"
+    [ "$status" -ne 0 ]
 }
 
 # ---------------------------------------------------------------------------
-# AC3: L73 のコメントが保持または更新されている
-# GREEN 寄りだが、コメント行の存在確認として記録する
-# 修正前でもコメントは存在するため、このテストは PASS する可能性がある
-# ただし rename 前後でコメントが消去されていないことを担保するために配置する
+# AC3: session-state.sh モックコメント（run_observe_once ヘルパー内）が存在しないこと
+# #1197 で run_observe_once ヘルパーごと削除済み
 # ---------------------------------------------------------------------------
-@test "ac3: L73 の session-state.sh モックコメントが存在する" {
-    # コメント行（"session-state.sh" と "モック" を含む）が存在する → PASS
-    grep -qE '#.*session-state\.sh.*モック' "$TARGET_FILE"
+@test "ac3: session-state.sh モックコメントが cld-observe-any.bats に存在しない（#1197 削除確認）" {
+    run grep -E '#.*session-state\.sh.*モック' "$TARGET_FILE"
+    [ "$status" -ne 0 ]
 }
 
 # ---------------------------------------------------------------------------

--- a/plugins/session/tests/test_ac1197_mock_intercept.bats
+++ b/plugins/session/tests/test_ac1197_mock_intercept.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# test_ac1197_mock_intercept.bats - Issue #1197 RED tests
+# Dead mock / run_observe_once helper の設計修正を検証する
+
+BATS_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/cld-observe-any.bats"
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+
+# ---------------------------------------------------------------------------
+# AC-1: 対象 file/script の修正実施
+# export -f _mock_session_state は dead mock（フルパス subprocess をインターセプトできない）
+# 修正後（option 3: 削除）はこの行が消えるため、grep が 0 を返す → PASS
+# ---------------------------------------------------------------------------
+@test "ac1 (#1197): export -f _mock_session_state が cld-observe-any.bats から削除されていること (RED)" {
+    count=$(grep -c 'export -f _mock_session_state' "$BATS_FILE" || true)
+    [[ "$count" -eq 0 ]] || {
+        echo "FAIL: 'export -f _mock_session_state' が $count 行残存（dead mock 未削除）"
+        false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: 該当テストの green 化（run_observe_once 削除による dead code 解消）
+# run_observe_once ヘルパーは全テストが独立 heredoc を使用するため未呼び出し
+# 修正後は関数定義ごと削除されるため grep が 0 を返す → PASS
+# ---------------------------------------------------------------------------
+@test "ac2 (#1197): run_observe_once dead code ヘルパーが cld-observe-any.bats から削除されていること (RED)" {
+    count=$(grep -c '^run_observe_once()' "$BATS_FILE" || true)
+    [[ "$count" -eq 0 ]] || {
+        echo "FAIL: run_observe_once 関数定義が $count 行残存（dead code 未削除）"
+        false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: twl validate または該当 specialist で WARNING 解消確認
+# twl check が errors なしで完了することを確認
+# ---------------------------------------------------------------------------
+@test "ac3 (#1197): twl check が errors なしで完了すること (RED)" {
+    run twl check 2>&1
+    echo "$output"
+    # errors があれば "errors:" が出力に含まれる
+    [[ "$output" != *"errors:"* ]] || {
+        echo "FAIL: twl check に errors が検出された"
+        false
+    }
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: regression test — _mock_session_state の参照が残存しないこと
+# 削除後に再追加されていないことを確認する回帰ガード
+# ---------------------------------------------------------------------------
+@test "ac4 (#1197): _mock_session_state の参照が cld-observe-any.bats に残存しないこと (RED)" {
+    count=$(grep -c '_mock_session_state' "$BATS_FILE" || true)
+    [[ "$count" -eq 0 ]] || {
+        echo "FAIL: '_mock_session_state' が $count 行残存（回帰リスク）"
+        false
+    }
+}

--- a/plugins/session/tests/test_ac1197_mock_intercept.bats
+++ b/plugins/session/tests/test_ac1197_mock_intercept.bats
@@ -34,14 +34,21 @@ CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 
 # ---------------------------------------------------------------------------
 # AC-3: twl validate または該当 specialist で WARNING 解消確認
-# twl check が errors なしで完了することを確認
+# worker-code-reviewer (confidence 92%) が報告した dead mock パターンが解消されていること:
+#   - フルパス subprocess をインターセプトできない export -f が存在しないこと
+#   - run_observe_once ヘルパーが存在しないこと（dead code）
 # ---------------------------------------------------------------------------
-@test "ac3 (#1197): twl check が errors なしで完了すること" {
-    run twl check 2>&1
-    echo "$output"
-    # errors があれば "errors:" が出力に含まれる
-    [[ "$output" != *"errors:"* ]] || {
-        echo "FAIL: twl check に errors が検出された"
+@test "ac3 (#1197): worker-code-reviewer が報告した dead mock パターンが cld-observe-any.bats から解消されていること" {
+    # export -f でフルパスサブプロセスをインターセプトしようとするパターンの不在
+    run grep -E 'export -f.*(_mock_session_state|session-state)' "$BATS_FILE"
+    [[ "$status" -ne 0 ]] || {
+        echo "FAIL: dead mock export パターンが残存: $output"
+        false
+    }
+    # run_observe_once dead code helper の不在
+    run grep -E '^run_observe_once\(\)' "$BATS_FILE"
+    [[ "$status" -ne 0 ]] || {
+        echo "FAIL: dead code ヘルパー run_observe_once が残存: $output"
         false
     }
 }

--- a/plugins/session/tests/test_ac1197_mock_intercept.bats
+++ b/plugins/session/tests/test_ac1197_mock_intercept.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
-# test_ac1197_mock_intercept.bats - Issue #1197 RED tests
-# Dead mock / run_observe_once helper の設計修正を検証する
+# test_ac1197_mock_intercept.bats - Issue #1197 regression guard
+# Dead mock / run_observe_once helper の削除を検証する
 
 BATS_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)/cld-observe-any.bats"
 SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
@@ -11,7 +11,7 @@ CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 # export -f _mock_session_state は dead mock（フルパス subprocess をインターセプトできない）
 # 修正後（option 3: 削除）はこの行が消えるため、grep が 0 を返す → PASS
 # ---------------------------------------------------------------------------
-@test "ac1 (#1197): export -f _mock_session_state が cld-observe-any.bats から削除されていること (RED)" {
+@test "ac1 (#1197): export -f _mock_session_state が cld-observe-any.bats から削除されていること" {
     count=$(grep -c 'export -f _mock_session_state' "$BATS_FILE" || true)
     [[ "$count" -eq 0 ]] || {
         echo "FAIL: 'export -f _mock_session_state' が $count 行残存（dead mock 未削除）"
@@ -24,7 +24,7 @@ CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 # run_observe_once ヘルパーは全テストが独立 heredoc を使用するため未呼び出し
 # 修正後は関数定義ごと削除されるため grep が 0 を返す → PASS
 # ---------------------------------------------------------------------------
-@test "ac2 (#1197): run_observe_once dead code ヘルパーが cld-observe-any.bats から削除されていること (RED)" {
+@test "ac2 (#1197): run_observe_once dead code ヘルパーが cld-observe-any.bats から削除されていること" {
     count=$(grep -c '^run_observe_once()' "$BATS_FILE" || true)
     [[ "$count" -eq 0 ]] || {
         echo "FAIL: run_observe_once 関数定義が $count 行残存（dead code 未削除）"
@@ -36,7 +36,7 @@ CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 # AC-3: twl validate または該当 specialist で WARNING 解消確認
 # twl check が errors なしで完了することを確認
 # ---------------------------------------------------------------------------
-@test "ac3 (#1197): twl check が errors なしで完了すること (RED)" {
+@test "ac3 (#1197): twl check が errors なしで完了すること" {
     run twl check 2>&1
     echo "$output"
     # errors があれば "errors:" が出力に含まれる
@@ -50,7 +50,7 @@ CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
 # AC-4: regression test — _mock_session_state の参照が残存しないこと
 # 削除後に再追加されていないことを確認する回帰ガード
 # ---------------------------------------------------------------------------
-@test "ac4 (#1197): _mock_session_state の参照が cld-observe-any.bats に残存しないこと (RED)" {
+@test "ac4 (#1197): _mock_session_state の参照が cld-observe-any.bats に残存しないこと" {
     count=$(grep -c '_mock_session_state' "$BATS_FILE" || true)
     [[ "$count" -eq 0 ]] || {
         echo "FAIL: '_mock_session_state' が $count 行残存（回帰リスク）"


### PR DESCRIPTION
## 概要

Closes #1197

`cld-observe-any.bats` の `run_observe_once` ヘルパー（L24-79）と `_mock_session_state` エクスポートを削除する。

## 問題

`_mock_session_state` は `export -f` でサブシェルに伝播されるが、`cld-observe-any` 本体 L421 はフルパス `"$SCRIPT_DIR/session-state.sh"` でサブプロセスを直接起動するため、exported bash 関数はインターセプトされない。テストは `|| state="unknown"` フォールバックで動作していた。

`run_observe_once` 自体も dead code（全テストが独立 heredoc を使用、ヘルパーは一度も呼び出されていない）。

## 対応

**Option 3 選択（現状維持 + dead code 削除）**: フォールバック動作で十分とみなし、dead mock とヘルパーを削除。

## 変更内容

- `plugins/session/tests/cld-observe-any.bats`: `run_observe_once` ヘルパー（62行）を削除
- `plugins/session/tests/test_ac1197_mock_intercept.bats`: 回帰ガードテスト追加（AC-1〜4）

## テスト

- 既存 45 テスト: 合否カウント変化なし（20 fail は他 Issue の RED テスト）
- AC テスト 4/4 GREEN