### PR TITLE
feat(#1050): cmd_inject_file に named buffer を使用してバッファ衝突を防止

### DIFF
--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -398,7 +398,12 @@ cmd_inject_file() {
     fi
 
     # tmux load-buffer + paste-buffer で改行を含むテキストを安全に送達
-    tmux load-buffer "$file_path" || {
+    # 前提: tmux >= 2.0 (delete-buffer -b は tmux 2.0+ で追加)
+    # named buffer でバッファ衝突を防止 (#1050)
+    local _buf_name="session-comm-$$-$(date +%s%N)"
+    # shellcheck disable=SC2064
+    trap "tmux delete-buffer -b $_buf_name 2>/dev/null || true" EXIT
+    tmux load-buffer -b "$_buf_name" "$file_path" || {
         echo "Error: failed to load buffer from '$file_path'" >&2
         exit 1
     }
@@ -408,16 +413,18 @@ cmd_inject_file() {
     tmux_major=$(tmux -V | sed 's/tmux \([0-9]*\)\..*/\1/')
     tmux_minor=$(tmux -V | sed 's/tmux [0-9]*\.\([0-9]*\).*/\1/')
     if [[ "$tmux_major" -gt 3 ]] || { [[ "$tmux_major" -eq 3 ]] && [[ "$tmux_minor" -ge 2 ]]; }; then
-        tmux paste-buffer -p -t "$target" || {
+        tmux paste-buffer -b "$_buf_name" -p -t "$target" || {
             echo "Error: failed to paste buffer to '$window_name'" >&2
             exit 1
         }
     else
-        tmux paste-buffer -t "$target" || {
+        tmux paste-buffer -b "$_buf_name" -t "$target" || {
             echo "Error: failed to paste buffer to '$window_name'" >&2
             exit 1
         }
     fi
+    tmux delete-buffer -b "$_buf_name" 2>/dev/null || true
+    trap - EXIT
 
     if ! $no_enter; then
         # paste-buffer 後に待機（Ink の非同期イベントループがペースト処理を

--- a/plugins/session/tests/ac-test-mapping-1050.yaml
+++ b/plugins/session/tests/ac-test-mapping-1050.yaml
@@ -1,0 +1,85 @@
+mappings:
+  - ac_index: 1
+    ac_text: "cmd_inject_file が tmux load-buffer -b <unique-name> \"$file_path\" で named buffer に読み込む"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac1[structural][RED]: cmd_inject_file が load-buffer -b <unique-name> を使用する"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 1
+    ac_text: "buffer 名が session-comm-$$-$(date +%s%N) 形式の一意名"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac1[structural][RED]: buffer 名が session-comm-PID 形式の一意名を使用する"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 2
+    ac_text: "同 named buffer を tmux paste-buffer -b <unique-name> [-p] -t \"$target\" で貼り付け"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac2[structural][RED]: cmd_inject_file が paste-buffer -b <unique-name> を使用する"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 2
+    ac_text: "続けて tmux delete-buffer -b <unique-name> で削除する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac2[structural][RED]: cmd_inject_file が delete-buffer -b <unique-name> を呼ぶ"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 2
+    ac_text: "EXIT trap で delete-buffer が保証される"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac2[structural][RED]: EXIT trap で delete-buffer が保証される"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 3
+    ac_text: "bats テスト tests/issue-1050-inject-file-named-buffer.bats を新規追加し、以下を検証する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac3[functional][RED]: 単一 inject-file が named buffer (-b オプション付き) 経由で target に届ける"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 3
+    ac_text: "並列 inject-file で各 target が自分宛の内容のみ受信する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac3[functional][RED]: 並列 10 プロセス inject-file で各 target が自分宛の内容のみ受信する"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 3
+    ac_text: "named buffer 使用後に tmux delete-buffer -b が呼ばれる"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac3[structural][RED]: named buffer 使用後に tmux delete-buffer -b が呼ばれる"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 4
+    ac_text: "既存テスト tests/session-comm.test.sh および tests/session-comm-robustness.test.sh の AC1-3 が引き続き green"
+    test_file: ""
+    test_name: "# skip: 既存テスト維持確認 — 実装後に手動または CI で確認"
+    impl_files: []
+    # impl_files 推定失敗: 既存テストの維持確認のため RED test 不要
+  - ac_index: 5
+    ac_text: "plugins/twl/refs/observation-pattern-catalog.md の [BUFFER-COLLIDE] を更新"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac5[structural][RED]: observation-pattern-catalog.md の [BUFFER-COLLIDE] に named buffer 化記述が含まれる"
+    impl_files:
+      - "plugins/twl/refs/observation-pattern-catalog.md"
+  - ac_index: 5
+    ac_text: "[BUFFER-COLLIDE] の action フィールドが serial 15s 制約解除を記述する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac5[structural][RED]: [BUFFER-COLLIDE] の action フィールドが serial 15s 制約解除を記述する"
+    impl_files:
+      - "plugins/twl/refs/observation-pattern-catalog.md"
+  - ac_index: 5
+    ac_text: "[BUFFER-COLLIDE] の detection_condition が paste-buffer -b なし検出を記述する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac5[structural][RED]: [BUFFER-COLLIDE] の detection_condition が paste-buffer -b なし検出を記述する"
+    impl_files:
+      - "plugins/twl/refs/observation-pattern-catalog.md"
+  - ac_index: 6
+    ac_text: "tmux 前提条件として tmux >= 2.0 を cmd_inject_file 冒頭コメントまたは usage に明示する"
+    test_file: "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+    test_name: "ac6[structural][RED]: cmd_inject_file 冒頭コメントまたは usage に tmux 2.0 以上の前提条件が明示される"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+  - ac_index: 7
+    ac_text: "twl validate が green、twl check PASS、deps.yaml 変更なし"
+    test_file: ""
+    test_name: "# skip: プロセス AC — 実装後に手動確認"
+    impl_files: []
+    # impl_files 推定失敗: プロセス AC のため RED test 不要

--- a/plugins/session/tests/issue-1050-inject-file-named-buffer.bats
+++ b/plugins/session/tests/issue-1050-inject-file-named-buffer.bats
@@ -1,0 +1,465 @@
+#!/usr/bin/env bats
+# issue-1050-inject-file-named-buffer.bats
+# Issue #1050: cmd_inject_file の tmux named buffer 化（バッファ衝突防止）
+# Spec: issue-1050
+# Coverage: --type=structural,functional,concurrent
+
+# ===========================================================================
+# setup / teardown
+# ===========================================================================
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
+    SANDBOX="$(mktemp -d)"
+    export SANDBOX SCRIPT PLUGIN_ROOT
+}
+
+teardown() {
+    [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+# ===========================================================================
+# helper: mock tmux（named buffer 対応版）
+# named buffer を ${SANDBOX}/buffers/${NAME} に保存し、
+# paste-buffer で ${SANDBOX}/targets/${TARGET} に書き込む
+# ===========================================================================
+
+_create_mock_tmux_named_buffer() {
+    local mock="$SANDBOX/bin/tmux"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/buffers" "$SANDBOX/targets"
+    # NOTE: 非クォート heredoc で外部変数 $SANDBOX を展開する
+    # NOTE: local はトップレベルスクリプト(関数外)では使用不可 — buf_name 等は直接代入する
+    cat > "$mock" << MOCK
+#!/bin/bash
+case "\$1" in
+    -V)
+        echo "tmux 3.4"
+        ;;
+    has-session)
+        exit 0
+        ;;
+    list-windows)
+        echo "session:0 mock-window"
+        ;;
+    load-buffer)
+        # parse: load-buffer -b NAME FILE
+        buf_name=""; file_arg=""
+        shift  # skip "load-buffer"
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                *)  file_arg="\$1"; shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" && -n "\$file_arg" ]]; then
+            cp "\$file_arg" "${SANDBOX}/buffers/\${buf_name}"
+        elif [[ -n "\$file_arg" ]]; then
+            # anonymous buffer（実装前の動作）
+            cp "\$file_arg" "${SANDBOX}/buffers/__anonymous__"
+        fi
+        exit 0
+        ;;
+    paste-buffer)
+        # parse: paste-buffer -b NAME [-p] -t TARGET
+        buf_name=""; target=""
+        shift  # skip "paste-buffer"
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                -t) target="\$2"; shift 2 ;;
+                -p) shift ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" && -n "\$target" ]]; then
+            buf_file="${SANDBOX}/buffers/\${buf_name}"
+            if [[ -f "\$buf_file" ]]; then
+                cat "\$buf_file" >> "${SANDBOX}/targets/\${target}"
+            fi
+        elif [[ -n "\$target" ]]; then
+            # anonymous buffer（実装前の動作）
+            if [[ -f "${SANDBOX}/buffers/__anonymous__" ]]; then
+                cat "${SANDBOX}/buffers/__anonymous__" >> "${SANDBOX}/targets/\${target}"
+            fi
+        fi
+        exit 0
+        ;;
+    delete-buffer)
+        # parse: delete-buffer -b NAME
+        buf_name=""
+        shift  # skip "delete-buffer"
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" ]]; then
+            rm -f "${SANDBOX}/buffers/\${buf_name}"
+        fi
+        exit 0
+        ;;
+    send-keys)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK
+    chmod +x "$mock"
+}
+
+_create_mock_session_state_input_waiting() {
+    mkdir -p "$SANDBOX/mock_scripts"
+    cat > "$SANDBOX/mock_scripts/session-state.sh" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == "state" ]]; then echo "input-waiting"; exit 0; fi
+if [[ "$1" == "wait" ]]; then exit 0; fi
+exit 0
+MOCK
+    chmod +x "$SANDBOX/mock_scripts/session-state.sh"
+}
+
+# ===========================================================================
+# AC-1 (structural): named buffer で load-buffer を呼ぶ
+# RED: 実装前は `tmux load-buffer "$file_path"` (anonymous) のため FAIL する
+# ===========================================================================
+
+@test "ac1[structural][RED]: cmd_inject_file が load-buffer -b <unique-name> を使用する" {
+    # AC-1: `tmux load-buffer -b <unique-name> "$file_path"` で named buffer に読み込む
+    # 実装前: `tmux load-buffer "$file_path"` (anonymous) のため grep が FAIL する
+    grep -qF 'load-buffer -b' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh の cmd_inject_file に 'load-buffer -b' が含まれていない（named buffer 未実装）" >&2
+        return 1
+    }
+}
+
+@test "ac1[structural][RED]: buffer 名が session-comm-PID 形式の一意名を使用する" {
+    # AC-1 詳細: 一意名は session-comm-$$-$(date +%s%N) 形式（PID + ナノ秒）
+    # 実装前: anonymous buffer のため buffer_name 変数が存在しない → FAIL
+    grep -qE 'session-comm-\$\$-\$\(date' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh に 'session-comm-\$\$-\$(date' 形式の buffer 名が含まれていない" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC-2 (structural): paste-buffer -b, delete-buffer -b を使用する
+# RED: 実装前は anonymous buffer + delete-buffer なし のため FAIL する
+# ===========================================================================
+
+@test "ac2[structural][RED]: cmd_inject_file が paste-buffer -b <unique-name> を使用する" {
+    # AC-2: `tmux paste-buffer -b <unique-name> [-p] -t "$target"` で貼り付ける
+    # 実装前: `tmux paste-buffer -t "$target"` (anonymous) のため FAIL する
+    grep -qF 'paste-buffer -b' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh の cmd_inject_file に 'paste-buffer -b' が含まれていない（named buffer 未実装）" >&2
+        return 1
+    }
+}
+
+@test "ac2[structural][RED]: cmd_inject_file が delete-buffer -b <unique-name> を呼ぶ" {
+    # AC-2: paste 後に `tmux delete-buffer -b <unique-name>` で削除する
+    # 実装前: delete-buffer 呼び出しが存在しない → FAIL
+    grep -qF 'delete-buffer -b' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh の cmd_inject_file に 'delete-buffer -b' が含まれていない（cleanup 未実装）" >&2
+        return 1
+    }
+}
+
+@test "ac2[structural][RED]: EXIT trap で delete-buffer が保証される" {
+    # AC-2 詳細: immediate-expansion trap で cleanup を保証する
+    # `trap "tmux delete-buffer -b $_buf 2>/dev/null || true" EXIT` パターン
+    # 実装前: trap が存在しない → FAIL
+    grep -qE 'trap.*delete-buffer.*EXIT|trap.*EXIT.*delete-buffer' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh に delete-buffer の EXIT trap が含まれていない" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC-3 (functional): 並列 inject-file で各 target が正しい内容を受信する
+# RED: 実装前は anonymous buffer のため並列実行で buffer が上書きされ、
+#      異なる target に異なる content が届く保証がない
+# ===========================================================================
+
+@test "ac3[functional][RED]: 単一 inject-file が named buffer (-b オプション付き) 経由で target に届ける" {
+    # named buffer 実装を検証するために、load-buffer -b が実際に呼ばれているかを
+    # mock の tmux 呼び出しログから確認する
+    # RED: 実装前は load-buffer に -b オプションがないため、ログに "-b" が記録されない
+    _create_mock_tmux_named_buffer
+    _create_mock_session_state_input_waiting
+
+    # mock tmux をログ記録機能付きに強化（呼び出し引数を記録）
+    local call_log="$SANDBOX/tmux_call_args.log"
+    cat >> "$SANDBOX/bin/tmux" << PATCH
+# append call args to log
+echo "\$*" >> "${call_log}"
+PATCH
+    # call_log 追記を先頭に挿入するため改めて全体を再生成する
+    local mock="$SANDBOX/bin/tmux"
+    cat > "$mock" << MOCK_REWRITE
+#!/bin/bash
+echo "\$*" >> "${call_log}"
+case "\$1" in
+    -V) echo "tmux 3.4" ;;
+    has-session) exit 0 ;;
+    list-windows) echo "session:0 mock-window" ;;
+    load-buffer)
+        buf_name=""; file_arg=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in -b) buf_name="\$2"; shift 2 ;; *) file_arg="\$1"; shift ;; esac
+        done
+        if [[ -n "\$buf_name" && -n "\$file_arg" ]]; then
+            cp "\$file_arg" "${SANDBOX}/buffers/\${buf_name}"
+        fi
+        exit 0
+        ;;
+    paste-buffer)
+        buf_name=""; target=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in -b) buf_name="\$2"; shift 2 ;; -t) target="\$2"; shift 2 ;; -p) shift ;; *) shift ;; esac
+        done
+        if [[ -n "\$buf_name" && -n "\$target" ]]; then
+            buf_file="${SANDBOX}/buffers/\${buf_name}"
+            [[ -f "\$buf_file" ]] && cat "\$buf_file" >> "${SANDBOX}/targets/\${target}"
+        fi
+        exit 0
+        ;;
+    delete-buffer)
+        buf_name=""
+        shift
+        while [[ \$# -gt 0 ]]; do case "\$1" in -b) buf_name="\$2"; shift 2 ;; *) shift ;; esac; done
+        [[ -n "\$buf_name" ]] && rm -f "${SANDBOX}/buffers/\${buf_name}"
+        exit 0
+        ;;
+    send-keys) exit 0 ;;
+    *) exit 0 ;;
+esac
+MOCK_REWRITE
+    chmod +x "$mock"
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "content_for_target_0" > "$test_file"
+
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null || true
+
+    # RED: 実装前は `load-buffer "$file_path"` (オプションなし) のため、
+    # ログに "load-buffer -b" が含まれない → FAIL
+    [[ -f "$call_log" ]] || {
+        echo "FAIL: tmux が一度も呼ばれなかった（call_log が存在しない）" >&2
+        return 1
+    }
+    grep -qF 'load-buffer -b' "$call_log" || {
+        echo "FAIL: tmux call log に 'load-buffer -b' が含まれていない（named buffer 未使用）" >&2
+        echo "  actual calls:" >&2
+        cat "$call_log" >&2
+        return 1
+    }
+}
+
+@test "ac3[functional][RED]: 並列 10 プロセス inject-file で各 target が自分宛の内容のみ受信する" {
+    # AC-3 並列検証: 10 プロセスを並列実行し、各 target_i が file_i の内容と一致する
+    # RED: 実装前（anonymous buffer）では buffer が上書きされ、別の content が混入する可能性あり
+    # テスト全体タイムアウト: 30 秒（@bats-timeout が使用できない場合は内部で制御）
+    _create_mock_tmux_named_buffer
+    _create_mock_session_state_input_waiting
+
+    # 10 個のテストファイルを作成
+    for i in $(seq 0 9); do
+        echo "file_content_${i}" > "$SANDBOX/file_${i}.txt"
+    done
+
+    # 並列で inject-file を実行
+    # resolve_target は "session:N" 形式（セッション名:インデックス）を直接受け付ける
+    local pids=()
+    for i in $(seq 0 9); do
+        PATH="$SANDBOX/bin:$PATH" \
+        _TEST_MODE=1 \
+        SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+            bash "$SCRIPT" inject-file --no-enter --force "session:${i}" "$SANDBOX/file_${i}.txt" 2>/dev/null &
+        pids+=($!)
+    done
+
+    # 全プロセス完了を待機（最大 30 秒）
+    local wait_deadline=$(( $(date +%s) + 30 ))
+    for pid in "${pids[@]}"; do
+        local remaining=$(( wait_deadline - $(date +%s) ))
+        if [[ "$remaining" -le 0 ]]; then
+            echo "FAIL: 並列テストが 30 秒以内に完了しなかった" >&2
+            kill "${pids[@]}" 2>/dev/null || true
+            return 1
+        fi
+        wait "$pid" || true
+    done
+
+    # 各 session:i が file_i の内容と完全一致することを diff で検証
+    local all_passed=true
+    for i in $(seq 0 9); do
+        local target_file="$SANDBOX/targets/session:${i}"
+        local expected="$SANDBOX/file_${i}.txt"
+
+        if [[ ! -f "$target_file" ]]; then
+            echo "FAIL: session:${i} ターゲットファイルが作成されていない（named buffer 未実装）" >&2
+            all_passed=false
+            continue
+        fi
+
+        if ! diff -q "$expected" "$target_file" > /dev/null 2>&1; then
+            echo "FAIL: session:${i} の内容が file_${i} と一致しない（buffer 競合の可能性）" >&2
+            echo "  expected: $(cat "$expected")" >&2
+            echo "  actual:   $(cat "$target_file")" >&2
+            all_passed=false
+        fi
+    done
+
+    [[ "$all_passed" == "true" ]] || return 1
+}
+
+@test "ac3[structural][RED]: named buffer 使用後に tmux delete-buffer -b が呼ばれる" {
+    # AC-3 cleanup 検証: paste-buffer 後に delete-buffer -b が呼ばれることを call log で確認する
+    # RED: delete-buffer -b の実装がない場合、call log に 'delete-buffer -b' が存在しない
+    local call_log="$SANDBOX/tmux_delete_call.log"
+    local mock="$SANDBOX/bin/tmux"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/buffers" "$SANDBOX/targets"
+    cat > "$mock" << MOCK_LOG
+#!/bin/bash
+echo "\$*" >> "${call_log}"
+case "\$1" in
+    -V) echo "tmux 3.4" ;;
+    has-session) exit 0 ;;
+    list-windows) echo "session:0 mock-window" ;;
+    load-buffer)
+        buf_name=""; file_arg=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in -b) buf_name="\$2"; shift 2 ;; *) file_arg="\$1"; shift ;; esac
+        done
+        if [[ -n "\$buf_name" && -n "\$file_arg" ]]; then cp "\$file_arg" "${SANDBOX}/buffers/\${buf_name}"; fi
+        exit 0
+        ;;
+    paste-buffer)
+        buf_name=""; target=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in -b) buf_name="\$2"; shift 2 ;; -t) target="\$2"; shift 2 ;; -p) shift ;; *) shift ;; esac
+        done
+        if [[ -n "\$buf_name" && -n "\$target" ]]; then
+            [[ -f "${SANDBOX}/buffers/\${buf_name}" ]] && cat "${SANDBOX}/buffers/\${buf_name}" >> "${SANDBOX}/targets/\${target}"
+        fi
+        exit 0
+        ;;
+    delete-buffer)
+        buf_name=""
+        shift
+        while [[ \$# -gt 0 ]]; do case "\$1" in -b) buf_name="\$2"; shift 2 ;; *) shift ;; esac; done
+        [[ -n "\$buf_name" ]] && rm -f "${SANDBOX}/buffers/\${buf_name}"
+        exit 0
+        ;;
+    send-keys) exit 0 ;;
+    *) exit 0 ;;
+esac
+MOCK_LOG
+    chmod +x "$mock"
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/cleanup_test.txt"
+    echo "cleanup_content" > "$test_file"
+
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null || true
+
+    # 実装後: delete-buffer -b が呼ばれる
+    # 実装前（RED）: call log に 'delete-buffer -b' が存在しない → FAIL
+    [[ -f "$call_log" ]] || {
+        echo "FAIL: tmux が一度も呼ばれなかった（call_log が存在しない）" >&2
+        return 1
+    }
+    grep -qF 'delete-buffer -b' "$call_log" || {
+        echo "FAIL: tmux call log に 'delete-buffer -b' が含まれていない（cleanup 未実装）" >&2
+        echo "  actual calls:" >&2
+        cat "$call_log" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC-5 (structural): observation-pattern-catalog.md の [BUFFER-COLLIDE] 更新
+# RED: 実装前は catalog が更新されていないため FAIL する
+# ===========================================================================
+
+@test "ac5[structural][RED]: observation-pattern-catalog.md の [BUFFER-COLLIDE] に named buffer 化記述が含まれる" {
+    # AC-5: description フィールドに named buffer 化の対策記述が追記されていること
+    local catalog="$PLUGIN_ROOT/../twl/refs/observation-pattern-catalog.md"
+
+    [[ -f "$catalog" ]] || {
+        echo "FAIL: observation-pattern-catalog.md が見つからない: $catalog" >&2
+        return 1
+    }
+
+    # 実装後: "named buffer" または "paste-buffer -b" などの記述が存在する
+    # 実装前（RED）: catalog が更新されていないため FAIL
+    grep -qiF 'named buffer' "$catalog" || {
+        echo "FAIL: observation-pattern-catalog.md に 'named buffer' の記述が含まれていない（AC-5 未実装）" >&2
+        return 1
+    }
+}
+
+@test "ac5[structural][RED]: [BUFFER-COLLIDE] の action フィールドが serial 15s 制約解除を記述する" {
+    # AC-5: action フィールドを「並列 inject-file は安全。serial 15s 制約を解除」へ書き直す
+    local catalog="$PLUGIN_ROOT/../twl/refs/observation-pattern-catalog.md"
+
+    [[ -f "$catalog" ]] || {
+        echo "FAIL: observation-pattern-catalog.md が見つからない: $catalog" >&2
+        return 1
+    }
+
+    # 実装後: "serial 15s 制約を解除" または "並列 inject-file は安全" などの記述
+    # 実装前（RED）: "serial 15s 以上を MUST" のままなので FAIL
+    grep -qE '制約を解除|serial.*解除|並列.*安全|parallel.*safe' "$catalog" || {
+        echo "FAIL: observation-pattern-catalog.md の BUFFER-COLLIDE action に serial 15s 制約解除の記述がない（AC-5 未実装）" >&2
+        return 1
+    }
+}
+
+@test "ac5[structural][RED]: [BUFFER-COLLIDE] の detection_condition が paste-buffer -b なし検出を記述する" {
+    # AC-5: detection_condition を「paste-buffer -b のない unbuffered 形に regress した場合」へ書き直す
+    local catalog="$PLUGIN_ROOT/../twl/refs/observation-pattern-catalog.md"
+
+    [[ -f "$catalog" ]] || {
+        echo "FAIL: observation-pattern-catalog.md が見つからない: $catalog" >&2
+        return 1
+    }
+
+    # 実装後: "paste-buffer -b" を含む detection_condition が存在する
+    # 実装前（RED）: 古い条件（"15s 未満"）のまま → FAIL
+    grep -qF 'paste-buffer -b' "$catalog" || {
+        echo "FAIL: observation-pattern-catalog.md の BUFFER-COLLIDE detection_condition に 'paste-buffer -b' が含まれていない（AC-5 未実装）" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# AC-6 (structural): cmd_inject_file 冒頭に tmux >= 2.0 前提条件コメントが存在する
+# RED: 実装前はコメントが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6[structural][RED]: cmd_inject_file 冒頭コメントまたは usage に tmux 2.0 以上の前提条件が明示される" {
+    # AC-6: delete-buffer -b は tmux 2.0+ 追加。cmd_inject_file のコメントまたは usage に
+    # "tmux 2.0" または "tmux >= 2.0" などの記述が明示されていること
+    # 実装前（RED）: 専用の前提条件コメントが存在しないため FAIL する
+    # 注意: 既存の "tmux >= 3.2" コメント（bracketed paste）は AC-6 を満たさない（バージョンが異なる）
+    grep -qE 'tmux[[:space:]]*[>=]+[[:space:]]*2\.0|tmux[[:space:]]*2\.0[[:space:]]|require.*tmux.*2\.0|前提.*tmux.*2\.0|tmux 2\.0' "$SCRIPT" || {
+        echo "FAIL: session-comm.sh に tmux 2.0 を明示した前提条件コメントが含まれていない（AC-6 未実装）" >&2
+        echo "  ヒント: 'tmux >= 2.0' または 'tmux 2.0' を cmd_inject_file のコメントに追記してください" >&2
+        return 1
+    }
+}

--- a/plugins/session/tests/session-comm.test.sh
+++ b/plugins/session/tests/session-comm.test.sh
@@ -55,9 +55,9 @@ run_test_skip() {
 echo ""
 echo "--- Structural: inject-file submit fix ---"
 
-# tmux >= 3.2 向けの -p フラグ実装が存在する
+# tmux >= 3.2 向けの -p フラグ実装が存在する（named buffer 化後は paste-buffer -b <name> -p の順）
 test_bracketed_paste_flag_exists() {
-    grep -q 'paste-buffer -p' "$SCRIPT"
+    grep -qE 'paste-buffer.*-p' "$SCRIPT"
 }
 run_test "bracketed paste mode (-p フラグ) が実装されている" test_bracketed_paste_flag_exists
 
@@ -157,8 +157,8 @@ test_inject_file_uses_bracketed_paste() {
 
     rm -f "$tmpfile"
 
-    # paste-buffer -p が呼ばれたことを確認
-    grep -q 'paste-buffer -p' "$call_log"
+    # paste-buffer で -p (bracketed paste) が呼ばれたことを確認（named buffer 化後は -b <name> -p の順）
+    grep -qE 'paste-buffer.*-p' "$call_log"
 }
 run_test "inject-file が bracketed paste mode (-p) で paste-buffer を呼ぶ" test_inject_file_uses_bracketed_paste
 

--- a/plugins/twl/refs/observation-pattern-catalog.md
+++ b/plugins/twl/refs/observation-pattern-catalog.md
@@ -190,12 +190,12 @@ hist-auto-yes-43-45:
 
 hist-inject-buffer-collide:
   regex: 'inject-file.*concurrent|paste.*buffer.*corrupt|buffer.*collide|tmux.*buffer.*fail'
-  severity: error
+  severity: info
   category: inject-buffer-collision
-  description: "[BUFFER-COLLIDE] inject-file を 2 セッション同時実行すると tmux paste buffer が破損する。inject 間隔は serial 15s 以上を MUST 化すること"
-  observation_signal: "inject 後に対象 pane でコマンドが二重実行 / 文字化け / 無応答が発生"
-  detection_condition: "2 以上の セッションが 15s 未満の間隔で inject-file を呼び出した場合"
-  action: "inject を直列化し 15s 以上の間隔を確保。並列 inject は禁止"
+  description: "[BUFFER-COLLIDE] inject-file の tmux named buffer 化（#1050）により解消済み。session-comm.sh は paste-buffer -b <unique-name> を使用するため、並列 inject-file は安全。serial 15s 制約を解除。"
+  observation_signal: "inject 後に対象 pane でコマンドが二重実行 / 文字化け / 無応答が発生（named buffer 化以前の現象）"
+  detection_condition: "paste-buffer -b のない unbuffered 形に regress した場合（session-comm.sh の named buffer 実装が削除されたとき）"
+  action: "serial 15s 制約は不要（named buffer で衝突回避済み）。regress 検出時は session-comm.sh の load-buffer -b / paste-buffer -b / delete-buffer -b 実装を復元すること"
   memory_hash: "06fd9a74"
 
 hist-inject-wait-timeout:


### PR DESCRIPTION
## 概要

Issue #1050 の実装。`cmd_inject_file` が anonymous buffer を使用していたため、並列実行時にバッファが衝突する問題を修正。

## 変更内容

- **named buffer 化**: `tmux load-buffer -b <unique-name>` / `paste-buffer -b <unique-name>` / `delete-buffer -b <unique-name>`
- **衝突回避**: バッファ名に `session-comm-$$-$(date +%s%N)` (PID+ナノ秒) を使用
- **EXIT trap**: 異常終了時もバッファがリークしないよう保証
- **tmux 2.0+ 前提コメント**: `delete-buffer -b` は tmux 2.0+ 追加
- **observation-pattern-catalog.md 更新**: `[BUFFER-COLLIDE]` の serial 15s 制約を解除

## テスト

- 新規: `plugins/session/tests/issue-1050-inject-file-named-buffer.bats` (12 tests, 全件 GREEN)
- 既存: `session-comm.test.sh` (9 PASS), `session-comm-robustness.test.sh` (15 PASS)

Closes #1050