### PR TITLE
test(session): bats ac4 を SESSION_COMM_SCRIPT_DIR sandbox 化（#1424）

### DIFF
--- a/plugins/session/tests/ac-test-mapping.yaml
+++ b/plugins/session/tests/ac-test-mapping.yaml
@@ -131,3 +131,93 @@ mappings:
     status: RED
     impl_files:
       - "plugins/session/scripts/lib/tmux-resolve.sh"
+
+  # ---------------------------------------------------------------------------
+  # Issue #1424: tech-debt(test): bats AC4 で session-comm-backend-mcp.sh を
+  #              直接上書き — SIGKILL 時モック残留リスク
+  #
+  # 修正方針: _TEST_MODE + SESSION_COMM_SCRIPT_DIR sandbox 化で本番ファイルに触れない
+  # テストファイル: plugins/session/tests/test_1424_bats_ac4_sandbox.bats
+  # ---------------------------------------------------------------------------
+
+  # AC1: issue-1410 bats への guardrail（本番ファイルへの直接 cp/cat> なし）
+  - ac_index: 1
+    issue: 1424
+    ac_text: "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats 全体に対し git grep -nE '(cp|cat>).*session-comm-backend-mcp.sh' がマッチしないこと"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac1: issue-1410 bats に本番 mcp backend への直接 cp/cat> がないこと（guardrail）"
+    status: GREEN
+    note: |
+      guardrail テスト。現在は変数 $backend_mcp 経由のため NO MATCH（PASS）。
+      Fix 後も SESSION_COMM_SCRIPT_DIR sandbox 化で本番ファイルに触れないため PASS 維持。
+      "現在も PASS だが Fix 前後で設計の意味が変わる" ことを記録する。
+    impl_files:
+      - "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats"
+
+  # AC2: issue-1404 bats への guardrail（同上）
+  - ac_index: 2
+    issue: 1424
+    ac_text: "plugins/session/tests/issue-1404-cmdinject-session-msg.bats についても AC1 同様（本番 mcp backend への上書き・cp なし）"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac2: issue-1404 bats に本番 mcp backend への直接 cp/cat> がないこと（guardrail）"
+    status: GREEN
+    note: "AC1 同様の guardrail。Fix 後も PASS 維持。"
+    impl_files:
+      - "plugins/session/tests/issue-1404-cmdinject-session-msg.bats"
+
+  # AC3: 両 bats 実行で全 11 ケース PASS
+  - ac_index: 3
+    issue: 1424
+    ac_text: "両 bats を bats ... で実行した結果、全 11 ケース（issue-1410: 6ケース ac1〜ac6、issue-1404: 5ケース ac1〜ac5）が PASS すること"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac3: 両 bats 実行で全 11 ケース PASS すること（issue-1410: 6件, issue-1404: 5件）"
+    status: GREEN
+    note: |
+      SESSION_COMM_SCRIPT_DIR sandbox 化後も既存の 11 ケースが PASS であることを確認する
+      リグレッション防止テスト。現ブランチでは既に PASS。
+    impl_files:
+      - "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats"
+      - "plugins/session/tests/issue-1404-cmdinject-session-msg.bats"
+
+  # AC4: bats 実行前後で sha256sum が一致すること
+  - ac_index: 4
+    issue: 1424
+    ac_text: "両 bats 実行前後で sha256sum plugins/session/scripts/session-comm-backend-mcp.sh が一致すること（本番ファイルが改変されていないこと）"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac4: 両 bats 実行前後で session-comm-backend-mcp.sh の sha256sum が一致すること"
+    status: GREEN
+    note: |
+      BACKEND_MCP_BAK パターンでは teardown が正常動作する間は sha256sum が一致するが、
+      SIGKILL 時に teardown が呼ばれないと本番ファイルがモック状態で残る。
+      Fix 後: SESSION_COMM_SCRIPT_DIR sandbox 化で本番ファイルに一切触れないため確実に一致。
+    impl_files:
+      - "plugins/session/scripts/session-comm-backend-mcp.sh"
+      - "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats"
+      - "plugins/session/tests/issue-1404-cmdinject-session-msg.bats"
+
+  # AC5-1: issue-1410 bats から BACKEND_MCP_BAK 削除確認（RED）
+  - ac_index: 5
+    issue: 1424
+    ac_text: "setup() / teardown() の BACKEND_MCP_BAK ハンドリングが不要になり削除されていること（grep -n BACKEND_MCP_BAK がマッチしないこと）"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac5: issue-1410 bats に BACKEND_MCP_BAK ハンドリングが残っていないこと"
+    status: RED
+    note: |
+      現在 BACKEND_MCP_BAK が issue-1410 bats に 9 箇所存在するため FAIL（RED）。
+      Fix: SESSION_COMM_SCRIPT_DIR sandbox 化により BACKEND_MCP_BAK が不要になり削除される。
+    impl_files:
+      - "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats"
+
+  # AC5-2: issue-1404 bats から BACKEND_MCP_BAK 削除確認（RED）
+  - ac_index: 5
+    issue: 1424
+    ac_text: "setup() / teardown() の BACKEND_MCP_BAK ハンドリングが不要になり削除されていること（issue-1404 bats）"
+    test_file: "plugins/session/tests/test_1424_bats_ac4_sandbox.bats"
+    test_name: "ac5: issue-1404 bats に BACKEND_MCP_BAK ハンドリングが残っていないこと"
+    status: RED
+    note: |
+      現在 BACKEND_MCP_BAK が issue-1404 bats に 9 箇所存在するため FAIL（RED）。
+      Fix: SESSION_COMM_SCRIPT_DIR sandbox 化により BACKEND_MCP_BAK が不要になり削除される。
+    impl_files:
+      - "plugins/session/tests/issue-1404-cmdinject-session-msg.bats"
+

