### PR TITLE
fix(#1414): _validate_command() print 二重出力を除去・cli.py に try/except 復元

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -144,7 +144,11 @@ def main():
     if args.subcommand == 'mcp':
         if args.mcp_subcommand == 'restart':
             from twl.mcp_server.lifecycle import restart_mcp_server
-            sys.exit(restart_mcp_server())
+            try:
+                sys.exit(restart_mcp_server())
+            except ValueError as e:
+                print(f"Error: mcp restart failed — {e}", file=sys.stderr)
+                sys.exit(1)
         else:
             mcp_parser.print_help(sys.stderr)
             sys.exit(1)

--- a/cli/twl/src/twl/mcp_server/lifecycle.py
+++ b/cli/twl/src/twl/mcp_server/lifecycle.py
@@ -31,12 +31,6 @@ def _validate_command(command: str) -> None:
         try:
             cmd_path = Path(command).resolve()
         except OSError as e:
-            print(
-                f"ERROR: mcp command rejected — path resolution failed.\n"
-                f"  command: {command}\n"
-                f"  reason: {e}",
-                file=sys.stderr,
-            )
             raise ValueError(f"command '{command}' path resolution failed: {e}") from e
         resolved_prefixes = frozenset(p.resolve() for p in allowed_prefixes)
         for prefix in resolved_prefixes:
@@ -45,25 +39,11 @@ def _validate_command(command: str) -> None:
                 return
             except ValueError:
                 continue
-        print(
-            f"ERROR: mcp command rejected — absolute path not in allowed prefixes.\n"
-            f"  command: {command}\n"
-            f"  allowed_prefixes: {sorted(str(p) for p in allowed_prefixes)}\n"
-            f"  reason: absolute path outside known binary directories",
-            file=sys.stderr,
-        )
         raise ValueError(
             f"command '{command}' not in allowed prefixes: "
             f"{sorted(str(p) for p in allowed_prefixes)}"
         )
     if command not in _ALLOWED_COMMANDS:
-        print(
-            f"ERROR: mcp command rejected — not in allowlist.\n"
-            f"  command: {command}\n"
-            f"  allowed_commands: {sorted(_ALLOWED_COMMANDS)}\n"
-            f"  reason: command not in allowlist",
-            file=sys.stderr,
-        )
         raise ValueError(
             f"command '{command}' not in allowlist: {sorted(_ALLOWED_COMMANDS)}"
         )

--- a/cli/twl/tests/ac-test-mapping.yaml
+++ b/cli/twl/tests/ac-test-mapping.yaml
@@ -414,3 +414,77 @@ mappings:
       - "test_ac4_file_remains_in_decisions_dir"
     impl_files:
       - "plugins/twl/architecture/decisions/ADR-033-cross-repo-protocol-pinning.md"
+
+  # ---------------------------------------------------------------------------
+  # Issue #1414: tech-debt(#1398): _validate_command() double-output — print(stderr) 削除 + cli.py try/except 復元
+  # ---------------------------------------------------------------------------
+
+  - ac_index: "1414-AC1"
+    ac_text: "cli/twl/src/twl/mcp_server/lifecycle.py の _validate_command() から print(file=sys.stderr) を全箇所削除する（OSError / 絶対パス reject / allowlist reject の3経路）。OSError 経路は raise ValueError(...) from e の連鎖を維持し、cli.py の except ValueError で捕捉可能であること"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC3StructuredLogging::test_ac3_value_error_message_contains_command"
+      - "TestAC3StructuredLogging::test_ac3_value_error_message_contains_allowlist_or_reason"
+      - "TestAC3StructuredLogging::test_ac3_structured_log_output_on_rejection"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+
+  - ac_index: "1414-AC2"
+    ac_text: "cli/twl/src/twl/cli.py の argparse ベースのディスパッチブロック（if args.subcommand == 'mcp': 〜 if args.mcp_subcommand == 'restart':、現 line 144-147 周辺）に try/except ValueError を復元する。restart_mcp_server() 呼び出しが _find_mcp_server_cmd() → _validate_command() 経由で raise する ValueError を捕捉し、print(f\"Error: mcp restart failed — {e}\", file=sys.stderr) + sys.exit(1) で構造化エラー出力する"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC6CliValueErrorHandling::test_ac6_mcp_restart_catches_value_error_exits_1"
+      - "TestAC6CliValueErrorHandling::test_ac6_error_message_printed_on_value_error"
+      - "TestAC6CliValueErrorHandling::test_ac6_cli_dispatch_has_try_except_for_value_error"
+    impl_files:
+      - "cli/twl/src/twl/cli.py"
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+
+  - ac_index: "1414-AC3"
+    ac_text: "_validate_command() が raise する ValueError のメッセージに、拒否理由（コマンド名・allowlist・許可 prefix リスト）が含まれること（既存挙動の維持）"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC3StructuredLogging::test_ac3_value_error_message_contains_command"
+      - "TestAC3StructuredLogging::test_ac3_value_error_message_contains_allowlist_or_reason"
+      - "TestAC1AllowlistValidation::test_ac1_unknown_command_raises_value_error"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+
+  - ac_index: "1414-AC4"
+    ac_text: "cli/twl/tests/test_mcp_lifecycle.py::TestAC3StructuredLogging::test_ac3_structured_log_output_on_rejection を更新し、_find_mcp_server_cmd() 直接呼び出しではなく cli.main() 経由で stderr に構造化情報が出力されることを検証する（テスト境界が unit → integration にシフトする点を docstring に明記）"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC3StructuredLogging::test_ac3_structured_log_output_on_rejection"
+    impl_files:
+      - "cli/twl/tests/test_mcp_lifecycle.py"
+
+  - ac_index: "1414-AC5"
+    ac_text: "test_mcp_lifecycle.py の TestAC6CliValueErrorHandling クラス内 4 テスト全てを GREEN にする"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC6CliValueErrorHandling::test_ac6_mcp_restart_catches_value_error_exits_1"
+      - "TestAC6CliValueErrorHandling::test_ac6_error_message_printed_on_value_error"
+      - "TestAC6CliValueErrorHandling::test_ac6_cli_dispatch_has_try_except_for_value_error"
+      - "TestAC6CliValueErrorHandling::test_ac6_cli_mcp_restart_exits_1_on_value_error_subprocess"
+    impl_files:
+      - "cli/twl/src/twl/cli.py"
+      - "cli/twl/tests/test_mcp_lifecycle.py"
+
+  - ac_index: "1414-AC6"
+    ac_text: "正常系（uv / uvx 起動）の挙動は影響を受けない"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC4LegitimateCommandsUnaffected::test_ac4_uv_command_is_in_allowlist"
+      - "TestAC4LegitimateCommandsUnaffected::test_ac4_uvx_command_is_in_allowlist"
+      - "TestAC4LegitimateCommandsUnaffected::test_ac4_uv_command_does_not_raise"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+      - "cli/twl/src/twl/cli.py"
+
+  - ac_index: "1414-AC7"
+    ac_text: "stderr 出力が単一経路になることを behavioral test で確認する。cli.main() 経由で不正コマンド検出時、captured.err に 'Error: mcp restart failed —' で始まる行が正確に 1 行のみ出現し、Python traceback（Traceback (most recent call last):）が含まれないことを assert する"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_names:
+      - "TestAC6CliValueErrorHandling::test_ac7_stderr_single_line_no_traceback_on_invalid_command"
+    impl_files:
+      - "cli/twl/tests/test_mcp_lifecycle.py"

--- a/cli/twl/tests/test_mcp_lifecycle.py
+++ b/cli/twl/tests/test_mcp_lifecycle.py
@@ -587,16 +587,16 @@ class TestAC6CliValueErrorHandling:
         cli_path = TWL_SRC / "twl" / "cli.py"
         content = cli_path.read_text()
 
-        # mcp restart のディスパッチ付近に ValueError 捕捉があること
-        # 「mcp」セクションに「ValueError」が含まれること
-        mcp_section_start = content.find("sys.argv[1] == 'mcp'")
+        # mcp restart のディスパッチ付近に ValueError 捕捉があること（argparse ベース）
+        # 「args.subcommand == 'mcp'」セクションに「ValueError」が含まれること
+        mcp_section_start = content.find("args.subcommand == 'mcp'")
         assert mcp_section_start != -1, (
-            "cli.py に mcp ディスパッチが見つからない"
+            "cli.py に mcp ディスパッチが見つからない（args.subcommand == 'mcp' が存在しない）"
         )
         # mcp セクション以降に ValueError が含まれること
         mcp_section = content[mcp_section_start:mcp_section_start + 500]
         assert "ValueError" in mcp_section, (
-            f"cli.py の mcp ディスパッチ付近に ValueError 捕捉が存在しない (AC6 未実装):\n{mcp_section}"
+            f"cli.py の mcp ディスパッチ付近に ValueError 捕捉が存在しない (AC2 未実装):\n{mcp_section}"
         )
 
     def test_ac6_cli_mcp_restart_exits_1_on_value_error_subprocess(self):
@@ -645,7 +645,10 @@ class TestAC6CliValueErrorHandling:
                     cli_mod.main()
                 except SystemExit:
                     pass
-                # ValueError propagate は捕捉せずに assert まで流す（traceback 有無を検証するため）
+                except ValueError:
+                    pytest.fail(
+                        "ValueError が cli.py で捕捉されず propagate した (AC2/Issue#1414 未実装)"
+                    )
 
         captured = capsys.readouterr()
 

--- a/cli/twl/tests/test_mcp_lifecycle.py
+++ b/cli/twl/tests/test_mcp_lifecycle.py
@@ -341,30 +341,40 @@ class TestAC3StructuredLogging:
                     )
 
     def test_ac3_structured_log_output_on_rejection(self, tmp_path, capsys):
