### PR TITLE
refactor(#1402): test_ac8_run_240_trials.py — loaded_ac8_module fixture + parametrize 統合

### DIFF
--- a/cli/twl/tests/ac-test-mapping-1402.yaml
+++ b/cli/twl/tests/ac-test-mapping-1402.yaml
@@ -1,0 +1,58 @@
+mappings:
+  - ac_index: 1
+    ac_text: >-
+      cli/twl/tests/test_ac8_run_240_trials.py 内に loaded_ac8_module fixture が追加され、
+      AC8_RUN_SCRIPT が存在しない場合 pytest.skip で skip、存在する場合は importlib でロードした
+      module オブジェクトを返す
+    test_file: "cli/twl/tests/test_ac1402_ac8_refactor.py"
+    test_names:
+      - "TestAC1LoadedFixtureExists::test_ac1_loaded_ac8_module_fixture_is_defined"
+      - "TestAC1LoadedFixtureExists::test_ac1_fixture_has_pytest_skip_for_missing_script"
+    impl_files:
+      - "cli/twl/tests/test_ac8_run_240_trials.py"
+
+  - ac_index: 2
+    ac_text: >-
+      TestAC1SkeletonImplemented の 4 hasattr テスト（main / run_trial / classify_failure /
+      goldfile_match）が pytest.mark.parametrize で 1 メソッドに統合されている
+    test_file: "cli/twl/tests/test_ac1402_ac8_refactor.py"
+    test_names:
+      - "TestAC2HasattrParametrizeIntegration::test_ac2_old_separate_methods_are_removed"
+      - "TestAC2HasattrParametrizeIntegration::test_ac2_parametrize_method_exists_in_skeleton_class"
+      - "TestAC2HasattrParametrizeIntegration::test_ac2_parametrize_covers_all_four_functions"
+    impl_files:
+      - "cli/twl/tests/test_ac8_run_240_trials.py"
+
+  - ac_index: 3
+    ac_text: >-
+      TestAC2CldMcpPoC::test_ac2_run_trial_with_mcp_route_succeeds が loaded_ac8_module
+      fixture を利用する形に書き換えられ、メソッド body 内に
+      importlib.util.spec_from_file_location の直接呼び出しが含まれない
+    test_file: "cli/twl/tests/test_ac1402_ac8_refactor.py"
+    test_names:
+      - "TestAC3NoDirectImportlibInMcpTest::test_ac3_mcp_test_method_has_no_direct_importlib_call"
+      - "TestAC3NoDirectImportlibInMcpTest::test_ac3_mcp_test_method_uses_loaded_ac8_module_fixture"
+    impl_files:
+      - "cli/twl/tests/test_ac8_run_240_trials.py"
+
+  - ac_index: 4
+    ac_text: >-
+      grep -c "importlib.util.spec_from_file_location" cli/twl/tests/test_ac8_run_240_trials.py
+      の結果が 2 以下（fixture 内 1 + test_ac1_script_importable の subprocess 文字列内 1）
+    test_file: "cli/twl/tests/test_ac1402_ac8_refactor.py"
+    test_names:
+      - "TestAC4ImportlibOccurrenceCount::test_ac4_importlib_spec_occurrence_count_is_at_most_2"
+    impl_files:
+      - "cli/twl/tests/test_ac8_run_240_trials.py"
+
+  - ac_index: 5
+    ac_text: >-
+      pytest cli/twl/tests/test_ac8_run_240_trials.py -v --collect-only のテスト ID 一覧と、
+      pytest cli/twl/tests/test_ac8_run_240_trials.py -v の skip/pass/fail 件数の合計が
+      リファクタ前後で等価（parametrize 化により ID は変化するが、実行件数の総和は同等）
+    test_file: "cli/twl/tests/test_ac1402_ac8_refactor.py"
+    test_names:
+      - "TestAC5ParametrizeTestIds::test_ac5_collected_ids_include_parametrize_format"
+      - "TestAC5ParametrizeTestIds::test_ac5_test_execution_count_preserved"
+    impl_files:
+      - "cli/twl/tests/test_ac8_run_240_trials.py"

--- a/cli/twl/tests/test_ac1402_ac8_refactor.py
+++ b/cli/twl/tests/test_ac1402_ac8_refactor.py
@@ -1,0 +1,410 @@
+"""
+RED tests for Issue #1402 -- DRY refactoring of test_ac8_run_240_trials.py
+
+TDD RED フェーズ用メタテスト。
+対象ファイル自体の構造を検査する。
+実装前（リファクタ前）は全件 FAIL する（意図的 RED）。
+
+AC1: loaded_ac8_module fixture が追加され、AC8_RUN_SCRIPT 存在時に module を返す
+AC2: TestAC1SkeletonImplemented の hasattr テスト 4 件が parametrize で 1 メソッドに統合
+AC3: test_ac2_run_trial_with_mcp_route_succeeds が loaded_ac8_module fixture を利用し、
+     メソッド body 内に importlib.util.spec_from_file_location の直接呼び出しがない
+AC4: importlib.util.spec_from_file_location の出現数が 2 以下
+AC5: pytest collection で parametrize 形式のテスト ID が存在する
+"""
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+# 対象ファイル（リファクタリング対象）
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+TARGET_FILE = REPO_ROOT / "cli" / "twl" / "tests" / "test_ac8_run_240_trials.py"
+
+# parametrize 統合後に期待されるテストメソッド名のキーワード
+EXPECTED_PARAM_METHOD_KEYWORD = "test_ac1_has_function"
+
+# parametrize 化後に消えていることを期待する旧メソッド名（4 件別々の定義）
+OLD_SEPARATE_METHODS = [
+    "test_ac1_has_function_main",
+    "test_ac1_has_function_run_trial",
+    "test_ac1_has_function_classify_failure",
+    "test_ac1_has_function_goldfile_match",
+]
+
+# AC4 しきい値
+IMPORTLIB_MAX_COUNT = 2
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー: ファイルを AST 解析して情報を取得
+# ---------------------------------------------------------------------------
+
+def _parse_target_file() -> ast.Module:
+    """対象ファイルを AST として解析して返す。"""
+    assert TARGET_FILE.exists(), f"対象ファイルが存在しない: {TARGET_FILE}"
+    source = TARGET_FILE.read_text(encoding="utf-8")
+    return ast.parse(source, filename=str(TARGET_FILE))
+
+
+def _get_all_function_defs(tree: ast.Module) -> list[ast.FunctionDef]:
+    """AST ツリーから全ての FunctionDef（トップレベル + クラス内）を収集する。"""
+    result = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            result.append(node)
+    return result
+
+
+def _get_fixture_names(tree: ast.Module) -> list[str]:
+    """@pytest.fixture デコレータが付いた関数名一覧を返す。"""
+    fixture_names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                # @pytest.fixture or @pytest.fixture(...)
+                if isinstance(decorator, ast.Attribute) and decorator.attr == "fixture":
+                    fixture_names.append(node.name)
+                elif isinstance(decorator, ast.Call):
+                    func = decorator.func
+                    if isinstance(func, ast.Attribute) and func.attr == "fixture":
+                        fixture_names.append(node.name)
+    return fixture_names
+
+
+def _get_parametrize_methods(tree: ast.Module) -> list[ast.FunctionDef]:
+    """@pytest.mark.parametrize デコレータが付いたメソッド一覧を返す。"""
+    result = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call):
+                    func = decorator.func
+                    # pytest.mark.parametrize の形式
+                    if (
+                        isinstance(func, ast.Attribute)
+                        and func.attr == "parametrize"
+                        and isinstance(func.value, ast.Attribute)
+                        and func.value.attr == "mark"
+                    ):
+                        result.append(node)
+    return result
+
+
+def _get_method_source(method_name: str, class_name: str) -> str:
+    """対象ファイルから特定クラスの特定メソッドのソーステキストを返す。"""
+    source = TARGET_FILE.read_text(encoding="utf-8")
+    lines = source.splitlines()
+    tree = ast.parse(source, filename=str(TARGET_FILE))
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, ast.FunctionDef) and item.name == method_name:
+                    start = item.lineno - 1
+                    end = item.end_lineno
+                    return "\n".join(lines[start:end])
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# AC1: loaded_ac8_module fixture が存在するか検査
+# ---------------------------------------------------------------------------
+
+class TestAC1LoadedFixtureExists:
+    """AC1: loaded_ac8_module fixture が追加されていることを検査する。
+
+    現在の状態（リファクタ前）: @pytest.fixture decorated な loaded_ac8_module が存在しない。
+    RED: FAIL する。
+    """
+
+    def test_ac1_loaded_ac8_module_fixture_is_defined(self):
+        # AC: loaded_ac8_module fixture が @pytest.fixture として定義されている
+        # RED: リファクタ前は fixture が存在しないため FAIL
+        tree = _parse_target_file()
+        fixture_names = _get_fixture_names(tree)
+        assert "loaded_ac8_module" in fixture_names, (
+            f"loaded_ac8_module fixture が @pytest.fixture として定義されていない。"
+            f"現在の fixture 一覧: {fixture_names}"
+        )
+
+    def test_ac1_fixture_has_pytest_skip_for_missing_script(self):
+        # AC: fixture 内に pytest.skip の呼び出しが含まれる（AC8_RUN_SCRIPT 不在時の skip 処理）
+        # RED: fixture 自体が存在しないため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(TARGET_FILE))
+
+        fixture_source = ""
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "loaded_ac8_module":
+                lines = source.splitlines()
+                start = node.lineno - 1
+                end = node.end_lineno
+                fixture_source = "\n".join(lines[start:end])
+                break
+
+        assert fixture_source, (
+            "loaded_ac8_module fixture が定義されていないため body を検査できない"
+        )
+        assert "pytest.skip" in fixture_source, (
+            "loaded_ac8_module fixture 内に pytest.skip が含まれていない"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2: hasattr テスト 4 件が parametrize で 1 メソッドに統合されているか
+# ---------------------------------------------------------------------------
+
+class TestAC2HasattrParametrizeIntegration:
+    """AC2: TestAC1SkeletonImplemented の 4 hasattr テストが parametrize で 1 メソッドに統合。
+
+    現在の状態（リファクタ前）: 4 つの別々のメソッドが存在する。
+    RED: FAIL する。
+    """
+
+    def test_ac2_old_separate_methods_are_removed(self):
+        # AC: 旧 4 メソッド（test_ac1_has_function_main 等）が独立メソッドとして存在しない
+        # RED: リファクタ前は 4 メソッドが別々に存在するため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(TARGET_FILE))
+
+        # TestAC1SkeletonImplemented クラスのメソッド名を収集
+        skeleton_methods = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "TestAC1SkeletonImplemented":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        skeleton_methods.append(item.name)
+
+        # 旧メソッドが残っている場合は FAIL
+        remaining_old_methods = [m for m in OLD_SEPARATE_METHODS if m in skeleton_methods]
+        assert not remaining_old_methods, (
+            f"旧 hasattr 個別メソッドがまだ残存している（parametrize 統合前）: "
+            f"{remaining_old_methods}"
+        )
+
+    def test_ac2_parametrize_method_exists_in_skeleton_class(self):
+        # AC: TestAC1SkeletonImplemented に @pytest.mark.parametrize 付きメソッドが存在する
+        # RED: リファクタ前は parametrize メソッドがないため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(TARGET_FILE))
+
+        skeleton_parametrize_methods = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "TestAC1SkeletonImplemented":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        for decorator in item.decorator_list:
+                            if isinstance(decorator, ast.Call):
+                                func = decorator.func
+                                if (
+                                    isinstance(func, ast.Attribute)
+                                    and func.attr == "parametrize"
+                                    and isinstance(func.value, ast.Attribute)
+                                    and func.value.attr == "mark"
+                                ):
+                                    skeleton_parametrize_methods.append(item.name)
+
+        assert skeleton_parametrize_methods, (
+            "TestAC1SkeletonImplemented に @pytest.mark.parametrize が付いたメソッドが存在しない"
+        )
+
+    def test_ac2_parametrize_covers_all_four_functions(self):
+        # AC: parametrize のパラメータに main/run_trial/classify_failure/goldfile_match が含まれる
+        # RED: parametrize メソッドが存在しないため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(TARGET_FILE))
+
+        expected_functions = {"main", "run_trial", "classify_failure", "goldfile_match"}
+        found_params: set[str] = set()
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "TestAC1SkeletonImplemented":
+                for item in node.body:
+                    if isinstance(item, ast.FunctionDef):
+                        for decorator in item.decorator_list:
+                            if isinstance(decorator, ast.Call):
+                                func = decorator.func
+                                if (
+                                    isinstance(func, ast.Attribute)
+                                    and func.attr == "parametrize"
+                                    and isinstance(func.value, ast.Attribute)
+                                    and func.value.attr == "mark"
+                                ):
+                                    # parametrize の args から文字列定数を収集
+                                    for arg in decorator.args:
+                                        if isinstance(arg, (ast.List, ast.Tuple)):
+                                            for elt in arg.elts:
+                                                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                                                    found_params.add(elt.value)
+
+        missing = expected_functions - found_params
+        assert not missing, (
+            f"parametrize パラメータに関数名が不足: {missing}。"
+            f"検出されたパラメータ: {found_params}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3: test_ac2_run_trial_with_mcp_route_succeeds 内に直接 importlib がないか
+# ---------------------------------------------------------------------------
+
+class TestAC3NoDirectImportlibInMcpTest:
+    """AC3: test_ac2_run_trial_with_mcp_route_succeeds が loaded_ac8_module fixture を利用し、
+    メソッド body 内に importlib.util.spec_from_file_location の直接呼び出しがない。
+
+    現在の状態（リファクタ前）: 行 169 に直接呼び出しが存在する。
+    RED: FAIL する。
+    """
+
+    def test_ac3_mcp_test_method_has_no_direct_importlib_call(self):
+        # AC: test_ac2_run_trial_with_mcp_route_succeeds のメソッド body に
+        #     importlib.util.spec_from_file_location が含まれない
+        # RED: リファクタ前は行 169 に直接呼び出しが存在するため FAIL
+        method_source = _get_method_source(
+            "test_ac2_run_trial_with_mcp_route_succeeds",
+            "TestAC2CldMcpPoC",
+        )
+        assert method_source, (
+            "test_ac2_run_trial_with_mcp_route_succeeds メソッドが TestAC2CldMcpPoC 内に見つからない"
+        )
+        assert "importlib.util.spec_from_file_location" not in method_source, (
+            "test_ac2_run_trial_with_mcp_route_succeeds メソッド body 内に "
+            "importlib.util.spec_from_file_location の直接呼び出しが残存している"
+        )
+
+    def test_ac3_mcp_test_method_uses_loaded_ac8_module_fixture(self):
+        # AC: test_ac2_run_trial_with_mcp_route_succeeds が loaded_ac8_module を引数に持つ
+        # RED: リファクタ前は fixture を使わずに直接 importlib を呼んでいるため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(TARGET_FILE))
+
+        fixture_used = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name == "TestAC2CldMcpPoC":
+                for item in node.body:
+                    if (
+                        isinstance(item, ast.FunctionDef)
+                        and item.name == "test_ac2_run_trial_with_mcp_route_succeeds"
+                    ):
+                        # 引数に loaded_ac8_module が含まれるか確認
+                        arg_names = [arg.arg for arg in item.args.args]
+                        if "loaded_ac8_module" in arg_names:
+                            fixture_used = True
+
+        assert fixture_used, (
+            "test_ac2_run_trial_with_mcp_route_succeeds が loaded_ac8_module fixture を "
+            "引数として使用していない"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4: importlib.util.spec_from_file_location の出現数が 2 以下
+# ---------------------------------------------------------------------------
+
+class TestAC4ImportlibOccurrenceCount:
+    """AC4: grep -c "importlib.util.spec_from_file_location" の結果が 2 以下。
+
+    現在の状態（リファクタ前）: 7 回出現。
+    RED: FAIL する。
+    """
+
+    def test_ac4_importlib_spec_occurrence_count_is_at_most_2(self):
+        # AC: importlib.util.spec_from_file_location の出現数が 2 以下
+        # RED: リファクタ前は 7 回出現するため FAIL
+        source = TARGET_FILE.read_text(encoding="utf-8")
+        count = source.count("importlib.util.spec_from_file_location")
+        assert count <= IMPORTLIB_MAX_COUNT, (
+            f"importlib.util.spec_from_file_location の出現数が {IMPORTLIB_MAX_COUNT} を超過: "
+            f"{count} 回。"
+            f"fixture 内 1 回 + test_ac1_script_importable の subprocess 文字列内 1 回の計 2 回が上限。"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC5: pytest collection で parametrize 形式のテスト ID が存在する
+# ---------------------------------------------------------------------------
+
+class TestAC5ParametrizeTestIds:
+    """AC5: pytest --collect-only で parametrize 形式のテスト ID が存在する。
+
+    現在の状態（リファクタ前）: parametrize がないため "[...]" 形式の ID が存在しない。
+    RED: FAIL する。
+    """
+
+    def test_ac5_collected_ids_include_parametrize_format(self):
+        # AC: pytest --collect-only で TestAC1SkeletonImplemented 内に [...] 形式の ID が存在する
+        # RED: リファクタ前は parametrize がないため [...] 形式が存在しない → FAIL
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                str(TARGET_FILE),
+                "-v",
+                "--collect-only",
+                "-q",
+                "--no-header",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(REPO_ROOT),
+        )
+        output = result.stdout + result.stderr
+
+        # parametrize 形式: TestAC1SkeletonImplemented::test_ac1_has_function[...]
+        # "[" + "]" の組合せで parametrize ID を検出
+        parametrize_ids = [
+            line for line in output.splitlines()
+            if "TestAC1SkeletonImplemented" in line
+            and "[" in line
+            and "]" in line
+        ]
+
+        assert parametrize_ids, (
+            "pytest --collect-only の結果に TestAC1SkeletonImplemented 配下の "
+            "parametrize 形式テスト ID（[...] 形式）が存在しない。\n"
+            f"collection 出力:\n{output[:2000]}"
+        )
+
+    def test_ac5_test_execution_count_preserved(self):
+        # AC: リファクタ前後でテスト実行件数の総和が等価（4 hasattr 分は維持される）
+        # RED: parametrize 統合前は TestAC1SkeletonImplemented に
+        #      個別 hasattr メソッドしか存在しないため、このテストは
+        #      "parametrize で 4 件が生成されていること" を確認できず FAIL
+        #
+        # 検証: parametrize で 4 パラメータ分のテストが生成されるか確認する
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                str(TARGET_FILE),
+                "-v",
+                "--collect-only",
+                "-q",
+                "--no-header",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(REPO_ROOT),
+        )
+        output = result.stdout + result.stderr
+
+        # TestAC1SkeletonImplemented の parametrize テスト ID を収集
+        skeleton_parametrize_ids = [
+            line for line in output.splitlines()
+            if "TestAC1SkeletonImplemented" in line
+            and "[" in line
+            and "]" in line
+        ]
+
+        # 4 関数分（main, run_trial, classify_failure, goldfile_match）の ID が存在するはず
+        assert len(skeleton_parametrize_ids) >= 4, (
+            f"TestAC1SkeletonImplemented の parametrize テスト ID が 4 件未満: "
+            f"{len(skeleton_parametrize_ids)} 件。\n"
+            f"検出 ID: {skeleton_parametrize_ids}"
+        )

--- a/cli/twl/tests/test_ac1402_ac8_refactor.py
+++ b/cli/twl/tests/test_ac1402_ac8_refactor.py
@@ -48,15 +48,6 @@ def _parse_target_file() -> ast.Module:
     return ast.parse(source, filename=str(TARGET_FILE))
 
 
-def _get_all_function_defs(tree: ast.Module) -> list[ast.FunctionDef]:
-    """AST ツリーから全ての FunctionDef（トップレベル + クラス内）を収集する。"""
-    result = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
-            result.append(node)
-    return result
-
-
 def _get_fixture_names(tree: ast.Module) -> list[str]:
     """@pytest.fixture デコレータが付いた関数名一覧を返す。"""
     fixture_names = []
@@ -71,25 +62,6 @@ def _get_fixture_names(tree: ast.Module) -> list[str]:
                     if isinstance(func, ast.Attribute) and func.attr == "fixture":
                         fixture_names.append(node.name)
     return fixture_names
-
-
-def _get_parametrize_methods(tree: ast.Module) -> list[ast.FunctionDef]:
-    """@pytest.mark.parametrize デコレータが付いたメソッド一覧を返す。"""
-    result = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef):
-            for decorator in node.decorator_list:
-                if isinstance(decorator, ast.Call):
-                    func = decorator.func
-                    # pytest.mark.parametrize の形式
-                    if (
-                        isinstance(func, ast.Attribute)
-                        and func.attr == "parametrize"
-                        and isinstance(func.value, ast.Attribute)
-                        and func.value.attr == "mark"
-                    ):
-                        result.append(node)
-    return result
 
 
 def _get_method_source(method_name: str, class_name: str) -> str:

--- a/cli/twl/tests/test_ac1402_ac8_refactor.py
+++ b/cli/twl/tests/test_ac1402_ac8_refactor.py
@@ -336,17 +336,9 @@ class TestAC5ParametrizeTestIds:
     def test_ac5_collected_ids_include_parametrize_format(self):
         # AC: pytest --collect-only で TestAC1SkeletonImplemented 内に [...] 形式の ID が存在する
         # RED: リファクタ前は parametrize がないため [...] 形式が存在しない → FAIL
+        # 注: -v を外して flat list 形式（NodeID::...） にすることで同一行に class + parametrize ID が現れる
         result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pytest",
-                str(TARGET_FILE),
-                "-v",
-                "--collect-only",
-                "-q",
-                "--no-header",
-            ],
+            [sys.executable, "-m", "pytest", str(TARGET_FILE), "--collect-only", "-q", "--no-header"],
             capture_output=True,
             text=True,
             timeout=60,
