### PR TITLE
feat(#1375): IDLE_COMPLETED_PHRASE_REGEX 拡張 — co-autopilot phrase 6件追加

### DIFF
--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -780,10 +780,10 @@ _check_window_alive "wt-co-explore-114550" "twill-ipatho1" && echo "alive" || ec
 行単位（`grep -qE`）で機能する。`次のステップ:` は A2 (LLM idle) + A3 (log mtime stale) + A4 (no menu) の他条件 AND によって false positive を抑制する前提:
 
 ```
-(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)
+(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|Wave [0-9]+ co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)
 ```
 
-*注: このコードブロックは `observer-idle-check.sh:14` の SSOT と同期した説明用コピー（Issue #1375 で co-autopilot 完了 phrase 5件追加）。実行時参照は `observer-idle-check.sh` のみ。*
+*注: このコードブロックは `observer-idle-check.sh:14` の SSOT と同期した説明用コピー（Issue #1375 で co-autopilot 完了 phrase 6件追加）。実行時参照は `observer-idle-check.sh` のみ。*
 
 **実装の分離**:
 - `_check_idle_completed()` → `skills/su-observer/scripts/lib/observer-idle-check.sh` (stateless 純粋関数)

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -780,8 +780,10 @@ _check_window_alive "wt-co-explore-114550" "twill-ipatho1" && echo "alive" || ec
 行単位（`grep -qE`）で機能する。`次のステップ:` は A2 (LLM idle) + A3 (log mtime stale) + A4 (no menu) の他条件 AND によって false positive を抑制する前提:
 
 ```
-(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:)
+(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)
 ```
+
+*注: このコードブロックは `observer-idle-check.sh:14` の SSOT と同期した説明用コピー（Issue #1375 で co-autopilot 完了 phrase 5件追加）。実行時参照は `observer-idle-check.sh` のみ。*
 
 **実装の分離**:
 - `_check_idle_completed()` → `skills/su-observer/scripts/lib/observer-idle-check.sh` (stateless 純粋関数)
@@ -822,6 +824,13 @@ for WIN in "${TARGET_WINS[@]}"; do
     fi
 done
 ```
+
+**co-autopilot 完了 phrase（Issue #1375 追加）**: co-autopilot 実行中の Pilot が発する完了 phrase を追加。Wave recap や Step 完了時の auto-kill 不発火を修正:
+- `co-autopilot complete` — Pilot recap 末尾の汎用完了マーカー
+- `hand control back to su-observer` — 次 Wave 委譲の完了宣言
+- `observer 側で次の` — Wave N 完了後の制御委譲
+- `Step [0-9]+ 完了処理` — Step N 完了処理の汎用パターン
+- `orchestrator --summary（done=` — orchestrator サマリ出力の完了マーカー
 
 **自動 kill オプション**: `IDLE_COMPLETED_AUTO_KILL=1`（opt-in、Issue #1132）で `[IDLE-COMPLETED]` 発火時に `tmux kill-window` を自動実行（Layer 0 Auto）。デフォルトは alert のみ（Layer 1 Confirm）。
 

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -11,7 +11,7 @@
 
 # COMPLETION_PHRASE_REGEX — SSOT (AC-1)
 # 行単位 grep -qE で機能する。A2+A3+A4 の他条件 AND により false positive を抑制。
-readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:)'
+readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)'
 
 # IDLE_COMPLETED_DEBOUNCE_SEC — デフォルト 60s、env var で override 可能 (AC-2)
 IDLE_COMPLETED_DEBOUNCE_SEC="${IDLE_COMPLETED_DEBOUNCE_SEC:-60}"

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -11,7 +11,7 @@
 
 # COMPLETION_PHRASE_REGEX — SSOT (AC-1)
 # 行単位 grep -qE で機能する。A2+A3+A4 の他条件 AND により false positive を抑制。
-readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)'
+readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|Wave [0-9]+ co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)'
 
 # IDLE_COMPLETED_DEBOUNCE_SEC — デフォルト 60s、env var で override 可能 (AC-2)
 IDLE_COMPLETED_DEBOUNCE_SEC="${IDLE_COMPLETED_DEBOUNCE_SEC:-60}"

--- a/plugins/twl/tests/bats/ac-test-mapping-1375.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1375.yaml
@@ -1,0 +1,67 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh:14 の IDLE_COMPLETED_PHRASE_REGEX (readonly 変数) に co-autopilot 完了 phrase 群を追加する: co-autopilot complete / Wave [0-9]+ co-autopilot complete / hand control back to su-observer / observer 側で次の / Step 5 完了処理 / orchestrator --summary（done="
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-1: 'co-autopilot complete' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: "1b"
+    ac_text: "'Wave [0-9]+ co-autopilot complete' phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-2: 'Wave N co-autopilot complete' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: "1c"
+    ac_text: "'hand control back to su-observer' phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-3: 'hand control back to su-observer' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: "1d"
+    ac_text: "'observer 側で次の' phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-4: 'observer 側で次の' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: "1e"
+    ac_text: "'Step 5 完了処理' phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-5: 'Step 5 完了処理' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: "1f"
+    ac_text: "'orchestrator --summary（done=' phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-6: 'orchestrator --summary（done=' is recognized as idle (Issue #1375)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: 2
+    ac_text: "plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md の L783 周辺（既存 regex 説明コードブロック）を SSOT と一致するよう同期更新し、L819 周辺（[IDLE-COMPLETED] channel 説明箇所）に追加 phrase の意図と参照元 (Issue #1375) を追記"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: null
+    # AC2 に対応する bats テストは未生成（ドキュメント更新の機械検証は RED フェーズ外）
+    # AC2 は実装者が手動で検証する
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md"
+  - ac_index: 3
+    ac_text: "plugins/twl/tests/bats/observer-idle-check.bats の末尾（既存 AC1-AC10 テスト群の後）に新セクション '# === Issue #1375 — co-autopilot phrase regression ===' を追加し、追加 phrase 6 件すべてが _check_idle_completed C2 条件を満たすことを assert する regression test を追加する"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "ac1375-1 〜 ac1375-6 (6 tests)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  - ac_index: 4
+    ac_text: "既存 regex 定義の SSOT 単一性を保持する（実行時参照は observer-idle-check.sh:14 のみ）"
+    test_file: null
+    test_name: null
+    # AC4 はプロセス AC（SSOT 単一性の保持）。機械的テストは不適。
+    # 実装者は grep で他ファイルへの regex 複製がないことを確認する
+    impl_files: []
+    # impl_files 推定失敗: SSOT 単一性の確認は全ファイル横断検索が必要。手動検証を推奨
+  - ac_index: 5
+    ac_text: "bash plugins/twl/tests/bats/observer-idle-check.bats が PASS する（GREEN — 既存 AC1-AC10 と新 ac1375-* の両方が通る）"
+    test_file: "plugins/twl/tests/bats/observer-idle-check.bats"
+    test_name: "全テスト（ac1375-1 〜 ac1375-6 を含む）"
+    # AC5 は GREEN フェーズ AC。RED フェーズ（現在）では ac1375-* は意図的に fail する。
+    # AC1 の実装（IDLE_COMPLETED_PHRASE_REGEX 拡張）完了後に GREEN になる。
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"

--- a/plugins/twl/tests/bats/observer-idle-check.bats
+++ b/plugins/twl/tests/bats/observer-idle-check.bats
@@ -583,3 +583,104 @@ nothing pending
   # JP indicator なし + completion phrase あり → idle 確定（exit 0）
   [ "${status}" -eq 0 ]
 }
+
+# ===========================================================================
+# Issue #1375 — co-autopilot phrase regression
+# IDLE_COMPLETED_PHRASE_REGEX に co-autopilot 完了 phrase 6件を追加
+# ===========================================================================
+
+@test "ac1375-1: 'co-autopilot complete' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'co-autopilot complete' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='co-autopilot complete
+Worked for 3m 22s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1375-2: 'Wave N co-autopilot complete' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'Wave [0-9]+ co-autopilot complete' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='Wave 3 co-autopilot complete
+Worked for 10m 5s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1375-3: 'hand control back to su-observer' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'hand control back to su-observer' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='hand control back to su-observer
+Worked for 5m 0s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1375-4: 'observer 側で次の' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'observer 側で次の' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='observer 側で次のステップを実行してください
+Worked for 2m 30s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1375-5: 'Step 5 完了処理' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'Step 5 完了処理' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='Step 5 完了処理: クリーンアップを実行します
+Worked for 1m 45s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1375-6: 'orchestrator --summary（done=' is recognized as idle (Issue #1375)" {
+  # AC: IDLE_COMPLETED_PHRASE_REGEX に 'orchestrator --summary（done=' が追加される
+  # RED: 現在の regex には含まれていないため fail（C2 条件不満足）
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='orchestrator --summary（done=3/3）
+Worked for 8m 12s
+> '
+    first_seen_ts=100
+    now_ts=161
+    _check_idle_completed \"\${pane_content}\" \"\${first_seen_ts}\" \"\${now_ts}\"
+  "
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

Issue #1375: `observer-idle-check.sh` の `IDLE_COMPLETED_PHRASE_REGEX` に co-autopilot 完了 phrase 群を追加し、observer auto-kill の不発火を修正する。

## 変更内容

- `plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh`: regex に 6 phrase 追加 (AC1)
- `plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md`: 説明用コードブロック同期更新 (AC2)
- `plugins/twl/tests/bats/observer-idle-check.bats`: regression test 6件追加 (AC3)

## 追加 phrase

- `co-autopilot complete`
- `Wave [0-9]+ co-autopilot complete`
- `hand control back to su-observer`
- `observer 側で次の`
- `Step 5 完了処理`
- `orchestrator --summary（done=`

Closes #1375