### PR TITLE
feat(#1374): LLM indicator SSOT lib 新設（cld-observe-any から分離）

### DIFF
--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -9,39 +9,8 @@ else
     SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 fi
 
-# LLM 思考 indicator 定数リスト（Claude Code UI 変更時はここを更新）
-# AC1: Claude Code 4.x 追加 indicator
-# AC2: 一般化 regex "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \([0-9])" で未知 indicator をカバー
-LLM_INDICATORS=(
-    "Thinking"
-    "Brewing"
-    "Brewed"
-    "Concocting"
-    "Ebbing"
-    "Proofing"
-    "Frosting"
-    "Reasoning"
-    "Computing"
-    "Planning"
-    "Composing"
-    "Processing"
-    "Running .* agents"
-    "[0-9]+ tool uses"
-    "thinking with max effort"
-    "Saut.*ed"
-    "Burrowing"
-    "Cerebrating"
-    "Spinning"
-    "Beboppin"
-    "Thundering"
-    "Baked"
-    "Cooked"
-    "Crunched"
-    "Churned"
-    "Skedaddling"
-    "Orchestrating"
-    "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \\([0-9])"
-)
+# LLM_INDICATORS SSOT: lib/llm-indicators.sh を参照 (#1374)
+source "${SCRIPT_DIR}/lib/llm-indicators.sh"
 
 # --- デフォルト値 ---
 WINDOWS=()

--- a/plugins/session/scripts/lib/llm-indicators.sh
+++ b/plugins/session/scripts/lib/llm-indicators.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# lib/llm-indicators.sh - LLM thinking indicator SSOT
+# Source this file to get LLM_INDICATORS array.
+# Usage: source "$(dirname "$0")/lib/llm-indicators.sh"
+#
+# References: plugins/session/scripts/cld-observe-any
+#             plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+#             plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+
+# Guard: do nothing if sourced multiple times
+[[ -n "${_LLM_INDICATORS_LOADED:-}" ]] && return 0
+_LLM_INDICATORS_LOADED=1
+
+LLM_INDICATORS=(
+    # --- existing EN indicators ---
+    "Thinking"
+    "Brewing"
+    "Brewed"
+    "Concocting"
+    "Ebbing"
+    "Proofing"
+    "Frosting"
+    "Reasoning"
+    "Computing"
+    "Planning"
+    "Composing"
+    "Processing"
+    "Running .* agents"
+    "[0-9]+ tool uses"
+    "thinking with max effort"
+    "Saut.*ed"
+    "Burrowing"
+    "Cerebrating"
+    "Spinning"
+    "Beboppin"
+    "Thundering"
+    "Baked"
+    "Cooked"
+    "Crunched"
+    "Churned"
+    "Skedaddling"
+    "Orchestrating"
+    "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \\([0-9])"
+
+    # --- AC5: EN 13 new indicators (#1374) ---
+    "Philosophising"
+    "Drizzling"
+    "Fluttering"
+    "Spelunking"
+    "Determining"
+    "Infusing"
+    "Prestidigitating"
+    "Cogitated"
+    "Frolicking"
+    "Marinating"
+    "Metamorphosing"
+    "Shimmying"
+    "Transfiguring"
+
+    # --- AC6: JP 6 indicators (#1374) ---
+    "生成中"
+    "構築中"
+    "処理中"
+    "作成中"
+    "分析中"
+    "検証中"
+)
+
+export LLM_INDICATORS

--- a/plugins/session/scripts/lib/llm-indicators.sh
+++ b/plugins/session/scripts/lib/llm-indicators.sh
@@ -40,7 +40,7 @@ LLM_INDICATORS=(
     "Churned"
     "Skedaddling"
     "Orchestrating"
-    "[A-Z][a-z]+(in'|ing|ed)(…| for [0-9]| \\([0-9])"
+    "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \\([0-9])"
 
     # --- AC5: EN 13 new indicators (#1374) ---
     "Philosophising"

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -1552,18 +1552,21 @@ EOF
 # ===========================================================================
 # Issue #1374: LLM indicator SSOT lib 新設（cld-observe-any から分離）
 # AC7: 新 lib を source した状態で LLM_INDICATORS が EN/JP 両方を含む
-# RED: plugins/session/scripts/lib/llm-indicators.sh が未存在のため fail
 # ===========================================================================
 
-REPO_ROOT_1374="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
-LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators.sh"
+setup_ac7() {
+    local this_dir
+    this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    REPO_ROOT_1374="$(cd "${this_dir}/../../.." && pwd)"
+    LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators.sh"
+}
 
 # ---------------------------------------------------------------------------
 # AC7/1: llm-indicators.sh が存在すること
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): plugins/session/scripts/lib/llm-indicators.sh が存在すること (RED)" {
+    setup_ac7
     # AC: plugins/session/scripts/lib/llm-indicators.sh を新設する
-    # RED: ファイルが未存在のため fail
     [ -f "$LLM_INDICATORS_LIB" ]
 }
 
@@ -1571,8 +1574,8 @@ LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators
 # AC7/2: source 後 LLM_INDICATORS が bash 配列として export される
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): source 後 LLM_INDICATORS bash 配列が export される (RED)" {
+    setup_ac7
     # AC: LLM_INDICATORS を bash 配列として export する（SSOT）
-    # RED: ファイルが未存在のため fail
     [ -f "$LLM_INDICATORS_LIB" ]
     run bash -c "
         source '${LLM_INDICATORS_LIB}'
@@ -1586,8 +1589,8 @@ LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators
 # AC7/3: LLM_INDICATORS が既存 EN indicator（Thinking, Brewing 等）を含む
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): LLM_INDICATORS が既存 EN indicator（Thinking, Brewing）を含む (RED)" {
+    setup_ac7
     # AC: LLM_INDICATORS に EN/JP 両方の indicator が含まれる
-    # RED: ファイルが未存在のため fail
     [ -f "$LLM_INDICATORS_LIB" ]
     run bash -c "
         source '${LLM_INDICATORS_LIB}'
@@ -1607,8 +1610,8 @@ LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators
 # AC7/4: LLM_INDICATORS が AC5 追加 EN 13 件を含む
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): LLM_INDICATORS が AC5 EN 13 件（Philosophising 等）を含む (RED)" {
+    setup_ac7
     # AC: EN 13 件を SSOT 配列に追加する
-    # RED: ファイルが未存在または indicator 未追加のため fail
     [ -f "$LLM_INDICATORS_LIB" ]
     run bash -c "
         source '${LLM_INDICATORS_LIB}'
@@ -1634,8 +1637,8 @@ LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators
 # AC7/5: LLM_INDICATORS が AC6 追加 JP 6 件を含む
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): LLM_INDICATORS が AC6 JP 6 件（生成中 等）を含む (RED)" {
+    setup_ac7
     # AC: JP 6 件を SSOT 配列に追加する
-    # RED: ファイルが未存在または JP indicator 未追加のため fail
     [ -f "$LLM_INDICATORS_LIB" ]
     run bash -c "
         source '${LLM_INDICATORS_LIB}'