@@ -354,8 +346,7 @@ class TestAC5ParametrizeTestIds:
         )
         output = result.stdout + result.stderr
 
-        # parametrize 形式: TestAC1SkeletonImplemented::test_ac1_has_function[...]
-        # "[" + "]" の組合せで parametrize ID を検出
+        # flat 形式: tests/test_ac8_run_240_trials.py::TestAC1SkeletonImplemented::test_ac1_has_function[main]
         parametrize_ids = [
             line for line in output.splitlines()
             if "TestAC1SkeletonImplemented" in line
@@ -374,19 +365,8 @@ class TestAC5ParametrizeTestIds:
         # RED: parametrize 統合前は TestAC1SkeletonImplemented に
         #      個別 hasattr メソッドしか存在しないため、このテストは
         #      "parametrize で 4 件が生成されていること" を確認できず FAIL
-        #
-        # 検証: parametrize で 4 パラメータ分のテストが生成されるか確認する
         result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "pytest",
-                str(TARGET_FILE),
-                "-v",
-                "--collect-only",
-                "-q",
-                "--no-header",
-            ],
+            [sys.executable, "-m", "pytest", str(TARGET_FILE), "--collect-only", "-q", "--no-header"],
             capture_output=True,
             text=True,
             timeout=60,
@@ -394,7 +374,7 @@ class TestAC5ParametrizeTestIds:
         )
         output = result.stdout + result.stderr
 
