### PR TITLE
fix(#1349): twl_check_specialist_handler stub envelope when manifest absent

### DIFF
--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1077,7 +1077,7 @@ def twl_check_completeness_handler(manifest_context: str) -> dict:
 
 
 def twl_check_specialist_handler(manifest_context: str) -> dict:
-    """Shadow mode: check specialist spawn completeness vs bash hook, log to shadow log."""
+    """Shadow mode: check specialist spawn completeness vs bash hook. Logs to shadow log when manifest file exists; returns stub envelope silently when manifest is absent (no runtime state to check)."""
     import glob
     import time
     from pathlib import Path

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1124,16 +1124,13 @@ def twl_check_specialist_handler(manifest_context: str) -> dict:
             if m:
                 missing_by_ctx[manifest_context] = m
         else:
-            # File not found for this context → scan all active manifest files
-            for mf in glob.glob(_MANIFEST_GLOB):
-                if os.path.islink(mf):
-                    continue
-                ctx = os.path.basename(mf).removeprefix(".specialist-manifest-").removesuffix(".txt")
-                if not _CTX_RE.match(ctx):
-                    continue
-                m = _check_context(ctx)
-                if m:
-                    missing_by_ctx[ctx] = m
+            # File not found for this context → stub envelope (R2-m2: no runtime state to check)
+            return {
+                "ok": True,
+                "items": [],
+                "exit_code": 0,
+                "summary": "stub",
+            }
 
     all_missing = [item for items in missing_by_ctx.values() for item in items]
     ok = len(all_missing) == 0

--- a/cli/twl/tests/test_mcp_validation.py
+++ b/cli/twl/tests/test_mcp_validation.py
@@ -751,3 +751,47 @@ class TestACNaming3CheckDocstring:
         assert "plugin file integrity" in doc, (
             f"twl_check の docstring に 'plugin file integrity' が含まれない: '{doc}' (AC-naming-3 未実装)"
         )
+
+
+# ---------------------------------------------------------------------------
+# AC5: manifest file 存在時の既存挙動不変（regression guard）
+# ---------------------------------------------------------------------------
+
+class TestAC25ManifestBehaviorUnchanged:
+    """AC5: manifest_context に対応する manifest file が存在する場合、既存挙動は不変であること.
+
+    このテストは regression guard として動作する。
+    AC1-3 の実装（stub envelope 追加）で manifest file 存在時も誤って "stub" を
+    返してしまうバグを防ぐ。GREEN スタート可（現在の実装は正しく動作している）。
+    """
+
+    def test_ac5_manifest_context_behavior_unchanged_when_file_exists(self):
+        # AC: manifest_context に対応する manifest file が存在する場合、
+        #     result["summary"] は "stub" を含まず、
+        #     "all specialists present" または "N specialist(s) missing" を返すこと
+        # REGRESSION GUARD: AC1-3 実装後も manifest file 存在時の挙動が変わらないことを保証
+        import os
+        from pathlib import Path
+        from twl.mcp_server.tools import twl_check_specialist_handler
+
+        manifest_path = Path("/tmp/.specialist-manifest-test-ac5-issue1349.txt")
+        try:
+            manifest_path.write_text("worker-code-reviewer\n")
+
+            result = twl_check_specialist_handler("test-ac5-issue1349")
+
+            assert isinstance(result, dict), (
+                f"twl_check_specialist_handler の戻り値が dict でない: {type(result)} (AC5)"
+            )
+            summary = str(result.get("summary", ""))
+            assert "stub" not in summary, (
+                f"manifest file 存在時に summary に 'stub' が含まれてしまっている: '{summary}' "
+                f"(AC5 regression: AC1-3 実装で既存挙動を壊してはならない)"
+            )
+            assert ("all specialists present" in summary or "specialist(s) missing" in summary), (
+                f"manifest file 存在時の summary が期待する形式でない: '{summary}' "
+                f"(期待: 'all specialists present' または 'N specialist(s) missing')"
+            )
+        finally:
+            if manifest_path.exists():
+                os.unlink(str(manifest_path))

--- a/cli/twl/tests/test_mcp_validation.py
+++ b/cli/twl/tests/test_mcp_validation.py
@@ -770,7 +770,7 @@ class TestAC25ManifestBehaviorUnchanged:
         #     result["summary"] は "stub" を含まず、
         #     "all specialists present" または "N specialist(s) missing" を返すこと
         # REGRESSION GUARD: AC1-3 実装後も manifest file 存在時の挙動が変わらないことを保証
-        import os
+        # NOTE: /tmp 直書きだが "issue1349" サフィックスで一意性を確保。pytest-xdist 未使用のため並列衝突リスクなし
         from pathlib import Path
         from twl.mcp_server.tools import twl_check_specialist_handler
 
@@ -793,5 +793,4 @@ class TestAC25ManifestBehaviorUnchanged:
                 f"(期待: 'all specialists present' または 'N specialist(s) missing')"
             )
         finally:
-            if manifest_path.exists():
-                os.unlink(str(manifest_path))
+            manifest_path.unlink(missing_ok=True)


### PR DESCRIPTION
## 概要

manifest file が存在しないコンテキストで `twl_check_specialist_handler` を呼ぶと、scan-all フォールバックに入りランタイムの manifest 状態を誤参照していた問題を修正。

## 変更内容

- **tools.py**: manifest file 不在時に stub envelope `{ok: True, items: [], summary: 'stub'}` を返すよう変更（R2-m2 仕様準拠）
- **test_mcp_validation.py**: AC5 regression guard テスト追加（manifest file 存在時の既存挙動が保護されること）

## テスト結果

`pytest cli/twl/tests/test_mcp_validation.py` → **33 passed**

- `TestAC23dSpecialistStubEnvelope::test_ac2_3d_specialist_handler_stub_envelope`: PASS（AC1/2/3）
- `TestAC21eCheckSpecialistSignature`: PASS（AC4）
- `TestAC25ManifestBehaviorUnchanged`: PASS（AC5）

Closes #1349