### PR TITLE
test(co-explore): AC-5 env 経路 dynamic regression bats 追加 (#1327)

### DIFF
--- a/plugins/twl/tests/bats/ac-test-mapping-1327.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1327.yaml
@@ -1,0 +1,38 @@
+mappings:
+  - ac_index: 1
+    ac_text: "dynamic regression bats ファイルが存在する（issue-1327-co-explore-autosave-dynamic.bats）"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "baseline: static regression test file (issue-1321) is present"
+    impl_files:
+      - "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+
+  - ac_index: 2
+    ac_text: "CO_EXPLORE_AUTOSAVE env var の OS レベル継承（子プロセスへの伝播）が確認される"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "baseline: CO_EXPLORE_AUTOSAVE env var propagates to child processes (OS inheritance)"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+
+  - ac_index: 3
+    ac_text: "CO_EXPLORE_AUTOSAVE=1 でスキル実行時に [auto-confirm] が出力される（SKILL.md executor 対応後）"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "dynamic(skip): CO_EXPLORE_AUTOSAVE=1 causes [auto-confirm] output in skill execution"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+    # skip: SKILL.md executor (e2e-screening) 対応後に有効化
+
+  - ac_index: 4
+    ac_text: "500 行超の summary では CO_EXPLORE_AUTOSAVE=1 を無視してメニュー表示（safety override）"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "dynamic(skip): large summary (>500 lines) overrides CO_EXPLORE_AUTOSAVE=1 (safety)"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+    # skip: SKILL.md executor (e2e-screening) 対応後に有効化
+
+  - ac_index: 5
+    ac_text: "refine モード引数でスキル実行時に CO_EXPLORE_AUTOSAVE=1 が自動 enable される"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "dynamic(skip): refine mode auto-enables CO_EXPLORE_AUTOSAVE in spawned session"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+    # skip: SKILL.md executor (e2e-screening) 対応後に有効化

--- a/plugins/twl/tests/bats/ac-test-mapping-1327.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1327.yaml
@@ -36,3 +36,11 @@ mappings:
     impl_files:
       - "skills/co-explore/SKILL.md"
     # skip: SKILL.md executor (e2e-screening) 対応後に有効化
+
+  - ac_index: 6
+    ac_text: "CO_EXPLORE_AUTOSAVE 未設定時はインタラクティブメニュー表示（自動確認なし）"
+    test_file: "tests/bats/issue-1327-co-explore-autosave-dynamic.bats"
+    test_name: "dynamic(skip): unset CO_EXPLORE_AUTOSAVE requires interactive menu (no auto-confirm)"
+    impl_files:
+      - "skills/co-explore/SKILL.md"
+    # skip: SKILL.md executor (e2e-screening) 対応後に有効化

--- a/plugins/twl/tests/bats/issue-1327-co-explore-autosave-dynamic.bats
+++ b/plugins/twl/tests/bats/issue-1327-co-explore-autosave-dynamic.bats
@@ -58,7 +58,8 @@ setup() {
 # 有効化手順:
 #   1. SKILL.md executor コマンド（例: twl skill-exec co-explore）が利用可能になる
 #   2. 各テストの skip 行を削除
-#   3. # Implementation hint のコードを実際のテスト呼び出しに置き換える
+#   3. テスト末尾の `false` を削除
+#   4. # Implementation hint のコードを実際のテスト呼び出しに置き換える
 # ===========================================================================
 
 @test "dynamic(skip): CO_EXPLORE_AUTOSAVE=1 causes [auto-confirm] output in skill execution" {

--- a/plugins/twl/tests/bats/issue-1327-co-explore-autosave-dynamic.bats
+++ b/plugins/twl/tests/bats/issue-1327-co-explore-autosave-dynamic.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# issue-1327-co-explore-autosave-dynamic.bats
+#
+# Issue #1327: tech-debt(co-explore): AC-5 env 経路 dynamic regression テスト追加
+#
+# AC-5（Issue #1321）で実装された CO_EXPLORE_AUTOSAVE=1 env 経路の動的 regression テスト。
+# 現行の静的 grep テスト（issue-1321-co-explore-autosave.bats）を補完する。
+#
+# DEPENDENCY:
+#   SKILL.md executor が利用可能になった際に dynamic テストを有効化する。
+#   executor 利用可能確認後、skip 行を削除して有効化すること。
+#
+# STATIC TEST BASELINE:
+#   tests/bats/issue-1321-co-explore-autosave.bats (AC1-AC5 静的検証、9件 PASS)
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  SKILL_FILE="${REPO_ROOT}/skills/co-explore/SKILL.md"
+  export SKILL_FILE
+
+  STATIC_TEST_FILE="${REPO_ROOT}/tests/bats/issue-1321-co-explore-autosave.bats"
+  export STATIC_TEST_FILE
+}
+
+# ===========================================================================
+# Static baseline integrity — dynamic テストの前提条件確認
+# ===========================================================================
+
+@test "baseline: static regression test file (issue-1321) is present" {
+  # Issue #1321 の静的テストファイルが存在することを確認
+  [ -f "${STATIC_TEST_FILE}" ]
+}
+
+@test "baseline: SKILL.md has CO_EXPLORE_AUTOSAVE implementation (>= 3 references)" {
+  # 動的テストの前提: SKILL.md に CO_EXPLORE_AUTOSAVE の実装が存在する
+  local count
+  count=$(grep -c "CO_EXPLORE_AUTOSAVE" "${SKILL_FILE}" || true)
+  [ "${count}" -ge 3 ]
+}
+
+@test "baseline: CO_EXPLORE_AUTOSAVE env var propagates to child processes (OS inheritance)" {
+  # env 経路の OS レベル継承動作確認
+  # SKILL.md executor が CO_EXPLORE_AUTOSAVE を読める前提を保証する
+  local result
+  result=$(CO_EXPLORE_AUTOSAVE=1 bash -c 'echo "${CO_EXPLORE_AUTOSAVE:-}"')
+  [ "${result}" = "1" ]
+}
+
+# ===========================================================================
+# Dynamic tests — SKILL.md executor (e2e-screening) 対応後に有効化
+#
+# 有効化手順:
+#   1. SKILL.md executor コマンド（例: twl skill-exec co-explore）が利用可能になる
+#   2. 各テストの skip 行を削除
+#   3. # Implementation hint のコードを実際のテスト呼び出しに置き換える
+# ===========================================================================
+
+@test "dynamic(skip): CO_EXPLORE_AUTOSAVE=1 causes [auto-confirm] output in skill execution" {
+  skip "SKILL.md executor (e2e-screening) not yet available — Issue #1327"
+  # 期待動作（SKILL.md executor 利用可能後）:
+  #   1. CO_EXPLORE_AUTOSAVE=1 を設定してスキルを実行
+  #   2. executor が SKILL.md の summary-gate 判定を実行
+  #   3. 出力に "[auto-confirm] CO_EXPLORE_AUTOSAVE=1: summary-gate [A] を自動選択しました" を含む
+  #
+  # Implementation hint:
+  #   run env CO_EXPLORE_AUTOSAVE=1 twl skill-exec co-explore --test-mode
+  #   [[ "$output" == *"[auto-confirm] CO_EXPLORE_AUTOSAVE=1"* ]]
+  false
+}
+
+@test "dynamic(skip): large summary (>500 lines) overrides CO_EXPLORE_AUTOSAVE=1 (safety)" {
+  skip "SKILL.md executor (e2e-screening) not yet available — Issue #1327"
+  # 期待動作（SKILL.md executor 利用可能後）:
+  #   1. CO_EXPLORE_AUTOSAVE=1 を設定し、500 行超の summary を渡してスキルを実行
+  #   2. AC-3 の safety override が発動し、メニューが表示される（自動選択されない）
+  #   3. 出力に "[auto-confirm]" を含まない
+  #
+  # Implementation hint:
+  #   LARGE_SUMMARY=$(seq 1 501 | awk '{print "line " $0}')
+  #   run env CO_EXPLORE_AUTOSAVE=1 twl skill-exec co-explore \
+  #     --test-mode --summary "${LARGE_SUMMARY}"
+  #   [[ "$output" != *"[auto-confirm]"* ]]
+  false
+}
+
+@test "dynamic(skip): refine mode auto-enables CO_EXPLORE_AUTOSAVE in spawned session" {
+  skip "SKILL.md executor (e2e-screening) not yet available — Issue #1327"
+  # 期待動作（SKILL.md executor 利用可能後）:
+  #   1. CO_EXPLORE_AUTOSAVE 未設定で "refine" 引数付きスキルを実行
+  #   2. AC-4 の refine モード検出が CO_EXPLORE_AUTOSAVE=1 を自動 enable
+  #   3. 出力に "[auto-confirm]" を含む
+  #
+  # Implementation hint:
+  #   run env -u CO_EXPLORE_AUTOSAVE twl skill-exec co-explore refine --test-mode
+  #   [[ "$output" == *"[auto-confirm]"* ]]
+  false
+}
+
+@test "dynamic(skip): unset CO_EXPLORE_AUTOSAVE requires interactive menu (no auto-confirm)" {
+  skip "SKILL.md executor (e2e-screening) not yet available — Issue #1327"
+  # 期待動作（SKILL.md executor 利用可能後）:
+  #   1. CO_EXPLORE_AUTOSAVE 未設定でスキルを実行
+  #   2. summary-gate でメニュー [A]/[B]/[C] が表示される（自動選択なし）
+  #   3. 出力に "[auto-confirm]" を含まない
+  #
+  # Implementation hint:
+  #   run env -u CO_EXPLORE_AUTOSAVE twl skill-exec co-explore --test-mode
+  #   [[ "$output" != *"[auto-confirm]"* ]]
+  false
+}


### PR DESCRIPTION
## Summary
Closes #1327

Issue #1321 の AC-5「regression bats: env 経路で auto-confirm 確認」に対して、
SKILL.md テキスト静的確認を補完する動的 regression テストを追加する。

## Changes
- **issue-1327-co-explore-autosave-dynamic.bats** (7テスト):
  - baseline: 静的テスト存在確認・SKILL.md 実装確認・OS レベル env 継承確認 (3 PASS)
  - dynamic: CO_EXPLORE_AUTOSAVE 動作検証 (4 SKIP — SKILL.md executor 整備後に有効化)
- **ac-test-mapping-1327.yaml**: 5エントリの AC→テスト マッピング

## SKIP マーカーの理由
SKILL.md は LLM 実行仕様ファイルであり、動的 integration テストには tmux セッション起動が必要。
SKILL.md executor (e2e-screening) が整備された際に skip 行を削除して有効化する。

## Test Results
```
1..7
ok 1 baseline: static regression test file (issue-1321) is present
ok 2 baseline: SKILL.md has CO_EXPLORE_AUTOSAVE implementation (>= 3 references)
ok 3 baseline: CO_EXPLORE_AUTOSAVE env var propagates to child processes (OS inheritance)
ok 4 dynamic(skip): CO_EXPLORE_AUTOSAVE=1 causes [auto-confirm] output in skill execution # skip
ok 5 dynamic(skip): large summary (>500 lines) overrides CO_EXPLORE_AUTOSAVE=1 (safety) # skip
ok 6 dynamic(skip): refine mode auto-enables CO_EXPLORE_AUTOSAVE in spawned session # skip
ok 7 dynamic(skip): unset CO_EXPLORE_AUTOSAVE requires interactive menu (no auto-confirm) # skip
```