-        # TestAC1SkeletonImplemented の parametrize テスト ID を収集
+        # flat 形式でパラメータ付き ID を収集
         skeleton_parametrize_ids = [
             line for line in output.splitlines()
             if "TestAC1SkeletonImplemented" in line

--- a/cli/twl/tests/test_ac8_run_240_trials.py
+++ b/cli/twl/tests/test_ac8_run_240_trials.py
@@ -1,0 +1,468 @@
+"""
+RED tests for Issue #1038 -- Phase1 Beta Trial Orchestration.
+
+TDD RED フェーズ用テストスタブ。
+実装前は全件 FAIL する（意図的 RED）。
+
+AC1: ac8_run_240_trials.py の skeleton（main + run_trial + classify_failure + goldfile_match）が実装されている
+AC2: cld -p で mcp__twl__twl_state_read を呼び出して exit 0 になることを 1 trial 検証する unit test
+AC4: driver script で 12 trial（6 op × 2 route × 1 trial）が動作し、CSV に 12 行出力される
+AC5: 12 trial の success=true 行が 12 件（goldfile 一致 100%）
+AC6: ac8_data/<timestamp>.csv に 240 行（header 除く）が保存されている
+AC7: CSV が REQUIRED_CSV_COLUMNS を全て含む
+AC8: 6 操作 × 2 経路 × 20 trials の組合せ全て揃っている（pivot で 240/240 確認）
+AC9: python3 ac8_significance_test.py --csv <path> が JSON 出力で完了し overall_judgment が正当な値
+AC11: phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が追加されている
+AC12a: test_issue_1027_followup.py の structure 系 8 tests が GREEN（mapping 記録のみ）
+AC12b: test_issue_1027_followup.py の measurement-dependent 4 tests が GREEN（mapping 記録のみ）
+"""
+
+import csv
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# パス定義
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CLI_TWL_DIR = REPO_ROOT / "cli" / "twl"
+PLUGINS_TWL_DIR = REPO_ROOT / "plugins" / "twl"
+
+SCRIPT_DIR = CLI_TWL_DIR / "tests" / "scripts"
+AC8_RUN_SCRIPT = SCRIPT_DIR / "ac8_run_240_trials.py"
+SIGNIFICANCE_SCRIPT = SCRIPT_DIR / "ac8_significance_test.py"
+AC8_GOLDFILES_DIR = SCRIPT_DIR / "ac8_goldfiles"
+AC8_DATA_DIR = SCRIPT_DIR / "ac8_data"
+PROTOCOL_DOC = PLUGINS_TWL_DIR / "architecture" / "phases" / "phase1-ai-failure-rate-protocol.md"
+
+REQUIRED_OPERATIONS = [
+    "issue_init",
+    "read_field",
+    "status_transition",
+    "rbac_violation",
+    "failed_done_force",
+    "sets_nested_key",
+]
+REQUIRED_ROUTES = ["cli", "mcp"]
+TRIALS_PER_OP_ROUTE = 20
+TOTAL_TRIALS = len(REQUIRED_OPERATIONS) * len(REQUIRED_ROUTES) * TRIALS_PER_OP_ROUTE  # 240
+
+REQUIRED_CSV_COLUMNS = [
+    "operation",
+    "route",
+    "trial_index",
+    "success",
+    "failure_pattern",
+    "session_id",
+    "timestamp",
+]
+
+
+# ---------------------------------------------------------------------------
+# fixture: loaded_ac8_module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def loaded_ac8_module():
+    if not AC8_RUN_SCRIPT.exists():
+        pytest.skip(f"AC8_RUN_SCRIPT が存在しない: {AC8_RUN_SCRIPT}")
+    spec = importlib.util.spec_from_file_location("ac8_run_240_trials", AC8_RUN_SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# ---------------------------------------------------------------------------
+# AC1: ac8_run_240_trials.py skeleton 実装確認
+# ---------------------------------------------------------------------------
+
+class TestAC1SkeletonImplemented:
+    """AC1: ac8_run_240_trials.py の skeleton（main + run_trial + classify_failure + goldfile_match）
+    が新規実装されている。
+
+    ファイル未存在のため全件 FAIL する（RED）。
+    """
+
+    def test_ac1_script_file_exists(self):
+        # AC: cli/twl/tests/scripts/ac8_run_240_trials.py が存在する
+        # RED: 未実装のため FAIL
+        assert AC8_RUN_SCRIPT.exists(), (
+            f"ac8_run_240_trials.py が存在しない: {AC8_RUN_SCRIPT}"
+        )
+
+    @pytest.mark.parametrize("func_name", [
+        "main", "run_trial", "classify_failure", "goldfile_match"
+    ])
+    def test_ac1_has_function(self, loaded_ac8_module, func_name):
+        assert hasattr(loaded_ac8_module, func_name), f"{func_name}() 関数が定義されていない"
+        assert callable(getattr(loaded_ac8_module, func_name)), f"{func_name} が callable でない"
+
+    def test_ac1_script_importable(self):
+        # AC: ac8_run_240_trials.py が import エラーなく読み込める
+        # RED: ファイル未存在のため FAIL
+        if not AC8_RUN_SCRIPT.exists():
+            raise NotImplementedError("AC #1 未実装: ac8_run_240_trials.py が存在しない")
+        result = subprocess.run(
+            [sys.executable, "-c", f"import importlib.util; spec=importlib.util.spec_from_file_location('m','{AC8_RUN_SCRIPT}'); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m)"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, f"import 失敗: {result.stderr}"
+
+
+# ---------------------------------------------------------------------------
+# AC2: cld -p で mcp__twl__twl_state_read を呼び出して exit 0 になる PoC unit test
+# ---------------------------------------------------------------------------
+
+class TestAC2CldMcpPoC:
+    """AC2: cld -p で mcp__twl__twl_state_read を呼び出して exit 0 になることを 1 trial 検証する unit test。
+
+    RED: cld コマンドの PoC 動作が未確認のため FAIL する。
+    """
+
+    def test_ac2_cld_command_available(self):
+        # AC: cld -p で mcp__twl__twl_state_read を呼び出して exit 0 になる PoC が完成している
+        # RED: PoC 未実装のため FAIL（cld PATH 存在確認ではなく PoC 完了確認）
+        raise NotImplementedError(
+            "AC #2 未実装: cld -p による mcp__twl__twl_state_read PoC が未完了"
+        )
+
+    def test_ac2_cld_mcp_twl_state_read_exit0(self):
+        # AC: cld -p で mcp__twl__twl_state_read を呼び出した際、exit 0 で終了する（1 trial 検証）
+        # RED: PoC 動作未実装のため FAIL
+        raise NotImplementedError(
+            "AC #2 未実装: cld -p で mcp__twl__twl_state_read を呼び出す PoC が未実装"
+        )
+
+    def test_ac2_run_trial_with_mcp_route_succeeds(self, loaded_ac8_module):
+        # AC: run_trial() を mcp 経路で実行した場合、success=True が返る
+        # RED: ac8_run_240_trials.py 未実装のため SKIP → FAIL
+        result = loaded_ac8_module.run_trial(operation="issue_init", route="mcp", trial_index=0)
+        assert result.get("success") is True, f"MCP route で success=True が返らない: {result}"
+
+
+# ---------------------------------------------------------------------------
+# AC4: driver script で 12 trial（6 op × 2 route × 1 trial）が動作し CSV に 12 行出力
+# ---------------------------------------------------------------------------
+
+class TestAC4TwelveTrialSmoke:
+    """AC4: driver script で 12 trial（6 op × 2 route × 1 trial）が動作し、CSV に 12 行（header 除く）出力される。
+
+    RED: ac8_run_240_trials.py 未実装のため FAIL する。
+    """
+
+    def test_ac4_script_runs_12_trials(self):
+        # AC: ac8_run_240_trials.py が --trials 1 オプションで 6×2=12 trial を実行できる
+        # RED: 未実装のため FAIL
+        if not AC8_RUN_SCRIPT.exists():
+            raise NotImplementedError("AC #4 未実装: ac8_run_240_trials.py が存在しない")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_csv = Path(tmpdir) / "smoke.csv"
+            result = subprocess.run(
+                [sys.executable, str(AC8_RUN_SCRIPT), "--trials", "1", "--output", str(out_csv)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+            assert result.returncode == 0, f"Script 失敗: {result.stderr}"
+            assert out_csv.exists(), f"CSV が出力されていない: {out_csv}"
+            with open(out_csv, newline="") as f:
+                rows = list(csv.DictReader(f))
+            assert len(rows) == 12, f"12 行期待、実際: {len(rows)} 行"
+
+    def test_ac4_csv_has_12_rows_header_excluded(self):
+        # AC: CSV の行数がヘッダを除いて 12 行である（6 op × 2 route × 1 trial）
+        # RED: 未実装のため FAIL
+        if not AC8_RUN_SCRIPT.exists():
+            raise NotImplementedError("AC #4 未実装: ac8_run_240_trials.py が存在しない")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_csv = Path(tmpdir) / "smoke.csv"
+            subprocess.run(
+                [sys.executable, str(AC8_RUN_SCRIPT), "--trials", "1", "--output", str(out_csv)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+            lines = out_csv.read_text().strip().splitlines()
+            # lines[0] はヘッダ
+            data_lines = lines[1:]
+            assert len(data_lines) == 12, f"データ行 12 期待、実際: {len(data_lines)}"
+
+
+# ---------------------------------------------------------------------------
+# AC5: 12 trial の success=true 行が 12 件（goldfile 一致 100%）
+# ---------------------------------------------------------------------------
+
+class TestAC5SmokeSuccessRate:
+    """AC5: 12 trial の success=true 行が 12 件（goldfile 一致 100%）。
+
+    RED: ac8_run_240_trials.py 未実装のため FAIL する。
+    """
+
+    def test_ac5_all_12_trials_success(self):
+        # AC: smoke run（12 trial）の全行で success=true である
+        # RED: 未実装のため FAIL
+        if not AC8_RUN_SCRIPT.exists():
+            raise NotImplementedError("AC #5 未実装: ac8_run_240_trials.py が存在しない")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_csv = Path(tmpdir) / "smoke.csv"
+            subprocess.run(
+                [sys.executable, str(AC8_RUN_SCRIPT), "--trials", "1", "--output", str(out_csv)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+            with open(out_csv, newline="") as f:
+                rows = list(csv.DictReader(f))
+            success_rows = [r for r in rows if r.get("success", "").lower() in ("true", "1", "yes")]
+            assert len(success_rows) == 12, (
+                f"success=true 行が 12 件期待、実際: {len(success_rows)} 件\n"
+                f"失敗行: {[r for r in rows if r not in success_rows]}"
+            )
+
+    def test_ac5_goldfile_match_function_works(self, loaded_ac8_module):
+        # AC: goldfile_match() 関数が goldfiles ディレクトリ内の既存ファイルに対して True を返す
+        # RED: 未実装のため SKIP → FAIL
+        goldfile = AC8_GOLDFILES_DIR / "issue_init_cli.txt"
+        assert goldfile.exists(), f"goldfile が見つからない: {goldfile}"
+        expected = goldfile.read_text()
+        result = loaded_ac8_module.goldfile_match(output=expected, operation="issue_init", route="cli")
+        assert result is True, f"goldfile_match が True を返さない: {result}"
+
+
+# ---------------------------------------------------------------------------
+# AC6: ac8_data/<timestamp>.csv に 240 行（header 除く）が保存されている
+# ---------------------------------------------------------------------------
+
+class TestAC6TwoHundredFortyRows:
+    """AC6: cli/twl/tests/scripts/ac8_data/<timestamp>.csv に 240 行（header 除く）が保存されている。
+
+    RED: 240 trial 実測未完了のため FAIL する。
+    """
+
+    def test_ac6_data_dir_has_csv(self):
+        # AC: ac8_data/ ディレクトリに CSV ファイルが少なくとも 1 件存在する
+        # RED: 実測未完了のため FAIL
+        assert AC8_DATA_DIR.exists(), f"ac8_data/ ディレクトリが存在しない: {AC8_DATA_DIR}"
+        csvs = list(AC8_DATA_DIR.glob("*.csv"))
+        assert len(csvs) >= 1, f"ac8_data/ に CSV が存在しない（240 trial 実測待ち）"
+
+    def test_ac6_csv_has_240_data_rows(self):
+        # AC: ac8_data/ の最新 CSV（タイムスタンプ降順1件目）のデータ行数が 240 以上
+        # RED: 実測未完了のため FAIL
+        if not AC8_DATA_DIR.exists():
+            raise NotImplementedError("AC #6 未実装: ac8_data/ ディレクトリが存在しない")
+        csvs = sorted(AC8_DATA_DIR.glob("*.csv"), reverse=True)
+        if not csvs:
+            raise NotImplementedError("AC #6 未実装: ac8_data/ に CSV が存在しない")
+        latest_csv = csvs[0]
+        with open(latest_csv, newline="") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) >= 240, (
+            f"240 行期待（ヘッダ除く）、実際: {len(rows)} 行 ({latest_csv.name})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC7: CSV が REQUIRED_CSV_COLUMNS を全て含む
+# ---------------------------------------------------------------------------
+
+class TestAC7CsvColumns:
+    """AC7: CSV が REQUIRED_CSV_COLUMNS (operation, route, trial_index, success,
+    failure_pattern, session_id, timestamp) を全て含む。
+
+    RED: 実測 CSV 未作成のため FAIL する。
+    """
+
+    def test_ac7_csv_has_all_required_columns(self):
+        # AC: ac8_data/ の最新 CSV が REQUIRED_CSV_COLUMNS を全て含む
+        # RED: 実測 CSV 未作成のため FAIL
+        if not AC8_DATA_DIR.exists():
+            raise NotImplementedError("AC #7 未実装: ac8_data/ ディレクトリが存在しない")
+        csvs = sorted(AC8_DATA_DIR.glob("*.csv"), reverse=True)
+        if not csvs:
+            raise NotImplementedError("AC #7 未実装: ac8_data/ に CSV が存在しない")
+        latest_csv = csvs[0]
+        with open(latest_csv, newline="") as f:
+            reader = csv.DictReader(f)
+            fieldnames = reader.fieldnames or []
+        missing = [c for c in REQUIRED_CSV_COLUMNS if c not in fieldnames]
+        assert not missing, (
+            f"CSV に必須カラムが不足: {missing} (CSV: {latest_csv.name})"
+        )
+
+    def test_ac7_run_script_outputs_required_columns(self):
+        # AC: ac8_run_240_trials.py が出力する CSV に REQUIRED_CSV_COLUMNS が含まれる
+        # RED: 未実装のため FAIL
+        if not AC8_RUN_SCRIPT.exists():
+            raise NotImplementedError("AC #7 未実装: ac8_run_240_trials.py が存在しない")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_csv = Path(tmpdir) / "col_check.csv"
+            subprocess.run(
+                [sys.executable, str(AC8_RUN_SCRIPT), "--trials", "1", "--output", str(out_csv)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                check=True,
+            )
+            with open(out_csv, newline="") as f:
+                reader = csv.DictReader(f)
+                fieldnames = reader.fieldnames or []
+            missing = [c for c in REQUIRED_CSV_COLUMNS if c not in fieldnames]
+            assert not missing, f"出力 CSV に必須カラムが不足: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# AC8: 6 操作 × 2 経路 × 20 trials の組合せ全て揃っている（pivot で 240/240 確認）
+# ---------------------------------------------------------------------------
+
+class TestAC8AllCombinations:
+    """AC8: 6 操作 × 2 経路 × 20 trials の組合せ全て揃っている。
+
+    RED: 実測 CSV 未作成のため FAIL する。
+    """
+
+    def test_ac8_all_operation_route_combinations_present(self):
+        # AC: CSV の操作×経路ピボットで 12 組合せ全てに 20 以上の trial が存在する
+        # RED: 実測 CSV 未作成のため FAIL
+        if not AC8_DATA_DIR.exists():
+            raise NotImplementedError("AC #8 未実装: ac8_data/ ディレクトリが存在しない")
+        csvs = sorted(AC8_DATA_DIR.glob("*.csv"), reverse=True)
+        if not csvs:
+            raise NotImplementedError("AC #8 未実装: ac8_data/ に CSV が存在しない")
+        latest_csv = csvs[0]
+        with open(latest_csv, newline="") as f:
+            rows = list(csv.DictReader(f))
+        # pivot: {(operation, route): count}
+        pivot: dict[tuple[str, str], int] = {}
+        for row in rows:
+            key = (row.get("operation", ""), row.get("route", ""))
+            pivot[key] = pivot.get(key, 0) + 1
+        missing_combos = []
+        for op in REQUIRED_OPERATIONS:
+            for route in REQUIRED_ROUTES:
+                count = pivot.get((op, route), 0)
+                if count < TRIALS_PER_OP_ROUTE:
+                    missing_combos.append((op, route, count))
+        assert not missing_combos, (
+            f"20 trial 未満の組合せが存在: {missing_combos}"
+        )
+
+    def test_ac8_total_trial_count_is_240(self):
+        # AC: CSV の総 trial 数（ヘッダ除く）が 240 である
+        # RED: 実測 CSV 未作成のため FAIL
+        if not AC8_DATA_DIR.exists():
+            raise NotImplementedError("AC #8 未実装: ac8_data/ ディレクトリが存在しない")
+        csvs = sorted(AC8_DATA_DIR.glob("*.csv"), reverse=True)
+        if not csvs:
+            raise NotImplementedError("AC #8 未実装: ac8_data/ に CSV が存在しない")
+        latest_csv = csvs[0]
+        with open(latest_csv, newline="") as f:
+            rows = list(csv.DictReader(f))
+        assert len(rows) == TOTAL_TRIALS, (
+            f"総 trial 数 {TOTAL_TRIALS} 期待、実際: {len(rows)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC9: ac8_significance_test.py が JSON 出力で完了し overall_judgment が正当な値
+# ---------------------------------------------------------------------------
+
+class TestAC9SignificanceTestOutput:
+    """AC9: python3 ac8_significance_test.py --csv <path> が JSON 出力で完了。
+    overall_judgment が "全達成"|"部分達成"|"未達成" のいずれかで記載されている。
+
+    注: script 自体は実装済み。実測 CSV を使った overall_judgment 確認が RED 状態。
+    """
+
+    def test_ac9_significance_script_exists(self):
+        # AC: ac8_significance_test.py が存在する
+        assert SIGNIFICANCE_SCRIPT.exists(), (
+            f"ac8_significance_test.py が存在しない: {SIGNIFICANCE_SCRIPT}"
+        )
+
+    def test_ac9_overall_judgment_valid_with_real_csv(self):
+        # AC: 実測 CSV を渡した場合に overall_judgment が "全達成"|"部分達成"|"未達成" のいずれかである
+        # RED: 実測 CSV 未作成のため FAIL
+        if not AC8_DATA_DIR.exists():
+            raise NotImplementedError("AC #9 未実装: ac8_data/ ディレクトリが存在しない")
+        csvs = sorted(AC8_DATA_DIR.glob("*.csv"), reverse=True)
+        if not csvs:
+            raise NotImplementedError("AC #9 未実装: ac8_data/ に実測 CSV が存在しない")
+        latest_csv = csvs[0]
+        result = subprocess.run(
+            [sys.executable, str(SIGNIFICANCE_SCRIPT), "--csv", str(latest_csv)],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, f"Script 失敗: {result.stderr}"
+        output = json.loads(result.stdout)
+        assert "overall_judgment" in output, "overall_judgment キーが JSON に存在しない"
+        valid_judgments = {"全達成", "部分達成", "未達成"}
+        assert output["overall_judgment"] in valid_judgments, (
+            f"overall_judgment が正当な値でない: {output['overall_judgment']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC11: phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が追加されている
+# ---------------------------------------------------------------------------
+
+class TestAC11ProtocolDocSummarySection:
+    """AC11: phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が追加されている。
+
+    RED: section 未追加のため FAIL する。
+    """
+
+    def test_ac11_protocol_doc_exists(self):
+        # AC: phase1-ai-failure-rate-protocol.md が存在する
+        assert PROTOCOL_DOC.exists(), f"Protocol doc が存在しない: {PROTOCOL_DOC}"
+
+    def test_ac11_protocol_doc_has_measured_result_section(self):
+        # AC: phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が存在する
+        # RED: section 未追加のため FAIL
+        assert PROTOCOL_DOC.exists(), f"Protocol doc が存在しない: {PROTOCOL_DOC}"
+        content = PROTOCOL_DOC.read_text(encoding="utf-8")
+        assert "## 実測結果サマリ" in content, (
+            "phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が存在しない"
+        )
+
+    def test_ac11_summary_section_has_overall_judgment(self):
+        # AC: 「## 実測結果サマリ」section に overall_judgment の記載がある
+        # RED: section 未追加のため FAIL
+        assert PROTOCOL_DOC.exists(), f"Protocol doc が存在しない: {PROTOCOL_DOC}"
+        content = PROTOCOL_DOC.read_text(encoding="utf-8")
+        assert "## 実測結果サマリ" in content, (
+            "phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が存在しない"
+        )
+        # overall_judgment の記載確認
+        section_start = content.index("## 実測結果サマリ")
+        section_content = content[section_start:]
+        assert "overall_judgment" in section_content or "全達成" in section_content or "部分達成" in section_content or "未達成" in section_content, (
+            "実測結果サマリ section に overall_judgment または判定結果の記載がない"
+        )
+
+    def test_ac11_summary_section_has_per_operation_table(self):
+        # AC: 「## 実測結果サマリ」section に per_operation 表が存在する
+        # RED: section 未追加のため FAIL
+        assert PROTOCOL_DOC.exists(), f"Protocol doc が存在しない: {PROTOCOL_DOC}"
+        content = PROTOCOL_DOC.read_text(encoding="utf-8")
+        assert "## 実測結果サマリ" in content, (
+            "phase1-ai-failure-rate-protocol.md に「## 実測結果サマリ」section が存在しない"
+        )
+        section_start = content.index("## 実測結果サマリ")
+        section_content = content[section_start:]
+        # Markdown テーブルの存在確認（| で始まる行）
+        table_lines = [ln for ln in section_content.splitlines() if ln.strip().startswith("|")]
+        assert len(table_lines) >= 2, (
+            "実測結果サマリ section に per_operation 表（Markdown テーブル）が存在しない"
+        )

--- a/cli/twl/tests/test_ac8_run_240_trials.py
+++ b/cli/twl/tests/test_ac8_run_240_trials.py
@@ -20,7 +20,6 @@ AC12b: test_issue_1027_followup.py の measurement-dependent 4 tests が GREEN�
 import csv
 import importlib.util
 import json
-import os
 import subprocess
 import sys
 import tempfile


### PR DESCRIPTION
## 概要

Issue #1402 の DRY 違反修正。`cli/twl/tests/test_ac8_run_240_trials.py` 内で importlib によるモジュールロード処理が 5 メソッドで重複していた問題を fixture + parametrize で共通化。

## 変更内容

- **AC1**: `loaded_ac8_module` fixture 追加（AC8_RUN_SCRIPT 不在時 `pytest.skip`）
- **AC2**: `TestAC1SkeletonImplemented` の 4 hasattr テストを `pytest.mark.parametrize` で 1 メソッドに統合
- **AC3**: `test_ac2_run_trial_with_mcp_route_succeeds` を fixture 利用形式に書き換え（直接 importlib 呼び出し除去）
- **AC4**: `importlib.util.spec_from_file_location` 出現数 7→2（`test_ac5_goldfile_match_function_works` も fixture 化）
- **AC5**: parametrize 化により test ID は変化するが実行件数の総和は等価

## テスト

- `test_ac1402_ac8_refactor.py`: 10/10 PASS（AC1〜AC5 全件 GREEN）
- `grep -c 'importlib.util.spec_from_file_location'`: 2（fixture 内 1 + subprocess 文字列内 1）

Closes #1402