### PR TITLE
fix(auto-merge): session-scoped post-kill check で他セッション同名 window の誤検知を解消 (#1393)

### DIFF
--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -244,9 +244,13 @@ if [[ "$REPO_MODE" == "worktree" ]]; then
     WORKER_WINDOW=$(python3 -m twl.autopilot.state read --autopilot-dir "$(resolve_autopilot_dir)" --type issue --issue "$ISSUE_NUM" --field window 2>/dev/null || echo "")
     if [[ -n "$WORKER_WINDOW" ]]; then
       echo "[auto-merge] Issue #${ISSUE_NUM}: Worker window (${WORKER_WINDOW}) kill — worktree 削除前"
+      # #1393: kill 前に Worker window が属するセッションを解決（post-kill check を session-scoped にするため）
+      WORKER_SESSION=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null \
+        | awk -v wn="$WORKER_WINDOW" '$2 == wn {split($1, a, ":"); print a[1]; exit}')
       safe_kill_window "$WORKER_WINDOW"
-      # #898 safety net: kill 後に window が残存していれば worktree 削除を中止（CWD 消失事故防止）
-      if tmux list-windows -a -F '#{window_name}' 2>/dev/null | grep -qxF -- "$WORKER_WINDOW"; then
+      # #898 safety net: kill 後に Worker session の window が残存していれば worktree 削除を中止（CWD 消失事故防止）
+      # #1393: list-windows -a（全セッション）ではなく session-scoped check で他セッション同名 window の誤検知を防ぐ
+      if [[ -n "$WORKER_SESSION" ]] && tmux list-windows -t "$WORKER_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF -- "$WORKER_WINDOW"; then
         echo "[auto-merge] Issue #${ISSUE_NUM}: ERROR: Worker window kill 失敗 — worktree 削除中止 (unsafe state)" >&2
         exit 1
       fi

--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -245,11 +245,13 @@ if [[ "$REPO_MODE" == "worktree" ]]; then
     if [[ -n "$WORKER_WINDOW" ]]; then
       echo "[auto-merge] Issue #${ISSUE_NUM}: Worker window (${WORKER_WINDOW}) kill — worktree 削除前"
       # #1393: kill 前に Worker window が属するセッションを解決（post-kill check を session-scoped にするため）
+      # sub(/:[^:]+$/, "", $1) で末尾の ":window_index" を除去（session 名にコロンが含まれる場合も正しく抽出）
       WORKER_SESSION=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null \
-        | awk -v wn="$WORKER_WINDOW" '$2 == wn {split($1, a, ":"); print a[1]; exit}')
+        | awk -v wn="$WORKER_WINDOW" '$2 == wn {sub(/:[^:]+$/, "", $1); print $1; exit}')
       safe_kill_window "$WORKER_WINDOW"
       # #898 safety net: kill 後に Worker session の window が残存していれば worktree 削除を中止（CWD 消失事故防止）
       # #1393: list-windows -a（全セッション）ではなく session-scoped check で他セッション同名 window の誤検知を防ぐ
+      # WORKER_SESSION が空（window が kill 前から不在 or tmux 未起動）の場合は check をスキップ（安全側フォールバック）
       if [[ -n "$WORKER_SESSION" ]] && tmux list-windows -t "$WORKER_SESSION" -F '#{window_name}' 2>/dev/null | grep -qxF -- "$WORKER_WINDOW"; then
         echo "[auto-merge] Issue #${ISSUE_NUM}: ERROR: Worker window kill 失敗 — worktree 削除中止 (unsafe state)" >&2
         exit 1

