### PR TITLE
fix(#1404): cmd_inject を session_msg send 経由に統一（TWILL_MSG_BACKEND 尊重）

### DIFF
--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -295,21 +295,18 @@ cmd_inject() {
         exit 1
     }
     local lock_file="${lock_dir}/session-comm-${target//[^a-zA-Z0-9]/-}.lock"
-    # shellcheck source=./session-comm-backend-tmux.sh
-    source "${SCRIPT_DIR}/session-comm-backend-tmux.sh"
     {
         flock -w 30 9 || {
             echo "Error: failed to acquire send lock for '$window_name'" >&2
             exit 1
         }
-        # Delegate to backend (AC-1: no direct send-keys in this file)
         if $no_enter; then
-            _backend_tmux_send "$target" "$text" --no-enter || {
+            session_msg send "$target" "$text" --no-enter || {
                 echo "Error: failed to send keys to '$window_name'" >&2
                 exit 1
             }
         else
-            _backend_tmux_send "$target" "$text" || {
+            session_msg send "$target" "$text" || {
                 echo "Error: failed to send keys to '$window_name'" >&2
                 exit 1
             }

--- a/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
+++ b/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
@@ -88,8 +88,9 @@ _extract_cmd_inject_body() {
 # ===========================================================================
 
 @test "ac4: TWILL_MSG_BACKEND=mcp で cmd_inject が mcp backend に dispatch される" {
-    # mock session-state.sh: always input-waiting
     mkdir -p "$SANDBOX/bin"
+
+    # mock session-state.sh: always input-waiting
     cat > "$SANDBOX/bin/session-state.sh" <<'EOF'
 #!/usr/bin/env bash
 echo "input-waiting"
@@ -97,13 +98,12 @@ exit 0
 EOF
     chmod +x "$SANDBOX/bin/session-state.sh"
 
-    # mock tmux: target 解決用（display-message で pane ID を返す）
+    # mock tmux: list-windows -a -F で resolve_target が期待する形式を返す
     cat > "$SANDBOX/bin/tmux" <<'EOF'
 #!/usr/bin/env bash
 case "${1:-}" in
-    display-message) echo "mock-pane" ;;
-    list-windows)    echo "main" ;;
-    has-session)     exit 0 ;;
+    list-windows) echo "testsession:0 main" ;;
+    has-session)  exit 0 ;;
     send-keys)
         echo "FAIL: tmux send-keys was called directly (should go through session_msg → mcp backend)" >&2
         exit 1
@@ -116,21 +116,17 @@ EOF
     # mock session-comm-backend-mcp.sh: call を記録して成功
     local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
     local mock_mcp="$SANDBOX/mock-mcp-called"
-    local orig_mcp=""
-    if [[ -f "$backend_mcp" ]]; then
-        orig_mcp=$(cat "$backend_mcp")
-    fi
+    local orig_mcp_content=""
+    [[ -f "$backend_mcp" ]] && orig_mcp_content=$(cat "$backend_mcp")
 
-    # 一時的に backend-mcp.sh を差し替え（teardown で復元）
     cat > "$backend_mcp" <<EOF
 #!/usr/bin/env bash
-# mock: mcp backend stub
 _backend_mcp_send() {
-    echo "mcp-backend-called" > "$mock_mcp"
+    echo "mcp-backend-called" > "${mock_mcp}"
     return 0
 }
 _backend_shadow_send() {
-    echo "shadow-backend-called" > "$mock_mcp"
+    echo "shadow-backend-called" > "${mock_mcp}"
     return 0
 }
 EOF
@@ -141,9 +137,9 @@ EOF
     TWILL_MSG_BACKEND=mcp \
     bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || exit_code=$?
 
-    # 元の backend-mcp.sh を復元
-    if [[ -n "$orig_mcp" ]]; then
-        echo "$orig_mcp" > "$backend_mcp"
+    # backend-mcp.sh を復元
+    if [[ -n "$orig_mcp_content" ]]; then
+        echo "$orig_mcp_content" > "$backend_mcp"
     else
         rm -f "$backend_mcp"
     fi
@@ -175,15 +171,14 @@ exit 0
 EOF
     chmod +x "$SANDBOX/bin/session-state.sh"
 
