### PR TITLE
feat(chain-runner): step_auto_merge に WAVE-PR-MERGED イベント発火を追加 (#1428)

### DIFF
--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2608,6 +2608,13 @@ scripts:
     path: scripts/auto-merge.sh
     description: "autopilot-first auto-merge（4 Layer ガード付き、Worker マージ禁止の機械的担保）"
 
+  emit-wave-pr-merged-event:
+    type: script
+    path: scripts/emit-wave-pr-merged-event.sh
+    calls:
+      - script: auto-merge
+    description: "#1428 Layer 1 post-merge event emitter: .supervisor/events/wave-{N}-pr-merged-{issue}.json atomic write + twl_notify_supervisor_handler mailbox push（best-effort）"
+
   generate-invariants-bats:
     type: script
     path: scripts/generate-invariants-bats.sh

--- a/plugins/twl/refs/ref-pr-merge-event-emission.md
+++ b/plugins/twl/refs/ref-pr-merge-event-emission.md
@@ -1,0 +1,53 @@
+# ref-pr-merge-event-emission — WAVE-PR-MERGED イベント発火の技術メモ
+
+Issue #1428 実装メモ。Layer 1 post-merge event emitter の設計判断と運用上の注意を記載する。
+
+## 概要
+
+`chain-runner.sh::step_auto_merge` が auto-merge 成功直後に
+`emit-wave-pr-merged-event.sh` を呼び出し、以下の 2 つを実行する:
+
+1. `.supervisor/events/wave-{N}-pr-merged-{issue}.json` への event ファイル atomic write
+2. `twl_notify_supervisor_handler` による mailbox push（`supervisor` 宛て）
+
+## mailbox push 失敗時のフォールバック
+
+`twl_notify_supervisor_handler` の呼び出しが失敗した場合（import エラー、mailbox write エラー等）:
+
+- **WARN ログ** を stderr に出力するのみで exit 0 を返す（best-effort）
+- **events/ ファイルは既に atomic write 完了**しているため SSoT として残る
+- Layer 2 watchdog（S3 = 別 Issue）が `inotify` または polling で events/ を監視し、
+  mailbox push を補完できる設計とする
+
+**結論**: events/ ファイルが primary SSoT であり、mailbox push は delivery 最適化（low-latency）に過ぎない。
+watchdog は専用 glob パターン `wave-*-pr-merged-*.json` で拾う。
+
+## wave 番号取得とフォールバック
+
+- `.supervisor/wave-queue.json` の `current_wave` フィールドを参照する
+- ファイル不在 / フィールド不在 / 非整数値の場合: `wave=-1` で続行
+- `wave=-1` の event JSON には `"warning"` フィールドを追加し、
+  watchdog が異常状態であることを把握できるようにする
+
+## event ファイル命名規則
+
+`wave-{N}-pr-merged-{issue}.json`（例: `wave-3-pr-merged-1428.json`）
+
+既存の `{EVENT_NAME}-{window}-{timestamp}.json` 規則と異なるが**意図的**:
+- wave progress event は issue/wave 番号で一意に識別できるためタイムスタンプ不要
+- watchdog が専用 glob で識別しやすくするため小文字 + 固定フォーマット
+
+## atomic write の実装
+
+```bash
+TMPFILE="$(mktemp "${EVENTS_DIR}/.wave-pr-merged-${ISSUE_NUM}.XXXXXX.tmp")"
+echo "$PAYLOAD_JSON" > "$TMPFILE" && mv "$TMPFILE" "$EVENT_FILE"
+```
+
+`mv` は同一ファイルシステム上で POSIX atomic であり、
+watchdog が部分書き込みを読む可能性を排除する。
+
+## 実装ファイル
+
+- `plugins/twl/scripts/emit-wave-pr-merged-event.sh` — event 生成 + notify (新規)
+- `plugins/twl/scripts/chain-runner.sh` — `step_auto_merge` に hook 追加 (#1428)

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -1460,6 +1460,15 @@ step_auto_merge() {
     # .autopilot/ 配下の checkpoints/issues/trace を audit dir に永続化し、
     # 後続の worktree 削除で消失する中間成果物を保全する。
     _audit_snapshot_autopilot
+    # #1428: post-merge event emission (Layer 1 of #1425)
+    # auto-merge.sh に渡した引数をそのまま emit スクリプトに転送する。
+    # 失敗しても ok 判定を維持（best-effort）。
+    local emit_script="$script_dir/emit-wave-pr-merged-event.sh"
+    if [[ -x "$emit_script" ]]; then
+      "$emit_script" "$@" || \
+        printf '[%s] WARN post-merge event emission failed (best-effort)\n' \
+               "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >&2
+    fi
   else
     local rc=$?
     err "auto-merge" "auto-merge.sh 失敗 (exit=$rc)"

--- a/plugins/twl/scripts/emit-wave-pr-merged-event.sh
+++ b/plugins/twl/scripts/emit-wave-pr-merged-event.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# emit-wave-pr-merged-event.sh — Issue #1428 Layer 1 post-merge event emitter
+#
+# Usage: emit-wave-pr-merged-event.sh --issue N --pr N --branch BRANCH
+#
+# 処理:
+#   1. .supervisor/wave-queue.json から current_wave を取得（失敗時 wave=-1）
+#   2. .supervisor/events/wave-{N}-pr-merged-{issue}.json を atomic write で生成
+#   3. Python one-liner で twl_notify_supervisor_handler を呼び出し（best-effort）
+#
+# exit 0 を常に返す（best-effort: 失敗は WARN のみ stderr 出力）
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# 引数パース
+# ---------------------------------------------------------------------------
+ISSUE_NUM=""
+PR_NUM=""
+BRANCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)  ISSUE_NUM="$2"; shift 2 ;;
+    --pr)     PR_NUM="$2"; shift 2 ;;
+    --branch) BRANCH="$2"; shift 2 ;;
+    *)        shift ;;
+  esac
+done
+
+if [[ -z "$ISSUE_NUM" || -z "$PR_NUM" || -z "$BRANCH" ]]; then
+  printf '[emit-wave-pr-merged-event] WARN: --issue, --pr, --branch が必要です\n' >&2
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# .supervisor ディレクトリ解決
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd 2>/dev/null || echo "")"
+SUPERVISOR_DIR="${SUPERVISOR_DIR:-${REPO_ROOT}/main/.supervisor}"
+
+if [[ ! -d "$SUPERVISOR_DIR" ]]; then
+  # fallback: CWD 基準
+  SUPERVISOR_DIR="${SUPERVISOR_DIR:-.supervisor}"
+fi
+
+EVENTS_DIR="${SUPERVISOR_DIR}/events"
+WAVE_QUEUE="${SUPERVISOR_DIR}/wave-queue.json"
+
+# ---------------------------------------------------------------------------
+# Step 1: wave 番号取得
+# ---------------------------------------------------------------------------
+WAVE=-1
+WAVE_WARNING=""
+
+if [[ -f "$WAVE_QUEUE" ]]; then
+  WAVE_VAL="$(jq -r '.current_wave // empty' "$WAVE_QUEUE" 2>/dev/null || echo "")"
+  if [[ "$WAVE_VAL" =~ ^-?[0-9]+$ ]]; then
+    WAVE="$WAVE_VAL"
+  else
+    WAVE_WARNING="wave-queue.json に current_wave が見つからない"
+    printf '[emit-wave-pr-merged-event] WARN: %s\n' "$WAVE_WARNING" >&2
+  fi
+else
+  WAVE_WARNING="wave-queue.json が存在しない: $WAVE_QUEUE"
+  printf '[emit-wave-pr-merged-event] WARN: %s\n' "$WAVE_WARNING" >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: event JSON を atomic write
+# ---------------------------------------------------------------------------
+mkdir -p "$EVENTS_DIR" || {
+  printf '[emit-wave-pr-merged-event] WARN: events/ ディレクトリ作成失敗: %s\n' "$EVENTS_DIR" >&2
+  exit 0
+}
+
+EVENT_FILE="${EVENTS_DIR}/wave-${WAVE}-pr-merged-${ISSUE_NUM}.json"
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+HOST="$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo "unknown")"
+
+# JSON 生成（jq で安全にエスケープ）
+PAYLOAD_JSON="$(jq -n \
+  --arg event "WAVE-PR-MERGED" \
+  --argjson wave "$WAVE" \
+  --argjson issue "$ISSUE_NUM" \
+  --argjson pr "$PR_NUM" \
+  --arg branch "$BRANCH" \
+  --arg timestamp "$TIMESTAMP" \
+  --arg host "$HOST" \
+  '{event: $event, wave: $wave, issue: $issue, pr: $pr, branch: $branch, timestamp: $timestamp, host: $host}')" || {
+  printf '[emit-wave-pr-merged-event] WARN: event JSON 生成失敗\n' >&2
+  exit 0
+}
+
+# warning フィールドを追加（wave=-1 の場合）
+if [[ -n "$WAVE_WARNING" ]]; then
+  PAYLOAD_JSON="$(echo "$PAYLOAD_JSON" | jq --arg w "$WAVE_WARNING" '. + {warning: $w}')"
+fi
+
+# atomic write: mktemp → write → mv
+TMPFILE="$(mktemp "${EVENTS_DIR}/.wave-pr-merged-${ISSUE_NUM}.XXXXXX.tmp")" || {
+  printf '[emit-wave-pr-merged-event] WARN: tmpfile 作成失敗\n' >&2
+  exit 0
+}
+
+echo "$PAYLOAD_JSON" > "$TMPFILE" && mv "$TMPFILE" "$EVENT_FILE" || {
+  rm -f "$TMPFILE" 2>/dev/null || true
+  printf '[emit-wave-pr-merged-event] WARN: event ファイル atomic write 失敗: %s\n' "$EVENT_FILE" >&2
+  exit 0
+}
+
+printf '[emit-wave-pr-merged-event] event 書き出し完了: %s\n' "$EVENT_FILE"
+
+# ---------------------------------------------------------------------------
+# Step 3: twl_notify_supervisor_handler を Python one-liner で呼び出す（best-effort）
+# ---------------------------------------------------------------------------
+AUTOPILOT_DIR="${AUTOPILOT_DIR:-}"
+
+NOTIFY_RESULT="$(python3 -c "
+import json, sys, os
+try:
+    from twl.mcp_server.tools_comm import twl_notify_supervisor_handler
+    payload = json.loads(sys.argv[1])
+    autopilot_dir = os.environ.get('AUTOPILOT_DIR') or None
+    result = twl_notify_supervisor_handler(
+        event='WAVE-PR-MERGED',
+        payload=payload,
+        autopilot_dir=autopilot_dir,
+    )
+    parsed = json.loads(result)
+    if parsed.get('status') == 'error':
+        print('NOTIFY_ERROR: ' + parsed.get('error', ''), file=sys.stderr)
+    else:
+        print('OK', file=sys.stdout)
+except Exception as e:
+    print('NOTIFY_EXCEPTION: ' + str(e), file=sys.stderr)
+" "$PAYLOAD_JSON" 2>&1)" || true
+
+if echo "$NOTIFY_RESULT" | grep -q "NOTIFY_"; then
+  printf '[emit-wave-pr-merged-event] WARN: mailbox push 失敗 (best-effort): %s\n' "$NOTIFY_RESULT" >&2
+  if [[ -n "${TWL_NOTIFY_SUPERVISOR_CALL_LOG:-}" ]]; then
+    echo "FAILED: $NOTIFY_RESULT" >> "$TWL_NOTIFY_SUPERVISOR_CALL_LOG"
+  fi
+else
+  printf '[emit-wave-pr-merged-event] mailbox push 完了\n'
+  if [[ -n "${TWL_NOTIFY_SUPERVISOR_CALL_LOG:-}" ]]; then
+    echo "CALLED: WAVE-PR-MERGED $PAYLOAD_JSON" >> "$TWL_NOTIFY_SUPERVISOR_CALL_LOG"
+  fi
+fi
+
+exit 0