--- a/plugins/twl/tests/bats/scripts/auto-merge-898-safety-net-false-positive.bats
+++ b/plugins/twl/tests/bats/scripts/auto-merge-898-safety-net-false-positive.bats
@@ -1,0 +1,193 @@
+#!/usr/bin/env bats
+# auto-merge-898-safety-net-false-positive.bats
+#
+# Issue #1393: #898 safety net が他セッション同名 window を誤検知する問題
+#
+# 修正前の問題: post-kill check が `list-windows -a -F '#{window_name}'`（全セッション）を
+# 使うため、対象 Worker window を kill 後も別セッションに同名 window が存在すると
+# kill 失敗と誤判定して exit 1 する（false positive）。
+#
+# 修正方針: kill 前に Worker window が属するセッションを解決し、
+# post-kill check を `list-windows -t <session>` に切り替えて session-scoped にする。
+#
+# tmux stub の -F 引数検出:
+#   -F '#{session_name}:#{window_index} #{window_name}' → TMUX_ALL_WINDOWS（session:index 形式）
+#   -F '#{window_name}' + no -t         → TMUX_ALL_WINDOW_NAMES（window 名のみ、旧チェック用）
+#   -F '#{window_name}' + has -t        → TMUX_SESSION_WINDOWS（session-scoped、新チェック用）
+#
+# RED/GREEN summary:
+#   AC-1: 修正前 → exit 1（false positive）   修正後 → exit 0 ✓
+#   AC-2: 修正前後とも → exit 1（true positive 維持）✓
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  # python3 stub: non-autopilot 経路
+  WINDOW_FIELD_OUT="${WINDOW_FIELD_OUT:-ap-#1393}"
+  export WINDOW_FIELD_OUT
+
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"state read"*"--field status"*)       echo "done" ;;
+  *"state read"*"--field is_quick"*)     echo "false" ;;
+  *"state read"*"--field current_step"*) echo "" ;;
+  *"state read"*"--field window"*)       echo "${WINDOW_FIELD_OUT:-ap-#1393}" ;;
+  *"state write"*)                       exit 0 ;;
+  *)                                     exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+
+  stub_command "gh" '
+    case "$*" in
+      *"pr merge"*"--squash"*)        exit 0 ;;
+      *"pr view"*"mergeStateStatus"*) echo "CLEAN" ;;
+      *)                              exit 0 ;;
+    esac
+  '
+
+  cat > "$STUB_BIN/git" <<GITSTUB
+#!/usr/bin/env bash
+case "\$*" in
+  "rev-parse --git-dir")
+    echo "$SANDBOX/.bare/worktrees/feat1393" ;;
+  "rev-parse --show-toplevel")
+    echo "$SANDBOX" ;;
+  "worktree list --porcelain")
+    cat <<PORCELAIN
+worktree $SANDBOX/main
+branch refs/heads/main
+
+worktree $SANDBOX/worktrees/feat1393
+branch refs/heads/feat/1393-test
+
+PORCELAIN
+    ;;
+  "worktree remove --force "*)
+    [[ "\${WORKTREE_REMOVE_FAIL:-false}" == "true" ]] && exit 1 || exit 0 ;;
+  "checkout main"|"pull origin main")
+    exit 0 ;;
+  "push origin --delete "*|"branch -D "*)
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+GITSTUB
+  chmod +x "$STUB_BIN/git"
+
+  TMUX_KILL_WINDOW_LOG="$SANDBOX/tmux-kill-window.log"
+  export TMUX_KILL_WINDOW_LOG
+  : > "$TMUX_KILL_WINDOW_LOG"
+
+  # tmux stub: -F 引数と -t の有無で 3 種類の list-windows 呼び出しを区別する
+  #
+  # TMUX_ALL_WINDOWS      = "session:index window_name" 形式
+  #                          safe_kill_window + 事前セッション解決用
+  # TMUX_ALL_WINDOW_NAMES = window 名のみ（1行1名）
+  #                          旧 post-kill check 用（-a -F '#{window_name}'）
+  # TMUX_SESSION_WINDOWS  = window 名のみ
+  #                          新 session-scoped post-kill check 用（-t session -F '#{window_name}'）
+  TMUX_ALL_WINDOWS="${TMUX_ALL_WINDOWS:-worker-session:0 ap-#1393}"
+  TMUX_ALL_WINDOW_NAMES="${TMUX_ALL_WINDOW_NAMES:-ap-#1393}"
+  TMUX_SESSION_WINDOWS="${TMUX_SESSION_WINDOWS:-}"
+  export TMUX_ALL_WINDOWS TMUX_ALL_WINDOW_NAMES TMUX_SESSION_WINDOWS
+
+  cat > "$STUB_BIN/tmux" <<'TMUXSTUB'
+#!/usr/bin/env bash
+case "$1" in
+  display-message)
+    echo "main" ;;
+  list-windows)
+    # -t が引数に含まれるか確認（session-scoped query）
+    HAS_T=false
+    # -F の値を取得（次の引数）
+    FORMAT_VAL=""
+    prev=""
+    for arg in "$@"; do
+      [[ "$arg" == "-t" ]] && HAS_T=true
+      [[ "$prev" == "-F" ]] && FORMAT_VAL="$arg"
+      prev="$arg"
+    done
+
+    if $HAS_T; then
+      # session-scoped: 新 post-kill check 用
+      printf '%s\n' "${TMUX_SESSION_WINDOWS:-}"
+    elif printf '%s' "$FORMAT_VAL" | grep -q 'session_name'; then
+      # global + session:index 形式: safe_kill_window + 事前セッション解決用
+      printf '%s\n' "${TMUX_ALL_WINDOWS:-}"
+    else
+      # global + window 名のみ: 旧 post-kill check 用
+      printf '%s\n' "${TMUX_ALL_WINDOW_NAMES:-}"
+    fi ;;
+  kill-window)
+    printf '%s\n' "$*" >> "${TMUX_KILL_WINDOW_LOG}"
+    [[ "${TMUX_KILL_FAIL:-false}" == "true" ]] && exit 1
+    exit 0 ;;
+  *)
+    exit 0 ;;
+esac
+TMUXSTUB
+  chmod +x "$STUB_BIN/tmux"
+
+  stub_command "twl" 'exit 0'
+
+  mkdir -p "$SANDBOX/main"
+  cd "$SANDBOX/main"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC-1: kill 成功 + 他セッションに同名 window 残存 → exit 0（false positive 解消）
+#
+# RED:   修正前: list-windows -a -F '#{window_name}' が other-session の ap-#1393 を
+#        返すため grep が true → exit 1（false positive）
+# GREEN: 修正後: list-windows -t worker-session が空を返すため exit 0
+# ===========================================================================
+@test "#1393 AC-1: kill 後に他セッションに同名 window が残存しても exit 0（false positive 解消）" {
+  # Worker session に ap-#1393 が存在（kill 対象）、other-session にも存在
+  export TMUX_ALL_WINDOWS="worker-session:0 ap-#1393
+other-session:0 ap-#1393"
+
+  # 旧 post-kill check 用: other-session が ap-#1393 を持つため global list に現れる
+  export TMUX_ALL_WINDOW_NAMES="ap-#1393"
+
+  # 新 session-scoped check 用: worker-session は kill 後に空
+  export TMUX_SESSION_WINDOWS=""
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 1393 --pr 1394 --branch feat/1393-test
+
+  assert_success
+  assert_output --partial "Worker window (ap-#1393) kill"
+  assert_output --partial "worktree 削除成功"
+  # kill-window が実際に呼ばれた
+  assert [ -s "$TMUX_KILL_WINDOW_LOG" ]
+}
+
+# ===========================================================================
+# AC-2: kill 失敗（Worker session に window 残存）→ exit 1（true positive 維持）
+#
+# RED/GREEN どちらも: exit 1 を返すことを確認（regression guard）
+# ===========================================================================
+@test "#1393 AC-2: Worker session に window が残存する場合は exit 1（true positive 維持）" {
+  # Worker session のみに ap-#1393 が存在
+  export TMUX_ALL_WINDOWS="worker-session:0 ap-#1393"
+
+  # 旧 post-kill check 用: worker session の window が global list に現れる
+  export TMUX_ALL_WINDOW_NAMES="ap-#1393"
+
+  # 新 session-scoped check 用: kill 後も worker-session に残存
+  export TMUX_SESSION_WINDOWS="ap-#1393"
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 1393 --pr 1394 --branch feat/1393-test
+
+  assert_failure
+  assert_output --partial "ERROR: Worker window kill 失敗"
+  assert_output --partial "unsafe state"
+  refute_output --partial "worktree 削除成功"
+}