--- a/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
+++ b/plugins/session/tests/issue-1404-cmdinject-session-msg.bats
@@ -10,16 +10,10 @@ setup() {
     PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
     SANDBOX="$(mktemp -d)"
-    BACKEND_MCP_BAK=""  # ac4 で設定。teardown が安全ネットとして復元
-    export SANDBOX SCRIPT PLUGIN_ROOT BACKEND_MCP_BAK
+    export SANDBOX SCRIPT PLUGIN_ROOT
 }
 
 teardown() {
-    # ac4: 本番 backend-mcp.sh が上書きされた場合の安全ネット復元
-    if [[ -n "${BACKEND_MCP_BAK:-}" && -f "$BACKEND_MCP_BAK" ]]; then
-        local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
-        mv "$BACKEND_MCP_BAK" "$backend_mcp"
-    fi
     [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
 }
 
@@ -94,39 +88,23 @@ _extract_cmd_inject_body() {
 # ===========================================================================
 
 @test "ac4: TWILL_MSG_BACKEND=mcp で cmd_inject が mcp backend に dispatch される" {
-    mkdir -p "$SANDBOX/bin"
+    local mock_mcp="$SANDBOX/mock-mcp-called"
+
+    # sandbox: SANDBOX/scripts/ に必要ファイルを配置（本番ファイルに一切触れない）
+    mkdir -p "$SANDBOX/scripts" "$SANDBOX/bin"
+    cp "$PLUGIN_ROOT/scripts/session-comm-backend-tmux.sh" "$SANDBOX/scripts/"
 
     # mock session-state.sh: always input-waiting
-    cat > "$SANDBOX/bin/session-state.sh" <<'EOF'
+    cat > "$SANDBOX/scripts/session-state.sh" <<'EOF'
 #!/usr/bin/env bash
-echo "input-waiting"
+if [[ "$1" == "state" ]]; then echo "input-waiting"; fi
 exit 0
 EOF
-    chmod +x "$SANDBOX/bin/session-state.sh"
+    chmod +x "$SANDBOX/scripts/session-state.sh"
 
-    # mock tmux: list-windows -a -F で resolve_target が期待する形式を返す
-    cat > "$SANDBOX/bin/tmux" <<'EOF'
-#!/usr/bin/env bash
-case "${1:-}" in
-    list-windows) echo "testsession:0 main" ;;
-    has-session)  exit 0 ;;
-    send-keys)
-        echo "FAIL: tmux send-keys was called directly (should go through session_msg → mcp backend)" >&2
-        exit 1
-        ;;
-    *) exit 0 ;;
-esac
-EOF
-    chmod +x "$SANDBOX/bin/tmux"
-
-    # mock session-comm-backend-mcp.sh: call を記録して成功
-    local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
-    local mock_mcp="$SANDBOX/mock-mcp-called"
-    # teardown 安全ネット用バックアップ（bats kill 時でも復元される）
-    BACKEND_MCP_BAK="$SANDBOX/session-comm-backend-mcp.sh.bak"
-    [[ -f "$backend_mcp" ]] && cp "$backend_mcp" "$BACKEND_MCP_BAK"
-
-    cat > "$backend_mcp" <<EOF
+    # mock mcp backend を SANDBOX/scripts/ に配置（本番には一切触れない）
+    local sandbox_mcp="$SANDBOX/scripts/session-comm-backend-mcp.sh"
+    cat > "$sandbox_mcp" <<EOF
 #!/usr/bin/env bash
 _backend_mcp_send() {
     echo "mcp-backend-called" > "${mock_mcp}"
@@ -137,20 +115,31 @@ _backend_shadow_send() {
     return 0
 }
 EOF
+    chmod +x "$sandbox_mcp"
 
-    # --force: state チェックをスキップ（session-state.sh は SCRIPT_DIR 絶対パス呼出のため PATH mock 非介入）
+    # mock tmux: list-windows で resolve_target が期待する形式を返す
+    # send-keys が呼ばれたら FAIL（mcp backend 経由になるべき）
+    cat > "$SANDBOX/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    list-windows) echo "testsession:0 main" ;;
+    has-session)  exit 0 ;;
+    send-keys)
+        echo "FAIL: tmux send-keys was called directly (should go through session_msg -> mcp backend)" >&2
+        exit 1
+        ;;
+    *) exit 0 ;;
+esac
+EOF
+    chmod +x "$SANDBOX/bin/tmux"
+
+    # _TEST_MODE + SESSION_COMM_SCRIPT_DIR で sandbox を参照（本番ファイルに触れない）
     PATH="$SANDBOX/bin:$PATH" \
     SESSION_COMM_LOCK_DIR="/tmp" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/scripts" \
     TWILL_MSG_BACKEND=mcp \
     bash "$SCRIPT" inject "main" "hello" --force 2>/dev/null || true