@@ -1661,10 +1664,8 @@ LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators
 # AC7/6: cld-observe-any が LLM_INDICATORS inline 定義を持たず lib を source する
 # ---------------------------------------------------------------------------
 @test "AC7(#1374): cld-observe-any の inline LLM_INDICATORS が削除され lib source に切り替わる (RED)" {
+    setup_ac7
     # AC: cld-observe-any L15-44 の inline 配列定義を削除し新 lib を source で参照する
-    # RED: inline 定義がまだ存在するため fail（実装後は inline が消えて source 行が追加される）
-    # inline 定義（LLM_INDICATORS=( ... )）が消え、lib の source 行が存在すること
-    # 現状: inline 定義あり → grep で見つかれば fail（RED テスト）
     run bash -c "
         # inline LLM_INDICATORS=( 定義が cld-observe-any に残っていれば RED（未実装）
         if grep -q '^LLM_INDICATORS=(' '${CLD_OBSERVE_ANY}'; then

--- a/plugins/session/tests/cld-observe-any.bats
+++ b/plugins/session/tests/cld-observe-any.bats
@@ -1548,3 +1548,135 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" =~ "FATAL" ]]
 }
+
+# ===========================================================================
+# Issue #1374: LLM indicator SSOT lib 新設（cld-observe-any から分離）
+# AC7: 新 lib を source した状態で LLM_INDICATORS が EN/JP 両方を含む
+# RED: plugins/session/scripts/lib/llm-indicators.sh が未存在のため fail
+# ===========================================================================
+
+REPO_ROOT_1374="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../.." && pwd)"
+LLM_INDICATORS_LIB="${REPO_ROOT_1374}/plugins/session/scripts/lib/llm-indicators.sh"
+
+# ---------------------------------------------------------------------------
+# AC7/1: llm-indicators.sh が存在すること
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): plugins/session/scripts/lib/llm-indicators.sh が存在すること (RED)" {
+    # AC: plugins/session/scripts/lib/llm-indicators.sh を新設する
+    # RED: ファイルが未存在のため fail
+    [ -f "$LLM_INDICATORS_LIB" ]
+}
+
+# ---------------------------------------------------------------------------
+# AC7/2: source 後 LLM_INDICATORS が bash 配列として export される
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): source 後 LLM_INDICATORS bash 配列が export される (RED)" {
+    # AC: LLM_INDICATORS を bash 配列として export する（SSOT）
+    # RED: ファイルが未存在のため fail
+    [ -f "$LLM_INDICATORS_LIB" ]
+    run bash -c "
+        source '${LLM_INDICATORS_LIB}'
+        # LLM_INDICATORS が配列として定義されており要素が存在する
+        [[ \"\${#LLM_INDICATORS[@]}\" -gt 0 ]]
+    "
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC7/3: LLM_INDICATORS が既存 EN indicator（Thinking, Brewing 等）を含む
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): LLM_INDICATORS が既存 EN indicator（Thinking, Brewing）を含む (RED)" {
+    # AC: LLM_INDICATORS に EN/JP 両方の indicator が含まれる
+    # RED: ファイルが未存在のため fail
+    [ -f "$LLM_INDICATORS_LIB" ]
+    run bash -c "
+        source '${LLM_INDICATORS_LIB}'
+        # 既存 EN indicator の存在確認
+        found_thinking=0
+        found_brewing=0
+        for ind in \"\${LLM_INDICATORS[@]}\"; do
+            [[ \"\$ind\" == *'Thinking'* ]] && found_thinking=1
+            [[ \"\$ind\" == *'Brewing'* ]] && found_brewing=1
+        done
+        [[ \$found_thinking -eq 1 && \$found_brewing -eq 1 ]]
+    "
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC7/4: LLM_INDICATORS が AC5 追加 EN 13 件を含む
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): LLM_INDICATORS が AC5 EN 13 件（Philosophising 等）を含む (RED)" {
+    # AC: EN 13 件を SSOT 配列に追加する
+    # RED: ファイルが未存在または indicator 未追加のため fail
+    [ -f "$LLM_INDICATORS_LIB" ]
+    run bash -c "
+        source '${LLM_INDICATORS_LIB}'
+        REQUIRED=(Philosophising Drizzling Fluttering Spelunking Determining Infusing Prestidigitating Cogitated Frolicking Marinating Metamorphosing Shimmying Transfiguring)
+        missing=()
+        for word in \"\${REQUIRED[@]}\"; do
+            found=0
+            for ind in \"\${LLM_INDICATORS[@]}\"; do
+                [[ \"\$ind\" == *\"\$word\"* ]] && found=1 && break
+            done
+            [[ \$found -eq 0 ]] && missing+=(\"\$word\")
+        done
+        if [[ \${#missing[@]} -gt 0 ]]; then
+            echo \"MISSING EN indicators: \${missing[*]}\"
+            exit 1
+        fi
+        echo 'PASS: EN 13 件確認'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC7/5: LLM_INDICATORS が AC6 追加 JP 6 件を含む
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): LLM_INDICATORS が AC6 JP 6 件（生成中 等）を含む (RED)" {
+    # AC: JP 6 件を SSOT 配列に追加する
+    # RED: ファイルが未存在または JP indicator 未追加のため fail
+    [ -f "$LLM_INDICATORS_LIB" ]
+    run bash -c "
+        source '${LLM_INDICATORS_LIB}'
+        REQUIRED_JP=(生成中 構築中 処理中 作成中 分析中 検証中)
+        missing_jp=()
+        for word in \"\${REQUIRED_JP[@]}\"; do
+            found=0
+            for ind in \"\${LLM_INDICATORS[@]}\"; do
+                [[ \"\$ind\" == *\"\$word\"* ]] && found=1 && break
+            done
+            [[ \$found -eq 0 ]] && missing_jp+=(\"\$word\")
+        done
+        if [[ \${#missing_jp[@]} -gt 0 ]]; then
+            echo \"MISSING JP indicators: \${missing_jp[*]}\"
+            exit 1
+        fi
+        echo 'PASS: JP 6 件確認'
+    "
+    [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC7/6: cld-observe-any が LLM_INDICATORS inline 定義を持たず lib を source する
+# ---------------------------------------------------------------------------
+@test "AC7(#1374): cld-observe-any の inline LLM_INDICATORS が削除され lib source に切り替わる (RED)" {
+    # AC: cld-observe-any L15-44 の inline 配列定義を削除し新 lib を source で参照する
+    # RED: inline 定義がまだ存在するため fail（実装後は inline が消えて source 行が追加される）
+    # inline 定義（LLM_INDICATORS=( ... )）が消え、lib の source 行が存在すること
+    # 現状: inline 定義あり → grep で見つかれば fail（RED テスト）
+    run bash -c "
+        # inline LLM_INDICATORS=( 定義が cld-observe-any に残っていれば RED（未実装）
+        if grep -q '^LLM_INDICATORS=(' '${CLD_OBSERVE_ANY}'; then
+            echo 'FAIL: inline LLM_INDICATORS=( が cld-observe-any に残存している（lib 分離未実装）'
+            exit 1
+        fi
+        # lib の source 行が存在すること
+        if ! grep -q 'llm-indicators.sh' '${CLD_OBSERVE_ANY}'; then
+            echo 'FAIL: llm-indicators.sh の source 行が cld-observe-any に未追加'
+            exit 1
+        fi
+        echo 'PASS: inline 削除 + lib source 確認'
+    "
+    [ "$status" -eq 0 ]
+}

--- a/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
+++ b/plugins/twl/scripts/issue-lifecycle-orchestrator.sh
@@ -56,13 +56,9 @@ if ! [[ "$STARTUP_GRACE_PERIOD" =~ ^[0-9]+$ ]]; then
   STARTUP_GRACE_PERIOD=15
 fi
 
-# AC3: LLM thinking indicator 検出 (SSOT: cld-observe-any, #1087)
-# LLM_INDICATORS 配列を cld-observe-any から動的に読み込み、detect_thinking() で再利用
-_COA_SCRIPT="${SCRIPTS_ROOT}/../../session/scripts/cld-observe-any"
+# LLM thinking indicator 検出 (SSOT: lib/llm-indicators.sh, #1374)
 LLM_INDICATORS=()
-if [[ -f "$_COA_SCRIPT" ]]; then
-  eval "$(awk '/^LLM_INDICATORS=\(/{p=1} p{print} /^\)$/{if(p){p=0; exit}}' "$_COA_SCRIPT" 2>/dev/null)" 2>/dev/null || true
-fi
+source "${SCRIPTS_ROOT}/../../session/scripts/lib/llm-indicators.sh" 2>/dev/null || true
 
 # detect_thinking: pane テキストから LLM thinking indicator を検出
 # AC4(d): past tense "word for Nm Ns" または "word for Ns" 完了形は IDLE 扱い（thinking としてカウントしない）

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -787,6 +787,7 @@ _check_window_alive "wt-co-explore-114550" "twill-ipatho1" && echo "alive" || ec
 - `_check_idle_completed()` → `skills/su-observer/scripts/lib/observer-idle-check.sh` (stateless 純粋関数)
 - `IDLE_COMPLETED_TS[$WIN]` 連想配列 → `cld-observe-any` メインループスコープで管理
 - `evaluate_window()` は stateless 設計を維持（連想配列を内部に持たない）
+- **LLM indicator SSOT**: `plugins/session/scripts/lib/llm-indicators.sh` が `LLM_INDICATORS` 配列の唯一の定義源（#1374）。`cld-observe-any`・`issue-lifecycle-orchestrator.sh`・`observer-idle-check.sh` の3ファイルが `source` 経由で参照する
 
 **既存 channel との関係**:
 - `[PHASE-DONE]` / `[PILOT-PHASE-COMPLETE]` 等は completion phrase 1 回 emit（一過性）

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -101,7 +101,7 @@ tmux capture-pane -t <worker-win> -p -S -50 | grep -E '⏵⏵ auto mode|permissi
 
 - **A1**: `tmux capture-pane -p -S -60` の内容ハッシュ（stable / dynamic）
 - **A2**: LLM thinking indicator（`Thinking/Brewing/Concocting/Sautéing/Steeping/Simmering/Marinating/Newspapering/Tomfoolering/Flummoxing/Proofing/Befuddling/Generating/Waddling/Thundering/Lollygagging` + **現在進行形のみ**。`Sautéed for N`/`Worked for N`/`Baked for N` 等の **過去形 + "for N"** は IDLE 扱い — v18 past tense filter、Phase AA Wave AA.2 実装済）
-  - **SSOT**: `plugins/session/scripts/cld-observe-any` の `LLM_INDICATORS` 配列 + `detect_thinking()` 関数が A2 判定の唯一の信頼源。`issue-lifecycle-orchestrator.sh` は `LLM_INDICATORS` を動的に読み込み（#1087 SSOT 共有）
+  - **SSOT**: `plugins/session/scripts/lib/llm-indicators.sh` が `LLM_INDICATORS` 配列の唯一の定義源（#1374）。参照方法: `source "$(dirname "$0")/lib/llm-indicators.sh"` または相対パスで `source`。以下3ファイルが参照: `cld-observe-any`（source）、`issue-lifecycle-orchestrator.sh`（source）、`observer-idle-check.sh`（動的 source）
   - **debounce 延長（#1087）**: `issue-lifecycle-orchestrator.sh` の `DEBOUNCE_TRANSIENT_SEC` は 120s（Sonnet 4.6 max effort thinking time 対応）。thinking indicator 検出時は `.debounce_ts` をリセットして Worker kill を防止
 - **A3**: pipe-pane log mtime（active / stale）
 - **A4**: `pane_dead`（tmux 窓健全性）

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -41,11 +41,20 @@ _check_idle_completed() {
     echo "$pane_content" | grep -qE "$IDLE_COMPLETED_PHRASE_REGEX" || return 1
 
     # C3: LLM indicator 不在 (Thinking/Brewing 等の現在進行形)
-    # SSOT: cld-observe-any の LLM_INDICATORS 配列と同期を保つこと (pitfalls §4.10 A2)
+    # SSOT: lib/llm-indicators.sh を参照 (#1374)
     # 過去形 + "for N" は IDLE 扱い（Sautéed for / Worked for 等）— v18 past tense filter 準拠
-    local llm_indicators='Thinking|Brewing|Brewed|Concocting|Ebbing|Proofing|Frosting|Reasoning|Computing|Planning|Composing|Processing|Burrowing|Cerebrating|Spinning|Beboppin|Thundering|Baked|Cooked|Crunched|Churned|Skedaddling|Orchestrating|Running .* agents|[0-9]+ tool uses|thinking with max effort'
-    if echo "$pane_content" | tail -15 | grep -qE "($llm_indicators)"; then
-        return 1
+    local _lib_dir
+    _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    local _llm_lib="${_lib_dir}/../../../../session/scripts/lib/llm-indicators.sh"
+    if [[ -f "$_llm_lib" ]]; then
+        source "$_llm_lib"
+    fi
+    if [[ ${#LLM_INDICATORS[@]} -gt 0 ]]; then
+        local _alternation
+        _alternation="$(IFS='|'; echo "${LLM_INDICATORS[*]}")"
+        if echo "$pane_content" | tail -15 | grep -qE "($_alternation)"; then
+            return 1
+        fi
     fi
 
     # C4: first_seen_ts が設定済み（0 = 未設定 = 初回検出サイクル; Unix timestamp > 0 が必要）

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -45,7 +45,7 @@ _check_idle_completed() {
     # 過去形 + "for N" は IDLE 扱い（Sautéed for / Worked for 等）— v18 past tense filter 準拠
     local _lib_dir
     _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    local _llm_lib="${_lib_dir}/../../../../session/scripts/lib/llm-indicators.sh"
+    local _llm_lib="${_lib_dir}/../../../../../session/scripts/lib/llm-indicators.sh"
     if [[ -f "$_llm_lib" ]]; then
         source "$_llm_lib"
     fi

--- a/plugins/twl/tests/bats/ac-test-mapping-1374.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1374.yaml
@@ -1,0 +1,188 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/session/scripts/lib/llm-indicators.sh を新設し、LLM_INDICATORS を bash 配列として export する（SSOT）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac1(#1374)/1: plugins/session/scripts/lib/llm-indicators.sh が存在すること"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 1
+    ac_text: "plugins/session/scripts/lib/llm-indicators.sh を新設し、LLM_INDICATORS を bash 配列として export する（SSOT）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac1(#1374)/2: llm-indicators.sh が LLM_INDICATORS を bash 配列として定義する"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 1
+    ac_text: "plugins/session/scripts/lib/llm-indicators.sh を新設し、LLM_INDICATORS を bash 配列として export する（SSOT）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac1(#1374)/3: llm-indicators.sh の LLM_INDICATORS が export されている"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 1
+    ac_text: "plugins/session/scripts/lib/llm-indicators.sh を新設し、LLM_INDICATORS を bash 配列として export する（SSOT）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac1(#1374)/4: llm-indicators.sh に source guard または function-only load guard があること"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 2
+    ac_text: "plugins/session/scripts/cld-observe-any L15-44 の inline 配列定義を削除し、新 lib を source で参照する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac2(#1374)/1: cld-observe-any の inline LLM_INDICATORS 定義が削除されていること"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: 2
+    ac_text: "plugins/session/scripts/cld-observe-any L15-44 の inline 配列定義を削除し、新 lib を source で参照する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac2(#1374)/2: cld-observe-any が llm-indicators.sh を source する行を持つこと"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: 2
+    ac_text: "plugins/session/scripts/cld-observe-any L15-44 の inline 配列定義を削除し、新 lib を source で参照する"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC7(#1374): cld-observe-any の inline LLM_INDICATORS が削除され lib source に切り替わる"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 3
+    ac_text: "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh L46 の local llm_indicators=... alternation 文字列を新 lib 由来の配列から動的生成する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac3(#1374)/1: observer-idle-check.sh の local llm_indicators=... ハードコードが削除されていること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 3
+    ac_text: "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh L46 の local llm_indicators=... alternation 文字列を新 lib 由来の配列から動的生成する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac3(#1374)/2: observer-idle-check.sh が llm-indicators.sh を参照する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 3
+    ac_text: "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh L46 の local llm_indicators=... alternation 文字列を新 lib 由来の配列から動的生成する"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac8(#1374)/1: observer-idle-check.sh が llm-indicators.sh を source または参照していること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 4
+    ac_text: "plugins/twl/scripts/issue-lifecycle-orchestrator.sh L62-79 の awk 抽出を新 lib source 方式に切り替える（cld-observe-any から inline 配列削除後、awk 抽出は空配列を返すため必須）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac4(#1374)/1: issue-lifecycle-orchestrator.sh の awk LLM_INDICATORS 抽出が削除されていること"
+    impl_files:
+      - "plugins/twl/scripts/issue-lifecycle-orchestrator.sh"
+
+  - ac_index: 4
+    ac_text: "plugins/twl/scripts/issue-lifecycle-orchestrator.sh L62-79 の awk 抽出を新 lib source 方式に切り替える（cld-observe-any から inline 配列削除後、awk 抽出は空配列を返すため必須）"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac4(#1374)/2: issue-lifecycle-orchestrator.sh が llm-indicators.sh を source する"
+    impl_files:
+      - "plugins/twl/scripts/issue-lifecycle-orchestrator.sh"
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 5
+    ac_text: "EN 13 件を SSOT 配列に追加: Philosophising, Drizzling, Fluttering, Spelunking, Determining, Infusing, Prestidigitating, Cogitated, Frolicking, Marinating, Metamorphosing, Shimmying, Transfiguring"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac5(#1374)/2: LLM_INDICATORS に AC5 EN 13 件が全て含まれること"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 5
+    ac_text: "EN 13 件を SSOT 配列に追加: Philosophising, Drizzling, Fluttering, Spelunking, Determining, Infusing, Prestidigitating, Cogitated, Frolicking, Marinating, Metamorphosing, Shimmying, Transfiguring"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC7(#1374): LLM_INDICATORS が AC5 EN 13 件（Philosophising 等）を含む"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 6
+    ac_text: "JP 6 件を SSOT 配列に追加: 生成中, 構築中, 処理中, 作成中, 分析中, 検証中"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac6(#1374)/1: LLM_INDICATORS に JP 6 件（生成中 等）が全て含まれること"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 6
+    ac_text: "JP 6 件を SSOT 配列に追加: 生成中, 構築中, 処理中, 作成中, 分析中, 検証中"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC7(#1374): LLM_INDICATORS が AC6 JP 6 件（生成中 等）を含む"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 7
+    ac_text: "tests/cld-observe-any.bats で「新 lib を source した状態で LLM_INDICATORS が EN/JP 両方を含む」ことを assert する bats を追加"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC7(#1374): plugins/session/scripts/lib/llm-indicators.sh が存在すること"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 7
+    ac_text: "tests/cld-observe-any.bats で「新 lib を source した状態で LLM_INDICATORS が EN/JP 両方を含む」ことを assert する bats を追加"
+    test_file: "plugins/session/tests/cld-observe-any.bats"
+    test_name: "AC7(#1374): source 後 LLM_INDICATORS bash 配列が export される"
+    impl_files:
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 8
+    ac_text: "tests/bats/observer-idle-check.bats の SSOT 参照を新 lib に変更し、JP indicator が C3 で正しく detect されることを bats fixture で検証する"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac8(#1374)/2: observer-idle-check.sh のコメントが 'SSOT: lib/llm-indicators.sh' に更新されている"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 8
+    ac_text: "tests/bats/observer-idle-check.bats の SSOT 参照を新 lib に変更し、JP indicator が C3 で正しく detect されることを bats fixture で検証する"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac8(#1374)/3: JP indicator '生成中' が C3 で検出され idle 判定されない"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 8
+    ac_text: "tests/bats/observer-idle-check.bats の SSOT 参照を新 lib に変更し、JP indicator が C3 で正しく detect されることを bats fixture で検証する"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac8(#1374)/4: JP indicator '構築中' が C3 で検出され idle 判定されない"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+      - "plugins/session/scripts/lib/llm-indicators.sh"
+
+  - ac_index: 9
+    ac_text: "observer-idle-check.sh のコメント「SSOT: cld-observe-any の LLM_INDICATORS 配列と同期を保つこと」を「SSOT: lib/llm-indicators.sh を参照」に更新する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac9(#1374)/1: observer-idle-check.sh の古い SSOT コメントが更新されていること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 9
+    ac_text: "observer-idle-check.sh のコメント「SSOT: cld-observe-any の LLM_INDICATORS 配列と同期を保つこと」を「SSOT: lib/llm-indicators.sh を参照」に更新する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac9(#1374)/2: observer-idle-check.sh に「SSOT: lib/llm-indicators.sh を参照」コメントがあること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 10
+    ac_text: "monitor-channel-catalog.md または pitfalls §4.10 に SSOT lib の場所と参照規約を追記する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac10(#1374)/1: monitor-channel-catalog.md に llm-indicators.sh への言及があること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md"
+
+  - ac_index: 10
+    ac_text: "monitor-channel-catalog.md または pitfalls §4.10 に SSOT lib の場所と参照規約を追記する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac10(#1374)/2: pitfalls-catalog.md §4.10 に llm-indicators.sh への言及があること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"
+
+  - ac_index: 10
+    ac_text: "monitor-channel-catalog.md または pitfalls §4.10 に SSOT lib の場所と参照規約を追記する"
+    test_file: "plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats"
+    test_name: "ac10(#1374)/3: SSOT lib の参照規約（source 方法）が記載されていること"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md"
+      - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"

--- a/plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats
+++ b/plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats
@@ -1,0 +1,509 @@
+#!/usr/bin/env bats
+# issue-1374-llm-indicators-ssot.bats
+#
+# RED-phase tests for Issue #1374:
+#   tech-debt: LLM indicator SSOT lib 新設（cld-observe-any から分離）
+#
+# AC coverage:
+#   AC1  - plugins/session/scripts/lib/llm-indicators.sh を新設し LLM_INDICATORS を bash 配列として export（SSOT）
+#   AC2  - cld-observe-any L15-44 の inline 配列定義を削除し新 lib を source で参照する
+#   AC3  - observer-idle-check.sh L46 の local llm_indicators=... を新 lib 由来に変更
+#   AC4  - issue-lifecycle-orchestrator.sh L62-79 の awk 抽出を新 lib source 方式に切り替え
+#   AC5  - EN 13 件を SSOT 配列に追加（Philosophising, Drizzling, Fluttering, Spelunking,
+#           Determining, Infusing, Prestidigitating, Cogitated, Frolicking, Marinating,
+#           Metamorphosing, Shimmying, Transfiguring）
+#   AC6  - JP 6 件を SSOT 配列に追加（生成中, 構築中, 処理中, 作成中, 分析中, 検証中）
+#   AC9  - observer-idle-check.sh のコメントを「SSOT: lib/llm-indicators.sh を参照」に更新
+#   AC10 - monitor-channel-catalog.md または pitfalls §4.10 に SSOT lib の場所と参照規約を追記
+#
+# 全テストは実装前（RED）状態で fail する。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  LLM_INDICATORS_LIB="${REPO_ROOT}/../session/scripts/lib/llm-indicators.sh"
+  CLD_OBSERVE_ANY="${REPO_ROOT}/../session/scripts/cld-observe-any"
+  OBSERVER_IDLE_CHECK="${REPO_ROOT}/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  ORCHESTRATOR="${REPO_ROOT}/scripts/issue-lifecycle-orchestrator.sh"
+  MONITOR_CATALOG="${REPO_ROOT}/skills/su-observer/refs/monitor-channel-catalog.md"
+  PITFALLS_CATALOG="${REPO_ROOT}/skills/su-observer/refs/pitfalls-catalog.md"
+
+  export LLM_INDICATORS_LIB CLD_OBSERVE_ANY OBSERVER_IDLE_CHECK ORCHESTRATOR
+  export MONITOR_CATALOG PITFALLS_CATALOG
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC1: plugins/session/scripts/lib/llm-indicators.sh を新設
+#      LLM_INDICATORS を bash 配列として export する（SSOT）
+# ===========================================================================
+
+@test "ac1(#1374)/1: plugins/session/scripts/lib/llm-indicators.sh が存在すること (RED)" {
+  # AC: plugins/session/scripts/lib/llm-indicators.sh を新設する
+  # RED: ファイルが未存在のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+}
+
+@test "ac1(#1374)/2: llm-indicators.sh が LLM_INDICATORS を bash 配列として定義する (RED)" {
+  # AC: LLM_INDICATORS を bash 配列として export する（SSOT）
+  # RED: ファイルが未存在のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    # LLM_INDICATORS が配列として定義されており要素が存在する
+    [[ \"\${#LLM_INDICATORS[@]}\" -gt 0 ]]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1374)/3: llm-indicators.sh の LLM_INDICATORS が export されている (RED)" {
+  # AC: export されていること（source した子プロセスから参照可能）
+  # RED: ファイルが未存在または export 未実施のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    # export -p で LLM_INDICATORS が確認できること
+    # bash では配列の export は declare -a + export で実現
+    export -p | grep -q 'LLM_INDICATORS'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1374)/4: llm-indicators.sh に source guard または function-only load guard があること (RED)" {
+  # AC: source guard が存在し、直接実行時に main 到達前に exit しない安全性を保証する
+  # RED: ファイルが未存在のため fail
+  # NOTE: bash の lib ファイルなので BASH_SOURCE guard または --source-only パターンを確認
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    # 直接実行しても exit 1 等で落ちないこと（lib は source 専用）
+    # source guard: BASH_SOURCE[0] != \$0 の場合のみ実行等
+    # または: スクリプト本体が関数定義のみで main がない構造
+    grep -qE 'BASH_SOURCE|source.only|_DAEMON_LOAD_ONLY|source guard' '${LLM_INDICATORS_LIB}' || \
+    ! grep -qE '^[^#]*exit [0-9]' '${LLM_INDICATORS_LIB}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: cld-observe-any L15-44 の inline 配列定義を削除し新 lib を source で参照
+# ===========================================================================
+
+@test "ac2(#1374)/1: cld-observe-any の inline LLM_INDICATORS 定義が削除されていること (RED)" {
+  # AC: cld-observe-any L15-44 の inline 配列定義を削除する
+  # RED: inline 定義がまだ存在するため fail
+  run bash -c "
+    if grep -q '^LLM_INDICATORS=(' '${CLD_OBSERVE_ANY}'; then
+        echo 'FAIL: inline LLM_INDICATORS=( が cld-observe-any に残存（lib 分離未実装）'
+        exit 1
+    fi
+    echo 'PASS: inline 定義なし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2(#1374)/2: cld-observe-any が llm-indicators.sh を source する行を持つこと (RED)" {
+  # AC: 新 lib を source で参照する
+  # RED: source 行が未追加のため fail
+  run grep -qE 'source.*llm-indicators\.sh|\. .*llm-indicators\.sh' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2(#1374)/3: cld-observe-any が llm-indicators.sh を source 後 LLM_INDICATORS を参照できる (RED)" {
+  # AC: source 後に LLM_INDICATORS が利用可能であること
+  # RED: lib 未存在 + source 行未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    # cld-observe-any から source 行を抽出して実行し、LLM_INDICATORS が利用可能か確認
+    # _TEST_MODE=1 で main loop 手前まで実行
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR=\"\$(dirname '${CLD_OBSERVE_ANY}')\" \
+        bash '${CLD_OBSERVE_ANY}' --source-only 2>/dev/null || true
+    source '${LLM_INDICATORS_LIB}'
+    [[ \"\${#LLM_INDICATORS[@]}\" -gt 0 ]]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: observer-idle-check.sh L46 の local llm_indicators=... を新 lib 由来に変更
+# ===========================================================================
+
+@test "ac3(#1374)/1: observer-idle-check.sh の local llm_indicators=... ハードコードが削除されていること (RED)" {
+  # AC: L46 の local llm_indicators=... alternation 文字列を削除し新 lib 由来に変更する
+  # RED: ハードコード定義がまだ存在するため fail
+  run bash -c "
+    if grep -q '^    local llm_indicators=' '${OBSERVER_IDLE_CHECK}'; then
+        echo 'FAIL: local llm_indicators= ハードコードが残存（lib 分離未実装）'
+        exit 1
+    fi
+    echo 'PASS: ハードコードなし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3(#1374)/2: observer-idle-check.sh が llm-indicators.sh を参照する (RED)" {
+  # AC: 新 lib 由来の配列から動的生成、または lib に alternation 文字列関数を提供する
+  # RED: llm-indicators.sh の明示的 source/参照が未追加のため fail
+  # NOTE: 単に LLM_INDICATORS を含むだけでは不十分（ハードコード残存の可能性）
+  run grep -qE 'llm-indicators\.sh' "${OBSERVER_IDLE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3(#1374)/3: observer-idle-check.sh の C3 が llm-indicators.sh 由来の LLM_INDICATORS を使用する (RED)" {
+  # AC: C3 判定が lib 由来の配列に基づく
+  # RED: lib 由来ではないため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    source '${OBSERVER_IDLE_CHECK}'
+    # lib 由来の LLM_INDICATORS が source された状態で _check_idle_completed が動作すること
+    # Brewing（既存 EN indicator）がある場合に idle 判定されないこと
+    pane_content='Brewing for 5m 30s
+nothing pending
+処理中です'
+    first_seen_ts=100
+    now_ts=200
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  # Brewing（LLM indicator）があるため idle 判定されない（non-0）
+  [ "${status}" -ne 0 ]
+}
+
+# ===========================================================================
+# AC4: issue-lifecycle-orchestrator.sh L62-79 の awk 抽出を新 lib source 方式に切り替え
+# ===========================================================================
+
+@test "ac4(#1374)/1: issue-lifecycle-orchestrator.sh の awk LLM_INDICATORS 抽出が削除されていること (RED)" {
+  # AC: L62-79 の awk 抽出を新 lib source 方式に切り替える
+  # RED: awk 抽出コードがまだ存在するため fail
+  run bash -c "
+    if grep -qE \"awk '/\^LLM_INDICATORS=\" '${ORCHESTRATOR}'; then
+        echo 'FAIL: awk LLM_INDICATORS 抽出コードが orchestrator に残存'
+        exit 1
+    fi
+    echo 'PASS: awk 抽出なし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4(#1374)/2: issue-lifecycle-orchestrator.sh が llm-indicators.sh を source する (RED)" {
+  # AC: awk 抽出の代わりに llm-indicators.sh を source する
+  # RED: source 行が未追加のため fail
+  run grep -qE 'source.*llm-indicators\.sh|\. .*llm-indicators\.sh' "${ORCHESTRATOR}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4(#1374)/3: orchestrator が lib source 後 LLM_INDICATORS を detect_thinking で利用できる (RED)" {
+  # AC: lib source 方式切り替え後も detect_thinking() が動作すること
+  # RED: lib 未存在 + source 行未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    # orchestrator から detect_thinking 関数定義を抽出して動作確認
+    # LLM_INDICATORS が空でないこと
+    [[ \"\${#LLM_INDICATORS[@]}\" -gt 0 ]]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC5: EN 13 件を SSOT 配列に追加
+#      Philosophising, Drizzling, Fluttering, Spelunking, Determining,
+#      Infusing, Prestidigitating, Cogitated, Frolicking, Marinating,
+#      Metamorphosing, Shimmying, Transfiguring
+#      （既登録の Frosting / Saut.*ed / Crunched は除外済）
+# ===========================================================================
+
+@test "ac5(#1374)/1: LLM_INDICATORS に Philosophising が含まれること (RED)" {
+  # AC: EN 13 件の追加（Philosophising は最初の 1 件）
+  # RED: llm-indicators.sh 未存在 + indicator 未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    found=0
+    for ind in \"\${LLM_INDICATORS[@]}\"; do
+        [[ \"\$ind\" == *'Philosophising'* ]] && found=1 && break
+    done
+    [[ \$found -eq 1 ]]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5(#1374)/2: LLM_INDICATORS に AC5 EN 13 件が全て含まれること (RED)" {
+  # AC: EN 13 件全て SSOT 配列に追加する
+  # RED: llm-indicators.sh 未存在または indicator 未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    REQUIRED=(
+        Philosophising Drizzling Fluttering Spelunking Determining
+        Infusing Prestidigitating Cogitated Frolicking Marinating
+        Metamorphosing Shimmying Transfiguring
+    )
+    missing=()
+    for word in \"\${REQUIRED[@]}\"; do
+        found=0
+        for ind in \"\${LLM_INDICATORS[@]}\"; do
+            [[ \"\$ind\" == *\"\$word\"* ]] && found=1 && break
+        done
+        [[ \$found -eq 0 ]] && missing+=(\"\$word\")
+    done
+    if [[ \${#missing[@]} -gt 0 ]]; then
+        echo \"MISSING EN 13 件: \${missing[*]}\"
+        exit 1
+    fi
+    echo \"PASS: EN 13 件確認 (total=\${#LLM_INDICATORS[@]})\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5(#1374)/3: Frosting / Saut.*ed / Crunched は既登録のため AC5 追加分に除外されていること (regression guard)" {
+  # AC: 既登録の Frosting / Saut.*ed / Crunched は除外済（重複追加しない）
+  # このテストは現実装でも PASS する（regression guard）
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    # 既登録 indicator が引き続き配列に存在すること（除外 = 削除ではなく重複追加しない意）
+    found_frosting=0
+    for ind in \"\${LLM_INDICATORS[@]}\"; do
+        [[ \"\$ind\" == *'Frosting'* ]] && found_frosting=1 && break
+    done
+    [[ \$found_frosting -eq 1 ]]
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac5(#1374)/4: Philosophising indicator がある pane で STAGNATE emit されないこと (RED)" {
+  # AC: 新規追加 EN indicator が実際の thinking guard として機能すること
+  # RED: llm-indicators.sh 未存在 + cld-observe-any inline 定義未削除のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    TMPD=\"\$(mktemp -d)\"
+    win='ap-philosophising-win'
+
+    capture='Philosophising… (8s)
+Contemplating the solution...'
+    export capture
+
+    logfile=\"\${TMPD}/\${win}.log\"
+    touch -t \"\$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')\" \"\$logfile\" 2>/dev/null || touch \"\$logfile\"
+
+    tmux() {
+        case \"\$1\" in
+            list-windows) echo \"test-session:0 \$win\";;
+            display-message) echo \"0 claude\";;
+            capture-pane)
+                if [[ \"\${*}\" == *'-S -1'* ]]; then echo ''; else printf '%s\n' \"\$capture\"; fi;;
+            *) return 0;;
+        esac
+    }
+    export -f tmux
+
+    _TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR=\"\$(dirname '${CLD_OBSERVE_ANY}')\" \
+        bash '${CLD_OBSERVE_ANY}' --window \"\$win\" --once \
+        --log-dir \"\$TMPD\" \
+        --stagnate-sec 5 2>/dev/null
+    exit_code=\$?
+    rm -rf \"\$TMPD\"
+    exit \$exit_code
+  "
+  [ "${status}" -eq 0 ]
+  # Philosophising が LLM indicator として認識されれば STAGNATE は emit されない
+  ! echo "${output}" | grep -q "STAGNATE"
+}
+
+# ===========================================================================
+# AC6: JP 6 件を SSOT 配列に追加
+#      生成中, 構築中, 処理中, 作成中, 分析中, 検証中
+# ===========================================================================
+
+@test "ac6(#1374)/1: LLM_INDICATORS に JP 6 件（生成中 等）が全て含まれること (RED)" {
+  # AC: JP 6 件を SSOT 配列に追加する
+  # RED: llm-indicators.sh 未存在または JP indicator 未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    source '${LLM_INDICATORS_LIB}'
+    REQUIRED_JP=(生成中 構築中 処理中 作成中 分析中 検証中)
+    missing_jp=()
+    for word in \"\${REQUIRED_JP[@]}\"; do
+        found=0
+        for ind in \"\${LLM_INDICATORS[@]}\"; do
+            [[ \"\$ind\" == *\"\$word\"* ]] && found=1 && break
+        done
+        [[ \$found -eq 0 ]] && missing_jp+=(\"\$word\")
+    done
+    if [[ \${#missing_jp[@]} -gt 0 ]]; then
+        echo \"MISSING JP indicators: \${missing_jp[*]}\"
+        exit 1
+    fi
+    echo 'PASS: JP 6 件確認'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6(#1374)/2: '処理中' indicator で STAGNATE が emit されないこと (RED)" {
+  # AC: JP indicator が実際の thinking guard として機能する
+  # RED: JP indicator 未追加のため cld-observe-any が 処理中 を indicator と認識しない → STAGNATE emit
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    TMPD=\"\$(mktemp -d)\"
+    win='ap-shori-win'
+
+    capture='処理中... (12s)
+ファイルを解析しています'
+    export capture
+
+    logfile=\"\${TMPD}/\${win}.log\"
+    touch -t \"\$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')\" \"\$logfile\" 2>/dev/null || touch \"\$logfile\"
+
+    tmux() {
+        case \"\$1\" in
+            list-windows) echo \"test-session:0 \$win\";;
+            display-message) echo \"0 claude\";;
+            capture-pane)
+                if [[ \"\${*}\" == *'-S -1'* ]]; then echo ''; else printf '%s\n' \"\$capture\"; fi;;
+            *) return 0;;
+        esac
+    }
+    export -f tmux
+
+    output_text=\$(_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR=\"\$(dirname '${CLD_OBSERVE_ANY}')\" \
+        bash '${CLD_OBSERVE_ANY}' --window \"\$win\" --once \
+        --log-dir \"\$TMPD\" \
+        --stagnate-sec 5 2>/dev/null)
+    exit_code=\$?
+    rm -rf \"\$TMPD\"
+
+    if echo \"\$output_text\" | grep -q 'STAGNATE'; then
+        echo \"FAIL: JP indicator '処理中' が thinking guard として機能していない（STAGNATE emit）\"
+        exit 1
+    fi
+    echo 'PASS: STAGNATE emit なし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac6(#1374)/3: '生成中' indicator で STAGNATE が emit されないこと (RED)" {
+  # AC: JP indicator '生成中' も thinking guard として機能する
+  # RED: JP indicator 未追加のため fail
+  [ -f "${LLM_INDICATORS_LIB}" ]
+  run bash -c "
+    TMPD=\"\$(mktemp -d)\"
+    win='ap-seisei-win'
+
+    capture='生成中... (7s)
+コードを生成しています'
+    export capture
+
+    logfile=\"\${TMPD}/\${win}.log\"
+    touch -t \"\$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202001010000.00')\" \"\$logfile\" 2>/dev/null || touch \"\$logfile\"
+
+    tmux() {
+        case \"\$1\" in
+            list-windows) echo \"test-session:0 \$win\";;
+            display-message) echo \"0 claude\";;
+            capture-pane)
+                if [[ \"\${*}\" == *'-S -1'* ]]; then echo ''; else printf '%s\n' \"\$capture\"; fi;;
+            *) return 0;;
+        esac
+    }
+    export -f tmux
+
+    output_text=\$(_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR=\"\$(dirname '${CLD_OBSERVE_ANY}')\" \
+        bash '${CLD_OBSERVE_ANY}' --window \"\$win\" --once \
+        --log-dir \"\$TMPD\" \
+        --stagnate-sec 5 2>/dev/null)
+    rm -rf \"\$TMPD\"
+
+    if echo \"\$output_text\" | grep -q 'STAGNATE'; then
+        echo \"FAIL: JP indicator '生成中' が thinking guard として機能していない\"
+        exit 1
+    fi
+    echo 'PASS: STAGNATE emit なし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC9: observer-idle-check.sh のコメントを「SSOT: lib/llm-indicators.sh を参照」に更新
+# ===========================================================================
+
+@test "ac9(#1374)/1: observer-idle-check.sh の古い SSOT コメントが更新されていること (RED)" {
+  # AC: コメント「SSOT: cld-observe-any の LLM_INDICATORS 配列と同期を保つこと」を
+  #     「SSOT: lib/llm-indicators.sh を参照」に更新する
+  # RED: 古いコメントが残存しているため fail
+  run bash -c "
+    if grep -q 'cld-observe-any の LLM_INDICATORS 配列と同期を保つこと' '${OBSERVER_IDLE_CHECK}'; then
+        echo 'FAIL: 古いコメント「cld-observe-any の LLM_INDICATORS 配列と同期を保つこと」が残存'
+        exit 1
+    fi
+    echo 'PASS: 古いコメントなし'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac9(#1374)/2: observer-idle-check.sh に「SSOT: lib/llm-indicators.sh を参照」コメントがあること (RED)" {
+  # AC: 新しいコメントが追加されていること
+  # RED: 新コメントが未追加のため fail
+  run grep -qE 'SSOT.*llm-indicators\.sh|llm-indicators\.sh.*SSOT' "${OBSERVER_IDLE_CHECK}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC10: monitor-channel-catalog.md または pitfalls §4.10 に SSOT lib の場所と参照規約を追記
+# ===========================================================================
+
+@test "ac10(#1374)/1: monitor-channel-catalog.md に llm-indicators.sh への言及があること (RED)" {
+  # AC: monitor-channel-catalog.md に SSOT lib の場所と参照規約を追記する
+  # RED: 言及が未追加のため fail
+  run grep -qE 'llm-indicators\.sh' "${MONITOR_CATALOG}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10(#1374)/2: pitfalls-catalog.md §4.10 に llm-indicators.sh への言及があること (RED)" {
+  # AC: pitfalls §4.10 に SSOT lib の場所と参照規約を追記する
+  # RED: 言及が未追加のため fail
+  run bash -c "
+    # §4.10 セクション内に llm-indicators.sh の言及があること
+    section_start=\$(grep -n '4\.10' '${PITFALLS_CATALOG}' | head -1 | cut -d: -f1)
+    [[ -n \"\$section_start\" ]] || { echo '§4.10 not found'; exit 1; }
+    tail -n \"+\${section_start}\" '${PITFALLS_CATALOG}' | head -100 | grep -qE 'llm-indicators\.sh'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10(#1374)/3: SSOT lib の参照規約（source 方法）が記載されていること (RED)" {
+  # AC: lib の場所（plugins/session/scripts/lib/llm-indicators.sh）と参照方法が記載される
+  # RED: 参照規約が未記載のため fail
+  run bash -c "
+    # monitor-channel-catalog.md または pitfalls-catalog.md に参照規約がある
+    grep -rqE 'plugins/session/scripts/lib/llm-indicators\.sh|source.*llm-indicators' \
+        '${MONITOR_CATALOG}' '${PITFALLS_CATALOG}' 2>/dev/null
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10(#1374)/4: SSOT lib 参照規約が 3 ファイル（cld-observe-any, orchestrator, observer-idle-check）への適用方法を含むこと (RED)" {
+  # AC: どのファイルがどのように llm-indicators.sh を参照すべきかの規約
+  # RED: 規約が未記載のため fail
+  run bash -c "
+    # llm-indicators.sh が言及されており、かつ参照元ファイルへの適用方法の記述がある
+    # 「どのファイルが source すべきか」という規約の存在を確認する
+    grep -rqE 'llm-indicators\.sh' \
+        '${MONITOR_CATALOG}' '${PITFALLS_CATALOG}' 2>/dev/null && \
+    grep -rqE '(cld-observe-any|issue-lifecycle-orchestrator|observer-idle-check).*llm-indicators|llm-indicators.*(cld-observe-any|issue-lifecycle-orchestrator|observer-idle-check)' \
+        '${MONITOR_CATALOG}' '${PITFALLS_CATALOG}' 2>/dev/null
+  "
+  [ "${status}" -eq 0 ]
+}

--- a/plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats
+++ b/plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats
@@ -85,13 +85,7 @@ teardown() {
   # RED: ファイルが未存在のため fail
   # NOTE: bash の lib ファイルなので BASH_SOURCE guard または --source-only パターンを確認
   [ -f "${LLM_INDICATORS_LIB}" ]
-  run bash -c "
-    # 直接実行しても exit 1 等で落ちないこと（lib は source 専用）
-    # source guard: BASH_SOURCE[0] != \$0 の場合のみ実行等
-    # または: スクリプト本体が関数定義のみで main がない構造
-    grep -qE 'BASH_SOURCE|source.only|_DAEMON_LOAD_ONLY|source guard' '${LLM_INDICATORS_LIB}' || \
-    ! grep -qE '^[^#]*exit [0-9]' '${LLM_INDICATORS_LIB}'
-  "
+  run grep -qE 'BASH_SOURCE|source.only|_DAEMON_LOAD_ONLY|_LLM_INDICATORS_LOADED' "${LLM_INDICATORS_LIB}"
   [ "${status}" -eq 0 ]
 }
 

--- a/plugins/twl/tests/bats/observer-idle-check.bats
+++ b/plugins/twl/tests/bats/observer-idle-check.bats
@@ -522,7 +522,7 @@ nothing pending but still thinking'
   # AC: JP 6 件を SSOT 配列に追加した後、observer-idle-check.sh の C3 が JP indicator も検出する
   # RED: llm-indicators.sh 未存在 + observer-idle-check.sh が JP indicator を未検出のため fail
   [ -f "${OBSERVER_LIB}" ]
-  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  LLM_LIB="${REPO_ROOT}/../session/scripts/lib/llm-indicators.sh"
   [ -f "${LLM_LIB}" ]
   run bash -c "
     source '${OBSERVER_LIB}'
@@ -546,7 +546,7 @@ nothing pending
   # AC: JP indicator「構築中」も C3 guard として機能する
   # RED: JP indicator が observer-idle-check.sh の C3 に組み込まれていないため fail
   [ -f "${OBSERVER_LIB}" ]
-  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  LLM_LIB="${REPO_ROOT}/../session/scripts/lib/llm-indicators.sh"
   [ -f "${LLM_LIB}" ]
   run bash -c "
     source '${OBSERVER_LIB}'
@@ -568,7 +568,7 @@ nothing pending
   # AC: JP indicator が存在しない場合、既存の completion phrase で idle 確定すること
   # RED: lib 未存在のため fail（実装後は regression guard として GREEN を維持）
   [ -f "${OBSERVER_LIB}" ]
-  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  LLM_LIB="${REPO_ROOT}/../session/scripts/lib/llm-indicators.sh"
   [ -f "${LLM_LIB}" ]
   run bash -c "
     source '${OBSERVER_LIB}'

--- a/plugins/twl/tests/bats/observer-idle-check.bats
+++ b/plugins/twl/tests/bats/observer-idle-check.bats
@@ -470,3 +470,116 @@ nothing pending but still thinking'
   # Thinking... が存在する場合は idle と判定しない（non-0）
   [ "${status}" -ne 0 ]
 }
+
+# ===========================================================================
+# Issue #1374: LLM indicator SSOT lib 新設（AC8）
+# observer-idle-check.sh の SSOT 参照を llm-indicators.sh に変更し、
+# JP indicator が C3 で正しく detect されることを fixture で検証する
+# RED: llm-indicators.sh 未存在 + observer-idle-check.sh 未更新のため fail
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# AC8/1(#1374): observer-idle-check.sh が llm-indicators.sh を参照していること
+# ---------------------------------------------------------------------------
+@test "ac8(#1374)/1: observer-idle-check.sh が llm-indicators.sh を source または参照していること (RED)" {
+  # AC: observer-idle-check.sh L46 のハードコード alternation を新 lib 由来に変更する
+  # RED: まだ lib 参照が追加されていないため fail
+  run grep -E 'llm-indicators\.sh|LLM_INDICATORS' "${OBSERVER_LIB}"
+  [ "${status}" -eq 0 ]
+  # 参照が llm-indicators.sh（SSOT lib）を向いていること
+  run grep -qE 'llm-indicators\.sh' "${OBSERVER_LIB}"
+  [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC8/2(#1374): observer-idle-check.sh のコメントが更新されていること
+# "SSOT: lib/llm-indicators.sh を参照" の記述があること
+# ---------------------------------------------------------------------------
+@test "ac8(#1374)/2: observer-idle-check.sh のコメントが 'SSOT: lib/llm-indicators.sh' に更新されている (RED)" {
+  # AC: コメント「SSOT: cld-observe-any の LLM_INDICATORS 配列と同期を保つこと」を
+  #     「SSOT: lib/llm-indicators.sh を参照」に更新する
+  # RED: 古いコメントがまだ残っているため fail（または新コメントが未追加）
+  [ -f "${OBSERVER_LIB}" ]
+  # 古いコメントが残っていれば RED（未実装）
+  run bash -c "
+    if grep -q 'cld-observe-any の LLM_INDICATORS 配列と同期を保つこと' '${OBSERVER_LIB}'; then
+        echo 'FAIL: 古いコメントが残存している（更新未実施）'
+        exit 1
+    fi
+    if ! grep -qE 'llm-indicators\.sh' '${OBSERVER_LIB}'; then
+        echo 'FAIL: llm-indicators.sh への参照コメントが追加されていない'
+        exit 1
+    fi
+    echo 'PASS: コメント更新確認'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC8/3(#1374): JP indicator（生成中）がある場合、C3 で idle と判定されない
+# ---------------------------------------------------------------------------
+@test "ac8(#1374)/3: JP indicator '生成中' が C3 で検出され idle 判定されない (RED)" {
+  # AC: JP 6 件を SSOT 配列に追加した後、observer-idle-check.sh の C3 が JP indicator も検出する
+  # RED: llm-indicators.sh 未存在 + observer-idle-check.sh が JP indicator を未検出のため fail
+  [ -f "${OBSERVER_LIB}" ]
+  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  [ -f "${LLM_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    # JP indicator '生成中' が存在する pane content — C3 で idle 判定されないこと
+    pane_content='生成中... (5s)
+nothing pending
+ファイルを処理しています'
+    first_seen_ts=100
+    now_ts=200  # debounce 超過（elapsed=100s > 60s）
+    # _check_idle_completed が non-0 を返す（JP indicator により C3 fail）
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  # JP indicator があるため idle 判定されない（non-0）
+  [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC8/4(#1374): JP indicator（構築中）がある場合も C3 で検出される
+# ---------------------------------------------------------------------------
+@test "ac8(#1374)/4: JP indicator '構築中' が C3 で検出され idle 判定されない (RED)" {
+  # AC: JP indicator「構築中」も C3 guard として機能する
+  # RED: JP indicator が observer-idle-check.sh の C3 に組み込まれていないため fail
+  [ -f "${OBSERVER_LIB}" ]
+  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  [ -f "${LLM_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='構築中... (10s)
+nothing pending
+ビルドを実行しています'
+    first_seen_ts=100
+    now_ts=200
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  # JP indicator があるため idle 判定されない（non-0）
+  [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# AC8/5(#1374): JP indicator が不在で completion phrase あり → idle 確定
+# ---------------------------------------------------------------------------
+@test "ac8(#1374)/5: JP indicator 不在 + completion phrase あり → idle 確定（regression guard） (RED)" {
+  # AC: JP indicator が存在しない場合、既存の completion phrase で idle 確定すること
+  # RED: lib 未存在のため fail（実装後は regression guard として GREEN を維持）
+  [ -f "${OBSERVER_LIB}" ]
+  LLM_LIB="${REPO_ROOT}/plugins/session/scripts/lib/llm-indicators.sh"
+  [ -f "${LLM_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    # JP indicator なし、completion phrase あり
+    pane_content='nothing pending
+タスクが完了しました
+> '
+    first_seen_ts=100
+    now_ts=165  # elapsed=65s > 60s
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  # JP indicator なし + completion phrase あり → idle 確定（exit 0）
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Issue #1374: tech-debt — LLM indicator SSOT lib 新設

`plugins/session/scripts/lib/llm-indicators.sh` を新設し、複数ファイルに散在していた `LLM_INDICATORS` 配列の SSOT を一箇所に集約する。

## Changes（予定）

- `plugins/session/scripts/lib/llm-indicators.sh` 新設（SSOT）
- `plugins/session/scripts/cld-observe-any` inline 配列削除 → lib source
- `plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh` lib 参照に変更
- `plugins/twl/scripts/issue-lifecycle-orchestrator.sh` awk 抽出 → lib source
- EN 13 件 + JP 6 件の新規 indicator 追加
- docs: monitor-channel-catalog.md / pitfalls-catalog.md に参照規約追記

## Test Coverage

- `plugins/twl/tests/bats/issue-1374-llm-indicators-ssot.bats` — 26 RED tests
- `plugins/session/tests/cld-observe-any.bats` — AC7 tests 追記
- `plugins/twl/tests/bats/observer-idle-check.bats` — AC8 tests 追記

Closes #1374