--- a/plugins/twl/tests/bats/scripts/auto-merge-worker-kill.bats
+++ b/plugins/twl/tests/bats/scripts/auto-merge-worker-kill.bats
@@ -29,12 +29,12 @@ setup() {
 #!/usr/bin/env bash
 # auto-merge.sh から呼ばれる `python3 -m twl.autopilot.state` の mock
 case "$*" in
-  *"state read"*"--field status"*) echo "done" ;;
-  *"state read"*"--field is_quick"*) echo "false" ;;
+  *"state read"*"--field status"*)       echo "done" ;;
+  *"state read"*"--field is_quick"*)     echo "false" ;;
   *"state read"*"--field current_step"*) echo "" ;;
-  *"state read"*"--field window"*) echo "${WINDOW_FIELD_OUT:-ap-#898}" ;;
-  *"state write"*) exit 0 ;;
-  *) exit 0 ;;
+  *"state read"*"--field window"*)       echo "${WINDOW_FIELD_OUT}" ;;
+  *"state write"*)                       exit 0 ;;
+  *)                                     exit 0 ;;
 esac
 PYSTUB
   chmod +x "$STUB_BIN/python3"
@@ -88,27 +88,35 @@ GITSTUB
 
   # tmux stub: display-message / list-windows / kill-window を mock
   # TMUX_KILL_WINDOW_LOG に kill-window 呼出履歴を記録