-
-    # backend-mcp.sh を復元（teardown も安全ネットとして同じ復元を行う）
-    if [[ -f "$BACKEND_MCP_BAK" ]]; then
-        mv "$BACKEND_MCP_BAK" "$backend_mcp"
-    else
-        rm -f "$backend_mcp"
-    fi
-    BACKEND_MCP_BAK=""
 
     if [[ ! -f "$mock_mcp" ]]; then
         echo "FAIL: TWILL_MSG_BACKEND=mcp を設定しても mcp backend が呼ばれなかった" >&2

--- a/plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats
+++ b/plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats
@@ -10,16 +10,10 @@ setup() {
     PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
     SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
     SANDBOX="$(mktemp -d)"
-    BACKEND_MCP_BAK=""  # ac4 で設定。teardown が安全ネットとして復元
-    export SANDBOX SCRIPT PLUGIN_ROOT BACKEND_MCP_BAK
+    export SANDBOX SCRIPT PLUGIN_ROOT
 }
 
 teardown() {
-    # ac4: 本番 backend-mcp.sh が上書きされた場合の安全ネット復元
-    if [[ -n "${BACKEND_MCP_BAK:-}" && -f "$BACKEND_MCP_BAK" ]]; then
-        local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
-        mv "$BACKEND_MCP_BAK" "$backend_mcp"
-    fi
     [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
 }
 
@@ -104,26 +98,42 @@ _extract_cmd_inject_file_body() {
 # ===========================================================================
 
 @test "ac4: TWILL_MSG_BACKEND=mcp で cmd_inject_file が mcp backend に dispatch される" {
-    mkdir -p "$SANDBOX/bin"
-
-    # テスト対象ファイルを作成（inject-file には実ファイルが必要）
+    local mock_mcp="$SANDBOX/mock-mcp-called"
     local test_file="$SANDBOX/test-input.txt"
     echo "hello from file" > "$test_file"
 
+    # sandbox: SANDBOX/scripts/ に必要ファイルを配置（本番ファイルに一切触れない）
+    mkdir -p "$SANDBOX/scripts" "$SANDBOX/bin"
+    cp "$PLUGIN_ROOT/scripts/session-comm-backend-tmux.sh" "$SANDBOX/scripts/"
+
     # mock session-state.sh: always input-waiting
-    cat > "$SANDBOX/bin/session-state.sh" <<'EOF'
+    cat > "$SANDBOX/scripts/session-state.sh" <<'EOF'
 #!/usr/bin/env bash
-echo "input-waiting"
+if [[ "$1" == "state" ]]; then echo "input-waiting"; fi
 exit 0
 EOF
-    chmod +x "$SANDBOX/bin/session-state.sh"
+    chmod +x "$SANDBOX/scripts/session-state.sh"
 
-    # mock tmux: list-windows で resolve_target が期待する形式 + load-buffer/paste-buffer を処理
-    # send-keys が呼ばれたら FAIL（mcp backend 経由になるべき）
-    local mock_mcp="$SANDBOX/mock-mcp-called"
-    cat > "$SANDBOX/bin/tmux" <<EOF
+    # mock mcp backend を SANDBOX/scripts/ に配置（本番には一切触れない）
+    local sandbox_mcp="$SANDBOX/scripts/session-comm-backend-mcp.sh"
+    cat > "$sandbox_mcp" <<EOF
 #!/usr/bin/env bash
-case "\${1:-}" in
+_backend_mcp_send() {
+    echo "mcp-backend-called" > "${mock_mcp}"
+    return 0
+}
+_backend_shadow_send() {
+    echo "shadow-backend-called" > "${mock_mcp}"
+    return 0
+}
+EOF
+    chmod +x "$sandbox_mcp"
+
+    # mock tmux: list-windows + load-buffer/paste-buffer
+    # send-keys が呼ばれたら FAIL（mcp backend 経由になるべき）
+    cat > "$SANDBOX/bin/tmux" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
     list-windows) echo "testsession:0 main" ;;
     has-session)  exit 0 ;;
     load-buffer)  exit 0 ;;