-        # AC: 検証失敗時に stdout または stderr に構造化情報が出力される
-        # RED: 現状は出力なし
-        from twl.mcp_server.lifecycle import _find_mcp_server_cmd
+        """AC4 (Issue #1414): cli.main() 経由で stderr に構造化情報が出力されることを検証する。
 
-        mcp_json = self._make_mcp_json("nc", tmp_path)
+        テスト境界: unit（_find_mcp_server_cmd 直接呼び出し）から
+        integration（cli.main() 経由）にシフトした。
+        これにより cli.py の try/except ValueError が存在しない限り
+        stderr への "Error: mcp restart failed — ..." 出力は発生せず、
+        テストは RED のままとなる（Issue #1414 実装後に GREEN になる）。
 
-        with patch("subprocess.run") as mock_run:
-            mock_run.return_value = MagicMock(
-                returncode=0,
-                stdout=str(tmp_path) + "\n",
-            )
-            with patch("pathlib.Path.exists", return_value=True), \
-                 patch("builtins.open", return_value=open(mcp_json)):
+        AC: cli.main() 経由で不正コマンド検出時、stderr に構造化エラー行が出力される。
+        RED: cli.py に try/except ValueError がないため、ValueError が propagate して
+             "Error: mcp restart failed — ..." の stderr 出力がなく FAIL する。
+        """
+        import twl.cli as cli_mod
+
+        error_msg = "command 'nc' not in allowlist: ['uv', 'uvx']"
+        with patch("twl.mcp_server.lifecycle.restart_mcp_server") as mock_restart:
+            mock_restart.side_effect = ValueError(error_msg)
+            with patch.object(sys, "argv", ["twl", "mcp", "restart"]):
                 try:
