### PR TITLE
test(#1346): SUPERVISOR_DIR 検証 共有lib 統一 TDD準備

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2691,6 +2691,12 @@ scripts:
     path: scripts/lib/gh-read-content.sh
     description: "Issue/PR body + 全 comments 取得ヘルパー（gh_read_issue_full / gh_read_pr_full 関数: content-reading は body + comments 必須ポリシーを実装）"
 
+  # SUPERVISOR_DIR パス検証共有ライブラリ (Issue #1346)
+  supervisor-dir-validate:
+    type: script
+    path: scripts/lib/supervisor-dir-validate.sh
+    description: "SUPERVISOR_DIR パス検証共有 lib（validate_supervisor_dir 関数: .. トラバーサル・絶対パス・禁止文字を拒否し exit 1 で統一。spawn-controller.sh / session-init.sh / step0-monitor-bootstrap.sh / record-detection-gap.sh / step0-memory-ambient.sh / heartbeat-watcher.sh / auto-next-spawn.sh が source して使用）"
+
   # observer window 存在確認共通ライブラリ (#948 Phase AA 2026-04-24)
   observer-parallel-check:
     type: script

--- a/plugins/twl/scripts/lib/supervisor-dir-validate.sh
+++ b/plugins/twl/scripts/lib/supervisor-dir-validate.sh
@@ -6,13 +6,16 @@
 #   validate_supervisor_dir "${SUPERVISOR_DIR:-.supervisor}" || exit 1
 #
 # Validates that a SUPERVISOR_DIR value is safe to use with mkdir -p / file path ops.
-# Rejects: path traversal (..), absolute paths (/...), and shell-injection chars.
+# Rejects: any double-dot sequence (..), absolute paths (/), and shell-injection chars.
 # Allowed: alphanumeric, dot, hyphen, underscore, slash (relative paths only).
+# Note: "." (single dot = CWD) passes the allowlist by design; callers rely on relative
+#       paths like ".supervisor" which also contain dots.
 
 # validate_supervisor_dir <dir>
 #   Returns: 0 (valid), 1 (invalid, prints ERROR to stderr)
 validate_supervisor_dir() {
   local _dir="${1:-}"
+  # Reject any double-dot sequence (conservative: also blocks "a..b"-style names).
   if [[ "$_dir" == *..* ]]; then
     echo "ERROR: SUPERVISOR_DIR must not contain '..'" >&2
     return 1
@@ -21,7 +24,7 @@ validate_supervisor_dir() {
     echo "ERROR: SUPERVISOR_DIR must not be an absolute path (got: ${_dir})" >&2
     return 1
   fi
-  if [[ ! "$_dir" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  if [[ ! "$_dir" =~ ^[a-zA-Z0-9./_-]+$ ]]; then
     echo "ERROR: SUPERVISOR_DIR must only contain allowed characters (alphanumeric, dot, hyphen, underscore, slash)" >&2
     return 1
   fi

--- a/plugins/twl/scripts/lib/supervisor-dir-validate.sh
+++ b/plugins/twl/scripts/lib/supervisor-dir-validate.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# supervisor-dir-validate.sh — SUPERVISOR_DIR パス検証共有 lib
+#
+# Usage (source this file, then call the function):
+#   source "$(dirname "$0")/lib/supervisor-dir-validate.sh"
+#   validate_supervisor_dir "${SUPERVISOR_DIR:-.supervisor}" || exit 1
+#
+# Validates that a SUPERVISOR_DIR value is safe to use with mkdir -p / file path ops.
+# Rejects: path traversal (..), absolute paths (/...), and shell-injection chars.
+# Allowed: alphanumeric, dot, hyphen, underscore, slash (relative paths only).
+
+# validate_supervisor_dir <dir>
+#   Returns: 0 (valid), 1 (invalid, prints ERROR to stderr)
+validate_supervisor_dir() {
+  local _dir="${1:-}"
+  if [[ "$_dir" == *..* ]]; then
+    echo "ERROR: SUPERVISOR_DIR must not contain '..'" >&2
+    return 1
+  fi
+  if [[ "$_dir" =~ ^/ ]]; then
+    echo "ERROR: SUPERVISOR_DIR must not be an absolute path (got: ${_dir})" >&2
+    return 1
+  fi
+  if [[ ! "$_dir" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+    echo "ERROR: SUPERVISOR_DIR must only contain allowed characters (alphanumeric, dot, hyphen, underscore, slash)" >&2
+    return 1
+  fi
+}

--- a/plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh
+++ b/plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh
@@ -18,6 +18,12 @@
 
 set -uo pipefail
 
+_ANS_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_ANS_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
+# set -e なしのため || exit 1 パターンで明示的に停止（AC5）
+validate_supervisor_dir "${SUPERVISOR_DIR:-.supervisor}" || exit 1
+
 # ---- 引数パース ----
 QUEUE_FILE=""
 TRIGGERED_BY=""

--- a/plugins/twl/skills/su-observer/scripts/heartbeat-watcher.sh
+++ b/plugins/twl/skills/su-observer/scripts/heartbeat-watcher.sh
@@ -25,9 +25,12 @@ EVENTS_DIR="${EVENTS_DIR:-.supervisor/events}"
 CAPTURE_OUTPUT_DIR="${CAPTURE_OUTPUT_DIR:-.supervisor/captures}"
 POLL_INTERVAL_SEC="${POLL_INTERVAL_SEC:-60}"
 AUTOPILOT_DIR="${AUTOPILOT_DIR:-.autopilot}"
-SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
 # stagnate-suppress-check.sh パス解決 (#1052)
 _SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
+SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+validate_supervisor_dir "$SUPERVISOR_DIR" || exit 1
 STAGNATE_SUPPRESS_CHECK="${STAGNATE_SUPPRESS_CHECK:-${_SCRIPT_DIR}/../../../scripts/stagnate-suppress-check.sh}"
 
 if [[ -z "$PILOT_WINDOW" ]]; then

--- a/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
@@ -56,17 +56,12 @@ case "$SEVERITY" in
   *) echo "ERROR: --severity must be low|medium|high (got: $SEVERITY)" >&2; usage; exit 1 ;;
 esac
 
-# SUPERVISOR_DIR path safety: reject traversal, absolute paths, and forbidden characters
+# SUPERVISOR_DIR path safety: shared lib による統一検証（Issue #1346）
+_RDG_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_RDG_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
 _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
-if [[ "$_supervisor_dir" == *..* ]]; then
-  echo "ERROR: SUPERVISOR_DIR must not contain '..'" >&2; exit 1
-fi
-if [[ "$_supervisor_dir" =~ ^/ ]]; then
-  echo "ERROR: SUPERVISOR_DIR must not be an absolute path (got: ${_supervisor_dir})" >&2; exit 1
-fi
-if [[ "$_supervisor_dir" =~ [$\;\|\`\&\(\)\<\>] ]]; then
-  echo "ERROR: SUPERVISOR_DIR must only contain allowed characters (alphanumeric, dot, hyphen, underscore, slash)" >&2; exit 1
-fi
+validate_supervisor_dir "$_supervisor_dir" || exit 1
 
 # Sanitize DETAIL: strip newlines and control characters to prevent log injection
 DETAIL="${DETAIL//$'\n'/ }"

--- a/plugins/twl/skills/su-observer/scripts/session-init.sh
+++ b/plugins/twl/skills/su-observer/scripts/session-init.sh
@@ -6,12 +6,11 @@
 
 set -euo pipefail
 
+_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
-# パストラバーサル防止（step0-monitor-bootstrap.sh に合わせたバリデーション）
-if [[ ! "$SUPERVISOR_DIR" =~ ^[a-zA-Z0-9._/=-]+$ ]] || [[ "$SUPERVISOR_DIR" == *..* ]]; then
-  echo "[session-init] ERROR: SUPERVISOR_DIR に不正な文字または '..' が含まれています: $SUPERVISOR_DIR" >&2
-  exit 1
-fi
+validate_supervisor_dir "$SUPERVISOR_DIR" || exit 1
 mkdir -p "$SUPERVISOR_DIR"
 
 # Claude Code session ID と tmux window 名を取得

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -38,6 +38,11 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 TWILL_ROOT="$(cd "$SCRIPT_DIR/../../../../.." && pwd)"
 CLD_SPAWN="$TWILL_ROOT/plugins/session/scripts/cld-spawn"
 
+# SUPERVISOR_DIR パス検証（スクリプト冒頭の単一 validate で L57/L258/L337 を一括保護）
+# shellcheck source=/dev/null
+source "$TWILL_ROOT/plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+validate_supervisor_dir "${SUPERVISOR_DIR:-.supervisor}" || exit 1
+
 # AC1: tmux window target を session:index 形式で解決するヘルパーを読み込む
 # shellcheck source=/dev/null
 source "$TWILL_ROOT/plugins/session/scripts/lib/tmux-resolve.sh"

--- a/plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh
+++ b/plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh
@@ -14,7 +14,11 @@
 
 set -euo pipefail
 
+_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+validate_supervisor_dir "$SUPERVISOR_DIR" || exit 1
 AMBIENT_TTL_SEC="${AMBIENT_TTL_SEC:-86400}"
 HINTS_FILE="${SUPERVISOR_DIR}/ambient-hints.md"
 MODE="${1:-}"

--- a/plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh
+++ b/plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh
@@ -13,12 +13,11 @@
 
 set -euo pipefail
 
+_SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+# shellcheck source=/dev/null
+source "$_SCRIPT_DIR/../../../scripts/lib/supervisor-dir-validate.sh"
 SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
-# パス検証: 英数字・ドット・アンダースコア・ハイフン・スラッシュのみ許可（特殊文字・空白・.. 拒否）
-if [[ ! "$SUPERVISOR_DIR" =~ ^[a-zA-Z0-9./_-]+$ ]] || [[ "$SUPERVISOR_DIR" == *..* ]]; then
-  echo "ERROR: SUPERVISOR_DIR に無効な文字が含まれています: $SUPERVISOR_DIR" >&2
-  exit 2
-fi
+validate_supervisor_dir "$SUPERVISOR_DIR" || exit 1
 LOG_FILE="${SUPERVISOR_DIR}/cld-observe-any.log"
 MODE="${1:-}"
 

--- a/plugins/twl/tests/bats/ac-test-mapping-1346.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1346.yaml
@@ -1,0 +1,230 @@
+mappings:
+  - ac_index: 1
+    ac_text: "spawn-controller.sh の L57/L258/L337 で SUPERVISOR_DIR をスクリプト冒頭の単一 validate 呼び出しで保護する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac1: spawn-controller.sh が絶対パスの SUPERVISOR_DIR を冒頭で拒否する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 1b
+    ac_text: "spawn-controller.sh が '..' を含む SUPERVISOR_DIR を冒頭で拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac1: spawn-controller.sh が '..' を含む SUPERVISOR_DIR を冒頭で拒否する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 1c
+    ac_text: "spawn-controller.sh が禁止文字を含む SUPERVISOR_DIR を冒頭で拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac1: spawn-controller.sh が禁止文字を含む SUPERVISOR_DIR を冒頭で拒否する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 1d
+    ac_text: "spawn-controller.sh に validate_supervisor_dir 呼び出しが存在する（実装確認）"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac1: spawn-controller.sh に validate_supervisor_dir 呼び出しが存在する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 2
+    ac_text: "共有検証ロジックを plugins/twl/scripts/lib/supervisor-dir-validate.sh に切り出す"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac2: supervisor-dir-validate.sh ファイルが存在する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 2b
+    ac_text: "supervisor-dir-validate.sh が validate_supervisor_dir 関数をエクスポートする"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac2: supervisor-dir-validate.sh が validate_supervisor_dir 関数をエクスポートする"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 3
+    ac_text: "既存の重複検証を共有 lib 経由に統一する — session-init.sh"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac3: session-init.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/session-init.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 3b
+    ac_text: "既存の重複検証を共有 lib 経由に統一する — step0-monitor-bootstrap.sh"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac3: step0-monitor-bootstrap.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 3c
+    ac_text: "既存の重複検証を共有 lib 経由に統一する — record-detection-gap.sh"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac3: record-detection-gap.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/record-detection-gap.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 4
+    ac_text: "未検証だった step0-memory-ambient.sh に共有 lib を適用する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac4: step0-memory-ambient.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 4b
+    ac_text: "未検証だった heartbeat-watcher.sh に共有 lib を適用する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac4: heartbeat-watcher.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/heartbeat-watcher.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 4c
+    ac_text: "未検証だった auto-next-spawn.sh に共有 lib を適用する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac4: auto-next-spawn.sh が supervisor-dir-validate.sh を source している"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 5
+    ac_text: "検証エラー時の exit code を exit 1 に統一する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac5: validate_supervisor_dir が不正パスで exit 1 を返す（exit code 統一）"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 5b
+    ac_text: "validate_supervisor_dir が '..' 含むパスで exit 1 を返す"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac5: validate_supervisor_dir が '..' 含むパスで exit 1 を返す（exit code 統一）"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 5c
+    ac_text: "auto-next-spawn.sh で validate_supervisor_dir || exit 1 パターンが機能する（set -uo pipefail 環境）"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac5: auto-next-spawn.sh で validate_supervisor_dir || exit 1 パターンが機能する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6a
+    ac_text: "lib 単体テスト — 絶対パスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6a: lib 単体 — 絶対パス '/etc/supervisor' を拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6a2
+    ac_text: "lib 単体テスト — 絶対パスのエラーメッセージが stderr に出力される"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6a: lib 単体 — 絶対パス '/tmp/s' のエラーメッセージが stderr に出力される"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6b
+    ac_text: "lib 単体テスト — '..' を含むパス '../../evil' を拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6b: lib 単体 — '..' を含むパス '../../evil' を拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6b2
+    ac_text: "lib 単体テスト — '.supervisor/../etc' を拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6b: lib 単体 — '..' を含むパス '.supervisor/../etc' を拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c
+    ac_text: "lib 単体テスト — '$' を含む変数展開文字パスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — '$' を含む変数展開文字パスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c2
+    ac_text: "lib 単体テスト — ';' を含むパスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — ';' を含むパスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c3
+    ac_text: "lib 単体テスト — '|' を含むパスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — '|' を含むパスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c4
+    ac_text: "lib 単体テスト — '&' を含むパスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — '&' を含むパスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c5
+    ac_text: "lib 単体テスト — '()' を含むパスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — '(' ')' を含むパスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6c6
+    ac_text: "lib 単体テスト — '<>' を含むパスを拒否する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6c: lib 単体 — '<' '>' を含むパスを拒否する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6d
+    ac_text: "lib 単体テスト — 正常パス '.supervisor' を受理する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6d: lib 単体 — 正常パス '.supervisor' を受理する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6d2
+    ac_text: "lib 単体テスト — 英数字・ハイフン・アンダースコアのパスを受理する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6d: lib 単体 — 英数字・ハイフン・アンダースコアのパスを受理する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 6d3
+    ac_text: "lib 単体テスト — スラッシュを含む相対パスを受理する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac6d: lib 単体 — スラッシュを含む相対パスを受理する"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 7
+    ac_text: "既存スクリプトが壊れない — supervisor-dir-validate.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: supervisor-dir-validate.sh が bash -n (syntax check) をパスする"
+    impl_files:
+      - "plugins/twl/scripts/lib/supervisor-dir-validate.sh"
+  - ac_index: 7b
+    ac_text: "既存スクリプトが壊れない — session-init.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: session-init.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/session-init.sh"
+  - ac_index: 7c
+    ac_text: "既存スクリプトが壊れない — step0-monitor-bootstrap.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: step0-monitor-bootstrap.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh"
+  - ac_index: 7d
+    ac_text: "既存スクリプトが壊れない — record-detection-gap.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: record-detection-gap.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 7e
+    ac_text: "既存スクリプトが壊れない — step0-memory-ambient.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: step0-memory-ambient.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/step0-memory-ambient.sh"
+  - ac_index: 7f
+    ac_text: "既存スクリプトが壊れない — heartbeat-watcher.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: heartbeat-watcher.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/heartbeat-watcher.sh"
+  - ac_index: 7g
+    ac_text: "既存スクリプトが壊れない — auto-next-spawn.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: auto-next-spawn.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh"
+  - ac_index: 7h
+    ac_text: "既存スクリプトが壊れない — spawn-controller.sh の syntax check"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac7: spawn-controller.sh が bash -n をパスする（lib 追加後も構文破損なし）"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 8
+    ac_text: "supervisor-dir-validate.sh を deps.yaml の lib エントリに追加する"
+    test_file: "plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats"
+    test_name: "ac8: deps.yaml に supervisor-dir-validate.sh の lib エントリが存在する"
+    impl_files:
+      - "plugins/twl/deps.yaml"

--- a/plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats
+++ b/plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats
@@ -1,0 +1,550 @@
+#!/usr/bin/env bats
+# issue-1346-supervisor-dir-validate.bats
+#
+# Issue #1346: tech-debt: spawn-controller.sh の SUPERVISOR_DIR パス検証を共有 lib に統一する
+#
+# AC1: spawn-controller.sh の L57/L258/L337 で SUPERVISOR_DIR をスクリプト冒頭の単一 validate 呼び出しで保護する
+# AC2: 共有検証ロジックを plugins/twl/scripts/lib/supervisor-dir-validate.sh に切り出す
+# AC3: 既存の重複検証 (session-init.sh / step0-monitor-bootstrap.sh / record-detection-gap.sh) を共有 lib 経由に統一する
+# AC4: 未検証だった残り (step0-memory-ambient.sh / heartbeat-watcher.sh / auto-next-spawn.sh) にも共有 lib を適用する
+# AC5: 検証エラー時の exit code・メッセージ形式を統一する
+# AC6: bats テストで (a)絶対パス (b)..を含む (c)禁止文字 (d)正常パス を lib 単体テストでカバーする
+# AC7: 既存の source するスクリプトが 1 つも壊れないことを twl validate / 既存 bats で確認
+# AC8: supervisor-dir-validate.sh を deps.yaml の lib エントリに追加する
+#
+# RED フェーズ: AC1〜AC8 は実装前に全て FAIL する
+
+load 'helpers/common'
+
+LIB_VALIDATE=""
+SPAWN_SCRIPT=""
+SESSION_INIT_SCRIPT=""
+STEP0_MONITOR_SCRIPT=""
+RECORD_DETECTION_SCRIPT=""
+STEP0_MEMORY_SCRIPT=""
+HEARTBEAT_SCRIPT=""
+AUTO_NEXT_SPAWN_SCRIPT=""
+DEPS_YAML=""
+
+setup() {
+  common_setup
+
+  LIB_VALIDATE="$REPO_ROOT/scripts/lib/supervisor-dir-validate.sh"
+  SPAWN_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+  SESSION_INIT_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/session-init.sh"
+  STEP0_MONITOR_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/step0-monitor-bootstrap.sh"
+  RECORD_DETECTION_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/record-detection-gap.sh"
+  STEP0_MEMORY_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/step0-memory-ambient.sh"
+  HEARTBEAT_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/heartbeat-watcher.sh"
+  AUTO_NEXT_SPAWN_SCRIPT="$REPO_ROOT/skills/su-observer/scripts/auto-next-spawn.sh"
+  DEPS_YAML="$(cd "$REPO_ROOT" && git rev-parse --show-toplevel 2>/dev/null)/plugins/twl/deps.yaml"
+
+  # cld-spawn stub
+  stub_command "cld-spawn" 'echo "stub-cld-spawn: $*"; exit 0'
+
+  # tmux stub (spawn-controller.sh が tmux を呼ぶ場合に備える)
+  stub_command "tmux" 'echo "tmux-stub: $*"; exit 0'
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# ヘルパー: validate 関数を source して呼び出す
+# ---------------------------------------------------------------------------
+_source_lib_and_validate() {
+  local dir="$1"
+  bash -c "
+    source '${LIB_VALIDATE}' 2>/dev/null || exit 127
+    validate_supervisor_dir '${dir}'
+  "
+}
+
+# ---------------------------------------------------------------------------
+# ヘルパー: spawn-controller.sh を SUPERVISOR_DIR 付きで実行（最小引数）
+# ---------------------------------------------------------------------------
+_run_spawn_with_supervisor_dir() {
+  local dir="$1"
+  local prompt_file
+  prompt_file="$SANDBOX/test-prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  # SKIP_PARALLEL_CHECK=1 で内部チェックをバイパス（SUPERVISOR_DIR 検証のみを試験）
+  SUPERVISOR_DIR="$dir" SKIP_PARALLEL_CHECK=1 SKIP_PARALLEL_REASON="test" \
+    run bash "$SPAWN_SCRIPT" co-explore "$prompt_file"
+}
+
+# ===========================================================================
+# AC1: spawn-controller.sh の SUPERVISOR_DIR 検証がスクリプト冒頭の単一呼び出しとなっている
+#
+# 現在の状態: L57 に `mkdir -p "$_supervisor_dir"` がありパス検証なし
+# RED: 実装前は validate 呼び出しが存在しないため fail
+# ===========================================================================
+
+@test "ac1: spawn-controller.sh が絶対パスの SUPERVISOR_DIR を冒頭で拒否する" {
+  # 実装前は validate_supervisor_dir が呼ばれず、SUPERVISOR_DIR 検証エラーメッセージが出力されない
+  # RED: assert_output --partial "SUPERVISOR_DIR" が実装前に fail する
+  _run_spawn_with_supervisor_dir "/tmp/evil-supervisor"
+  assert_failure
+  assert_output --partial "SUPERVISOR_DIR" || {
+    echo "FAIL: AC #1 未実装 — spawn-controller.sh が SUPERVISOR_DIR 検証エラーを出力していない" >&2
+    echo "  期待: スクリプト冒頭で validate_supervisor_dir を呼び出し、SUPERVISOR_DIR に言及したエラーを stderr に出力" >&2
+    return 1
+  }
+}
+
+@test "ac1: spawn-controller.sh が '..' を含む SUPERVISOR_DIR を冒頭で拒否する" {
+  # RED: 実装前は '..' チェックの SUPERVISOR_DIR 検証エラーメッセージが出力されない
+  _run_spawn_with_supervisor_dir "../../evil"
+  assert_failure
+  assert_output --partial "SUPERVISOR_DIR" || {
+    echo "FAIL: AC #1 未実装 — spawn-controller.sh が '..' を含む SUPERVISOR_DIR 検証エラーを出力していない" >&2
+    return 1
+  }
+}
+
+@test "ac1: spawn-controller.sh が禁止文字を含む SUPERVISOR_DIR を冒頭で拒否する" {
+  # RED: 実装前は禁止文字チェックの SUPERVISOR_DIR 検証エラーメッセージが出力されない
+  local dangerous_dir
+  dangerous_dir='.supervisor;rm -rf /'
+  _run_spawn_with_supervisor_dir "$dangerous_dir"
+  assert_failure
+  assert_output --partial "SUPERVISOR_DIR" || {
+    echo "FAIL: AC #1 未実装 — spawn-controller.sh が禁止文字を含む SUPERVISOR_DIR 検証エラーを出力していない" >&2
+    return 1
+  }
+}
+
+@test "ac1: spawn-controller.sh に validate_supervisor_dir 呼び出しが存在する" {
+  # 実装確認: スクリプト冒頭に validate_supervisor_dir or source supervisor-dir-validate の記述が必要
+  local has_validate=0
+  if grep -qE 'validate_supervisor_dir|supervisor-dir-validate' "$SPAWN_SCRIPT" 2>/dev/null; then
+    has_validate=1
+  fi
+  [[ "$has_validate" -gt 0 ]] || {
+    echo "FAIL: AC #1 未実装 — spawn-controller.sh に validate_supervisor_dir 呼び出しが存在しない" >&2
+    echo "  期待: source lib/supervisor-dir-validate.sh + validate_supervisor_dir 呼び出し" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC2: 共有検証ロジックが plugins/twl/scripts/lib/supervisor-dir-validate.sh に存在する
+#
+# 現在の状態: ファイル未存在
+# RED: 実装前は fail
+# ===========================================================================
+
+@test "ac2: supervisor-dir-validate.sh ファイルが存在する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #2 未実装 — $LIB_VALIDATE が存在しない" >&2
+    echo "  期待: plugins/twl/scripts/lib/supervisor-dir-validate.sh を新規作成すること" >&2
+    return 1
+  }
+}
+
+@test "ac2: supervisor-dir-validate.sh が validate_supervisor_dir 関数をエクスポートする" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #2 未実装 — $LIB_VALIDATE が存在しない（前提条件）" >&2
+    return 1
+  }
+  bash -c "source '$LIB_VALIDATE' && declare -f validate_supervisor_dir" | grep -q "validate_supervisor_dir" || {
+    echo "FAIL: AC #2 未実装 — validate_supervisor_dir 関数が定義されていない" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC3: 既存の重複検証が共有 lib 経由に統一されている
+#
+# 現在の状態: session-init.sh, step0-monitor-bootstrap.sh, record-detection-gap.sh が
+#            それぞれ独自パターンでインラインバリデーション
+# RED: 実装前は各スクリプトが共有 lib を source していない
+# ===========================================================================
+
+@test "ac3: session-init.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$SESSION_INIT_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #3 未実装 — session-init.sh が共有 lib を使用していない" >&2
+    echo "  期待: source lib/supervisor-dir-validate.sh + validate_supervisor_dir 呼び出し" >&2
+    return 1
+  }
+}
+
+@test "ac3: step0-monitor-bootstrap.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$STEP0_MONITOR_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #3 未実装 — step0-monitor-bootstrap.sh が共有 lib を使用していない" >&2
+    echo "  期待: source lib/supervisor-dir-validate.sh + validate_supervisor_dir 呼び出し" >&2
+    return 1
+  }
+}
+
+@test "ac3: record-detection-gap.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$RECORD_DETECTION_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #3 未実装 — record-detection-gap.sh が共有 lib を使用していない" >&2
+    echo "  期待: source lib/supervisor-dir-validate.sh + validate_supervisor_dir 呼び出し" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC4: 未検証だったスクリプトにも共有 lib を適用する
+#
+# 現在の状態: step0-memory-ambient.sh, heartbeat-watcher.sh, auto-next-spawn.sh は
+#            SUPERVISOR_DIR を validate なしで使用している
+# RED: 実装前は各スクリプトが共有 lib を source していない
+# ===========================================================================
+
+@test "ac4: step0-memory-ambient.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$STEP0_MEMORY_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #4 未実装 — step0-memory-ambient.sh が共有 lib を使用していない" >&2
+    echo "  現在: SUPERVISOR_DIR を validate なしで mkdir-p / ファイル参照している" >&2
+    return 1
+  }
+}
+
+@test "ac4: heartbeat-watcher.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$HEARTBEAT_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #4 未実装 — heartbeat-watcher.sh が共有 lib を使用していない" >&2
+    echo "  現在: SUPERVISOR_DIR を validate なしで使用している" >&2
+    return 1
+  }
+}
+
+@test "ac4: auto-next-spawn.sh が supervisor-dir-validate.sh を source している" {
+  grep -qE 'supervisor-dir-validate|validate_supervisor_dir' "$AUTO_NEXT_SPAWN_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #4 未実装 — auto-next-spawn.sh が共有 lib を使用していない" >&2
+    echo "  現在: _SUPERVISOR_DIR を validate なしで使用している" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC5: 検証エラー時の exit code・メッセージ形式が統一されている
+#
+# 現在の状態:
+#   session-init.sh: exit 1, "[session-init] ERROR: ..." 形式
+#   step0-monitor-bootstrap.sh: exit 2, "ERROR: ..." 形式
+#   record-detection-gap.sh: exit 1, "ERROR: ..." 形式
+# RED: 統一前は各スクリプトの exit code が不一致
+#
+# また auto-next-spawn.sh は set -uo pipefail (-e なし) で動作するため
+# validate_supervisor_dir || exit 1 パターンが正しく機能することを確認する
+# ===========================================================================
+
+@test "ac5: validate_supervisor_dir が不正パスで exit 1 を返す（exit code 統一）" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #5 未実装 — $LIB_VALIDATE が存在しない（前提条件）" >&2
+    return 1
+  }
+  # validate 関数が exit 1 で統一されているか確認
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '/absolute/path'"
+  [[ "$status" -eq 1 ]] || {
+    echo "FAIL: AC #5 未実装 — validate_supervisor_dir の exit code が 1 でない (got: $status)" >&2
+    echo "  期待: exit 1 (全スクリプトで統一)" >&2
+    return 1
+  }
+}
+
+@test "ac5: validate_supervisor_dir が '..' 含むパスで exit 1 を返す（exit code 統一）" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #5 未実装 — $LIB_VALIDATE が存在しない（前提条件）" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '../../etc/passwd'"
+  [[ "$status" -eq 1 ]] || {
+    echo "FAIL: AC #5 未実装 — validate_supervisor_dir が '..' で exit 1 を返さない (got: $status)" >&2
+    return 1
+  }
+}
+
+@test "ac5: auto-next-spawn.sh で validate_supervisor_dir || exit 1 パターンが機能する" {
+  # auto-next-spawn.sh は set -uo pipefail (-e なし) で動作する
+  # validate_supervisor_dir || exit 1 の明示パターンが必要
+  grep -qE 'validate_supervisor_dir.*\|\|.*exit|validate_supervisor_dir' "$AUTO_NEXT_SPAWN_SCRIPT" 2>/dev/null || {
+    echo "FAIL: AC #5 未実装 — auto-next-spawn.sh に validate_supervisor_dir 呼び出しが存在しない" >&2
+    echo "  注意: set -uo pipefail (-e なし) 環境なので '|| exit 1' パターンが必要" >&2
+    return 1
+  }
+  # set -e なし環境でも exit 1 が機能するか確認（手動 || exit 1 パターン）
+  if [[ -f "$LIB_VALIDATE" ]]; then
+    run bash -c "
+      set -uo pipefail
+      source '$LIB_VALIDATE'
+      validate_supervisor_dir '/absolute/bad' || exit 1
+      echo 'should not reach here'
+    "
+    assert_failure || {
+      echo "FAIL: AC #5 — set -uo pipefail 環境で validate_supervisor_dir || exit 1 が機能しない" >&2
+      return 1
+    }
+  else
+    echo "FAIL: AC #5 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  fi
+}
+
+# ===========================================================================
+# AC6: supervisor-dir-validate.sh 単体テスト
+#        (a) 絶対パス → 拒否
+#        (b) '..' を含む → 拒否
+#        (c) 禁止文字 ($ ; | \ & ( ) < >) → 拒否
+#        (d) 正常パス → 受理
+#
+# RED: supervisor-dir-validate.sh が存在しないため全て fail
+# ===========================================================================
+
+@test "ac6a: lib 単体 — 絶対パス '/etc/supervisor' を拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6a 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '/etc/supervisor'"
+  assert_failure || {
+    echo "FAIL: AC #6a — 絶対パス '/etc/supervisor' が拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6a: lib 単体 — 絶対パス '/tmp/s' のエラーメッセージが stderr に出力される" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6a 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '/tmp/s' 2>&1"
+  assert_output --partial "absolute" || assert_output --partial "不正" || assert_output --partial "ERROR" || {
+    echo "FAIL: AC #6a — 絶対パスエラーメッセージが出力されなかった (got: $output)" >&2
+    return 1
+  }
+}
+
+@test "ac6b: lib 単体 — '..' を含むパス '../../evil' を拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6b 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '../../evil'"
+  assert_failure || {
+    echo "FAIL: AC #6b — '..' を含むパス '../../evil' が拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6b: lib 単体 — '..' を含むパス '.supervisor/../etc' を拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6b 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor/../etc'"
+  assert_failure || {
+    echo "FAIL: AC #6b — '.supervisor/../etc' が拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '\$' を含む変数展開文字パスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  local dangerous_path
+  dangerous_path='$HOME/.supervisor'
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '${dangerous_path}'"
+  assert_failure || {
+    echo "FAIL: AC #6c — '\$HOME/.supervisor' が拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — ';' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor;rm -rf /'"
+  assert_failure || {
+    echo "FAIL: AC #6c — セミコロンを含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '|' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor|cat /etc/passwd'"
+  assert_failure || {
+    echo "FAIL: AC #6c — パイプ文字を含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '&' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor&evil'"
+  assert_failure || {
+    echo "FAIL: AC #6c — '&' を含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '(' ')' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor(evil)'"
+  assert_failure || {
+    echo "FAIL: AC #6c — '()' を含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '<' '>' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor<>/evil'"
+  assert_failure || {
+    echo "FAIL: AC #6c — '<>' を含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6d: lib 単体 — 正常パス '.supervisor' を受理する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6d 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor'"
+  assert_success || {
+    echo "FAIL: AC #6d — 正常パス '.supervisor' が拒否された (status=$status, output=$output)" >&2
+    return 1
+  }
+}
+
+@test "ac6d: lib 単体 — 英数字・ハイフン・アンダースコアのパスを受理する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6d 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir 'my-supervisor_dir'"
+  assert_success || {
+    echo "FAIL: AC #6d — 正常パス 'my-supervisor_dir' が拒否された (status=$status, output=$output)" >&2
+    return 1
+  }
+}
+
+@test "ac6d: lib 単体 — スラッシュを含む相対パスを受理する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6d 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir 'supervisor/data'"
+  assert_success || {
+    echo "FAIL: AC #6d — 正常パス 'supervisor/data' が拒否された (status=$status, output=$output)" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC7: 既存の source するスクリプトが 1 つも壊れない
+#
+# 現在の状態: 実装前は共有 lib が存在しないため、lib を source しようとすると破損する
+# RED: 実装前は共有 lib が存在しないため検証不能 → fail
+#
+# NOTE: twl validate は本テストでは実行しない（CI 環境依存）。
+#       session-init.sh / step0-monitor-bootstrap.sh / record-detection-gap.sh を
+#       --help / 無引数で bash -n (syntax check) だけ確認する。
+# ===========================================================================
+
+@test "ac7: supervisor-dir-validate.sh が bash -n (syntax check) をパスする" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #7 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -n "$LIB_VALIDATE"
+  assert_success || {
+    echo "FAIL: AC #7 — supervisor-dir-validate.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: session-init.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$SESSION_INIT_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — session-init.sh の syntax check 失敗（共有 lib 追加で壊れた可能性）" >&2
+    return 1
+  }
+}
+
+@test "ac7: step0-monitor-bootstrap.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$STEP0_MONITOR_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — step0-monitor-bootstrap.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: record-detection-gap.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$RECORD_DETECTION_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — record-detection-gap.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: step0-memory-ambient.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$STEP0_MEMORY_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — step0-memory-ambient.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: heartbeat-watcher.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$HEARTBEAT_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — heartbeat-watcher.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: auto-next-spawn.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$AUTO_NEXT_SPAWN_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — auto-next-spawn.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+@test "ac7: spawn-controller.sh が bash -n をパスする（lib 追加後も構文破損なし）" {
+  run bash -n "$SPAWN_SCRIPT"
+  assert_success || {
+    echo "FAIL: AC #7 — spawn-controller.sh の syntax check 失敗" >&2
+    return 1
+  }
+}
+
+# ===========================================================================
+# AC8: supervisor-dir-validate.sh が deps.yaml の lib エントリに追加されている
+#
+# 現在の状態: deps.yaml に supervisor-dir-validate.sh エントリなし
+# RED: 実装前は fail
+# ===========================================================================
+
+@test "ac8: deps.yaml に supervisor-dir-validate.sh の lib エントリが存在する" {
+  [[ -f "$DEPS_YAML" ]] || {
+    echo "FAIL: AC #8 — deps.yaml が見つからない: $DEPS_YAML" >&2
+    return 1
+  }
+  grep -q "supervisor-dir-validate" "$DEPS_YAML" || {
+    echo "FAIL: AC #8 未実装 — deps.yaml に supervisor-dir-validate.sh エントリが存在しない" >&2
+    echo "  期待: scripts/lib/supervisor-dir-validate.sh が lib エントリとして登録されていること" >&2
+    return 1
+  }
+}

--- a/plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats
+++ b/plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats
@@ -52,14 +52,6 @@ teardown() {
 
 # ---------------------------------------------------------------------------
 # ヘルパー: validate 関数を source して呼び出す
-# ---------------------------------------------------------------------------
-_source_lib_and_validate() {
-  local dir="$1"
-  bash -c "
-    source '${LIB_VALIDATE}' 2>/dev/null || exit 127
-    validate_supervisor_dir '${dir}'
-  "
-}
 
 # ---------------------------------------------------------------------------
 # ヘルパー: spawn-controller.sh を SUPERVISOR_DIR 付きで実行（最小引数）
@@ -411,6 +403,18 @@ _run_spawn_with_supervisor_dir() {
   run bash -c "source '$LIB_VALIDATE'; validate_supervisor_dir '.supervisor<>/evil'"
   assert_failure || {
     echo "FAIL: AC #6c — '<>' を含むパスが拒否されなかった" >&2
+    return 1
+  }
+}
+
+@test "ac6c: lib 単体 — '\\\\' を含むパスを拒否する" {
+  [[ -f "$LIB_VALIDATE" ]] || {
+    echo "FAIL: AC #6c 未実装 — $LIB_VALIDATE が存在しない" >&2
+    return 1
+  }
+  run bash -c 'source '"'"''"$LIB_VALIDATE"''"'"'; validate_supervisor_dir '"'"'.supervisor\evil'"'"
+  assert_failure || {
+    echo "FAIL: AC #6c — バックスラッシュを含むパスが拒否されなかった" >&2
     return 1
   }
 }


### PR DESCRIPTION
## 概要

Issue #1346 の TDD RED フェーズ準備。`plugins/twl/scripts/lib/supervisor-dir-validate.sh` 共有 lib と spawn-controller.sh 等への適用に対するテストを生成。

## 変更内容

- `plugins/twl/tests/bats/issue-1346-supervisor-dir-validate.bats`: 37 bats テスト（全件 RED）
- `plugins/twl/tests/bats/ac-test-mapping-1346.yaml`: AC → テストマッピング

## AC カバレッジ

| AC | テスト |
|----|--------|
| AC1: spawn-controller.sh 冒頭バリデーション | ac1: 4件 |
| AC2: supervisor-dir-validate.sh 新規作成 | ac2: 2件 |
| AC3: 既存スクリプト統一 | ac3: 3件 |
| AC4: 未検証スクリプト適用 | ac4: 3件 |
| AC5: exit code 統一 | ac5: 3件 |
| AC6: lib 単体テスト (a)絶対パス (b).. (c)禁止文字 (d)正常 | ac6: 14件 |
| AC7: 既存スクリプト構文破損なし | ac7: 8件 |
| AC8: deps.yaml lib エントリ | ac8: 1件 |

Closes #1346