### PR TITLE
refactor(observer): record-detection-gap.sh SUPERVISOR_DIR blocklist→allowlist regex (#1378)

### DIFF
--- a/plugins/twl/refs/baseline-bash.md
+++ b/plugins/twl/refs/baseline-bash.md
@@ -496,9 +496,8 @@ fi
 
 | ファイル | 箇所 | 内容 |
 |---|---|---|
-| `plugins/twl/skills/su-observer/scripts/record-detection-gap.sh` | L61-69 | `SUPERVISOR_DIR`: `*..* ` / `^/` / 禁止文字 reject の blocklist 3段階チェック（PR #1345 導入）|
 | `plugins/twl/scripts/worktree-delete.sh` | L25 | `branch`: `\.\.` / `^/` blocklist + `^[a-zA-Z0-9/_.-]+$` allowlist の混在 |
 | `plugins/twl/skills/su-observer/scripts/session-init.sh` | L11 | `SUPERVISOR_DIR`: allowlist `^[a-zA-Z0-9._/=-]+$` + 追加 `*..* ` blocklist の混在 |
 | `plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh` | L18 | `SUPERVISOR_DIR`: allowlist `^[a-zA-Z0-9./_-]+$` + `*..* ` blocklist の混在 |
 
-**対応方針**: `record-detection-gap.sh` の SUPERVISOR_DIR は純粋 blocklist のため優先度高。mixed 方式は allowlist で網羅できているため blocklist 部分を削除するだけで改善可能。
+**対応方針**: mixed 方式は allowlist で網羅できているため blocklist 部分を削除するだけで改善可能。後続 Issue で個別対応予定。

--- a/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
@@ -56,16 +56,12 @@ case "$SEVERITY" in
   *) echo "ERROR: --severity must be low|medium|high (got: $SEVERITY)" >&2; usage; exit 1 ;;
 esac
 
-# SUPERVISOR_DIR path safety: reject traversal, absolute paths, and forbidden characters
+# allowlist regex per baseline-bash §11
 _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