-  # TMUX_WINDOW_LIST_OUT で list-windows の出力を制御 (デフォルトは window 生存)
+  # TMUX_ALL_WINDOWS     : "session:index window_name" 形式（safe_kill_window + 事前セッション解決用）
+  # TMUX_SESSION_WINDOWS : window 名のみ（post-kill session-scoped check 用、#1393 修正後）
   # TMUX_KILL_FAIL=true のときは kill-window を失敗させる
   TMUX_KILL_WINDOW_LOG="$SANDBOX/tmux-kill-window.log"
   export TMUX_KILL_WINDOW_LOG
   : > "$TMUX_KILL_WINDOW_LOG"
 
-  TMUX_WINDOW_LIST_OUT="${TMUX_WINDOW_LIST_OUT:-ap-#898}"
-  export TMUX_WINDOW_LIST_OUT
+  TMUX_ALL_WINDOWS="${TMUX_ALL_WINDOWS:-sess1:0 ap-#898}"
+  TMUX_SESSION_WINDOWS="${TMUX_SESSION_WINDOWS:-}"
+  export TMUX_ALL_WINDOWS TMUX_SESSION_WINDOWS
 
-  cat > "$STUB_BIN/tmux" <<TMUXSTUB
+  cat > "$STUB_BIN/tmux" <<'TMUXSTUB'
 #!/usr/bin/env bash
-case "\$1" in
+case "$1" in
   display-message)
-    # auto-merge.sh L125: tmux display-message -p '#W' → non-ap window
     echo "main" ;;
   list-windows)
-    # '\${TMUX_WINDOW_LIST_OUT}' の複数行を出力 (window 名一覧)
-    printf '%s\n' "\${TMUX_WINDOW_LIST_OUT:-}" ;;
+    # -t が引数に含まれる → session-scoped（post-kill check 用）
+    HAS_T=false
+    for arg in "$@"; do [[ "$arg" == "-t" ]] && HAS_T=true; done
+    if $HAS_T; then
+      printf '%s\n' "${TMUX_SESSION_WINDOWS:-}"
+    else
+      # global (-a): session:index 形式（safe_kill_window + 事前セッション解決用）
+      printf '%s\n' "${TMUX_ALL_WINDOWS:-}"
+    fi ;;
   kill-window)
