### PR TITLE
docs(refs): bash 入力検証の allowlist regex 規約を baseline-bash.md §11 に明文化 (#1348)

### DIFF
--- a/plugins/twl/refs/baseline-bash.md
+++ b/plugins/twl/refs/baseline-bash.md
@@ -379,3 +379,126 @@ my_function "$@"
 ```
 
 **レビュー観点**: bats テストで `source "$TARGET_SCRIPT"` を生成する場合、対象スクリプトを Grep して `BASH_SOURCE` guard または `--source-only` / `_DAEMON_LOAD_ONLY` pattern が存在するかを確認する。不在の場合は `set -euo pipefail` + 引数解析で **main 到達前に exit に巻き込まれる** リスクがあるため、`impl_files` メモにフラグ追加要求を記載する。
+
+## 11. bash スクリプトの入力検証: allowlist regex による入力バリデーション規約
+
+bash スクリプトでパス・識別子・列挙値を受け取る場合、**allowlist regex 方式**（許可されたパターンのみを受理）を採用する。blocklist 方式（禁止パターンを列挙して除外）は採用しない。
+
+### 規約
+
+> **bash スクリプトの入力検証（パス・識別子・列挙値）は allowlist regex 方式を採用する。**
+
+入力が allowlist パターンに **一致しない** 場合は即座にエラー終了する（fail-closed）。
+
+### パターン例
+
+#### 数値（正整数）
+
+```bash
+# GOOD: allowlist — 正整数のみ受理
+if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: invalid issue number: ${ISSUE_NUMBER}" >&2; exit 1
+fi
+```
+
+パターン: `^[1-9][0-9]*$`
+
+#### 安全パス（ディレクトリ名・ファイル名）
+
+```bash
+# GOOD: allowlist — 英数字・ドット・ハイフン・アンダースコア・スラッシュのみ受理
+if [[ ! "$WORK_DIR" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  echo "Error: invalid path: ${WORK_DIR}" >&2; exit 1
+fi
+```
+
+パターン: `^[A-Za-z0-9._/-]+$`
+
+#### 列挙値（case 文による allowlist）
+
+```bash
+# GOOD: case 文で許可値を列挙し、それ以外を reject
+case "$SEVERITY" in
+  low|medium|high) ;;
+  *) echo "Error: invalid severity: ${SEVERITY}" >&2; exit 1 ;;
+esac
+```
+
+#### 識別子（リポジトリ名など）
+
+```bash
+# GOOD: allowlist — owner/repo 形式のみ受理
+if [[ ! "$ISSUE_REPO" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+  echo "Error: invalid repo: ${ISSUE_REPO}" >&2; exit 1
+fi
+```
+
+### blocklist 方式との比較
+
+| 観点 | allowlist | blocklist |
+|---|---|---|
+| 境界値網羅 | 許可パターン外はすべて拒否（fail-closed） | 禁止パターン漏れが許可になる（fail-open） |
+| 新攻撃面への耐性 | 新しいインジェクション手法も自動排除 | 新手法が禁止リストに含まれるまで脆弱 |
+| コードの明示性 | 許可仕様が regex 1行で表現可能 | 禁止パターンが増殖し管理困難 |
+
+**Why fail-closed が重要か**: blocklist は「既知の危険パターン」を列挙するため、想定外の入力（例: Unicode エスケープ、新しいシェル特殊文字）が許可される。allowlist は「許可されたパターン以外すべて拒否」するため、未知の攻撃面に対しても安全性が保たれる。
+
+### BAD: blocklist 方式（採用禁止）
+
+```bash
+# BAD: blocklist — 禁止パターンを列挙。網羅性が保証されない
+if [[ "$_dir" == *..* ]]; then
+  echo "Error: path traversal detected" >&2; exit 1
+fi
+if [[ "$_dir" =~ ^/ ]]; then
+  echo "Error: absolute path not allowed" >&2; exit 1
+fi
+if [[ "$_dir" =~ [$\;\|\`\&\(\)\<\>] ]]; then
+  echo "Error: forbidden characters" >&2; exit 1
+fi
+# → '$'、';'、'|'、'`' などを列挙しても新しい特殊文字が抜ける可能性がある
+```
+
+### Prior art: spawn-controller.sh の allowlist 実装
+
+`plugins/twl/skills/su-observer/scripts/spawn-controller.sh` は allowlist 方式の実装例:
+
+**L167: `CHAIN_ISSUE` regex バリデーション（正整数 allowlist）**
+
+```bash
+if [[ ! "$CHAIN_ISSUE" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --issue の値は正整数である必要があります: ${CHAIN_ISSUE}" >&2
+  exit 2
+fi
+```
+
+**L113-125: `VALID_SKILLS` 配列チェック（列挙値 allowlist）**
+
+```bash
+VALID_SKILLS=(co-explore co-issue co-architect co-autopilot co-project co-utility co-self-improve)
+
+SKILL_FOUND=false
+for s in "${VALID_SKILLS[@]}"; do
+  if [[ "$SKILL_NORMALIZED" == "$s" ]]; then
+    SKILL_FOUND=true
+    break
+  fi
+done
+if [[ "$SKILL_FOUND" == "false" ]]; then
+  echo "Error: invalid skill name '$SKILL'." >&2
+  exit 2
+fi
+```
+
+### blocklist 方式の棚卸し（2026-05-04 時点）
+
+以下のスクリプトで blocklist 方式または mixed 方式（allowlist と blocklist の混在）が確認された。後続 Issue で allowlist 方式への置換を検討する:
+
+| ファイル | 箇所 | 内容 |
+|---|---|---|
+| `plugins/twl/skills/su-observer/scripts/record-detection-gap.sh` | L61-69 | `SUPERVISOR_DIR`: `*..* ` / `^/` / 禁止文字 reject の blocklist 3段階チェック（PR #1345 導入）|
+| `plugins/twl/scripts/worktree-delete.sh` | L25 | `branch`: `\.\.` / `^/` blocklist + `^[a-zA-Z0-9/_.-]+$` allowlist の混在 |
+| `plugins/twl/skills/su-observer/scripts/session-init.sh` | L11 | `SUPERVISOR_DIR`: allowlist `^[a-zA-Z0-9._/=-]+$` + 追加 `*..* ` blocklist の混在 |
+| `plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh` | L18 | `SUPERVISOR_DIR`: allowlist `^[a-zA-Z0-9./_-]+$` + `*..* ` blocklist の混在 |
+
+**対応方針**: `record-detection-gap.sh` の SUPERVISOR_DIR は純粋 blocklist のため優先度高。mixed 方式は allowlist で網羅できているため blocklist 部分を削除するだけで改善可能。

--- a/plugins/twl/refs/baseline-bash.md
+++ b/plugins/twl/refs/baseline-bash.md
@@ -472,7 +472,7 @@ if [[ ! "$CHAIN_ISSUE" =~ ^[1-9][0-9]*$ ]]; then
 fi
 ```
 
-**L113-125: `VALID_SKILLS` 配列チェック（列挙値 allowlist）**
+**L84: `VALID_SKILLS` 配列宣言 + L113-125: バリデーションループ（列挙値 allowlist）**
 
 ```bash
 VALID_SKILLS=(co-explore co-issue co-architect co-autopilot co-project co-utility co-self-improve)

--- a/plugins/twl/refs/baseline-security-checklist.md
+++ b/plugins/twl/refs/baseline-security-checklist.md
@@ -50,6 +50,18 @@ disable-model-invocation: true
 | `yaml.load(data)` | コード実行 | `yaml.safe_load()` |
 | `open(user_path)` | パストラバーサル | `pathlib.Path.resolve()` + 親ディレクトリ検証 |
 
+### bash 入力検証
+
+bash スクリプトで受け取るパス・識別子・列挙値の検証は **allowlist regex 方式** を採用する。詳細な規約・パターン例・prior art は [`baseline-bash.md` §11](baseline-bash.md) を参照。
+
+| パターン | リスク | 対策 |
+|---------|-------|------|
+| blocklist 方式（禁止文字列の列挙）によるパス検証 | パストラバーサル（参照: 上記 TypeScript/Python 節） | allowlist regex `^[A-Za-z0-9._/-]+$` で受理パターンを明示 |
+| 未検証の識別子（issue 番号・ブランチ名・skill 名）を shell コマンドに渡す | コマンドインジェクション | 数値: `^[1-9][0-9]*$`、識別子: `^[A-Za-z0-9._-]+$` で allowlist 検証 |
+| 列挙値の未検証（severity・action 等） | 想定外の値による処理分岐 | `case "$VAR" in val1\|val2) ;; *) exit 1 ;; esac` で allowlist 列挙 |
+
+**パストラバーサルとの関係**: TypeScript の `path.resolve()` / Python の `pathlib.Path.resolve()` に相当する bash の対策が allowlist regex によるパス検証である。`*..* ` や `^/` の blocklist チェックは網羅性が保証されないため採用しない（→ [`baseline-bash.md` §11](baseline-bash.md) 参照）。
+
 ## False Positive リスト
 
 以下のパターンは**報告しない**（誤検出リスクが高い）:

--- a/plugins/twl/tests/bats/ac-test-mapping-1348.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1348.yaml
@@ -1,0 +1,66 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/twl/refs/baseline-bash.md に「bash スクリプトの入力検証（パス・識別子・列挙値）は allowlist regex 方式を採用する」規約セクションを追加する（配置先は本 Issue で確定: bash 固有 DSL に密着し既存 regex 節と隣接できるため）"
+    test_file: "plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats"
+    test_names:
+      - "issue-1348-bash-allowlist-rule: AC1 section '## 11.' exists in baseline-bash.md"
+      - "issue-1348-bash-allowlist-rule: AC1 section heading mentions allowlist or allow-list"
+      - "issue-1348-bash-allowlist-rule: AC1 section heading mentions regex or 正規表現"
+      - "issue-1348-bash-allowlist-rule: AC1 §11 appears after §10 in file"
+    impl_files:
+      - "plugins/twl/refs/baseline-bash.md"
+
+  - ac_index: 2
+    ac_text: "規約セクションに allowlist パターン例（数値: ^[1-9][0-9]*$、安全パス: ^[A-Za-z0-9._/-]+$、列挙: case ... in foo|bar) ;;）と blocklist と比較した利点（境界値網羅・新攻撃面に対する fail-closed 性質）を明記する"
+    test_file: "plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats"
+    test_names:
+      - "issue-1348-bash-allowlist-rule: AC2 numeric pattern example present (^[1-9][0-9]*$)"
+      - "issue-1348-bash-allowlist-rule: AC2 safe-path pattern example present (^[A-Za-z0-9._/-]+$)"
+      - "issue-1348-bash-allowlist-rule: AC2 enum case-in pattern present in §11"
+      - "issue-1348-bash-allowlist-rule: AC2 enum pipe-alternation example present in §11 (foo|bar)"
+      - "issue-1348-bash-allowlist-rule: AC2 fail-closed benefit mentioned"
+      - "issue-1348-bash-allowlist-rule: AC2 blocklist comparison mentioned (境界値 or blocklist)"
+    impl_files:
+      - "plugins/twl/refs/baseline-bash.md"
+
+  - ac_index: 3
+    ac_text: "既存スクリプトの prior art として plugins/twl/skills/su-observer/scripts/spawn-controller.sh の CHAIN_ISSUE regex バリデーション（L167）と VALID_SKILLS 配列チェック（L113-125）を引用する"
+    test_file: "plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats"
+    test_names:
+      - "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh referenced in baseline-bash.md"
+      - "issue-1348-bash-allowlist-rule: AC3 CHAIN_ISSUE regex validation referenced"
+      - "issue-1348-bash-allowlist-rule: AC3 VALID_SKILLS array check referenced"
+      - "issue-1348-bash-allowlist-rule: AC3 line number reference L167 or spawn-controller line cited"
+      - "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh CHAIN_ISSUE regex exists at expected line in source"
+      - "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh VALID_SKILLS array exists in source"
+    impl_files:
+      - "plugins/twl/refs/baseline-bash.md"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+
+  - ac_index: 4
+    ac_text: "plugins/twl/refs/baseline-security-checklist.md に bash 入力検証の allowlist 規約への参照を追加する（bash 固有セクションが存在しない場合は新節「bash 入力検証」を追加し、同ファイルのパストラバーサル節と相互参照する）"
+    test_file: "plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats"
+    test_names:
+      - "issue-1348-bash-allowlist-rule: AC4 bash 入力検証 section exists in security checklist"
+      - "issue-1348-bash-allowlist-rule: AC4 cross-link to baseline-bash.md exists in security checklist"
+      - "issue-1348-bash-allowlist-rule: AC4 allowlist reference exists in security checklist"
+      - "issue-1348-bash-allowlist-rule: AC4 cross-reference to path traversal section present"
+    impl_files:
+      - "plugins/twl/refs/baseline-security-checklist.md"
+
+  - ac_index: 5
+    ac_text: "後続作業として PR #1345 の record-detection-gap.sh SUPERVISOR_DIR バリデーション（L59-69）を allowlist 方式に置換する Issue を分離起票する（または本 Issue で同時修正、実装担当者の判断に委任）"
+    test_file: null
+    test_names: []
+    impl_files: []
+    # NOTE: AC5 はファイルコンテンツで検証困難なためテストスキップ。
+    # GitHub Issue 起票またはコメント記録にて完了確認する。
+
+  - ac_index: 6
+    ac_text: "plugins/twl/scripts/ および plugins/twl/skills/*/scripts/ 内の bash 入力検証パターンを grep で棚卸しし、blocklist 方式の箇所を列挙して baseline-bash.md の新規節内または Issue コメントに記録する（棚卸し結果の記録をもって AC 完了とする）"
+    test_file: "plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats"
+    test_names:
+      - "issue-1348-bash-allowlist-rule: AC6 blocklist inventory section exists in baseline-bash.md §11"
+      - "issue-1348-bash-allowlist-rule: AC6 at least one blocklist script path recorded in §11"
+    impl_files:
+      - "plugins/twl/refs/baseline-bash.md"

--- a/plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats
+++ b/plugins/twl/tests/bats/issue-1348-bash-allowlist-rule.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+# issue-1348-bash-allowlist-rule.bats - Issue #1348: baseline-bash.md に bash 入力検証の
+# allowlist regex 規約セクション（§11）を追加する
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  TESTS_DIR="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${TESTS_DIR}/.." && pwd)"
+  BASELINE="${REPO_ROOT}/refs/baseline-bash.md"
+  SECURITY_CHECKLIST="${REPO_ROOT}/refs/baseline-security-checklist.md"
+  SPAWN_CONTROLLER="${REPO_ROOT}/skills/su-observer/scripts/spawn-controller.sh"
+  export REPO_ROOT BASELINE SECURITY_CHECKLIST SPAWN_CONTROLLER
+}
+
+# ===========================================================================
+# Helper: §11 の開始行と終了行を取得する
+# Usage: eval "$(_get_section11_bounds)"
+#        echo "$section11_start $next_section"
+# ===========================================================================
+_get_section11_bounds() {
+  cat <<'HELPER'
+local section11_start total_lines next_section
+total_lines=$(wc -l < "${BASELINE}")
+section11_start=$(grep -n '^## 11\.' "${BASELINE}" | head -1 | cut -d: -f1)
+[ -n "${section11_start}" ] || return 1
+next_section=$(awk -v start="${section11_start}" 'NR > start && /^## [0-9]+\./ { print NR; exit }' "${BASELINE}")
+if [ -z "${next_section}" ]; then
+  next_section="${total_lines}"
+fi
+HELPER
+}
+
+# ===========================================================================
+# AC1: §11 allowlist regex 規約セクションが baseline-bash.md に存在する
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: AC1 section '## 11.' exists in baseline-bash.md" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 11\.' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC1 section heading mentions allowlist or allow-list" {
+  [ -f "${BASELINE}" ]
+  grep -qiE '^## 11\..*allow.?list' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC1 section heading mentions regex or 正規表現" {
+  [ -f "${BASELINE}" ]
+  grep -qiE '^## 11\..*regex|^## 11\..*正規表現|^## 11\..*バリデーション|^## 11\..*入力検証' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC1 §11 appears after §10 in file" {
+  [ -f "${BASELINE}" ]
+  local line_10 line_11
+  line_10=$(grep -n '^## 10\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  line_11=$(grep -n '^## 11\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_10}" ]
+  [ -n "${line_11}" ]
+  [ "${line_11}" -gt "${line_10}" ]
+}
+
+# ===========================================================================
+# AC2: パターン例と blocklist 比較の記述が §11 内に存在する
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: AC2 numeric pattern example present (^[1-9][0-9]*\$)" {
+  [ -f "${BASELINE}" ]
+  grep -qF '^[1-9][0-9]*$' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC2 safe-path pattern example present (^[A-Za-z0-9._/-]+\$)" {
+  [ -f "${BASELINE}" ]
+  grep -qF '^[A-Za-z0-9._/-]+$' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC2 enum case-in pattern present in §11" {
+  [ -f "${BASELINE}" ]
+  eval "$(_get_section11_bounds)"
+  local found
+  found=$(awk -v s="${section11_start}" -v e="${next_section}" \
+    'NR >= s && NR <= e && /case[[:space:]]/ { found=1 } END { print found+0 }' "${BASELINE}")
+  [ "${found}" -eq 1 ]
+}
+
+@test "issue-1348-bash-allowlist-rule: AC2 enum pipe-alternation example present in §11 (foo|bar)" {
+  [ -f "${BASELINE}" ]
+  eval "$(_get_section11_bounds)"
+  local found
+  found=$(awk -v s="${section11_start}" -v e="${next_section}" \
+    'NR >= s && NR <= e && /[a-z][a-z_-]*[|][a-z]/ { found=1 } END { print found+0 }' "${BASELINE}")
+  [ "${found}" -eq 1 ]
+}
+
+@test "issue-1348-bash-allowlist-rule: AC2 fail-closed benefit mentioned" {
+  [ -f "${BASELINE}" ]
+  grep -qiE 'fail.closed|fail_closed' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC2 blocklist comparison mentioned (境界値 or blocklist)" {
+  [ -f "${BASELINE}" ]
+  grep -qiE 'blocklist|block.list|境界値|denylist|deny.list' "${BASELINE}"
+}
+
+# ===========================================================================
+# AC3: spawn-controller.sh の prior art への引用が §11 内に存在する
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh referenced in baseline-bash.md" {
+  [ -f "${BASELINE}" ]
+  grep -qE 'spawn-controller\.sh' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC3 CHAIN_ISSUE regex validation referenced" {
+  [ -f "${BASELINE}" ]
+  grep -qE 'CHAIN_ISSUE' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC3 VALID_SKILLS array check referenced" {
+  [ -f "${BASELINE}" ]
+  grep -qE 'VALID_SKILLS' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC3 line number reference L167 or spawn-controller line cited" {
+  [ -f "${BASELINE}" ]
+  grep -qE 'L167|spawn-controller.*L1[0-9][0-9]|L1[0-9][0-9].*spawn-controller' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh CHAIN_ISSUE regex exists at expected line in source" {
+  [ -f "${SPAWN_CONTROLLER}" ]
+  grep -qE 'CHAIN_ISSUE.*\^\[1-9\]\[0-9\]\*\$|\^\[1-9\]\[0-9\]\*\$.*CHAIN_ISSUE' "${SPAWN_CONTROLLER}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC3 spawn-controller.sh VALID_SKILLS array exists in source" {
+  [ -f "${SPAWN_CONTROLLER}" ]
+  grep -qE 'VALID_SKILLS=' "${SPAWN_CONTROLLER}"
+}
+
+# ===========================================================================
+# AC4: baseline-security-checklist.md に bash 入力検証セクション or cross-link が存在する
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: AC4 bash 入力検証 section exists in security checklist" {
+  [ -f "${SECURITY_CHECKLIST}" ]
+  grep -qiE '^##.*bash.*入力検証|^##.*bash.*input.validat|^##.*bash.*allowlist' "${SECURITY_CHECKLIST}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC4 cross-link to baseline-bash.md exists in security checklist" {
+  [ -f "${SECURITY_CHECKLIST}" ]
+  grep -qE 'baseline-bash\.md|baseline-bash' "${SECURITY_CHECKLIST}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC4 allowlist reference exists in security checklist" {
+  [ -f "${SECURITY_CHECKLIST}" ]
+  grep -qiE 'allowlist|allow.list' "${SECURITY_CHECKLIST}"
+}
+
+@test "issue-1348-bash-allowlist-rule: AC4 cross-reference to path traversal section present" {
+  [ -f "${SECURITY_CHECKLIST}" ]
+  local has_allowlist has_path_traversal
+  has_allowlist=$(grep -ciE 'allowlist|allow.list' "${SECURITY_CHECKLIST}")
+  has_path_traversal=$(grep -ciE 'パストラバーサル|path.traversal' "${SECURITY_CHECKLIST}")
+  [ "${has_allowlist}" -gt 0 ]
+  [ "${has_path_traversal}" -gt 0 ]
+}
+
+# ===========================================================================
+# AC5: NOTE のみ（follow-up Issue 起票はファイルコンテンツで検証困難）
+# NOTE: AC5 は本テストファイルではカバーしない。Issue #1348 の AC5 は
+#       別途 GitHub Issue 起票またはコメント記録にて完了確認する。
+# ===========================================================================
+
+# ===========================================================================
+# AC6: §11 内に棚卸し結果（blocklist 方式の箇所リスト）が記録されている
+# NOTE: Issue AC6 は「baseline-bash.md §11 内または Issue コメントに記録する」という
+#       2つの達成パスを認めている。bats テストは §11 内記録のみを機械検証でき、
+#       Issue コメント経由の達成は検証不能なため、§11 内記録を前提とする。
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: AC6 blocklist inventory section exists in baseline-bash.md §11" {
+  [ -f "${BASELINE}" ]
+  eval "$(_get_section11_bounds)"
+  local found
+  found=$(awk -v s="${section11_start}" -v e="${next_section}" \
+    'NR >= s && NR <= e && /棚卸し|blocklist.*箇所|blocklist.*一覧|blocklist.*リスト|inventory/ { found=1 } END { print found+0 }' "${BASELINE}")
+  [ "${found}" -eq 1 ]
+}
+
+@test "issue-1348-bash-allowlist-rule: AC6 at least one blocklist script path recorded in §11" {
+  [ -f "${BASELINE}" ]
+  eval "$(_get_section11_bounds)"
+  local found
+  found=$(awk -v s="${section11_start}" -v e="${next_section}" \
+    'NR >= s && NR <= e && /plugins\/twl\/(scripts|skills)/ { found=1 } END { print found+0 }' "${BASELINE}")
+  [ "${found}" -eq 1 ]
+}
+
+# ===========================================================================
+# regression: §1–§10 のヘッディングが変わっていない
+# ===========================================================================
+
+@test "issue-1348-bash-allowlist-rule: regression §1 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 1\. Character Class' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §2 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 2\. for-loop' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §3 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 3\. local' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §4 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 4\.' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §5 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 5\. source' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §6 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 6\.' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §7 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 7\. recursive glob' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §8 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 8\. tmux 破壊的操作のターゲット解決' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §9 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 9\. bats heredoc 内変数展開' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §10 heading unchanged" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 10\. source 対象スクリプトの guard' "${BASELINE}"
+}
+
+@test "issue-1348-bash-allowlist-rule: regression §1-§11 all present and consecutive" {
+  [ -f "${BASELINE}" ]
+  local count
+  count=$(grep -cE '^## [1-9][0-9]*\.' "${BASELINE}")
+  [ "${count}" -eq 11 ]
+}


### PR DESCRIPTION
## 概要

Issue #1348 に基づき、bash スクリプトの入力検証は allowlist regex 方式を採用するという規約を `baseline-bash.md` に明文化する。

## 変更内容

- `plugins/twl/refs/baseline-bash.md`（§11 allowlist regex 規約セクション追加）
  - allowlist パターン例（数値・安全パス・列挙値・識別子）
  - blocklist 方式との比較（fail-closed・境界値網羅）
  - prior art: spawn-controller.sh L167 CHAIN_ISSUE regex / L113-125 VALID_SKILLS 配列
  - blocklist 方式の棚卸し結果（4ファイル記録）
- `plugins/twl/refs/baseline-security-checklist.md`（bash 入力検証セクション追加 + cross-link）

## テスト

- bats テスト 33 件 / 33 PASS（AC1–AC4, AC6, regression §1–§11 すべて GREEN）

## Related

Closes #1348