-                    _find_mcp_server_cmd()
-                    pytest.fail("ValueError が raise されなかった (AC3 未実装)")
-                except ValueError:
+                    cli_mod.main()
+                except SystemExit:
                     pass
+                except ValueError:
+                    # ValueError が cli.py で捕捉されず propagate した場合は FAIL
+                    pytest.fail(
+                        "ValueError が cli.py で捕捉されず propagate した (AC2/Issue#1414 未実装)"
+                    )
 
         captured = capsys.readouterr()
-        combined_output = captured.out + captured.err
-        # stdout/stderr に何らかの情報が出力されていること（構造化ログ）
-        assert combined_output.strip(), (
-            "検証失敗時に stdout/stderr に何も出力されていない (AC3 未実装)"
+        # cli.py が "Error: mcp restart failed — ..." を stderr に出力すること
+        assert "Error: mcp restart failed" in captured.err, (
+            f"cli.main() 経由で不正コマンド検出時に stderr に構造化エラー行が出力されていない "
+            f"(AC2/Issue#1414 未実装).\n"
+            f"stderr: {captured.err!r}"
         )
 
 
@@ -612,4 +622,46 @@ class TestAC6CliValueErrorHandling:
         )
         assert allowlist is not None, (
             "allowlist が未実装のため subprocess テストが意味をなさない (AC6 前提 未実装)"
+        )
+
+    def test_ac7_stderr_single_line_no_traceback_on_invalid_command(self, capsys):
+        """AC7: stderr 出力が単一経路になることを behavioral test で確認する。
+
+        cli.main() 経由で不正コマンド検出時:
+          - captured.err に "Error: mcp restart failed —" で始まる行が正確に 1 行のみ出現すること
+          - "Traceback (most recent call last):" が含まれないこと
+
+        RED: cli.py に try/except ValueError がないため、ValueError が propagate して
+             Python traceback が出力される（または "Error: mcp restart failed —" 行が存在しない）。
+             いずれの場合も assert が FAIL する（Issue #1414 実装後に GREEN になる）。
+        """
+        import twl.cli as cli_mod
+
+        error_detail = "command 'evil' not in allowlist: ['uv', 'uvx']"
+        with patch("twl.mcp_server.lifecycle.restart_mcp_server") as mock_restart:
+            mock_restart.side_effect = ValueError(error_detail)
+            with patch.object(sys, "argv", ["twl", "mcp", "restart"]):
+                try:
+                    cli_mod.main()
+                except SystemExit:
+                    pass
+                # ValueError propagate は捕捉せずに assert まで流す（traceback 有無を検証するため）
+
+        captured = capsys.readouterr()
+
+        # "Error: mcp restart failed —" で始まる行が正確に 1 行のみ出現すること
+        error_lines = [
+            line for line in captured.err.splitlines()
+            if line.startswith("Error: mcp restart failed —")
+        ]
+        assert len(error_lines) == 1, (
+            f"stderr に 'Error: mcp restart failed —' で始まる行が正確に 1 行のみ存在するべきだが "
+            f"{len(error_lines)} 行あった (AC7 未実装).\n"
+            f"stderr: {captured.err!r}"
+        )
+
+        # Python traceback が含まれないこと
+        assert "Traceback (most recent call last):" not in captured.err, (
+            f"stderr に Python traceback が含まれている (AC7 未実装 — try/except なしで ValueError propagate).\n"
+            f"stderr: {captured.err!r}"
         )


### PR DESCRIPTION
## 概要

Issue #1414: `_validate_command()` の `print(file=sys.stderr)` 二重出力を除去し、`cli.py` の `try/except ValueError` を復元する。

## 変更内容

### 実装（TODO）
- `lifecycle.py` の `_validate_command()` から `print(file=sys.stderr)` を全箇所削除（AC1）
- `cli.py` の mcp restart ブロックに `try/except ValueError` を追加（AC2）

### テスト（本コミット）
- `test_ac3_structured_log_output_on_rejection` を `cli.main()` 経由 integration test に更新（AC4）
- `test_ac7_stderr_single_line_no_traceback_on_invalid_command` 新規追加（AC7）
- `ac-test-mapping.yaml` に Issue #1414 の AC1〜AC7 全件マッピング追記

## 関連 Issue

Closes #1414