-    printf '%s\n' "\$*" >> "\${TMUX_KILL_WINDOW_LOG}"
-    if [[ "\${TMUX_KILL_FAIL:-false}" == "true" ]]; then exit 1; fi
+    printf '%s\n' "$*" >> "${TMUX_KILL_WINDOW_LOG}"
+    [[ "${TMUX_KILL_FAIL:-false}" == "true" ]] && exit 1
     exit 0 ;;
   *)
     exit 0 ;;
@@ -145,20 +153,23 @@ teardown() {
 
 @test "#898 (a): Worker window 生存 + kill 成功で worktree 削除続行" {
   export WINDOW_FIELD_OUT="ap-#898"
-  export TMUX_WINDOW_LIST_OUT="ap-#898
-main
-other-window"
+  # TMUX_ALL_WINDOWS: session:index 形式（safe_kill_window + 事前セッション解決用）
+  export TMUX_ALL_WINDOWS="sess1:0 ap-#898
+sess1:1 main
+sess1:2 other-window"
+  # TMUX_SESSION_WINDOWS: kill 後 worker session は空（kill 成功）
+  export TMUX_SESSION_WINDOWS=""
 
   run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
 
   assert_success
   # safety net 発火確認
-  echo "$output" | grep -qF "Worker window (ap-#898) 生存確認"
-  # kill-window 呼出記録確認
+  assert_output --partial "Worker window (ap-#898) kill"
+  # kill-window が session-scoped target（sess1:0）で呼ばれている
   [ -f "$TMUX_KILL_WINDOW_LOG" ]
-  grep -qF "kill-window -t ap-#898" "$TMUX_KILL_WINDOW_LOG"
+  grep -qF "kill-window -t sess1:0" "$TMUX_KILL_WINDOW_LOG"
   # worktree 削除成功メッセージ
-  echo "$output" | grep -qF "worktree 削除成功"
+  assert_output --partial "worktree 削除成功"
 }
 
 # ---------------------------------------------------------------------------
@@ -167,21 +178,20 @@ other-window"
 
 @test "#898 (b): Worker window 不在 (既 cleanup 済) でも通常動作継続" {
   export WINDOW_FIELD_OUT="ap-#898"
-  # tmux list-windows の出力に ap-#898 を含めない
-  export TMUX_WINDOW_LIST_OUT="main
-other-window"
+  # ap-#898 を含まない（worker window は既に cleanup 済み）
+  export TMUX_ALL_WINDOWS="sess1:0 main
+sess1:1 other-window"
+  export TMUX_SESSION_WINDOWS=""
 
   run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
 
   assert_success
-  # safety net の「生存確認」メッセージは出ない
-  ! echo "$output" | grep -qF "Worker window (ap-#898) 生存確認"
-  # kill-window は呼ばれていない
+  # kill-window は呼ばれていない（window が存在しないため）
   if [[ -s "$TMUX_KILL_WINDOW_LOG" ]]; then
     ! grep -qF "kill-window" "$TMUX_KILL_WINDOW_LOG"
   fi
   # worktree 削除は成功
-  echo "$output" | grep -qF "worktree 削除成功"
+  assert_output --partial "worktree 削除成功"
 }
 
 # ---------------------------------------------------------------------------
@@ -190,19 +200,18 @@ other-window"
 
 @test "#898 (c): Worker window kill 失敗で exit 1、worktree 削除せず abort" {
   export WINDOW_FIELD_OUT="ap-#898"
-  export TMUX_WINDOW_LIST_OUT="ap-#898
-main"
-  export TMUX_KILL_FAIL="true"
+  # Worker session に ap-#898 が存在（WORKER_SESSION="sess1" として解決される）
+  export TMUX_ALL_WINDOWS="sess1:0 ap-#898
+sess1:1 main"
+  # post-kill session-scoped check: window が残存（kill 失敗を模擬）
+  export TMUX_SESSION_WINDOWS="ap-#898"
 
   run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
 
   assert_failure
-  # ERROR メッセージ出力
-  echo "$output" | grep -qF "ERROR: Worker window kill 失敗"
-  # "unsafe state" キーワード
-  echo "$output" | grep -qF "unsafe state"
-  # worktree 削除は実行されていない (delete 成功メッセージ不在)
-  ! echo "$output" | grep -qF "worktree 削除成功"
+  assert_output --partial "ERROR: Worker window kill 失敗"
+  assert_output --partial "unsafe state"
+  refute_output --partial "worktree 削除成功"
 }
 
 # ---------------------------------------------------------------------------
@@ -210,19 +219,20 @@ main"
 # ---------------------------------------------------------------------------
 
 @test "#898 (d): state.window 空のときは safety net skip (Pilot 通常経路)" {
+  # WINDOW_FIELD_OUT を明示的に空文字に（python3 stub は ${WINDOW_FIELD_OUT} を直接出力）
   export WINDOW_FIELD_OUT=""
-  export TMUX_WINDOW_LIST_OUT="main
-other-window"
+  export TMUX_ALL_WINDOWS="sess1:0 main
+sess1:1 other-window"
+  export TMUX_SESSION_WINDOWS=""
 
   run bash "$SANDBOX/scripts/auto-merge.sh" --issue 898 --pr 899 --branch feat/898-test
 
   assert_success
-  # safety net は発火しない
-  ! echo "$output" | grep -qF "生存確認"
+  # WORKER_WINDOW が空のため safety net は発火しない
+  refute_output --partial "Worker window"
   # kill-window は呼ばれていない
   if [[ -s "$TMUX_KILL_WINDOW_LOG" ]]; then
     ! grep -qF "kill-window" "$TMUX_KILL_WINDOW_LOG"
   fi
-  # worktree 削除は成功
-  echo "$output" | grep -qF "worktree 削除成功"
+  assert_output --partial "worktree 削除成功"
 }


### PR DESCRIPTION
## 概要

Closes #1393

`auto-merge.sh` の #898 safety net（post-kill check）が `tmux list-windows -a`（全セッション）を使うため、Worker window kill 後も別セッションに同名 window が残存する場合に誤って `exit 1` する false positive を修正。

## 変更内容

### `plugins/twl/scripts/auto-merge.sh`

kill 前に Worker window が属するセッションを解決（`WORKER_SESSION`）し、post-kill check を session-scoped に変更:

```bash
# Before (#1393 バグ)
if tmux list-windows -a -F '#{window_name}' | grep -qxF -- "$WORKER_WINDOW"; then

# After (修正済み)
WORKER_SESSION=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' \
  | awk -v wn="$WORKER_WINDOW" '$2 == wn {split($1, a, ":"); print a[1]; exit}')
if [[ -n "$WORKER_SESSION" ]] && tmux list-windows -t "$WORKER_SESSION" -F '#{window_name}' | grep -qxF -- "$WORKER_WINDOW"; then
```

### テスト

- **新規**: `auto-merge-898-safety-net-false-positive.bats`
  - AC-1: 他セッションに同名 window 残存でも exit 0（false positive 解消）
  - AC-2: Worker session に window 残存で exit 1（true positive 維持）
- **更新**: `auto-merge-worker-kill.bats`
  - tmux stub を session:index 形式（safe_kill_window 互換）に更新
  - `TMUX_WINDOW_LIST_OUT` → `TMUX_ALL_WINDOWS` + `TMUX_SESSION_WINDOWS` に分離

## 影響範囲

- **変更スコープ**: `auto-merge.sh` の #898 safety net ブロックのみ
- **既存テスト**: 全4テスト（(a)-(d)）GREEN を維持
- **深刻度**: 安全側の失敗（merge は成功済み）。手動 worktree 削除が必要になる稀なケースを解消