-    # mock tmux: send-keys の呼び出しを記録
+    # mock tmux: list-windows -a -F で resolve_target が期待する形式 + send-keys 記録
     cat > "$SANDBOX/bin/tmux" <<EOF
 #!/usr/bin/env bash
 case "\${1:-}" in
-    display-message) echo "mock-pane" ;;
-    list-windows)    echo "main" ;;
-    has-session)     exit 0 ;;
+    list-windows) echo "testsession:0 main" ;;
+    has-session)  exit 0 ;;
     send-keys)
-        echo "\$@" > "$sent_file"
+        echo "\$@" > "${sent_file}"
         exit 0
         ;;
     *) exit 0 ;;

--- a/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
+++ b/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
@@ -1,0 +1,204 @@
+#!/usr/bin/env bats
+# issue-1404-cmdinject-session-msg.bats
+# Issue #1404: cmd_inject が TWILL_MSG_BACKEND を無視する — session_msg 経由への統一
+# Spec: issue-1404
+# Coverage: --type=structural,functional
+
+# RED: cmd_inject がまだ直接 source backend-tmux.sh + _backend_tmux_send を呼んでいるため FAIL
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
+    SANDBOX="$(mktemp -d)"
+    export SANDBOX SCRIPT PLUGIN_ROOT
+}
+
+teardown() {
+    [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+# ===========================================================================
+# helper: cmd_inject 関数本体のみ抽出（setup/teardown 外の grep 対象）
+# ===========================================================================
+
+_extract_cmd_inject_body() {
+    # cmd_inject() { ... } の本体のみ抽出（次の空行 or 次の関数定義まで）
+    awk '/^cmd_inject\(\) *\{/,/^\}/' "$SCRIPT" 2>/dev/null
+}
+
+# ===========================================================================
+# AC-1: cmd_inject が session-comm-backend-tmux.sh を直接 source しない（構造確認）
+#
+# RED: 現状 cmd_inject 本体に source "${SCRIPT_DIR}/session-comm-backend-tmux.sh" があるため FAIL
+# ===========================================================================
+
+@test "ac1: cmd_inject 関数が session-comm-backend-tmux.sh を直接 source しない" {
+    local body
+    body=$(_extract_cmd_inject_body)
+
+    if echo "$body" | grep -q 'source.*session-comm-backend-tmux\.sh'; then
+        echo "FAIL: cmd_inject が session-comm-backend-tmux.sh を直接 source している" >&2
+        echo "  session_msg send 経由に変更が必要" >&2
+        echo "  発見行:" >&2
+        echo "$body" | grep 'source.*session-comm-backend-tmux\.sh' | sed 's/^/    /' >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC-2: cmd_inject が _backend_tmux_send を直接呼び出さない（構造確認）
+#
+# RED: 現状 cmd_inject 本体に _backend_tmux_send 直呼び出しがあるため FAIL
+# ===========================================================================
+
+@test "ac2: cmd_inject 関数が _backend_tmux_send を直接呼び出さない" {
+    local body
+    body=$(_extract_cmd_inject_body)
+
+    if echo "$body" | grep -q '_backend_tmux_send'; then
+        echo "FAIL: cmd_inject が _backend_tmux_send を直接呼び出している" >&2
+        echo "  session_msg send 経由に統一が必要（TWILL_MSG_BACKEND を尊重するため）" >&2
+        echo "  発見行:" >&2
+        echo "$body" | grep '_backend_tmux_send' | sed 's/^/    /' >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC-3: cmd_inject 関数が session_msg を呼び出す（構造確認）
+#
+# RED: 現状 cmd_inject 本体に session_msg 呼び出しがないため FAIL
+# ===========================================================================
+
+@test "ac3: cmd_inject 関数が session_msg send を経由する" {
+    local body
+    body=$(_extract_cmd_inject_body)
+
+    if ! echo "$body" | grep -q 'session_msg'; then
+        echo "FAIL: cmd_inject に session_msg 呼び出しが存在しない" >&2
+        echo "  session_msg send <target> <text> [--no-enter] に変更が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC-4: TWILL_MSG_BACKEND=mcp 設定時、cmd_inject が mcp backend を呼ぶ（機能確認）
+#
+# RED: 現状 cmd_inject は TWILL_MSG_BACKEND を無視して tmux backend を直接呼ぶため FAIL
+# ===========================================================================
+
+@test "ac4: TWILL_MSG_BACKEND=mcp で cmd_inject が mcp backend に dispatch される" {
+    # mock session-state.sh: always input-waiting
+    mkdir -p "$SANDBOX/bin"
+    cat > "$SANDBOX/bin/session-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "input-waiting"
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/session-state.sh"
+
+    # mock tmux: target 解決用（display-message で pane ID を返す）
+    cat > "$SANDBOX/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    display-message) echo "mock-pane" ;;
+    list-windows)    echo "main" ;;
+    has-session)     exit 0 ;;
+    send-keys)
+        echo "FAIL: tmux send-keys was called directly (should go through session_msg → mcp backend)" >&2
+        exit 1
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SANDBOX/bin/tmux"
+
+    # mock session-comm-backend-mcp.sh: call を記録して成功
+    local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
+    local mock_mcp="$SANDBOX/mock-mcp-called"
+    local orig_mcp=""
+    if [[ -f "$backend_mcp" ]]; then
+        orig_mcp=$(cat "$backend_mcp")
+    fi
+
+    # 一時的に backend-mcp.sh を差し替え（teardown で復元）
+    cat > "$backend_mcp" <<EOF
+#!/usr/bin/env bash
+# mock: mcp backend stub
+_backend_mcp_send() {
+    echo "mcp-backend-called" > "$mock_mcp"
+    return 0
+}
+_backend_shadow_send() {
+    echo "shadow-backend-called" > "$mock_mcp"
+    return 0
+}
+EOF
+
+    local exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    SESSION_COMM_LOCK_DIR="/tmp" \
+    TWILL_MSG_BACKEND=mcp \
+    bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || exit_code=$?
+
+    # 元の backend-mcp.sh を復元
+    if [[ -n "$orig_mcp" ]]; then
+        echo "$orig_mcp" > "$backend_mcp"
+    else
+        rm -f "$backend_mcp"
+    fi
+
+    if [[ ! -f "$mock_mcp" ]]; then
+        echo "FAIL: TWILL_MSG_BACKEND=mcp を設定しても mcp backend が呼ばれなかった" >&2
+        echo "  cmd_inject が TWILL_MSG_BACKEND を無視して tmux backend を直呼びしている可能性" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC-5: TWILL_MSG_BACKEND=tmux（デフォルト）で cmd_inject が tmux backend を呼ぶ（後退確認）
+#
+# RED: session_msg 経由の dispatch が未実装のため挙動変化で確認困難だが、
+#      session_msg 関数定義後は tmux backend が呼ばれるはず
+# ===========================================================================
+
+@test "ac5: TWILL_MSG_BACKEND=tmux（デフォルト）で cmd_inject が tmux send-keys を実行する" {
+    local sent_file="$SANDBOX/tmux-sent"
+
+    mkdir -p "$SANDBOX/bin"
+
+    # mock session-state.sh: always input-waiting
+    cat > "$SANDBOX/bin/session-state.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "input-waiting"
+exit 0
+EOF
+    chmod +x "$SANDBOX/bin/session-state.sh"
+
+    # mock tmux: send-keys の呼び出しを記録
+    cat > "$SANDBOX/bin/tmux" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+    display-message) echo "mock-pane" ;;
+    list-windows)    echo "main" ;;
+    has-session)     exit 0 ;;
+    send-keys)
+        echo "\$@" > "$sent_file"
+        exit 0
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SANDBOX/bin/tmux"
+
+    PATH="$SANDBOX/bin:$PATH" \
+    SESSION_COMM_LOCK_DIR="/tmp" \
+    TWILL_MSG_BACKEND=tmux \
+    bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || true
+
+    if [[ ! -f "$sent_file" ]]; then
+        echo "FAIL: TWILL_MSG_BACKEND=tmux で tmux send-keys が呼ばれなかった" >&2
+        echo "  後退: tmux backend 経由の基本動作が壊れている可能性" >&2
+        return 1
+    fi
+}

