### PR TITLE
docs(#1433): ADR-034 Autonomous Wave Chain Reliability Architecture 起草

### DIFF
--- a/ac-test-mapping-1433.yaml
+++ b/ac-test-mapping-1433.yaml
@@ -1,0 +1,87 @@
+mappings:
+  - ac_index: 1
+    ac_text: "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md が新規作成されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac1: ADR-034 ファイルが存在する"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+
+  - ac_index: 2
+    ac_text: "Status: Accepted が記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac2: Status Accepted が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+
+  - ac_index: 3
+    ac_text: "Context section に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac3a: Context に Failure mode F1 が明記されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac3a (F1), ac3b (F2), ac3c (F3), ac3d (AUTO_KILL=0)
+
+  - ac_index: 4
+    ac_text: "Decision section に 5 つの principle が箇条書きで記載されている（LLM judgment exclusion / Multi-layer signal redundancy / Dedicated executor daemon / Observer role redefinition / Data SSoT enforcement）"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac4a: Decision に LLM judgment exclusion principle が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac4a (LLM judgment exclusion), ac4b (Multi-layer signal redundancy), ac4c (Dedicated executor daemon), ac4d (Observer role redefinition), ac4e (Data SSoT enforcement)
+
+  - ac_index: 5
+    ac_text: "Architecture section に 4-layer 図（Layer 0-4）が ASCII art または table で記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac5a: Architecture に Layer 0 が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac5a (Layer 0), ac5b (Layer 4)
+
+  - ac_index: 6
+    ac_text: "Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac6a: Consequences に reliability の利点が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac6a (reliability), ac6b (crash resilience), ac6c (observability), ac6d (operational complexity), ac6e (migration cost)
+
+  - ac_index: 7
+    ac_text: "Alternatives rejected section に 3 つの却下案（AUTO_KILL=1 復帰 / cld-observe-any 拡張のみ / Stop hook のみ）と却下理由が記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac7a: Alternatives に AUTO_KILL=1 復帰案の却下理由が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac7a (AUTO_KILL=1 復帰), ac7b (cld-observe-any 拡張のみ), ac7c (Stop hook のみ)
+
+  - ac_index: 8
+    ac_text: "Risk section に 6 項目（SPOF / race condition / gh API rate limit / event 欠損 / spawn race / event 蓄積）と mitigation が table 形式で記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac8a: Risk section に table 形式が存在する"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac8a (SPOF/table), ac8b (race condition), ac8c (rate limit), ac8d (event 欠損), ac8e (spawn race), ac8f (event 蓄積)
+    # Note: ac8a は '| SPOF |' パターンでテーブル用語列限定マッチ（偽陽性防止）
+
+  - ac_index: 9
+    ac_text: "Related section に ADR-013 / ADR-014 / ADR-029 への相互参照と Epic #1425 / Sub-Issues S1〜S7 への参照が記載されている"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac9a: Related に ADR-013 への参照が記載されている"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac9a (ADR-013), ac9b (ADR-014), ac9c (ADR-029), ac9d (Epic #1425), ac9e (S1〜S7)
+
+  - ac_index: 10
+    ac_text: "markdown lint（既存 ADR と同一フォーマット）に準拠している"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac10a: markdown lint - H1 見出しが ADR-034 で始まる"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+    # sub-tests: ac10a (H1 見出し), ac10b (## Status), ac10c (## Context), ac10d (## Decision), ac10e (## Consequences)
+
+  - ac_index: 11
+    ac_text: "Issue タイトルを ADR-030 から ADR-034 に更新済みであること（本文は ADR-034 前提に修正済み、タイトルの更新が残作業）"
+    test_file: "cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats"
+    test_name: "ac11: Issue タイトルが ADR-034 に更新済みである"
+    impl_files: []
+    # impl_files: [] - GitHub API が必要なプロセス AC のため検証対象ファイルなし
+    # test は bats skip で対処

--- a/cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats
+++ b/cli/twl/tests/architecture/test_1433_adr034_autonomous_chain.bats
@@ -1,0 +1,589 @@
+#!/usr/bin/env bats
+# test_1433_adr034_autonomous_chain.bats - ADR-034 自律波連鎖信頼性テスト
+#
+# Issue: #1433 ADR-034: Autonomous Wave Chain Reliability
+#
+# 検証する仕様:
+#   AC-1:  ADR-034 ファイルが新規作成されている
+#   AC-2:  Status: Accepted が記載されている
+#   AC-3:  Context に F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている
+#   AC-4:  Decision に 5 principles が箇条書きで記載されている
+#   AC-5:  Architecture に 4-layer 図（Layer 0-4）が記載されている
+#   AC-6:  Consequences に利点・コストが記載されている
+#   AC-7:  Alternatives rejected に 3 つの却下案と却下理由が記載されている
+#   AC-8:  Risk に 6 項目と mitigation が table 形式で記載されている
+#   AC-9:  Related に ADR 相互参照と Epic/Sub-Issues 参照が記載されている
+#   AC-10: markdown lint（既存 ADR と同一フォーマット）に準拠している
+#   AC-11: Issue タイトルが ADR-034 に更新済みであること（GitHub API 要）
+#
+# RED フェーズ:
+#   全 @test は ADR-034 ファイル未作成のため FAIL する（AC-11 は skip）
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../.." && pwd)"
+    ADR034="$REPO_ROOT/plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md"
+}
+
+# ===========================================================================
+# AC-1: ADR-034 ファイルが新規作成されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac1: ADR-034 ファイルが存在する" {
+    # AC: plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md が新規作成されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+}
+
+# ===========================================================================
+# AC-2: Status: Accepted が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac2: Status Accepted が記載されている" {
+    # AC: Status: Accepted が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'Accepted' "$ADR034" \
+        || { echo "FAIL: ADR-034 に 'Accepted' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-3: Context section に Failure mode F1 が明記されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac3a: Context に Failure mode F1 が明記されている" {
+    # AC: Context section に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'F1' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Context に 'F1' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-3: Context section に Failure mode F2 が明記されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac3b: Context に Failure mode F2 が明記されている" {
+    # AC: Context section に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'F2' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Context に 'F2' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-3: Context section に Failure mode F3 が明記されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac3c: Context に Failure mode F3 が明記されている" {
+    # AC: Context section に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'F3' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Context に 'F3' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-3: Context section に AUTO_KILL=0 維持制約が明記されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac3d: Context に AUTO_KILL=0 維持制約が明記されている" {
+    # AC: Context section に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'AUTO_KILL=0' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Context に 'AUTO_KILL=0' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-4: Decision に LLM judgment exclusion principle が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4a: Decision に LLM judgment exclusion principle が記載されている" {
+    # AC: Decision section に 5 つの principle が箇条書きで記載されている（LLM judgment exclusion）
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'LLM judgment' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Decision に 'LLM judgment' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-4: Decision に Multi-layer signal redundancy principle が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4b: Decision に Multi-layer signal redundancy principle が記載されている" {
+    # AC: Decision section に 5 つの principle が箇条書きで記載されている（Multi-layer signal redundancy）
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'Multi-layer signal redundancy' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Decision に 'Multi-layer signal redundancy' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-4: Decision に Dedicated executor daemon principle が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4c: Decision に Dedicated executor daemon principle が記載されている" {
+    # AC: Decision section に 5 つの principle が箇条書きで記載されている（Dedicated executor daemon）
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'Dedicated executor daemon' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Decision に 'Dedicated executor daemon' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-4: Decision に Observer role redefinition principle が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4d: Decision に Observer role redefinition principle が記載されている" {
+    # AC: Decision section に 5 つの principle が箇条書きで記載されている（Observer role redefinition）
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'Observer role redefinition' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Decision に 'Observer role redefinition' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-4: Decision に Data SSoT enforcement principle が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4e: Decision に Data SSoT enforcement principle が記載されている" {
+    # AC: Decision section に 5 つの principle が箇条書きで記載されている（Data SSoT enforcement）
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'Data SSoT enforcement' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Decision に 'Data SSoT enforcement' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-5: Architecture section に Layer 0 が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac5a: Architecture に Layer 0 が記載されている" {
+    # AC: Architecture section に 4-layer 図（Layer 0-4）が ASCII art または table で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE 'Layer 0|Layer0' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Architecture に 'Layer 0' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-5: Architecture section に Layer 4 が記載されている（4-layer 図の範囲確認）
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac5b: Architecture に Layer 4 が記載されている" {
+    # AC: Architecture section に 4-layer 図（Layer 0-4）が ASCII art または table で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE 'Layer 4|Layer4' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Architecture に 'Layer 4' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-6: Consequences section に reliability の利点が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6a: Consequences に reliability の利点が記載されている" {
+    # AC: Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'reliability' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Consequences に 'reliability' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-6: Consequences section に crash resilience の利点が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6b: Consequences に crash resilience の利点が記載されている" {
+    # AC: Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'crash resilience' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Consequences に 'crash resilience' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-6: Consequences section に observability の利点が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6c: Consequences に observability の利点が記載されている" {
+    # AC: Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'observability' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Consequences に 'observability' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-6: Consequences section に operational complexity のコストが記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6d: Consequences に operational complexity のコストが記載されている" {
+    # AC: Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'operational complexity' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Consequences に 'operational complexity' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-6: Consequences section に migration cost のコストが記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac6e: Consequences に migration cost のコストが記載されている" {
+    # AC: Consequences section に reliability / crash resilience / observability の利点と operational complexity / migration cost のコストが記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'migration cost' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Consequences に 'migration cost' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-7: Alternatives rejected に AUTO_KILL=1 復帰案の却下理由が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac7a: Alternatives に AUTO_KILL=1 復帰案の却下理由が記載されている" {
+    # AC: Alternatives rejected section に 3 つの却下案（AUTO_KILL=1 復帰）と却下理由が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'AUTO_KILL=1' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Alternatives に 'AUTO_KILL=1' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-7: Alternatives rejected に cld-observe-any 拡張案の却下理由が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac7b: Alternatives に cld-observe-any 拡張案の却下理由が記載されている" {
+    # AC: Alternatives rejected section に 3 つの却下案（cld-observe-any 拡張のみ）と却下理由が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'cld-observe-any' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Alternatives に 'cld-observe-any' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-7: Alternatives rejected に Stop hook のみ案の却下理由が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac7c: Alternatives に Stop hook のみ案の却下理由が記載されている" {
+    # AC: Alternatives rejected section に 3 つの却下案（Stop hook のみ）と却下理由が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'Stop hook' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Alternatives に 'Stop hook' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk section に table 形式で記載されている（テーブル境界の確認）
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac8a: Risk section に table 形式が存在する" {
+    # AC: Risk section に 6 項目と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF '| SPOF |' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に '| SPOF |' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk table に race condition が記載されている
+# RED: ファイルが存在しないため FAIL する
+# 注意: 用語列限定マッチに '| race condition |' を使用（偽陽性防止）
+# ===========================================================================
+
+@test "ac8b: Risk table に race condition が記載されている" {
+    # AC: Risk section に race condition と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'race condition' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に 'race condition' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk table に gh API rate limit が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac8c: Risk table に gh API rate limit が記載されている" {
+    # AC: Risk section に gh API rate limit と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'rate limit' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に 'rate limit' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk table に event 欠損が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac8d: Risk table に event 欠損が記載されている" {
+    # AC: Risk section に event 欠損と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'event' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に 'event' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk table に spawn race が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac8e: Risk table に spawn race が記載されている" {
+    # AC: Risk section に spawn race と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qi 'spawn race' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に 'spawn race' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-8: Risk table に event 蓄積（accumulation）が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac8f: Risk table に event 蓄積が記載されている" {
+    # AC: Risk section に event 蓄積と mitigation が table 形式で記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qiE 'event.*(accum|蓄積)|蓄積.*event' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Risk table に 'event 蓄積' または 'event accumulation' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-9: Related section に ADR-013 への相互参照が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac9a: Related に ADR-013 への参照が記載されている" {
+    # AC: Related section に ADR-013 / ADR-014 / ADR-029 への相互参照と Epic #1425 / Sub-Issues S1〜S7 への参照が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'ADR-013' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Related に 'ADR-013' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-9: Related section に ADR-014 への相互参照が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac9b: Related に ADR-014 への参照が記載されている" {
+    # AC: Related section に ADR-013 / ADR-014 / ADR-029 への相互参照が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'ADR-014' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Related に 'ADR-014' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-9: Related section に ADR-029 への相互参照が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac9c: Related に ADR-029 への参照が記載されている" {
+    # AC: Related section に ADR-013 / ADR-014 / ADR-029 への相互参照が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF 'ADR-029' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Related に 'ADR-029' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-9: Related section に Epic #1425 への参照が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac9d: Related に Epic #1425 への参照が記載されている" {
+    # AC: Related section に Epic #1425 / Sub-Issues S1〜S7 への参照が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qF '1425' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Related に '1425' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-9: Related section に Sub-Issues S1〜S7 への参照が記載されている
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac9e: Related に Sub-Issues S1〜S7 への参照が記載されている" {
+    # AC: Related section に Sub-Issues S1〜S7 への参照が記載されている
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE 'S[1-7]' "$ADR034" \
+        || { echo "FAIL: ADR-034 の Related に 'S1〜S7' のいずれかが見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-10: markdown lint - H1 見出しが ADR-034 で始まる
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac10a: markdown lint - H1 見出しが ADR-034 で始まる" {
+    # AC: markdown lint（既存 ADR と同一フォーマット）に準拠している
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE '^# ADR-034' "$ADR034" \
+        || { echo "FAIL: ADR-034 の H1 見出しが '# ADR-034' で始まっていません"; false; }
+}
+
+# ===========================================================================
+# AC-10: markdown lint - ## Status セクションが存在する
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac10b: markdown lint - Status セクションが存在する" {
+    # AC: markdown lint（既存 ADR と同一フォーマット）に準拠している
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE '^## Status' "$ADR034" \
+        || { echo "FAIL: ADR-034 に '## Status' セクションが見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-10: markdown lint - ## Context セクションが存在する
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac10c: markdown lint - Context セクションが存在する" {
+    # AC: markdown lint（既存 ADR と同一フォーマット）に準拠している
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE '^## Context' "$ADR034" \
+        || { echo "FAIL: ADR-034 に '## Context' セクションが見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-10: markdown lint - ## Decision セクションが存在する
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac10d: markdown lint - Decision セクションが存在する" {
+    # AC: markdown lint（既存 ADR と同一フォーマット）に準拠している
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE '^## Decision' "$ADR034" \
+        || { echo "FAIL: ADR-034 に '## Decision' セクションが見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-10: markdown lint - ## Consequences セクションが存在する
+# RED: ファイルが存在しないため FAIL する
+# ===========================================================================
+
+@test "ac10e: markdown lint - Consequences セクションが存在する" {
+    # AC: markdown lint（既存 ADR と同一フォーマット）に準拠している
+    # RED: 実装前はファイルが存在しないため FAIL する
+    [[ -f "$ADR034" ]] \
+        || { echo "FAIL: ADR-034 ファイルが見つかりません: $ADR034"; false; }
+
+    grep -qE '^## Consequences' "$ADR034" \
+        || { echo "FAIL: ADR-034 に '## Consequences' セクションが見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-11: Issue タイトルが ADR-034 に更新済みであること
+# GitHub API が必要なため skip する
+# ===========================================================================
+
+@test "ac11: Issue タイトルが ADR-034 に更新済みである" {
+    # AC: Issue タイトルを ADR-030 から ADR-034 に更新済みであること
+    # GitHub API が必要なため skip
+    skip "AC-11: GitHub API による Issue タイトル確認は自動化対象外（手動確認）"
+}

--- a/plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md
+++ b/plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md
@@ -4,6 +4,10 @@
 
 Accepted
 
+## Amends
+
+ADR-014 Decision 4（Wave 完了時の自動外部化）step 4 では `su-observer が Wave N+1 の Issue を co-autopilot に渡して spawn する` と明記している。本 ADR Decision 4（Observer role redefinition）はこの spawn 責務を `wave-progress-watchdog.sh`（Layer 2）に委譲する。su-observer は spawn 責任を持たず、監視・通知・報告に専念する（ADR-014 Decision 4 の部分改訂）。
+
 ## Context
 
 ### 観測された事故（2026-05-05〜06）
@@ -52,11 +56,11 @@ Wave N → Wave N+1 の自動連鎖を以下の 5 原則で実装する:
 
 4. **Observer role redefinition**: observer（su-observer）は監視・通知・報告レイヤーに専念し、spawn 判断を持たない。mailbox + ScheduleWakeup pattern で idle 化を防ぎ、visibility を確保する（F3 部分解消）。spawn の critical path には含めない。
 
-5. **Data SSoT enforcement**: wave-queue.json は spawn 時に強制 maintenance する。`CHAIN_WAVE_QUEUE_ENTRY` を opt-in から強制に変更し、spawn 時に current + next wave を必ず populate する（F1 解消）。
+5. **Data SSoT enforcement**: wave-queue.json は spawn 時に強制 maintenance する。`CHAIN_WAVE_QUEUE_ENTRY` を opt-in から強制に変更し、spawn 時に `current_wave`（整数）と `queue`（次 Wave 以降のエントリ配列）を必ず populate する（F1 解消）。wave-queue.schema.json の `required: [version, current_wave, queue]` と整合する。
 
 ## Architecture
 
-### 4-layer reliability architecture
+### 5-layer reliability architecture (Layer 0–4)
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -71,9 +75,11 @@ Wave N → Wave N+1 の自動連鎖を以下の 5 原則で実装する:
 │   - chain-runner 自身が完了 signal を出すため確実              │
 ├─────────────────────────────────────────────────────────────────┤
 │ Layer 2: Executor (wave-progress-watchdog.sh daemon)            │
-│   - events/ inotify / polling → auto-next-spawn.sh 呼び出し    │
+│   - events/ inotify (Linux) / polling fallback → auto-next-spawn.sh 呼び出し │
 │   - lock file で重複 spawn 防止                                 │
 │   - AUTO_KILL=0 維持のまま AUTO_NEXT_SPAWN と等価機能実現       │
+│   - current_wave 更新権限: wave-progress-watchdog.sh が単独保有 │
+│     （Wave N+1 spawn 完了後に atomic 更新する）                 │
 ├─────────────────────────────────────────────────────────────────┤
 │ Layer 3: Safety Net (gh API polling fallback)                   │
 │   - gh pr list --state merged を 60s 間隔で polling            │
@@ -156,7 +162,7 @@ Claude Code の `Stop` hook を利用し、chain-runner session 終了時に aut
 
 ### 関連 ADR
 
-- **ADR-013** ([Observer の First-Class 昇格](ADR-013-observer-first-class.md)): observer 型の定義と介入プロトコル（Auto/Confirm/Escalate）の原点。本 ADR の Layer 4 observer role redefinition はこの介入プロトコルを継承する。
+- **ADR-013** ([Observer の First-Class 昇格](ADR-013-observer-first-class.md)) ⚠️ Superseded by ADR-014: 介入プロトコル（Auto/Confirm/Escalate）の起源。実効定義は ADR-014 Decision 5 に継承されており、本 ADR の Layer 4 observer role redefinition はその継承版を参照する。
 - **ADR-014** ([Observer → Supervisor 再定義](ADR-014-supervisor-redesign.md)): su-observer のプロジェクト常駐ライフサイクルと三層記憶モデルを確立。本 ADR が F3（observer LLM idle）を解消することで ADR-014 の Wave 管理自動化パスが実現する。
 - **ADR-029** ([TWL MCP Integration Strategy](ADR-029-twl-mcp-integration-strategy.md)): mailbox（`twl_notify_supervisor / recv_msg`）の設計方針。本 ADR の Layer 1/4 は ADR-029 Tier C（tools_comm.py）を直接利用する。
 
@@ -169,11 +175,12 @@ Claude Code の `Stop` hook を利用し、chain-runner session 終了時に aut
 - **S4 #1430**: cld-observe-any AUTO_NEXT_SPAWN bind 解除（Layer 2 補完）
 - **S5 #1431**: observer skill ScheduleWakeup pattern + recv_msg loop（Layer 4 実装）
 - **S6 #1432**: gh API polling fallback in watchdog（Layer 3 実装）
+- **S7 #1433**: ADR-034 起草（本 Issue / 本 ADR）
 
 ### 推奨実装順序
 
 ```
-Wave A (parallel): S1 (queue 強制) + S4 (bind 解除) + S2 (event emit) + S7/本 ADR
+Wave A (parallel): S1 (queue 強制) + S4 (bind 解除) + S2 (event emit) + S7 #1433 (本 ADR)
    ↓
 Wave B (sequential): S3 (watchdog daemon) + S6 (gh fallback)
    ↓

--- a/plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md
+++ b/plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md
@@ -1,0 +1,183 @@
+# ADR-034: Autonomous Wave Chain Reliability Architecture
+
+## Status
+
+Accepted
+
+## Context
+
+### 観測された事故（2026-05-05〜06）
+
+Wave N → Wave N+1 自動連鎖が LLM judgment 依存のため、再発性事故が繰り返されている。
+
+1. **Wave 45 → 46 で 23h 放置事故**: Wave 45 の 4 PR が 2026-05-05 14:18-14:22 JST に全 merge 完了。observer は Pilot の自然 idle を待っていたが、Pilot は summary mode で残留し続け 23h 経過。2026-05-06T04:49Z にユーザー指摘で気付き手動 spawn。
+
+2. **Wave 46 → 47 で同パターン再発**: Wave 46 の 3 PR merge を Monitor が検知（2026-05-06 14:20 JST）。observer は状況を報告したが 3/3 完了後に能動 action なく idle 化。2026-05-06T06:39Z にユーザーが介入するまで停止。
+
+3. **doobidoo memory に lesson 保存しても LLM 内で運用に落ちない**: 同 session 内で「PR merge を spawn trigger とすべき」と memory hash `3ddf2a20` に保存したが、直後の Wave 46 → 47 で再発した。
+
+### Failure mode（実装確認済み）
+
+| # | Failure | 確認場所 |
+|---|---------|---------|
+| **F1: queue stale** | `.supervisor/wave-queue.json` の `current_wave` が opt-in のため stale 化 | `spawn-controller.sh` L207-225 |
+| **F2: AUTO_NEXT_SPAWN 死蔵** | `IDLE_COMPLETED_AUTO_NEXT_SPAWN=1` でも `AUTO_KILL=1` 必須 → 実運用 AUTO_KILL=0 で完全 skip | `cld-observe-any` L588-595 |
+| **F3: observer LLM idle** | observer は Pilot 自然 idle を待つ設計。Pilot が summary mode 残留で idle 化しない | `su-observer` SKILL.md |
+
+### AUTO_KILL=0 維持制約
+
+intervention-log `2026-05-04T01:58:09Z` で確認した重要な制約:
+
+> cld-observe-any restarted with IDLE_COMPLETED_AUTO_KILL=0 due to repeated false-positive kills of wt-co-issue windows during Phase 3/4 menu wait. Pattern: STAGNATE-600 + IDLE-COMPLETED triggered when wt enters input-waiting state with empty thinking. Issue #1375 root cause confirmed empirically.
+
+→ **AUTO_KILL=1 への復帰は false-positive kill リスクにより不可**。AUTO_KILL=0 維持を前提制約とする。
+
+### 利用可能な既存インフラ
+
+- `plugins/twl/skills/su-observer/scripts/auto-next-spawn.sh`（#1155): JSON Schema validation + argv allowlist + intervention-log audit 完備 — そのまま流用可
+- `cli/twl/src/twl/mcp_server/tools_comm.py`（#1034 Tier C）: mailbox `twl_send_msg/recv_msg/notify_supervisor` — 利用可
+- `.supervisor/events/` 構造化 JSON event ディレクトリ: IDLE-COMPLETED 等で運用中（1045+ events）— PR-merge channel 追加可
+- `plugins/twl/scripts/chain-runner.sh`: PR merge step + checkpoint 出力済み — post-merge hook 追加可
+- `plugins/twl/skills/su-observer/schemas/wave-queue.schema.json`: schema 定義済み — 流用可
+
+## Decision
+
+Wave N → Wave N+1 の自動連鎖を以下の 5 原則で実装する:
+
+1. **LLM judgment exclusion**: autonomous chain の critical path から LLM 判断を完全に除外する。spawn 実行の最終責任は system daemon（wave-progress-watchdog.sh）が持ち、LLM の状態・判断・応答速度に依存しない。
+
+2. **Multi-layer signal redundancy**: chain-runner による event emission（primary signal）と gh API polling（fallback）を独立して運用し、どちらか一方が失敗してもチェーンが継続する。
+
+3. **Dedicated executor daemon**: wave-progress-watchdog.sh が Wave spawn の責任を一手に担う専用 executor として機能する。lock file による重複 spawn 防止、AUTO_KILL=0 でも動作可能な独立デーモン設計とする（F2 解消）。
+
+4. **Observer role redefinition**: observer（su-observer）は監視・通知・報告レイヤーに専念し、spawn 判断を持たない。mailbox + ScheduleWakeup pattern で idle 化を防ぎ、visibility を確保する（F3 部分解消）。spawn の critical path には含めない。
+
+5. **Data SSoT enforcement**: wave-queue.json は spawn 時に強制 maintenance する。`CHAIN_WAVE_QUEUE_ENTRY` を opt-in から強制に変更し、spawn 時に current + next wave を必ず populate する（F1 解消）。
+
+## Architecture
+
+### 4-layer reliability architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Layer 0: Data SSoT (wave-queue.json 強制 maintenance)           │
+│   - spawn-controller.sh: CHAIN_WAVE_QUEUE_ENTRY を強制生成      │
+│   - spawn 時に current_wave + next_wave を必ず populate         │
+│   - wave-queue.json stale 問題 (F1) を解消                      │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 1: Primary Signal (chain-runner pr-merge event emission)  │
+│   - post-merge step: .supervisor/events/wave-{N}-merged-*.json  │
+│   - twl_notify_supervisor で mailbox push                       │
+│   - chain-runner 自身が完了 signal を出すため確実              │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 2: Executor (wave-progress-watchdog.sh daemon)            │
+│   - events/ inotify / polling → auto-next-spawn.sh 呼び出し    │
+│   - lock file で重複 spawn 防止                                 │
+│   - AUTO_KILL=0 維持のまま AUTO_NEXT_SPAWN と等価機能実現       │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 3: Safety Net (gh API polling fallback)                   │
+│   - gh pr list --state merged を 60s 間隔で polling            │
+│   - events 不在時に完了確認 → Layer 2 trigger                  │
+│   - Layer 1 失敗時の last resort                                │
+├─────────────────────────────────────────────────────────────────┤
+│ Layer 4: Observer Reactivation (mailbox + ScheduleWakeup)       │
+│   - observer が mailbox recv_msg で能動 polling                 │
+│   - idle 化を防ぎ visibility 確保（spawn 責任は持たない）       │
+│   - F3 解消（ただし spawn の critical path には含めない）       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Data flow
+
+```
+Worker: chain-runner pr-merge OK
+   │
+   ├──→ .supervisor/events/wave-{N}-pr-merged-{issue}.json  (Layer 1)
+   │         │
+   │         └──→ twl_notify_supervisor (mailbox push)
+   │                   │
+   │                   ├──→ Layer 2: wave-progress-watchdog.sh
+   │                   │     └──→ current_wave の全 PR が merged?
+   │                   │           ├─ yes → auto-next-spawn.sh (lock)
+   │                   │           │         └──→ Wave N+1 spawn
+   │                   │           └─ no  → 次 event を待機
+   │                   │
+   │                   └──→ Layer 4: observer mailbox recv (報告のみ)
+   │
+   └──→ Layer 3: gh pr list polling (60s) — 独立 fallback
+                   └──→ all merged かつ event 不在? → Layer 2 trigger
+```
+
+## Consequences
+
+### Positive
+
+- **Reliability**: F1/F2/F3 の 3 つの failure mode が独立 layer でそれぞれ解消される
+- **Crash resilience**: observer LLM が crash しても Wave 連鎖が継続する（spawn 責任が Layer 2 daemon にある）
+- **Observability**: events/ + intervention-log + mailbox の三重 audit trail により Wave 進捗を追跡可能
+
+### Negative
+
+- **Operational complexity**: wave-progress-watchdog.sh daemon が 1 つ増加し、起動・監視・ログ管理の運用コストが発生する
+- **Migration cost**: Sub-Issue S1〜S6 の実装に ~18-24h を要する（S1: spawn-controller 修正、S2: chain-runner event emit、S3: watchdog 新設、S4: cld-observe-any bind 解除、S5: observer ScheduleWakeup、S6: gh API fallback）
+
+## Alternatives Rejected
+
+### AUTO_KILL=1 復帰
+
+`cld-observe-any` を `IDLE_COMPLETED_AUTO_KILL=1` モードで再起動し、F2（AUTO_NEXT_SPAWN 死蔵）を解消する案。
+
+**却下理由**: intervention-log `2026-05-04T01:58:09Z` で確認済み。Phase 3/4 menu wait 状態の wt-co-issue windows で STAGNATE-600 + IDLE-COMPLETED が誤発火し、正常動作中の Worker pane を kill する false-positive kill が再発した（Issue #1375 で根本原因確認済み）。AUTO_KILL=0 維持を前提制約とする。
+
+### cld-observe-any 拡張のみ
+
+cld-observe-any 内に PR-MERGED polling thread を追加し、F2 と F3 を同時解消する案（Design C）。
+
+**却下理由**: cld-observe-any は既に 600+ lines であり、PR-MERGED polling thread の追加は Single Responsibility Principle 違反を招く。daemon の肥大化によりデバッグ・テストコストが増大する。また、cld-observe-any が gh API polling を内包することで「監視 daemon」と「spawn executor」の責務が混在し、将来の保守性が低下する。
+
+### Stop hook のみ
+
+Claude Code の `Stop` hook を利用し、chain-runner session 終了時に auto-next-spawn を直接呼び出す案（Design E）。
+
+**却下理由**: Stop hook は Claude Code session の終了に紐付くものであり、chain-runner subprocess（Bash run_in_background）の完了とは別概念。chain-runner が Bash subprocess として実行されている場合、その完了は Stop hook を発火させない。また hooks-mcp epic (#1037) との概念的重複があり、明確な責務分離ができない。
+
+## Risk
+
+| Risk | 説明 | Mitigation |
+|------|------|------------|
+| SPOF | wave-progress-watchdog.sh の crash | cld-observe-any heartbeat-watcher と同等の monitoring + Layer 3 が safety net として機能 |
+| race condition | Layer 1 と Layer 3 が同時検知 | lock file + wave-queue.json の atomic `current_wave` 更新で重複 spawn を防止 |
+| gh API rate limit | polling 負荷 | 60s 間隔 polling、ETag キャッシュ活用、token pre-load によるレート制限緩和 |
+| event 欠損 | chain-runner failure による Layer 1 signal lost | Layer 3（gh API polling）が backstop として独立動作し、event がなくても完了を検知 |
+| spawn race | observer + watchdog の二重 spawn | wave-queue.json `current_wave` チェック + lock file による排他制御 |
+| event 蓄積 | events/ が 1045+ files 確認済み | 既存 cleanup 機構と同等の retention policy を wave-progress-watchdog.sh に実装必須 |
+
+## Related
+
+### 関連 ADR
+
+- **ADR-013** ([Observer の First-Class 昇格](ADR-013-observer-first-class.md)): observer 型の定義と介入プロトコル（Auto/Confirm/Escalate）の原点。本 ADR の Layer 4 observer role redefinition はこの介入プロトコルを継承する。
+- **ADR-014** ([Observer → Supervisor 再定義](ADR-014-supervisor-redesign.md)): su-observer のプロジェクト常駐ライフサイクルと三層記憶モデルを確立。本 ADR が F3（observer LLM idle）を解消することで ADR-014 の Wave 管理自動化パスが実現する。
+- **ADR-029** ([TWL MCP Integration Strategy](ADR-029-twl-mcp-integration-strategy.md)): mailbox（`twl_notify_supervisor / recv_msg`）の設計方針。本 ADR の Layer 1/4 は ADR-029 Tier C（tools_comm.py）を直接利用する。
+
+### 関連 Issue
+
+- **Epic #1425**: autonomous Wave chain reliability の親 Epic（本 ADR の設計根拠を提供）
+- **S1 #1427**: spawn-controller wave-queue.json 自動 enqueue 強制（Layer 0 実装）
+- **S2 #1428**: chain-runner pr-merge event emission（Layer 1 実装）
+- **S3 #1429**: wave-progress-watchdog.sh 新設 daemon（Layer 2 実装）
+- **S4 #1430**: cld-observe-any AUTO_NEXT_SPAWN bind 解除（Layer 2 補完）
+- **S5 #1431**: observer skill ScheduleWakeup pattern + recv_msg loop（Layer 4 実装）
+- **S6 #1432**: gh API polling fallback in watchdog（Layer 3 実装）
+
+### 推奨実装順序
+
+```
+Wave A (parallel): S1 (queue 強制) + S4 (bind 解除) + S2 (event emit) + S7/本 ADR
+   ↓
+Wave B (sequential): S3 (watchdog daemon) + S6 (gh fallback)
+   ↓
+Wave C (single): S5 (observer ScheduleWakeup)
+```
+
+最小 mitigation として Wave A のみで 80% の信頼性向上が見込める（F1/F2 解消 + signal source 確保）。


### PR DESCRIPTION
## 概要

Wave N→N+1 自動連鎖の信頼性アーキテクチャを ADR として記録する。

Closes #1433

## 変更内容

- `plugins/twl/architecture/decisions/ADR-034-autonomous-chain-reliability.md` 新規作成
- AC-based bats テスト 37 件（全 GREEN）

## AC 確認

- [x] ADR-034 ファイルが新規作成されている
- [x] Status: Accepted が記載されている
- [x] Context に Failure mode F1/F2/F3 と AUTO_KILL=0 維持制約が明記
- [x] Decision に 5 つの principle が箇条書きで記載
- [x] Architecture に 4-layer 図（Layer 0-4）を記載
- [x] Consequences に利点（reliability/crash resilience/observability）とコスト（operational complexity/migration cost）
- [x] Alternatives rejected に 3 つの却下案と却下理由
- [x] Risk section に 6 項目（SPOF/race condition/gh API rate limit/event 欠損/spawn race/event 蓄積）と mitigation を table 形式で記載
- [x] Related に ADR-013/ADR-014/ADR-029 と Epic #1425/Sub-Issues S1〜S7 への参照
- [x] markdown lint（既存 ADR と同一フォーマット）準拠

Co-Authored-By: Claude <noreply@anthropic.com>