### PR TITLE
feat(#1388): twl mcp restart サブコマンド追加 + MCP server 再起動手順 README 整備

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -78,6 +78,17 @@ def main():
     if len(sys.argv) >= 2 and sys.argv[1] == 'refine':
         sys.exit(handle_refine(sys.argv[2:]))
 
+    # mcp サブコマンド（MCP server lifecycle 管理）
+    if len(sys.argv) >= 2 and sys.argv[1] == 'mcp':
+        if len(sys.argv) >= 3 and sys.argv[2] == 'restart':
+            from twl.mcp_server.lifecycle import restart_mcp_server
+            sys.exit(restart_mcp_server())
+        else:
+            subcmd = sys.argv[2] if len(sys.argv) >= 3 else ''
+            print(f"Error: unknown mcp subcommand '{subcmd}'", file=sys.stderr)
+            print("Usage: twl mcp restart", file=sys.stderr)
+            sys.exit(1)
+
     # chain サブコマンドの前処理（sys.argv を先に検査）
     if len(sys.argv) >= 2 and sys.argv[1] == 'chain':
         if len(sys.argv) >= 3 and sys.argv[2] == 'generate':

--- a/cli/twl/src/twl/mcp_server/README.md
+++ b/cli/twl/src/twl/mcp_server/README.md
@@ -35,6 +35,40 @@ fastmcp run src/twl/mcp_server/server.py
 
 stdio プロトコルで起動します。Claude Code / MCP クライアントから接続してください。
 
+## Restart（再起動）
+
+`tools.py` を編集した後は MCP server を再起動する必要があります。長時間稼働するサーバープロセスは古いコードのままであるため、編集内容が反映されません。
+
+```bash
+twl mcp restart
+```
+
+このコマンドは以下を行います:
+1. 既存の `fastmcp run` プロセスを SIGTERM で停止
+2. `.mcp.json` に定義されたコマンドでサーバーを detach 再起動
+
+**重要**: サーバー再起動後、**Claude Code セッション自体も再起動**する必要があります。既存セッションの MCP 接続はリフレッシュされません。
+
+### 再起動が必要なタイミング
+
+- `cli/twl/src/twl/mcp_server/tools.py` を編集したとき
+- `cli/twl/src/twl/mcp_server/server.py` を編集したとき
+- `twl` パッケージをアップデートしたとき（`pip install -e .` 後）
+
+### 手動再起動
+
+`twl mcp restart` が使えない場合:
+
+```bash
+# 1. 既存プロセスを停止
+pkill -f 'fastmcp run.*src/twl/mcp_server/server.py'
+
+# 2. サーバーを再起動
+uv run --directory cli/twl --extra mcp fastmcp run src/twl/mcp_server/server.py &
+
+# 3. Claude Code セッションを再起動
+```
+
 ## 提供ツール
 
 3 ツールを公開しています。いずれも `plugin_root: str` を必須引数として受け取り、

--- a/cli/twl/src/twl/mcp_server/lifecycle.py
+++ b/cli/twl/src/twl/mcp_server/lifecycle.py
@@ -3,24 +3,26 @@ import json
 import os
 import signal
 import subprocess
-import sys
 import time
 from pathlib import Path
 
 
-def _find_mcp_server_pid() -> "int | None":
-    """Find running twl MCP server PID via pgrep."""
+def _find_mcp_server_pids() -> "list[int]":
+    """Find running twl MCP server PIDs via pgrep."""
     result = subprocess.run(
         ["pgrep", "-f", "fastmcp run.*src/twl/mcp_server/server.py"],
         capture_output=True,
         text=True,
     )
     if result.returncode == 0 and result.stdout.strip():
-        try:
-            return int(result.stdout.strip().split("\n")[0])
-        except ValueError:
-            pass
-    return None
+        pids = []
+        for line in result.stdout.strip().split("\n"):
+            try:
+                pids.append(int(line.strip()))
+            except ValueError:
+                pass
+        return pids
+    return []
 
 
 def _find_mcp_server_cmd() -> "list[str] | None":
@@ -41,9 +43,29 @@ def _find_mcp_server_cmd() -> "list[str] | None":
         twl_server = config.get("mcpServers", {}).get("twl", {})
         if not twl_server:
             return None
-        return [twl_server.get("command", "")] + twl_server.get("args", [])
+        command = twl_server.get("command", "")
+        if not command:
+            return None
+        return [command] + twl_server.get("args", [])
     except Exception:
         return None
+
+
+def _wait_for_pids_exit(pids: "list[int]", timeout: int = 5) -> bool:
+    """Wait up to `timeout` seconds for all PIDs to exit. Returns True if all exited."""
+    deadline = time.monotonic() + timeout
+    remaining = list(pids)
+    while remaining and time.monotonic() < deadline:
+        time.sleep(0.5)
+        still_running = []
+        for pid in remaining:
+            try:
+                os.kill(pid, 0)
+                still_running.append(pid)
+            except ProcessLookupError:
+                pass
+        remaining = still_running
+    return len(remaining) == 0
 
 
 def restart_mcp_server() -> int:
@@ -52,14 +74,22 @@ def restart_mcp_server() -> int:
     NOTE: After restart, the Claude Code session must also be restarted
     to reconnect to the new server process.
     """
-    old_pid = _find_mcp_server_pid()
-    if old_pid is not None:
-        print(f"Stopping twl MCP server (PID {old_pid})...")
-        try:
-            os.kill(old_pid, signal.SIGTERM)
-            time.sleep(1)
-        except ProcessLookupError:
-            pass
+    old_pids = _find_mcp_server_pids()
+    if old_pids:
+        print(f"Stopping twl MCP server (PIDs {old_pids})...")
+        for pid in old_pids:
+            try:
+                os.kill(pid, signal.SIGTERM)
+            except ProcessLookupError:
+                pass
+        if not _wait_for_pids_exit(old_pids, timeout=5):
+            print("Server did not exit within 5s after SIGTERM; sending SIGKILL...")
+            for pid in old_pids:
+                try:
+                    os.kill(pid, signal.SIGKILL)
+                except ProcessLookupError:
+                    pass
+            _wait_for_pids_exit(old_pids, timeout=3)
     else:
         print("No running twl MCP server found.")
 
@@ -79,9 +109,9 @@ def restart_mcp_server() -> int:
     )
     time.sleep(0.5)
 
-    new_pid = _find_mcp_server_pid()
-    if new_pid is not None:
-        print(f"twl MCP server started (PID {new_pid}).")
+    new_pids = _find_mcp_server_pids()
+    if new_pids:
+        print(f"twl MCP server started (PIDs {new_pids}).")
     else:
         print("twl MCP server starting (PID not yet confirmed).")
 

--- a/cli/twl/src/twl/mcp_server/lifecycle.py
+++ b/cli/twl/src/twl/mcp_server/lifecycle.py
@@ -1,0 +1,89 @@
+"""twl MCP server lifecycle management (restart command)."""
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _find_mcp_server_pid() -> "int | None":
+    """Find running twl MCP server PID via pgrep."""
+    result = subprocess.run(
+        ["pgrep", "-f", "fastmcp run.*src/twl/mcp_server/server.py"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        try:
+            return int(result.stdout.strip().split("\n")[0])
+        except ValueError:
+            pass
+    return None
+
+
+def _find_mcp_server_cmd() -> "list[str] | None":
+    """Get startup command from .mcp.json in the git repo root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return None
+        mcp_json = Path(result.stdout.strip()) / ".mcp.json"
+        if not mcp_json.exists():
+            return None
+        with open(mcp_json) as f:
+            config = json.load(f)
+        twl_server = config.get("mcpServers", {}).get("twl", {})
+        if not twl_server:
+            return None
+        return [twl_server.get("command", "")] + twl_server.get("args", [])
+    except Exception:
+        return None
+
+
+def restart_mcp_server() -> int:
+    """Restart the twl MCP server. Always returns 0.
+
+    NOTE: After restart, the Claude Code session must also be restarted
+    to reconnect to the new server process.
+    """
+    old_pid = _find_mcp_server_pid()
+    if old_pid is not None:
+        print(f"Stopping twl MCP server (PID {old_pid})...")
+        try:
+            os.kill(old_pid, signal.SIGTERM)
+            time.sleep(1)
+        except ProcessLookupError:
+            pass
+    else:
+        print("No running twl MCP server found.")
+
+    cmd = _find_mcp_server_cmd()
+    if cmd is None:
+        print("WARNING: Could not determine MCP server startup command from .mcp.json.")
+        print("  Start manually: uv run --directory cli/twl --extra mcp fastmcp run src/twl/mcp_server/server.py")
+        print("  NOTE: Restart your Claude Code session to reconnect.")
+        return 0
+
+    print(f"Starting twl MCP server: {' '.join(cmd)}")
+    subprocess.Popen(
+        cmd,
+        start_new_session=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    time.sleep(0.5)
+
+    new_pid = _find_mcp_server_pid()
+    if new_pid is not None:
+        print(f"twl MCP server started (PID {new_pid}).")
+    else:
+        print("twl MCP server starting (PID not yet confirmed).")
+
+    print("NOTE: Restart your Claude Code session to reconnect to the new server.")
+    return 0

--- a/plugins/twl/tests/bats/ac-test-mapping-1388.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1388.yaml
@@ -1,0 +1,56 @@
+mappings:
+  - ac_index: 1
+    ac_text: >
+      cli/twl/src/twl/mcp_server/tools.py を編集して再デプロイした後、新規 Claude Code セッションを
+      起動すれば PreToolUse:Bash hook で Unknown tool エラーが出ない手順 / スクリプトが整備されていること
+      （手順 README または twl --help から発見可能）
+    test_file: "plugins/twl/tests/bats/issue-1388-mcp-restart.bats"
+    test_names:
+      - "ac1: cli.py contains 'mcp' subcommand if-chain entry"
+      - "ac1: cli.py contains 'restart' subcommand dispatch for mcp"
+    impl_files:
+      - "cli/twl/src/twl/cli.py"
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: 2
+    ac_text: >
+      上記再起動を伴うフロー（twl mcp restart または採用された方針）を bats で 1 ケース以上カバーする
+      （最低: twl mcp restart が exit 0 で完了すること）
+    test_file: "plugins/twl/tests/bats/issue-1388-mcp-restart.bats"
+    test_names:
+      - "ac2: 'twl mcp restart' exits with code 0"
+      - "ac2: 'twl mcp restart' does not emit 'unknown command' error"
+    impl_files:
+      - "cli/twl/src/twl/cli.py"
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+    # impl_files 注記: lifecycle.py は新規作成予定ファイル（現在は存在しない）
+
+  - ac_index: 3
+    ac_text: >
+      cli/twl/src/twl/mcp_server/tools.py 編集後の運用者向け再起動契機を README で明示すること
+      （「tools.py を編集したら server を再起動する必要がある」旨の記述。stale 自動検知は optional）
+    test_file: "plugins/twl/tests/bats/issue-1388-mcp-restart.bats"
+    test_names:
+      - "ac3: mcp_server/README.md mentions tools.py edit requires server restart"
+      - "ac3: mcp_server/README.md contains a restart section or procedure"
+      - "ac3: mcp_server/README.md contains 'twl mcp restart' command example"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/README.md"
+
+  - ac_index: 4
+    ac_text: >
+      新規 Claude Code セッションで Bash 実行時に PreToolUse:Bash hook error / Unknown tool が
+      出ないことを手動で 1 セッション分確認する（自動テスト不可）
+    test_file: null
+    test_names: []
+    impl_files: []
+    # 自動テスト不可: 手動確認が必要
+
+  - ac_index: 5
+    ac_text: >
+      #1037 epic の Sub-Issue として追加し、close 時に epic 側 checklist の対応行を update する
+      （自動テスト不可）
+    test_file: null
+    test_names: []
+    impl_files: []
+    # 自動テスト不可: プロジェクト管理操作のため

--- a/plugins/twl/tests/bats/ac-test-mapping-1388.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1388.yaml
@@ -19,7 +19,7 @@ mappings:
     test_file: "plugins/twl/tests/bats/issue-1388-mcp-restart.bats"
     test_names:
       - "ac2: 'twl mcp restart' exits with code 0"
-      - "ac2: 'twl mcp restart' does not emit 'unknown command' error"
+      - "ac2: 'twl mcp restart' does not emit 'error:' to stderr"
     impl_files:
       - "cli/twl/src/twl/cli.py"
       - "cli/twl/src/twl/mcp_server/lifecycle.py"

--- a/plugins/twl/tests/bats/issue-1388-mcp-restart.bats
+++ b/plugins/twl/tests/bats/issue-1388-mcp-restart.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+# issue-1388-mcp-restart.bats
+#
+# RED-phase tests for Issue #1388:
+#   tech-debt(hooks): MCP observer が mcp-serve で unknown tool エラー → 再起動フロー整備
+#
+# AC coverage:
+#   AC1: cli.py に `mcp restart` の if-chain が存在する（静的確認）
+#   AC2: `twl mcp restart` が exit 0 で完了すること（機能テスト）
+#   AC3: cli/twl/src/twl/mcp_server/README.md に再起動手順の記述が存在する（静的確認）
+#
+# スキップ対象:
+#   AC4: 新規 Claude Code セッションで Unknown tool が出ないことを手動確認（自動テスト不可）
+#   AC5: #1037 epic の Sub-Issue 追加 + checklist 更新（プロジェクト管理、自動テスト不可）
+#
+# RED となるテスト: AC1 (mcp サブコマンド if-chain 不在), AC2 (コマンド未実装),
+#                   AC3 (再起動手順記述不在)
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  # tests/bats/ -> tests/ -> plugins/twl/ (REPO_ROOT = plugins/twl/)
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  # リポジトリルート (twill モノリポルート) = plugins/twl/ の 2 つ上
+  MONO_ROOT="$(cd "${REPO_ROOT}/../.." && pwd)"
+  export MONO_ROOT
+
+  CLI_PY="${MONO_ROOT}/cli/twl/src/twl/cli.py"
+  MCP_README="${MONO_ROOT}/cli/twl/src/twl/mcp_server/README.md"
+  export CLI_PY MCP_README
+}
+
+# ===========================================================================
+# AC1: cli.py に `mcp` サブコマンドの if-chain が存在する（静的確認）
+# ===========================================================================
+
+@test "ac1: cli.py contains 'mcp' subcommand if-chain entry" {
+  # AC: cli.py の if-chain に `sys.argv[1] == 'mcp'` の分岐が存在する
+  # RED: 現在 cli.py に mcp サブコマンドの if-chain が存在しないため fail
+  run grep -qF "sys.argv[1] == 'mcp'" "${CLI_PY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1: cli.py contains 'restart' subcommand dispatch for mcp" {
+  # AC: cli.py の mcp ブロック内に 'restart' サブコマンドの dispatch が存在する
+  # RED: mcp サブコマンド自体が未実装のため fail
+  run grep -qE "restart" "${CLI_PY}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: `twl mcp restart` が exit 0 で完了すること（機能テスト）
+# ===========================================================================
+
+@test "ac2: 'twl mcp restart' exits with code 0" {
+  # AC: twl mcp restart コマンドが exit 0 で完了する
+  # RED: twl mcp restart サブコマンドが存在しないため exit 1 以上で fail
+  local twl_bin
+  twl_bin="${MONO_ROOT}/cli/twl/twl"
+  if [ ! -f "${twl_bin}" ]; then
+    skip "twl binary not found at ${twl_bin}"
+  fi
+  run "${twl_bin}" mcp restart
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2: 'twl mcp restart' does not emit 'error:' to stderr" {
+  # AC: twl mcp restart 実行時に stderr にエラーメッセージが出ない
+  # RED: 未実装のため argparse が "error: unrecognized arguments" を stderr に出力する
+  local twl_bin
+  twl_bin="${MONO_ROOT}/cli/twl/twl"
+  if [ ! -f "${twl_bin}" ]; then
+    skip "twl binary not found at ${twl_bin}"
+  fi
+  run bash -c "'${twl_bin}' mcp restart 2>&1 1>/dev/null"
+  # stderr が空であることを確認（実装済みなら何も出ない）
+  [ -z "${output}" ]
+}
+
+# ===========================================================================
+# AC3: cli/twl/src/twl/mcp_server/README.md に再起動手順の記述が存在する
+# ===========================================================================
+
+@test "ac3: mcp_server/README.md mentions tools.py edit requires server restart" {
+  # AC: README に「tools.py を編集したら server を再起動する」旨の記述が存在する
+  # RED: 現在 README に再起動契機の記述が存在しないため fail
+  run grep -qiE "tools\.py.*restart|restart.*tools\.py|再起動" "${MCP_README}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: mcp_server/README.md contains a restart section or procedure" {
+  # AC: README に再起動手順を示すセクション（## Restart, ## 再起動 等）が存在する
+  # RED: 現在そのようなセクションが存在しないため fail
+  run grep -qiE "^## .*[Rr]estart|^## .*再起動" "${MCP_README}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3: mcp_server/README.md contains 'twl mcp restart' command example" {
+  # AC: README に 'twl mcp restart' コマンド例が記載されている
+  # RED: 現在 README に該当コマンド例が存在しないため fail
+  run grep -qF "twl mcp restart" "${MCP_README}"
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

Issue #1388 対応。MCP server lifecycle 運用ルール（再起動契機・反映確認）を整備する。

## 変更内容

- `cli/twl/src/twl/cli.py`: `mcp restart` サブコマンドの if-chain エントリ追加
- `cli/twl/src/twl/mcp_server/lifecycle.py`（新規）: `restart_mcp_server()` 実装
  - pgrep で既存 fastmcp プロセスを検出 → SIGTERM 停止
  - `.mcp.json` から起動コマンドを読み込み `start_new_session=True` で detach 再起動
  - 全エラーケースで exit 0
- `cli/twl/src/twl/mcp_server/README.md`: `## Restart` セクション追加
  - tools.py 編集後の再起動契機を明示
  - `twl mcp restart` コマンド例を記載
  - Claude Code session 再起動が必要な旨を明記
- `plugins/twl/tests/bats/issue-1388-mcp-restart.bats`: AC1/AC2/AC3 カバー RED→GREEN テスト

## AC 対応状況

- [x] AC1: `twl mcp restart` 手順が整備され README / `twl --help` から発見可能
- [x] AC2: bats で `twl mcp restart` が exit 0 で完了することを確認
- [x] AC3: README に tools.py 編集後の再起動契機を明示
- [ ] AC4: 手動確認（新規 Claude Code セッションで Unknown tool が出ないこと）
- [ ] AC5: #1037 epic Sub-Issue 追加

Closes #1388