--- a/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
+++ b/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
@@ -10,10 +10,16 @@ setup() {
     PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
     SANDBOX="$(mktemp -d)"
-    export SANDBOX SCRIPT PLUGIN_ROOT
+    BACKEND_MCP_BAK=""  # ac4 で設定。teardown が安全ネットとして復元
+    export SANDBOX SCRIPT PLUGIN_ROOT BACKEND_MCP_BAK
 }
 
 teardown() {
+    # ac4: 本番 backend-mcp.sh が上書きされた場合の安全ネット復元
+    if [[ -n "${BACKEND_MCP_BAK:-}" && -f "$BACKEND_MCP_BAK" ]]; then
+        local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
+        mv "$BACKEND_MCP_BAK" "$backend_mcp"
+    fi
     [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
 }
 
@@ -116,8 +122,9 @@ EOF
     # mock session-comm-backend-mcp.sh: call を記録して成功
     local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
     local mock_mcp="$SANDBOX/mock-mcp-called"
-    local orig_mcp_content=""
-    [[ -f "$backend_mcp" ]] && orig_mcp_content=$(cat "$backend_mcp")
+    # teardown 安全ネット用バックアップ（bats kill 時でも復元される）
+    BACKEND_MCP_BAK="$SANDBOX/session-comm-backend-mcp.sh.bak"
+    [[ -f "$backend_mcp" ]] && cp "$backend_mcp" "$BACKEND_MCP_BAK"
 
     cat > "$backend_mcp" <<EOF
 #!/usr/bin/env bash
@@ -131,18 +138,19 @@ _backend_shadow_send() {
 }
 EOF
 
-    local exit_code=0
+    # --force: state チェックをスキップ（session-state.sh は SCRIPT_DIR 絶対パス呼出のため PATH mock 非介入）
     PATH="$SANDBOX/bin:$PATH" \
     SESSION_COMM_LOCK_DIR="/tmp" \
     TWILL_MSG_BACKEND=mcp \
-    bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || exit_code=$?
+    bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || true
 
-    # backend-mcp.sh を復元
-    if [[ -n "$orig_mcp_content" ]]; then
-        echo "$orig_mcp_content" > "$backend_mcp"
+    # backend-mcp.sh を復元（teardown も安全ネットとして同じ復元を行う）
+    if [[ -f "$BACKEND_MCP_BAK" ]]; then
+        mv "$BACKEND_MCP_BAK" "$backend_mcp"
     else
         rm -f "$backend_mcp"
     fi
+    BACKEND_MCP_BAK=""
 
     if [[ ! -f "$mock_mcp" ]]; then
         echo "FAIL: TWILL_MSG_BACKEND=mcp を設定しても mcp backend が呼ばれなかった" >&2


### PR DESCRIPTION
## 概要

Issue #1404 の対処。`cmd_inject` が `TWILL_MSG_BACKEND` を無視して直接 tmux backend を呼んでいた問題を修正。

## 変更内容

### `plugins/session/scripts/session-comm.sh`

`cmd_inject` 関数内で直接 `source session-comm-backend-tmux.sh` + `_backend_tmux_send` を呼んでいた箇所を `session_msg send` 経由に変更。

**変更前:**
```bash
source "${SCRIPT_DIR}/session-comm-backend-tmux.sh"
_backend_tmux_send "$target" "$text" --no-enter
```

**変更後:**
```bash
session_msg send "$target" "$text" --no-enter
```

### `plugins/session/tests/issue-1404-cmdinject-session-msg.bats`

5 件の bats テストを追加:
- ac1: `cmd_inject` が `session-comm-backend-tmux.sh` を直接 source しない（構造）
- ac2: `cmd_inject` が `_backend_tmux_send` を直接呼び出さない（構造）
- ac3: `cmd_inject` が `session_msg send` を経由する（構造）
- ac4: `TWILL_MSG_BACKEND=mcp` で mcp backend に dispatch される（機能）
- ac5: `TWILL_MSG_BACKEND=tmux` で tmux send-keys が実行される（後退確認）

## テスト結果

```
5/5 PASS
```

## 参照

- Issue #1404 (本 PR)
- Issue #1032 (Phase 2: Strategy pattern 実装)
- ADR-029 Decision 5

Closes #1404