@@ -139,38 +149,13 @@ esac
 EOF
     chmod +x "$SANDBOX/bin/tmux"
 
-    # mock session-comm-backend-mcp.sh: call を記録して成功
-    local backend_mcp="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
-    # teardown 安全ネット用バックアップ（bats kill 時でも復元される）
-    BACKEND_MCP_BAK="$SANDBOX/session-comm-backend-mcp.sh.bak"
-    [[ -f "$backend_mcp" ]] && cp "$backend_mcp" "$BACKEND_MCP_BAK"
-
-    # 変数展開が必要なため <<EOF（シングルクォートなし）を使用
-    cat > "$backend_mcp" <<EOF
-#!/usr/bin/env bash
-_backend_mcp_send() {
-    echo "mcp-backend-called" > "${mock_mcp}"
-    return 0
-}
-_backend_shadow_send() {
-    echo "shadow-backend-called" > "${mock_mcp}"
-    return 0
-}
-EOF
-
-    # --force: state チェックをスキップ（session-state.sh は SCRIPT_DIR 絶対パス呼出のため PATH mock 非介入）
+    # _TEST_MODE + SESSION_COMM_SCRIPT_DIR で sandbox を参照（本番ファイルに触れない）
     PATH="$SANDBOX/bin:$PATH" \
     SESSION_COMM_LOCK_DIR="/tmp" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/scripts" \
     TWILL_MSG_BACKEND=mcp \
     bash "$SCRIPT" inject-file "main" "$test_file" --force 2>/dev/null || true