--- a/plugins/twl/tests/bats/scripts/ac-test-mapping-1428.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping-1428.yaml
@@ -1,0 +1,60 @@
+mappings:
+  - ac_index: 1
+    ac_text: "`step_auto_merge` 関数で、`auto-merge.sh` が exit 0 を返した場合のみ post-merge hook を発火する"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC1: auto-merge 成功後に .supervisor/events/ にイベントファイルが生成される (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 2
+    ac_text: "post-merge hook が `.supervisor/events/wave-{N}-pr-merged-{issue}.json` を atomic write（temp file → mv）で生成する"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC2: events ファイルが atomic write (temp→mv) で生成される (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 3
+    ac_text: "event JSON が必須フィールドを持つ: event=WAVE-PR-MERGED, wave(int), issue(int), pr(int), branch(str), timestamp(UTC ISO 8601), host(str)"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC3: event JSON に必須フィールドが揃っている (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 4
+    ac_text: "post-merge hook が twl_notify_supervisor_handler を呼び出し、event 名 WAVE-PR-MERGED と payload を mailbox push する"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC4: post-merge hook が twl_notify_supervisor_handler を呼び出す (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 5
+    ac_text: "auto-merge 失敗時は event 発火しない"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC5: auto-merge 失敗時は events ファイルが生成されない"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 6
+    ac_text: "event 発火または mailbox push が失敗しても step_auto_merge 自体は ok 判定を維持する（best-effort、WARN ログのみ stderr 出力）"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC6: events 書き込み失敗時も step_auto_merge は exit 0 を維持し WARN を出力する (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 7
+    ac_text: "wave 番号は .supervisor/wave-queue.json の current_wave から取得し、取得失敗時は wave=-1 で続行（warning フィールド追加）"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC7a: wave-queue.json の current_wave=5 で wave-5-pr-merged-1428.json が生成される (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 7
+    ac_text: "wave 番号は .supervisor/wave-queue.json の current_wave から取得し、取得失敗時は wave=-1 で続行（warning フィールド追加）"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC7b: wave-queue.json が不在の場合 wave=-1 で続行し warning フィールドを持つ (RED)"
+    impl_files:
+      - "plugins/twl/scripts/chain-runner.sh"
+  - ac_index: 8
+    ac_text: "integration test を plugins/twl/tests/bats/scripts/ に追加（#897-C パターン）"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "AC1-AC7 が統合テストとして機能（AC8 は他 AC でカバー）"
+    impl_files: []
+  - ac_index: 9
+    ac_text: "mailbox push 失敗時のフォールバック挙動を技術メモに明文化（events/ が SSoT、Layer 2 watchdog が拾える設計）"
+    test_file: "plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats"
+    test_name: "#1428 AC9: 技術メモに mailbox push 失敗時フォールバック挙動が明文化されている (RED)"
+    impl_files:
+      - "plugins/twl/refs/ref-pr-merge-event-emission.md"

--- a/plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats
+++ b/plugins/twl/tests/bats/scripts/chain-runner-pr-merge-event-emission.bats
@@ -1,0 +1,311 @@
+#!/usr/bin/env bats
+# chain-runner-pr-merge-event-emission.bats
+# Issue #1428: step_auto_merge 完了後の WAVE-PR-MERGED イベント発火
+#
+# Spec: Issue #1428 — chain-runner.sh step_auto_merge に post-merge hook 追加
+#
+# Coverage:
+#   AC1: auto-merge.sh exit 0 → post-merge hook 発火、events/wave-*-pr-merged-*.json 生成
+#   AC2: events ファイルが atomic write (temp→mv) で生成される
+#   AC3: event JSON に必須フィールドが揃っていること
+#   AC4: post-merge hook が twl_notify_supervisor_handler を呼び出すこと
+#   AC5: auto-merge.sh 失敗時 (exit non-zero) → events ファイル生成なし
+#   AC6: events/notify 失敗時も step_auto_merge は ok 判定 (exit 0) を維持
+#   AC7: wave-queue.json の current_wave 取得 / 不在時 wave=-1 フォールバック
+#   AC9: 技術メモに mailbox push 失敗時フォールバック挙動が明文化されていること
+
+load '../helpers/common'
+
+SUPERVISOR_DIR_PATH=""
+
+setup() {
+  common_setup
+
+  SUPERVISOR_DIR_PATH="$SANDBOX/.supervisor"
+
+  mkdir -p "$SUPERVISOR_DIR_PATH/events"
+
+  export WORKER_ISSUE_NUM=1428
+  export SUPERVISOR_DIR="$SUPERVISOR_DIR_PATH"
+  export AUTOPILOT_DIR="$SANDBOX/.autopilot"
+
+  create_issue_json 1428 "running"
+
+  stub_command "git" '
+    case "$*" in
+      *"branch --show-current"*)
+        echo "feat/1428-chain-runner-pr-merge-event-emission" ;;
+      *"rev-parse --show-toplevel"*)
+        echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*)
+        echo "$SANDBOX/.git" ;;
+      *"status --porcelain"*)
+        echo "" ;;
+      *"worktree list --porcelain"*)
+        printf "worktree %s\nbranch refs/heads/main\n" "$SANDBOX" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  stub_command "gh" '
+    case "$*" in
+      *"pr view"*"--json number"*)
+        echo "42" ;;
+      *"pr view"*)
+        printf "{\"number\":42,\"headRefName\":\"feat/1428-test\"}\n" ;;
+      *"issue view"*"labels"*)
+        echo "" ;;
+      *)
+        exit 0 ;;
+    esac
+  '
+
+  cat > "$STUB_BIN/python3" <<'PYSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"state read"*"--field status"*)       echo "running" ;;
+  *"state read"*"--field is_quick"*)     echo "false" ;;
+  *"state read"*"--field current_step"*) echo "" ;;
+  *"state read"*"--field window"*)       echo "" ;;
+  *"state write"*)                       exit 0 ;;
+  *"audit"*)                             exit 0 ;;
+  *)                                     exit 0 ;;
+esac
+PYSTUB
+  chmod +x "$STUB_BIN/python3"
+
+  # auto-merge.sh stub: デフォルト成功
+  cat > "$SANDBOX/scripts/auto-merge.sh" <<'AUTOMERGE'
+#!/usr/bin/env bash
+exit 0
+AUTOMERGE
+  chmod +x "$SANDBOX/scripts/auto-merge.sh"
+
+  # wave-queue.json: デフォルト current_wave=3
+  cat > "$SUPERVISOR_DIR_PATH/wave-queue.json" <<'WAVE_JSON'
+{
+  "current_wave": 3
+}
+WAVE_JSON
+}
+
+teardown() {
+  # events/ を読み取り専用にしたテスト後に権限を戻す
+  chmod -R u+w "$SUPERVISOR_DIR_PATH" 2>/dev/null || true
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# Helper: step_auto_merge を chain-runner.sh auto-merge サブコマンドで実行
+# ---------------------------------------------------------------------------
+run_auto_merge() {
+  run env \
+    SUPERVISOR_DIR="$SUPERVISOR_DIR_PATH" \
+    WORKER_ISSUE_NUM=1428 \
+    AUTOPILOT_DIR="$SANDBOX/.autopilot" \
+    bash "$SANDBOX/scripts/chain-runner.sh" auto-merge \
+    --issue 1428 --pr 42 --branch feat/1428-test
+}
+
+# ===========================================================================
+# AC1: auto-merge.sh exit 0 → post-merge hook 発火、events ファイル生成
+# ===========================================================================
+
+@test "#1428 AC1: auto-merge 成功後に .supervisor/events/ にイベントファイルが生成される (RED)" {
+  run_auto_merge
+
+  # RED: _fire_post_merge_hook 未実装のため events/ にファイルが存在しない
+  local event_file
+  event_file="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave-*-pr-merged-1428.json" 2>/dev/null | head -1)"
+  [[ -n "$event_file" ]] \
+    || fail "events/wave-*-pr-merged-1428.json が生成されていない (AC1 RED: _fire_post_merge_hook 未実装)"
+}
+
+# ===========================================================================
+# AC2: atomic write (temp file → mv)
+# ===========================================================================
+
+@test "#1428 AC2: events ファイルが atomic write (temp→mv) で生成される (RED)" {
+  run_auto_merge
+
+  local event_file
+  event_file="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave-*-pr-merged-1428.json" 2>/dev/null | head -1)"
+  [[ -n "$event_file" ]] \
+    || fail "events/wave-*-pr-merged-1428.json が生成されていない (AC2 RED: _fire_post_merge_hook 未実装)"
+
+  # atomic write のシグネチャ: temp file (.tmp) が残っていない
+  local tmp_count
+  tmp_count="$(find "$SUPERVISOR_DIR_PATH/events" -name "*.tmp" 2>/dev/null | wc -l)"
+  [[ "$tmp_count" -eq 0 ]] \
+    || fail "temp file が残っている (non-atomic write): count=$tmp_count"
+}
+
+# ===========================================================================
+# AC3: event JSON 必須フィールド確認
+# ===========================================================================
+
+@test "#1428 AC3: event JSON に必須フィールドが揃っている (RED)" {
+  run_auto_merge
+
+  local event_file
+  event_file="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave-*-pr-merged-1428.json" 2>/dev/null | head -1)"
+  [[ -n "$event_file" ]] \
+    || fail "events/wave-*-pr-merged-1428.json が生成されていない (AC3 RED: _fire_post_merge_hook 未実装)"
+
+  local event_val wave_val issue_val pr_val branch_val ts_val host_val
+  event_val="$(jq -r '.event // empty' "$event_file" 2>/dev/null)"
+  wave_val="$(jq -r '.wave // empty' "$event_file" 2>/dev/null)"
+  issue_val="$(jq -r '.issue // empty' "$event_file" 2>/dev/null)"
+  pr_val="$(jq -r '.pr // empty' "$event_file" 2>/dev/null)"
+  branch_val="$(jq -r '.branch // empty' "$event_file" 2>/dev/null)"
+  ts_val="$(jq -r '.timestamp // empty' "$event_file" 2>/dev/null)"
+  host_val="$(jq -r '.host // empty' "$event_file" 2>/dev/null)"
+
+  [[ "$event_val" == "WAVE-PR-MERGED" ]] \
+    || fail "event フィールドが WAVE-PR-MERGED でない: '$event_val'"
+  [[ "$wave_val" =~ ^-?[0-9]+$ ]] \
+    || fail "wave フィールドが int でない: '$wave_val'"
+  [[ "$issue_val" =~ ^[0-9]+$ ]] \
+    || fail "issue フィールドが int でない: '$issue_val'"
+  [[ "$pr_val" =~ ^[0-9]+$ ]] \
+    || fail "pr フィールドが int でない: '$pr_val'"
+  [[ -n "$branch_val" ]] \
+    || fail "branch フィールドが空"
+  [[ "$ts_val" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} ]] \
+    || fail "timestamp が UTC ISO 8601 形式でない: '$ts_val'"
+  [[ -n "$host_val" ]] \
+    || fail "host フィールドが空"
+}
+
+# ===========================================================================
+# AC4: post-merge hook が twl_notify_supervisor_handler を呼び出す
+# ===========================================================================
+
+@test "#1428 AC4: post-merge hook が twl_notify_supervisor_handler を呼び出す (RED)" {
+  local notify_log="$SANDBOX/notify_called.log"
+  export TWL_NOTIFY_SUPERVISOR_CALL_LOG="$notify_log"
+
+  run_auto_merge
+
+  # RED: _fire_post_merge_hook 未実装のため notify が呼ばれない
+  [[ -f "$notify_log" ]] \
+    || fail "twl_notify_supervisor_handler が呼び出されていない (AC4 RED: _fire_post_merge_hook 未実装)"
+  grep -q "WAVE-PR-MERGED" "$notify_log" \
+    || fail "notify 呼び出しに WAVE-PR-MERGED が含まれていない"
+}
+
+# ===========================================================================
+# AC5: auto-merge 失敗時は event 発火しない
+# ===========================================================================
+
+@test "#1428 AC5: auto-merge 失敗時は events ファイルが生成されない" {
+  cat > "$SANDBOX/scripts/auto-merge.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$SANDBOX/scripts/auto-merge.sh"
+
+  run env \
+    SUPERVISOR_DIR="$SUPERVISOR_DIR_PATH" \
+    WORKER_ISSUE_NUM=1428 \
+    AUTOPILOT_DIR="$SANDBOX/.autopilot" \
+    bash "$SANDBOX/scripts/chain-runner.sh" auto-merge \
+    --issue 1428 --pr 42 --branch feat/1428-test
+
+  [[ "$status" -ne 0 ]] \
+    || fail "auto-merge 失敗時の exit code が 0 になっている (step_auto_merge が err 判定していない)"
+
+  local event_count
+  event_count="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave-*-pr-merged-*.json" 2>/dev/null | wc -l)"
+  [[ "$event_count" -eq 0 ]] \
+    || fail "auto-merge 失敗時に events ファイルが生成された: count=$event_count"
+}
+
+# ===========================================================================
+# AC6: event/notify 失敗でも step_auto_merge は ok 判定 (exit 0) を維持
+# ===========================================================================
+
+@test "#1428 AC6: events 書き込み失敗時も step_auto_merge は exit 0 を維持し WARN を出力する (RED)" {
+  # events/ を読み取り専用にして書き込みを失敗させる
+  chmod 444 "$SUPERVISOR_DIR_PATH/events"
+
+  run_auto_merge
+
+  # best-effort: exit 0 を維持（実装後も維持されること）
+  [[ "$status" -eq 0 ]] \
+    || fail "step_auto_merge の exit code が非ゼロ: $status (best-effort 違反)"
+
+  # RED: _fire_post_merge_hook 未実装のため WARN が出ない
+  echo "$output" | grep -qiE "WARN|warn" \
+    || fail "events 書き込み失敗時の WARN ログが出力されていない (AC6 RED: _fire_post_merge_hook 未実装)"
+}
+
+# ===========================================================================
+# AC7a: wave-queue.json が存在する場合 wave=current_wave でファイル生成
+# ===========================================================================
+
+@test "#1428 AC7a: wave-queue.json の current_wave=5 で wave-5-pr-merged-1428.json が生成される (RED)" {
+  cat > "$SUPERVISOR_DIR_PATH/wave-queue.json" <<'EOF'
+{
+  "current_wave": 5
+}
+EOF
+
+  run_auto_merge
+
+  # RED: _fire_post_merge_hook 未実装
+  local event_file
+  event_file="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave-5-pr-merged-1428.json" 2>/dev/null | head -1)"
+  [[ -n "$event_file" ]] \
+    || fail "wave-5-pr-merged-1428.json が生成されていない (AC7a RED: _fire_post_merge_hook 未実装)"
+}
+
+# ===========================================================================
+# AC7b: wave-queue.json が存在しない場合 wave=-1 でフォールバック
+# ===========================================================================
+
+@test "#1428 AC7b: wave-queue.json が不在の場合 wave=-1 で続行し warning フィールドを持つ (RED)" {
+  rm -f "$SUPERVISOR_DIR_PATH/wave-queue.json"
+
+  run_auto_merge
+
+  # RED: _fire_post_merge_hook 未実装
+  local event_file
+  event_file="$(find "$SUPERVISOR_DIR_PATH/events" -name "wave--1-pr-merged-1428.json" 2>/dev/null | head -1)"
+  [[ -n "$event_file" ]] \
+    || fail "wave--1-pr-merged-1428.json が生成されていない (AC7b RED: _fire_post_merge_hook 未実装)"
+
+  if [[ -n "$event_file" ]]; then
+    jq -e '.warning // empty' "$event_file" 2>/dev/null \
+      || fail "wave=-1 時に warning フィールドが存在しない"
+  fi
+}
+
+# ===========================================================================
+# AC9: 技術メモに mailbox push 失敗時フォールバック挙動が明文化されている
+# ===========================================================================
+
+@test "#1428 AC9: 技術メモに mailbox push 失敗時フォールバック挙動が明文化されている (RED)" {
+  local found=false
+  local tech_memo=""
+
+  for path in \
+    "$REPO_ROOT/refs/ref-pr-merge-event-emission.md" \
+    "$REPO_ROOT/refs/ref-wave-pr-merged-event.md" \
+    "$REPO_ROOT/architecture/decisions/adr-pr-merge-event.md"
+  do
+    if [[ -f "$path" ]]; then
+      tech_memo="$path"
+      found=true
+      break
+    fi
+  done
+
+  # RED: 技術メモがまだ作成されていない
+  [[ "$found" == "true" ]] \
+    || fail "技術メモが存在しない (AC9 RED): 実装時に ref-pr-merge-event-emission.md などを作成すること"
+
+  grep -qiE "fallback|フォールバック|watchdog|SSoT|Layer 2" "$tech_memo" \
+    || fail "技術メモに mailbox push 失敗時フォールバック挙動の記述がない"
+}


### PR DESCRIPTION
## 概要

Issue #1428 の実装。chain-runner.sh の step_auto_merge 完了後に post-merge hook を発火し、Wave N → Wave N+1 自動連鎖の Layer 1 signal source を確立する。

## 変更内容

- **emit-wave-pr-merged-event.sh** (新規): wave-queue.json から current_wave を取得し、`.supervisor/events/wave-{N}-pr-merged-{issue}.json` を atomic write (mktemp → mv) で生成。twl_notify_supervisor_handler を Python one-liner で呼び出し mailbox push (best-effort)
- **chain-runner.sh**: step_auto_merge 成功直後に emit-wave-pr-merged-event.sh を呼び出す hook を追加。失敗しても ok 判定を維持
- **ref-pr-merge-event-emission.md**: mailbox push 失敗時フォールバック挙動 (events/ が SSoT、Layer 2 watchdog 設計) を明文化
- **deps.yaml**: emit-wave-pr-merged-event script エントリ追加

## テスト

bats integration test 9 件追加、9/9 PASS

Closes #1428