-if [[ "$_supervisor_dir" == *..* ]]; then
-  echo "ERROR: SUPERVISOR_DIR must not contain '..'" >&2; exit 1
-fi
-if [[ "$_supervisor_dir" =~ ^/ ]]; then
-  echo "ERROR: SUPERVISOR_DIR must not be an absolute path (got: ${_supervisor_dir})" >&2; exit 1
-fi
-if [[ "$_supervisor_dir" =~ [$\;\|\`\&\(\)\<\>] ]]; then
-  echo "ERROR: SUPERVISOR_DIR must only contain allowed characters (alphanumeric, dot, hyphen, underscore, slash)" >&2; exit 1
+if [[ ! "$_supervisor_dir" =~ ^[A-Za-z0-9._/-]+$ ]] || \
+   [[ "$_supervisor_dir" =~ ^/ ]] || \
+   [[ "$_supervisor_dir" == *..* ]]; then
+  echo "ERROR: invalid path: ${_supervisor_dir} (must match ^[A-Za-z0-9._/-]+$)" >&2; exit 1
 fi
 
 # Sanitize free-text fields: strip newlines and control characters to prevent log injection

--- a/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-detection-gap.sh
@@ -56,12 +56,12 @@ case "$SEVERITY" in
   *) echo "ERROR: --severity must be low|medium|high (got: $SEVERITY)" >&2; usage; exit 1 ;;
 esac
 
-# allowlist regex per baseline-bash §11
+# allowlist regex per baseline-bash §11 (+ guards: ^/ rejects absolute paths; *..* rejects traversal)
 _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
 if [[ ! "$_supervisor_dir" =~ ^[A-Za-z0-9._/-]+$ ]] || \
    [[ "$_supervisor_dir" =~ ^/ ]] || \
    [[ "$_supervisor_dir" == *..* ]]; then
-  echo "ERROR: invalid path: ${_supervisor_dir} (must match ^[A-Za-z0-9._/-]+$)" >&2; exit 1
+  echo "ERROR: invalid path: ${_supervisor_dir} (must be relative, no '..', must match ^[A-Za-z0-9._/-]+$)" >&2; exit 1
 fi
 
 # Sanitize free-text fields: strip newlines and control characters to prevent log injection

--- a/plugins/twl/tests/bats/ac-test-mapping-1378.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1378.yaml
@@ -1,0 +1,62 @@
+mappings:
+  - ac_index: 1
+    ac_text: "record-detection-gap.sh L61-69 の blocklist 3 チェックを allowlist regex に置換する。エラーメッセージは baseline-bash.md §11 のパターン例（Error: invalid path: ${_supervisor_dir} 形式または must match ^[A-Za-z0-9._/-]+$ 形式）に準拠する"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac1: script contains allowlist regex pattern ^[A-Za-z0-9._/-]"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 2
+    ac_text: "allowlist regex 適用後も以下のセキュリティ要件が維持されることを bats テストで検証"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "(umbrella AC — covered by ac_index 3-7)"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+      - "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+  - ac_index: 3
+    ac_text: "正常パス（.supervisor、.supervisor-test、nested/deep/.supervisor）が受理される"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac3: .supervisor (default) is accepted with exit 0"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 4
+    ac_text: "絶対パス（/etc、/tmp/foo）が拒否される（exit 1 + ERROR メッセージ）"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac4: /etc is rejected with exit 1"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 5
+    ac_text: "path traversal を含むパス（../foo、foo/../bar）が拒否される（exit 1）"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac5: ../foo is rejected with exit 1"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 6
+    ac_text: "shell 特殊文字（$foo、a;b、a|b、a`b、a&b、a(b、a<b、a>b）を含むパスが拒否される"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac6: $foo is rejected with exit 1"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 7
+    ac_text: "空文字 / 未定義 SUPERVISOR_DIR で .supervisor フォールバックが受理される"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac7: unset SUPERVISOR_DIR falls back to .supervisor and is accepted"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 8
+    ac_text: "既存テスト（record-detection-gap.bats、issue-1250-record-detection-gap-flock.bats、record-detection-gap-deps-registered.bats）が引き続き PASS する"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac8: regression test file record-detection-gap.bats exists"
+    impl_files: []
+    # impl_files: 回帰確認のため impl_files なし（既存テストの PASS を手動確認）
+  - ac_index: 9
+    ac_text: "修正コードに '# allowlist regex per baseline-bash §11' のコメントを残し、規約準拠の根拠を明示する"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac9: script contains comment '# allowlist regex per baseline-bash §11'"
+    impl_files:
+      - "skills/su-observer/scripts/record-detection-gap.sh"
+  - ac_index: 10
+    ac_text: "baseline-bash.md §11 の「blocklist 方式の棚卸し」表から record-detection-gap.sh の行を削除する PR を本 Issue の修正に含める"
+    test_file: "tests/bats/issue-1378-record-detection-gap-allowlist.bats"
+    test_name: "ac10: baseline-bash.md has a section 11 for allowlist approach"
+    impl_files:
+      - "refs/baseline-bash.md"

--- a/plugins/twl/tests/bats/issue-1378-record-detection-gap-allowlist.bats
+++ b/plugins/twl/tests/bats/issue-1378-record-detection-gap-allowlist.bats
@@ -1,0 +1,256 @@
+#!/usr/bin/env bats
+# issue-1378-record-detection-gap-allowlist.bats
+#
+# RED-phase tests for Issue #1378:
+#   tech-debt(observer): record-detection-gap.sh L61-69 のパス検証を blocklist から allowlist regex へ
+#
+# AC coverage:
+#   AC1:  静的確認 — allowlist regex `^[A-Za-z0-9._/-]+$` が script に存在する
+#   AC3:  正常パス受理 (.supervisor, .supervisor-test, nested/deep/.supervisor)
+#   AC4:  絶対パス拒否 (/etc, /tmp/foo) + エラーメッセージ形式確認
+#   AC5:  path traversal 拒否 (../foo, foo/../bar) + エラーメッセージ形式確認
+#   AC6:  shell 特殊文字拒否 ($foo, a;b, a|b, a`b, a&b, a(b, a<b, a>b)
+#   AC7:  空文字/未定義 SUPERVISOR_DIR → .supervisor フォールバック受理
+#   AC8:  既存テストファイルが存在する（回帰参照）
+#   AC9:  `# allowlist regex per baseline-bash §11` コメントが script に存在する
+#   AC10: baseline-bash.md §11 セクションが存在する
+#
+# RED となるテスト: AC1 (allowlist pattern 不在), AC4b/AC5b/AC6b (error message format),
+#                   AC9 (comment 不在), AC10 (§11 不在)
+# PASS 可能性あり: AC3, AC7, AC8 (現行実装でも動作) — RED guard は bats では skip される
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  # tests/bats/ -> tests/ -> plugins/twl/ (REPO_ROOT)
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/record-detection-gap.sh"
+  BASELINE_BASH="${REPO_ROOT}/refs/baseline-bash.md"
+  export SCRIPT BASELINE_BASH
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+  cd "${TMPDIR_TEST}"
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC1: allowlist regex が script に存在する（静的確認）
+# ===========================================================================
+
+@test "ac1: script contains allowlist regex pattern ^[A-Za-z0-9._/-]" {
+  # AC: blocklist 3 チェックが allowlist regex に置換されている（静的確認）
+  # RED: 現在は blocklist 実装のため allowlist pattern が存在せず fail
+  run grep -qE '\^\[A-Za-z0-9' "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1: script contains allowlist anchored regex ending with +\$ marker" {
+  # AC: allowlist regex が ^ anchor と \$ 終端を持つ（全文一致パターン）
+  # RED: 現在の blocklist は部分マッチのため fail
+  run grep -qP '\^\[A-Za-z0-9[^\]]*\]\+\$' "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: 正常パスが受理される
+# ===========================================================================
+
+@test "ac3: .supervisor (default) is accepted with exit 0" {
+  # AC: 正常パス .supervisor が受理される（現行実装でも PASS の可能性あり）
+  run bash "${SCRIPT}" --type "allowlist-test" --detail "normal path"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: .supervisor-test is accepted with exit 0" {
+  # AC: 正常パス .supervisor-test（ハイフン含む）が受理される
+  SUPERVISOR_DIR=".supervisor-test" run bash "${SCRIPT}" --type "allowlist-test" --detail "hyphen path"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: nested/deep/.supervisor is accepted with exit 0" {
+  # AC: 正常パス nested/deep/.supervisor（スラッシュ含む）が受理される
+  mkdir -p nested/deep
+  SUPERVISOR_DIR="nested/deep/.supervisor" run bash "${SCRIPT}" --type "allowlist-test" --detail "nested path"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: 絶対パスが拒否される (exit 1 + ERROR メッセージ形式)
+# ===========================================================================
+
+@test "ac4: /etc is rejected with exit 1" {
+  # AC: 絶対パス /etc は exit 1 で拒否される
+  SUPERVISOR_DIR="/etc" run bash "${SCRIPT}" --type "test" --detail "absolute path"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac4: /etc rejection error message contains 'invalid path:' per baseline-bash §11" {
+  # AC: エラーメッセージは baseline-bash §11 パターン 'invalid path: <path>' 形式
+  # RED: 現行実装のメッセージ "must not be an absolute path" は新形式と不一致 → fail
+  SUPERVISOR_DIR="/etc" run bash -c "bash '${SCRIPT}' --type test --detail 'absolute path' 2>&1 >/dev/null"
+  [[ "${output}" =~ "invalid path:" ]]
+}
+
+@test "ac4: /tmp/foo is rejected with exit 1" {
+  # AC: 絶対パス /tmp/foo は exit 1 で拒否される
+  SUPERVISOR_DIR="/tmp/foo" run bash "${SCRIPT}" --type "test" --detail "absolute path"
+  [ "${status}" -eq 1 ]
+}
+
+# ===========================================================================
+# AC5: path traversal を含むパスが拒否される (exit 1)
+# ===========================================================================
+
+@test "ac5: ../foo is rejected with exit 1" {
+  # AC: path traversal ../foo は exit 1 で拒否される
+  SUPERVISOR_DIR="../foo" run bash "${SCRIPT}" --type "test" --detail "traversal"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac5: ../foo rejection error message contains 'invalid path:' per baseline-bash §11" {
+  # AC: エラーメッセージは 'invalid path:' 形式
+  # RED: 現行実装のメッセージ "must not contain '..'" は新形式と不一致 → fail
+  SUPERVISOR_DIR="../foo" run bash -c "bash '${SCRIPT}' --type test --detail traversal 2>&1 >/dev/null"
+  [[ "${output}" =~ "invalid path:" ]]
+}
+
+@test "ac5: foo/../bar is rejected with exit 1" {
+  # AC: path traversal foo/../bar は exit 1 で拒否される
+  SUPERVISOR_DIR="foo/../bar" run bash "${SCRIPT}" --type "test" --detail "embedded traversal"
+  [ "${status}" -eq 1 ]
+}
+
+# ===========================================================================
+# AC6: shell 特殊文字を含むパスが拒否される
+# ===========================================================================
+
+@test "ac6: \$foo is rejected with exit 1" {
+  # AC: $foo は exit 1 で拒否される
+  SUPERVISOR_DIR='$foo' run bash "${SCRIPT}" --type "test" --detail "dollar sign"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: \$foo rejection error message contains 'invalid path:' per baseline-bash §11" {
+  # AC: エラーメッセージは 'invalid path:' 形式
+  # RED: 現行実装のメッセージ "must only contain allowed characters" は新形式と不一致 → fail
+  SUPERVISOR_DIR='$foo' run bash -c "bash '${SCRIPT}' --type test --detail 'special char' 2>&1 >/dev/null"
+  [[ "${output}" =~ "invalid path:" ]]
+}
+
+@test "ac6: a;b is rejected with exit 1" {
+  # AC: セミコロンを含むパスは拒否される
+  SUPERVISOR_DIR='a;b' run bash "${SCRIPT}" --type "test" --detail "semicolon"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a|b is rejected with exit 1" {
+  # AC: パイプを含むパスは拒否される
+  SUPERVISOR_DIR='a|b' run bash "${SCRIPT}" --type "test" --detail "pipe"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a\`b is rejected with exit 1" {
+  # AC: バッククォートを含むパスは拒否される
+  SUPERVISOR_DIR='a`b' run bash "${SCRIPT}" --type "test" --detail "backtick"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a&b is rejected with exit 1" {
+  # AC: アンパサンドを含むパスは拒否される
+  SUPERVISOR_DIR='a&b' run bash "${SCRIPT}" --type "test" --detail "ampersand"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a(b is rejected with exit 1" {
+  # AC: 括弧を含むパスは拒否される
+  SUPERVISOR_DIR='a(b' run bash "${SCRIPT}" --type "test" --detail "paren"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a<b is rejected with exit 1" {
+  # AC: 不等号 < を含むパスは拒否される
+  SUPERVISOR_DIR='a<b' run bash "${SCRIPT}" --type "test" --detail "less-than"
+  [ "${status}" -eq 1 ]
+}
+
+@test "ac6: a>b is rejected with exit 1" {
+  # AC: 不等号 > を含むパスは拒否される
+  SUPERVISOR_DIR='a>b' run bash "${SCRIPT}" --type "test" --detail "greater-than"
+  [ "${status}" -eq 1 ]
+}
+
+# ===========================================================================
+# AC7: 空文字 / 未定義 SUPERVISOR_DIR で .supervisor フォールバックが受理される
+# ===========================================================================
+
+@test "ac7: unset SUPERVISOR_DIR falls back to .supervisor and is accepted" {
+  # AC: SUPERVISOR_DIR 未設定時は .supervisor にフォールバックし受理される
+  # PASS 可能性あり（現行実装でも動作する）
+  unset SUPERVISOR_DIR
+  run bash "${SCRIPT}" --type "fallback-test" --detail "unset supervisor dir"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac7: empty SUPERVISOR_DIR falls back to .supervisor and is accepted" {
+  # AC: SUPERVISOR_DIR="" のとき .supervisor フォールバックが受理される
+  # PASS 可能性あり（${SUPERVISOR_DIR:-.supervisor} で空文字もフォールバック）
+  SUPERVISOR_DIR="" run bash "${SCRIPT}" --type "fallback-test" --detail "empty supervisor dir"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC8: 既存テストファイルが存在する（回帰参照）
+# ===========================================================================
+
+@test "ac8: regression test file record-detection-gap.bats exists" {
+  # AC: 既存テストが引き続き PASS できる前提としてテストファイルが存在する
+  [ -f "${REPO_ROOT}/tests/bats/observer/record-detection-gap.bats" ]
+}
+
+@test "ac8: regression test file issue-1250-record-detection-gap-flock.bats exists" {
+  [ -f "${REPO_ROOT}/tests/bats/issue-1250-record-detection-gap-flock.bats" ]
+}
+
+@test "ac8: regression test file record-detection-gap-deps-registered.bats exists" {
+  [ -f "${REPO_ROOT}/tests/bats/scripts/record-detection-gap-deps-registered.bats" ]
+}
+
+# ===========================================================================
+# AC9: `# allowlist regex per baseline-bash §11` コメントが script に存在する
+# ===========================================================================
+
+@test "ac9: script contains comment '# allowlist regex per baseline-bash §11'" {
+  # AC: 修正コードに '# allowlist regex per baseline-bash §11' コメントが存在する
+  # RED: 実装前は存在しないため fail
+  run grep -qF '# allowlist regex per baseline-bash §11' "${SCRIPT}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC10: baseline-bash.md §11 セクションが存在し、棚卸し表からエントリが削除されている
+# ===========================================================================
+
+@test "ac10: baseline-bash.md has a section 11 for allowlist approach" {
+  # AC: baseline-bash.md §11 「blocklist 方式の棚卸し」が存在する
+  # RED: 現在 §1-§10 しか存在しないため fail
+  run grep -qE '^## 11\.' "${BASELINE_BASH}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac10: baseline-bash.md §11 table does not contain record-detection-gap.sh entry" {
+  # AC: §11 テーブルから record-detection-gap.sh の行が削除されている
+  # RED: §11 が存在しないため前提 fail → false で明示的に fail
+  if ! grep -qE '^## 11\.' "${BASELINE_BASH}"; then
+    false  # §11 未存在 → fail
+  fi
+  run grep -qF 'record-detection-gap.sh' "${BASELINE_BASH}"
+  [ "${status}" -ne 0 ]
+}


### PR DESCRIPTION
## 概要

Issue #1378 の修正。`record-detection-gap.sh` L61-69 の SUPERVISOR_DIR バリデーションを blocklist 3 チェックから allowlist regex 方式に置換。

## 変更内容

### record-detection-gap.sh
- L59-69: blocklist 3 if ブロック → allowlist regex 1 チェックに統合
- エラーメッセージを `invalid path: <path> (must match ...)` 形式に統一（baseline-bash §11 準拠）
- コメント `# allowlist regex per baseline-bash §11` 追加

### baseline-bash.md
- §11「blocklist 方式の棚卸し」表から `record-detection-gap.sh` エントリを削除
- 対応方針テキストを更新（移行完了を反映）

### テスト
- `issue-1378-record-detection-gap-allowlist.bats`: 28 件追加
- `ac-test-mapping-1378.yaml`: AC↔テストマッピング追加

## テスト結果
- 新規 28 件 PASS
- 既存テスト（record-detection-gap.bats, issue-1250-flock.bats, deps-registered.bats）: 全 PASS

Closes #1378