-
-    # backend-mcp.sh を復元（teardown も安全ネットとして同じ復元を行う）
-    if [[ -f "$BACKEND_MCP_BAK" ]]; then
-        mv "$BACKEND_MCP_BAK" "$backend_mcp"
-    else
-        rm -f "$backend_mcp"
-    fi
-    BACKEND_MCP_BAK=""
 
     if [[ ! -f "$mock_mcp" ]]; then
         echo "FAIL: TWILL_MSG_BACKEND=mcp を設定しても mcp backend が呼ばれなかった" >&2

--- a/plugins/session/tests/test_1424_bats_ac4_sandbox.bats
+++ b/plugins/session/tests/test_1424_bats_ac4_sandbox.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# test_1424_bats_ac4_sandbox.bats
+# Issue #1424: tech-debt(test): bats AC4 で session-comm-backend-mcp.sh を直接上書き
+#              — SIGKILL 時モック残留リスク
+#
+# 修正方針: session-comm.sh の _TEST_MODE + SESSION_COMM_SCRIPT_DIR 機構で sandbox 化し、
+#           本番ファイル plugins/session/scripts/session-comm-backend-mcp.sh に一切触れない。
+#
+# AC1: issue-1410 bats ファイルに git grep -nE '(cp|cat>).*session-comm-backend-mcp.sh' がマッチしない
+# AC2: issue-1404 bats ファイルについて AC1 同様
+# AC3: 両 bats 実行で全 11 ケース PASS すること（issue-1410: 6件, issue-1404: 5件）
+# AC4: 両 bats 実行前後で sha256sum plugins/session/scripts/session-comm-backend-mcp.sh が一致
+# AC5: grep -n BACKEND_MCP_BAK が両ファイルでマッチしないこと
+
+# ===========================================================================
+# setup / teardown
+# ===========================================================================
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    BATS_1410="$PLUGIN_ROOT/tests/issue-1410-cmdinject-file-session-msg.bats"
+    BATS_1404="$PLUGIN_ROOT/tests/issue-1404-cmdinject-session-msg.bats"
+    BACKEND_MCP="$PLUGIN_ROOT/scripts/session-comm-backend-mcp.sh"
+    export PLUGIN_ROOT BATS_1410 BATS_1404 BACKEND_MCP
+}
+
+teardown() {
+    : # no-op: このテストファイル自体は本番ファイルに触れない
+}
+
+# ===========================================================================
+# AC1: issue-1410 bats ファイルに本番 mcp backend への直接 cp/cat> がないこと
+#
+# guardrail テスト: 現在は変数 $backend_mcp 経由のため NO MATCH（PASS）
+# Fix 後も sandbox 化により本番ファイルへの cp/cat> が存在しないことを継続確認する
+#
+# 注意: この AC は "現在も PASS" だが Fix 前後で意味が変わる。
+# Fix 前: 変数経由のため grep がマッチしないだけで実態は本番ファイルに触れている
+# Fix 後: sandbox 化により本当に本番ファイルに触れない設計になっているはずで PASS 維持
+# ===========================================================================
+
+@test "ac1: issue-1410 bats に本番 mcp backend への直接 cp/cat> がないこと（guardrail）" {
+    # git grep パターン: 引用符付き・なし両パターンを検出
+    if git -C "$PLUGIN_ROOT" grep -nE \
+        '(cp[[:space:]]|cat[[:space:]]+>[[:space:]]*)"?[^"]*/?session-comm-backend-mcp\.sh' \
+        "tests/issue-1410-cmdinject-file-session-msg.bats" 2>/dev/null; then
+        echo "FAIL: issue-1410 bats に本番 session-comm-backend-mcp.sh への直接 cp/cat> が存在する" >&2
+        echo "  Fix: SESSION_COMM_SCRIPT_DIR sandbox 経由に変更が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC2: issue-1404 bats ファイルに本番 mcp backend への直接 cp/cat> がないこと
+#
+# AC1 同様の guardrail テスト
+# ===========================================================================
+
+@test "ac2: issue-1404 bats に本番 mcp backend への直接 cp/cat> がないこと（guardrail）" {
+    if git -C "$PLUGIN_ROOT" grep -nE \
+        '(cp[[:space:]]|cat[[:space:]]+>[[:space:]]*)"?[^"]*/?session-comm-backend-mcp\.sh' \
+        "tests/issue-1404-cmdinject-session-msg.bats" 2>/dev/null; then
+        echo "FAIL: issue-1404 bats に本番 session-comm-backend-mcp.sh への直接 cp/cat> が存在する" >&2
+        echo "  Fix: SESSION_COMM_SCRIPT_DIR sandbox 経由に変更が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC3: 両 bats 実行で全 11 ケース PASS すること
+#
+# RED: 現状 issue-1410 ac4 / issue-1404 ac4 が SESSION_COMM_SCRIPT_DIR sandbox を
+#      使っていないため FAIL（本番ファイルに触れない sandbox 未実装）
+# Fix 後: SESSION_COMM_SCRIPT_DIR sandbox 化で全 11 ケース GREEN になるはず
+# ===========================================================================
+
+@test "ac3: 両 bats 実行で全 11 ケース PASS すること（issue-1410: 6件, issue-1404: 5件）" {
+    # RED: sandbox 未実装のため issue-1410 ac4 / issue-1404 ac4 が FAIL する
+    # Fix 後は SESSION_COMM_SCRIPT_DIR sandbox を使い全ケース PASS となるはず
+
+    local bats_bin
+    bats_bin="$(command -v bats 2>/dev/null || true)"
+    if [[ -z "$bats_bin" ]]; then
+        echo "SKIP: bats コマンドが見つからない" >&2
+        return 1
+    fi
+
+    local output_file
+    output_file="$(mktemp)"
+
+    # 両ファイルをまとめて実行し exit code を確認
+    if ! "$bats_bin" "$BATS_1410" "$BATS_1404" > "$output_file" 2>&1; then
+        echo "FAIL: 両 bats を実行した結果、FAIL したケースが存在する" >&2
+        echo "--- bats output ---" >&2
+        cat "$output_file" >&2
+        echo "-------------------" >&2
+        rm -f "$output_file"
+        return 1
+    fi
+
+    local pass_count
+    pass_count=$(grep -c '^ok ' "$output_file" 2>/dev/null || echo 0)
+
+    rm -f "$output_file"
+
+    if [[ "$pass_count" -lt 11 ]]; then
+        echo "FAIL: PASS ケース数が 11 未満（actual: $pass_count）" >&2
+        echo "  issue-1410: 6 ケース（ac1〜ac6）, issue-1404: 5 ケース（ac1〜ac5）が全て PASS 必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC4: 両 bats 実行前後で session-comm-backend-mcp.sh の sha256sum が一致すること
+#
+# RED: 現状 ac4 テスト（1404/1410 両ファイル）が BACKEND_MCP_BAK パターンで
+#      本番ファイルを cp・cat > で上書きする。SIGKILL 時に teardown が呼ばれず
+#      モック状態のまま残る = sha256sum が変わる可能性がある。
+# Fix 後: SESSION_COMM_SCRIPT_DIR sandbox で本番ファイルに触れないため sha256sum 一致
+# ===========================================================================
+
+@test "ac4: 両 bats 実行前後で session-comm-backend-mcp.sh の sha256sum が一致すること" {
+    # RED: 現状は BACKEND_MCP_BAK パターンで本番ファイルを上書きするリスクがある
+    # この自体のテストは「正常終了時でも sha256sum が変わっていないか」を確認する
+
+    local bats_bin
+    bats_bin="$(command -v bats 2>/dev/null || true)"
+    if [[ -z "$bats_bin" ]]; then
+        echo "SKIP: bats コマンドが見つからない" >&2
+        return 1
+    fi
+
+    if [[ ! -f "$BACKEND_MCP" ]]; then
+        echo "FAIL: session-comm-backend-mcp.sh が見つからない: $BACKEND_MCP" >&2
+        return 1
+    fi
+
+    # 実行前のハッシュ
+    local hash_before
+    hash_before=$(sha256sum "$BACKEND_MCP" | awk '{print $1}')
+
+    # 両 bats を実行（exit code は無視 - テスト失敗は別 AC3 で確認）
+    "$bats_bin" "$BATS_1410" "$BATS_1404" > /dev/null 2>&1 || true
+
+    # 実行後のハッシュ
+    local hash_after
+    hash_after=$(sha256sum "$BACKEND_MCP" | awk '{print $1}')
+
+    if [[ "$hash_before" != "$hash_after" ]]; then
+        echo "FAIL: bats 実行後に session-comm-backend-mcp.sh の sha256sum が変化した" >&2
+        echo "  before: $hash_before" >&2
+        echo "  after:  $hash_after" >&2
+        echo "  BACKEND_MCP_BAK パターンの teardown が正常に復元できなかった可能性" >&2
+        echo "  Fix: SESSION_COMM_SCRIPT_DIR sandbox 化で本番ファイルに触れないようにする" >&2
+        # sha256sum が変化した場合は本番ファイルが壊れているため即時 FAIL
+        return 1
+    fi
+}
+
+# ===========================================================================
+# AC5: 両 bats ファイルに BACKEND_MCP_BAK ハンドリングが残っていないこと
+#
+# RED: 現状 grep -n BACKEND_MCP_BAK が両ファイルでマッチする（各 9 箇所）
+# Fix 後: SESSION_COMM_SCRIPT_DIR sandbox 化により BACKEND_MCP_BAK が不要になり削除される
+# ===========================================================================
+
+@test "ac5: issue-1410 bats に BACKEND_MCP_BAK ハンドリングが残っていないこと" {
+    # RED: 現在 BACKEND_MCP_BAK が存在するため FAIL
+    local matches
+    matches=$(grep -n 'BACKEND_MCP_BAK' "$BATS_1410" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        echo "FAIL: issue-1410 bats に BACKEND_MCP_BAK が残存している" >&2
+        echo "$matches" | sed 's/^/  /' >&2
+        echo "  Fix: setup()/teardown() の BACKEND_MCP_BAK ハンドリングを削除し" >&2
+        echo "       SESSION_COMM_SCRIPT_DIR sandbox 化に移行する" >&2
+        return 1
+    fi
+}
+
+@test "ac5: issue-1404 bats に BACKEND_MCP_BAK ハンドリングが残っていないこと" {
+    # RED: 現在 BACKEND_MCP_BAK が存在するため FAIL
+    local matches
+    matches=$(grep -n 'BACKEND_MCP_BAK' "$BATS_1404" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+        echo "FAIL: issue-1404 bats に BACKEND_MCP_BAK が残存している" >&2
+        echo "$matches" | sed 's/^/  /' >&2
+        echo "  Fix: setup()/teardown() の BACKEND_MCP_BAK ハンドリングを削除し" >&2
+        echo "       SESSION_COMM_SCRIPT_DIR sandbox 化に移行する" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
## 概要

Issue #1424 の修正: `issue-1410` / `issue-1404` 両 bats の ac4 テストが本番 `session-comm-backend-mcp.sh` を直接上書きしていた問題を修正。

## 変更内容

- `setup()` / `teardown()` から `BACKEND_MCP_BAK` ハンドリングを削除
- ac4 テストを `_TEST_MODE + SESSION_COMM_SCRIPT_DIR` 機構による `SANDBOX/scripts/` への mock 配置に変更
- 本番ファイルへの `cp` / `cat >` を完全に排除（SIGKILL 時のモック残留リスク解消）

## AC 検証結果

- ✅ AC1: issue-1410 bats に `cp/cat >` → `session-comm-backend-mcp.sh` パターンなし
- ✅ AC2: issue-1404 bats 同様
- ✅ AC3: 両 bats 11ケース全 PASS
- ✅ AC4: bats 実行前後で `sha256sum` 一致（本番ファイル改変なし）
- ✅ AC5: `BACKEND_MCP_BAK` ハンドリング完全削除

Closes #1424