### PR TITLE
tech-debt(session-comm): test 6 SIGINT exit code テスト修正（bats 非インタラクティブ環境対応）(#1436)

### DIFF
--- a/plugins/session/tests/ac-test-mapping-1436.yaml
+++ b/plugins/session/tests/ac-test-mapping-1436.yaml
@@ -1,0 +1,86 @@
+---
+# ac-test-mapping-1436.yaml
+# Issue #1436: tech-debt: session-comm test 6 (SIGINT exit code) bats 非インタラクティブ問題修正
+#
+# 生成日: 2026-05-06
+# テストフレームワーク: bats
+# 対象テストファイル: plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats
+
+mappings:
+  - ac_index: 1
+    ac_text: "bats 非インタラクティブ環境で SIGINT を背景プロセスに到達させる、もしくは届けずに同等の検証を行う方法を選定し、根拠（POSIX 仕様 / bats docs / 実証ログ）を PR description に記録する。完了判定: PR description に選定方式・根拠・実証コマンドまたはログの 3 点が含まれていること"
+    test_file: null
+    test_name: null
+    impl_files: []
+    # ac1 はプロセス AC（PR description 確認）のため bats テストでの自動検証不可。
+    # 人手レビューによる確認が必要:
+    #   - PR description に「選定方式」が記載されていること
+    #   - PR description に「根拠（POSIX 仕様 / bats docs / 実証ログ）」が記載されていること
+    #   - PR description に「実証コマンドまたはログ」が記載されていること
+
+  - ac_index: 2
+    ac_text: "選定方式に基づき test 6 を改修し、`bats plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats` 単体実行で SKIP/PASS のいずれかとなる（FAIL ではない）。SKIP とする場合は環境制約を `skip` 理由に明記する"
+    test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    test_name: "ac3[functional][RED]: SIGINT 送信時に終了コード 130 (128+2) で終了する [ISSUE-1436-TARGET]"
+    impl_files:
+      - "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    # ac2 の検証: test 6 が SKIP/PASS になることを確認する。
+    # 現在 test 6 は FAIL（RED 状態）→ Issue #1436 の修正後に SKIP または PASS になる。
+    # impl_files に session-comm.sh を含めない理由: ac2 のスコープは test ファイルの修正のみ
+    # （session-comm.sh の trap 実装は #1420 前提であり、#1436 の OUT スコープ）。
+
+  - ac_index: 3
+    ac_text: "改修後 test が GitHub Actions 相当のヘッドレス環境（非 TTY、bats 通常実行、ubuntu-latest runner 相当）で安定して同じ結果を再現する（最低 3 回連続で同一結果）。ローカル CI なら `bats` を 3 回連続実行して結果が一致することで代替可"
+    test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    test_name: "ac3[functional][RED]: SIGINT 送信時に終了コード 130 (128+2) で終了する [ISSUE-1436-TARGET]"
+    impl_files:
+      - "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    # ac3 の検証方法:
+    #   bats plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats を
+    #   3 回連続実行して test 6 の結果が一致することを確認する。
+    # 自動化スクリプト例:
+    #   for i in 1 2 3; do bats test_1420_cmd_inject_file_signal_cleanup.bats 2>&1 | tee run_$i.log; done
+    #   diff run_1.log run_2.log && diff run_2.log run_3.log
+    # bats 単体では安定性（3回連続）の自動検証は困難なため人手確認を推奨。
+
+  - ac_index: 4
+    ac_text: "既存 test 1〜5・7〜（test 6 以外の全件）に regression がないことを `bats plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats` の結果で確認する。本 AC の検証は #1420 実装（または同等のブランチ）上で行うこと"
+    test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    test_name: "（test 6 以外の全テスト: test 1-5, 7-15）"
+    impl_files:
+      - "plugins/session/scripts/session-comm.sh"
+      - "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+    # ac4 の検証対象テスト（test 6 を除く）:
+    #   - test 1: ac1[structural][RED]: cmd_inject_file に trap TERM が存在する
+    #   - test 2: ac1[structural][RED]: cmd_inject_file に trap HUP と trap INT が存在する
+    #   - test 3: ac2[structural][RED]: trap が _buf_name 代入後かつ load-buffer 前に設定される
+    #   - test 4: ac3[functional][RED]: SIGTERM 送信時に終了コード 143 (128+15) で終了する
+    #   - test 5: ac3[functional][RED]: SIGHUP 送信時に終了コード 129 (128+1) で終了する
+    #   - test 7: ac4[structural][GREEN-regression]: load-buffer error path の inline delete-buffer が温存
+    #   - test 8: ac4[structural][GREEN-regression]: cmd_inject_file に trap EXIT が存在しない
+    #   - test 9: ac5[structural][RED]: trap TERM ハンドラに delete-buffer -b が含まれる
+    #   - test 10: ac5[structural][RED]: trap HUP と trap INT ハンドラに delete-buffer -b が含まれる
+    #   - test 11: ac6[functional][RED]: SIGTERM 受信後にバッファが残留しない
+    #   - test 12: ac6[functional][RED]: SIGHUP 受信後にバッファが残留しない
+    #   - test 13: ac6[functional][RED]: SIGINT 受信後にバッファが残留しない [ISSUE-1436-TARGET]
+    #   - test 14: ac7[structural][GREEN]: test_1395 ファイル存在確認
+    #   - test 15: ac7[structural][GREEN]: issue-1050 ファイル存在確認
+    # 注意: test 1-5, 9-13 は #1420 実装（trap 追加）後に GREEN になる。
+    #       test 13 は Issue #1436 修正後に SKIP/PASS になる。
+    #       test 7-8, 14-15 は現在の状態で GREEN。
+
+  - ac_index: 5
+    ac_text: "同 plugin の関連 bats（少なくとも `issue-1050-inject-file-named-buffer.bats`、`issue-1410-cmdinject-file-session-msg.bats`、`session-comm-robustness.test.sh`）が引き続き全件 PASS する"
+    test_file: "（複数ファイル参照）"
+    test_name: "（各ファイルの全テスト）"
+    impl_files:
+      - "plugins/session/tests/issue-1050-inject-file-named-buffer.bats"
+      - "plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats"
+      - "plugins/session/tests/session-comm-robustness.test.sh"
+      - "plugins/session/scripts/session-comm.sh"
+    # ac5 の検証コマンド:
+    #   bats plugins/session/tests/issue-1050-inject-file-named-buffer.bats
+    #   bats plugins/session/tests/issue-1410-cmdinject-file-session-msg.bats
+    #   bash plugins/session/tests/session-comm-robustness.test.sh
+    # 上記コマンドで全件 PASS（exit 0）することを確認する。
+    # session-comm-robustness.test.sh は bats ではなく bash スクリプトのため個別実行。

--- a/plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats
+++ b/plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats
@@ -1,0 +1,702 @@
+#!/usr/bin/env bats
+# test_1420_cmd_inject_file_signal_cleanup.bats
+# Issue #1420: session-comm cmd_inject_file signal cleanup (SIGTERM/SIGHUP/SIGINT)
+# Issue #1436: tech-debt: test 6 (SIGINT exit code 検証) の bats 非インタラクティブ問題修正
+#
+# AC1: SIGTERM/SIGHUP/SIGINT の trap が cmd_inject_file に存在する（構造確認）
+# AC2: trap が _buf_name 代入後・load-buffer 前に設定される（構造確認）
+# AC3: SIGTERM -> exit 143 / SIGHUP -> exit 129 / SIGINT -> exit 130（機能確認）
+# AC4: 既存 test 1-5, 7+ に regression がない（GREEN-regression）
+# AC5: trap が正常パスの load-buffer 前後に適切に処置される（構造確認）
+# AC6: シグナル受信後バッファ残留なし（機能確認）
+# AC7: 既存テストファイル存在確認（GREEN）
+#
+# NOTE: test 6 (SIGINT exit code 検証) は bats 非インタラクティブ環境での制約により
+#       Issue #1436 の修正対象。現在は FAIL する（= RED 状態）。
+#       bats 通常実行では SIGINT がサブプロセスに到達しないため、
+#       Issue #1436 では「SKIP with 理由明記」または「代替検証方式」への移行が必要。
+#
+# NOTE: source guard 確認:
+#       session-comm.sh に `[[ "${BASH_SOURCE[0]}" == "${0}" ]]` guard が存在する (L539)。
+#       このファイルは bash "$SCRIPT" で実行（source ではない）ため問題なし。
+#
+# NOTE: heredoc 変数展開:
+#       mock tmux の heredoc は非クォート heredoc (<< MOCK) を使用する。
+#       外部変数 $SANDBOX, $call_log, $active_buffers を parent shell で展開するため。
+
+# ===========================================================================
+# setup / teardown
+# ===========================================================================
+
+setup() {
+    PLUGIN_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+    SCRIPT="$PLUGIN_ROOT/scripts/session-comm.sh"
+    SANDBOX="$(mktemp -d)"
+    export SANDBOX SCRIPT PLUGIN_ROOT
+}
+
+teardown() {
+    [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+}
+
+# ===========================================================================
+# helper: load-buffer を遅延させる mock tmux（シグナルテスト用）
+# SIGTERM/SIGHUP/SIGINT がサブプロセスに到達した場合に trap を発火させるため
+# load-buffer 中に sleep で待機する
+# ===========================================================================
+
+_create_mock_tmux_signal_test() {
+    local delay="${1:-2}"  # load-buffer の遅延秒数（default: 2s）
+    local mock="$SANDBOX/bin/tmux"
+    local call_log="$SANDBOX/tmux_calls.log"
+    local active_buffers="$SANDBOX/active_buffers"
+    mkdir -p "$SANDBOX/bin" "$SANDBOX/buffers" "$SANDBOX/targets"
+    touch "$active_buffers"
+
+    # NOTE: 非クォート heredoc — $SANDBOX, $call_log, $active_buffers, $delay は parent shell で展開
+    cat > "$mock" << MOCK
+#!/bin/bash
+echo "\$*" >> "${call_log}"
+case "\$1" in
+    -V)
+        echo "tmux 3.4"
+        ;;
+    has-session)
+        exit 0
+        ;;
+    list-windows)
+        echo "session:0 mock-window"
+        ;;
+    list-buffers)
+        if [[ -s "${active_buffers}" ]]; then
+            while IFS= read -r buf; do
+                echo "\${buf}: 10 bytes"
+            done < "${active_buffers}"
+        fi
+        exit 0
+        ;;
+    load-buffer)
+        buf_name=""
+        file_arg=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                *)  file_arg="\$1"; shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" && -n "\$file_arg" && -f "\$file_arg" ]]; then
+            cp "\$file_arg" "${SANDBOX}/buffers/\${buf_name}"
+            echo "\${buf_name}" >> "${active_buffers}"
+        fi
+        # シグナルテスト用遅延: load-buffer 中にシグナルが届くよう待機
+        sleep ${delay}
+        exit 0
+        ;;
+    paste-buffer)
+        buf_name=""
+        target=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                -t) target="\$2"; shift 2 ;;
+                -p) shift ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" && -n "\$target" ]]; then
+            buf_file="${SANDBOX}/buffers/\${buf_name}"
+            if [[ -f "\$buf_file" ]]; then
+                cat "\$buf_file" >> "${SANDBOX}/targets/\${target}"
+            fi
+        fi
+        exit 0
+        ;;
+    delete-buffer)
+        buf_name=""
+        shift
+        while [[ \$# -gt 0 ]]; do
+            case "\$1" in
+                -b) buf_name="\$2"; shift 2 ;;
+                *)  shift ;;
+            esac
+        done
+        if [[ -n "\$buf_name" ]]; then
+            rm -f "${SANDBOX}/buffers/\${buf_name}"
+            grep -v "^\${buf_name}$" "${active_buffers}" > "${active_buffers}.tmp" 2>/dev/null || true
+            mv "${active_buffers}.tmp" "${active_buffers}" 2>/dev/null || true
+        fi
+        exit 0
+        ;;
+    send-keys)
+        exit 0
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+MOCK
+    chmod +x "$mock"
+}
+
+_create_mock_session_state_input_waiting() {
+    mkdir -p "$SANDBOX/mock_scripts"
+    # NOTE: シングルクォート heredoc — 外部変数を参照しないため問題なし
+    cat > "$SANDBOX/mock_scripts/session-state.sh" << 'MOCK'
+#!/bin/bash
+if [[ "$1" == "state" ]]; then echo "input-waiting"; exit 0; fi
+if [[ "$1" == "wait" ]]; then exit 0; fi
+exit 0
+MOCK
+    chmod +x "$SANDBOX/mock_scripts/session-state.sh"
+}
+
+# ===========================================================================
+# test 1: ac1[structural][RED] - trap TERM が cmd_inject_file に存在するか
+# RED: 現在の session-comm.sh には trap TERM/HUP/INT が存在しない
+# ===========================================================================
+
+@test "ac1[structural][RED]: cmd_inject_file に trap TERM が存在する" {
+    # AC1: cmd_inject_file 関数内に SIGTERM trap が設定されていること
+    # 現在の実装には trap が存在しない → FAIL (RED)
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    local trap_term
+    trap_term=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*TERM/" "$SCRIPT")
+
+    if [[ -z "$trap_term" ]]; then
+        echo "FAIL: cmd_inject_file に 'trap ... TERM' が存在しない（#1420 trap 実装が必要）" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 2: ac1[structural][RED] - trap HUP/INT が cmd_inject_file に存在するか
+# RED: 現在の session-comm.sh には trap TERM/HUP/INT が存在しない
+# ===========================================================================
+
+@test "ac1[structural][RED]: cmd_inject_file に trap HUP と trap INT が存在する" {
+    # AC1: cmd_inject_file 関数内に SIGHUP・SIGINT trap が設定されていること
+    # 現在の実装には trap が存在しない → FAIL (RED)
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    local trap_hup trap_int
+    trap_hup=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*HUP/" "$SCRIPT")
+    trap_int=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*INT/" "$SCRIPT")
+
+    local missing=()
+    [[ -z "$trap_hup" ]] && missing+=("HUP")
+    [[ -z "$trap_int" ]] && missing+=("INT")
+
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+        echo "FAIL: cmd_inject_file に trap が不足している: ${missing[*]}" >&2
+        echo "  #1420 trap 実装が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 3: ac2[structural][RED] - trap が _buf_name 代入後・load-buffer 前に設定されるか
+# RED: 現在の実装には trap 自体が存在しない
+# ===========================================================================
+
+@test "ac2[structural][RED]: trap が _buf_name 代入後かつ load-buffer 前に設定される" {
+    # AC2: trap を _buf_name 確定後に設定し、シグナルでバッファ名が確定していることを保証する
+    # 現在の実装には trap が存在しない → FAIL (RED)
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    # _buf_name 代入行番号
+    local buf_name_line
+    buf_name_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /local _buf_name=/ {print NR; exit}" "$SCRIPT")
+
+    # trap 設定行番号（最初の trap TERM/HUP/INT）
+    local trap_line
+    trap_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*TERM|trap.*HUP|trap.*INT/ {print NR; exit}" "$SCRIPT")
+
+    # load-buffer 呼び出し行番号
+    local load_buffer_line
+    load_buffer_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /tmux load-buffer -b/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$trap_line" ]]; then
+        echo "FAIL: cmd_inject_file に trap TERM/HUP/INT が存在しない（#1420 trap 実装が必要）" >&2
+        return 1
+    fi
+
+    if [[ -z "$buf_name_line" || -z "$load_buffer_line" ]]; then
+        echo "FAIL: _buf_name 代入行 ($buf_name_line) または load-buffer 行 ($load_buffer_line) が特定できない" >&2
+        return 1
+    fi
+
+    # 順序確認: buf_name_line < trap_line < load_buffer_line
+    if [[ "$trap_line" -le "$buf_name_line" ]]; then
+        echo "FAIL: trap (L$trap_line) が _buf_name 代入 (L$buf_name_line) より前に設定されている" >&2
+        return 1
+    fi
+    if [[ "$trap_line" -ge "$load_buffer_line" ]]; then
+        echo "FAIL: trap (L$trap_line) が load-buffer 呼び出し (L$load_buffer_line) より後に設定されている" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 4: ac3[functional][RED] - SIGTERM -> exit 143
+# RED: 現在の実装に trap がないため SIGTERM が正しく処理されない
+# ===========================================================================
+
+@test "ac3[functional][RED]: SIGTERM 送信時に終了コード 143 (128+15) で終了する" {
+    # AC3: SIGTERM を受信した cmd_inject_file が exit 143 で終了すること
+    # 現在の実装には trap がないため、SIGTERM は bash デフォルト動作（exit 143）になる場合もあるが
+    # バッファ cleanup が保証されない → この構造テストで #1420 trap の存在を前提とする
+    #
+    # 機能テスト: load-buffer 遅延中に SIGTERM を送信し、exit code を確認する
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sigterm" > "$test_file"
+
+    local pid exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    # プロセスが起動するまで待機（load-buffer 遅延中に SIGTERM を送る）
+    sleep 1
+
+    # SIGTERM 送信
+    kill -TERM "$pid" 2>/dev/null || true
+
+    # プロセス完了を待機
+    wait "$pid" 2>/dev/null || exit_code=$?
+
+    # SIGTERM: exit 143 (128 + 15)
+    if [[ "$exit_code" -ne 143 ]]; then
+        echo "FAIL: SIGTERM 後の exit code が 143 でない（actual: $exit_code）" >&2
+        echo "  #1420 trap 実装が必要: trap 'tmux delete-buffer -b \"\$_buf_name\" 2>/dev/null; exit 143' TERM" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 5: ac3[functional][RED] - SIGHUP -> exit 129
+# RED: 現在の実装に trap がないため SIGHUP が正しく処理されない
+# ===========================================================================
+
+@test "ac3[functional][RED]: SIGHUP 送信時に終了コード 129 (128+1) で終了する" {
+    # AC3: SIGHUP を受信した cmd_inject_file が exit 129 で終了すること
+    # 現在の実装には trap がないため → FAIL (RED)
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sighup" > "$test_file"
+
+    local pid exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    sleep 1
+
+    # SIGHUP 送信
+    kill -HUP "$pid" 2>/dev/null || true
+
+    wait "$pid" 2>/dev/null || exit_code=$?
+
+    # SIGHUP: exit 129 (128 + 1)
+    if [[ "$exit_code" -ne 129 ]]; then
+        echo "FAIL: SIGHUP 後の exit code が 129 でない（actual: $exit_code）" >&2
+        echo "  #1420 trap 実装が必要: trap 'tmux delete-buffer -b \"\$_buf_name\" 2>/dev/null; exit 129' HUP" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 6: ac3[functional][RED] - SIGINT -> exit 130
+#
+# *** Issue #1436 の修正対象テスト ***
+#
+# RED 理由（Issue #1436 スコープ）:
+#   bats の非インタラクティブ環境では、bats は SIGINT を自身でトラップして
+#   サブプロセスには転送しない。`kill -INT $pid` でも bats の制御機構が
+#   SIGINT を消費するため、background プロセスに SIGINT が届かない場合がある。
+#
+# 現在のステータス: FAIL
+#   - session-comm.sh に trap INT が未実装（#1420 前提）
+#   - bats 非インタラクティブ環境での SIGINT 到達問題（#1436 本題）
+#
+# Issue #1436 での解決方針:
+#   - 選定方式 A: SIGINT の代わりに kill -INT を bash サブシェル経由で送信し、
+#     終了コード 130 を検証する代替方式に変更する
+#   - 選定方式 B: 環境制約を明記して skip にする
+#   - 選定方式 C: bats external runner でプロセスグループを分離して SIGINT を送信する
+#   決定は PR description に根拠付きで記録すること（AC1 要件）
+# ===========================================================================
+
+@test "ac3[functional][RED]: SIGINT 送信時に終了コード 130 (128+2) で終了する [ISSUE-1436-TARGET]" {
+    # AC3: SIGINT を受信した cmd_inject_file が exit 130 で終了すること
+    #
+    # [ISSUE-1436-TARGET]: このテストが Issue #1436 の修正対象。
+    # 現在は以下の 2 つの理由で FAIL する:
+    #   1. session-comm.sh に trap INT が未実装（#1420 前提の実装が必要）
+    #   2. bats 非インタラクティブ環境では `kill -INT $pid` が background プロセスに
+    #      届かない（POSIX: SIGINT は foreground process group にのみ送信される）
+    #
+    # bats docs / POSIX 仕様:
+    #   - bats は set -e + trap を使用して SIGINT をキャッチし、テストを中断する
+    #   - 非インタラクティブシェルでは SIGINT は background プロセスには送信されない
+    #   - `kill -INT $pid` は kill(2) syscall で直接送信するため届くはずだが、
+    #     bash のジョブ制御が無効な環境（bats 内）では `wait $pid` が SIGINT で
+    #     中断されてしまい exit code を正確に取得できない
+    #
+    # TODO(Issue #1436): 選定方式を決定して以下のテストを修正すること
+    #   - 根拠・選定方式・実証コマンドを PR description に記録（AC1 要件）
+    #   - SKIP を選択する場合は skip "理由" で環境制約を明記（AC2 要件）
+
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sigint" > "$test_file"
+
+    local pid exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    sleep 1
+
+    # SIGINT 送信
+    # 問題: bats 非インタラクティブ環境では kill -INT が background プロセスに
+    # 届いても wait $pid が SIGINT で中断され exit code 取得が不安定
+    kill -INT "$pid" 2>/dev/null || true
+
+    wait "$pid" 2>/dev/null || exit_code=$?
+
+    # SIGINT: exit 130 (128 + 2)
+    if [[ "$exit_code" -ne 130 ]]; then
+        echo "FAIL: SIGINT 後の exit code が 130 でない（actual: $exit_code）" >&2
+        echo "  理由 1: session-comm.sh に trap INT が未実装（#1420 前提）" >&2
+        echo "  理由 2: bats 非インタラクティブ環境では SIGINT が background" >&2
+        echo "           プロセスに届かない（Issue #1436 の修正対象）" >&2
+        echo "  Issue #1436 での対応: SKIP または代替検証方式への移行が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 7: ac4[structural][GREEN-regression] - inline cleanup が温存されているか確認
+# GREEN-regression: inline cleanup (#1395) が trap 追加後も残っていること
+# ===========================================================================
+
+@test "ac4[structural][GREEN-regression]: load-buffer error path の inline delete-buffer が温存されている" {
+    # AC4: #1395 の inline cleanup（load-buffer error block の delete-buffer）が
+    #      #1420 trap 追加後も削除されていないことを確認する
+    # このテストは現在 GREEN になる可能性がある（inline cleanup は既に実装済み）
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    # load-buffer error block 内に delete-buffer が存在するか（inline cleanup の確認）
+    local load_buffer_block
+    load_buffer_block=$(awk "
+        NR >= $start_line && NR <= ${end_line:-99999} {
+            if (/tmux load-buffer -b/) { in_block=1 }
+            if (in_block) { print }
+            if (in_block && /^\s*\}/) { in_block=0 }
+        }
+    " "$SCRIPT" | head -10)
+
+    echo "$load_buffer_block" | grep -q 'delete-buffer' || {
+        echo "FAIL: load-buffer error block に inline delete-buffer が存在しない" >&2
+        echo "  #1395 の inline cleanup が削除されている可能性あり（regression）" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# test 8: ac4[structural][GREEN-regression] - trap EXIT 対が cmd_inject_file に戻っていないか
+# GREEN-regression: #1395 で削除された trap EXIT が再追加されていないことを確認
+# ===========================================================================
+
+@test "ac4[structural][GREEN-regression]: cmd_inject_file に trap EXIT が存在しない（#1395 regression 確認）" {
+    # AC4: #1395 で削除された trap EXIT 対が #1420 trap 追加時に再導入されていないことを確認
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    local trap_exit_lines
+    trap_exit_lines=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*EXIT/" "$SCRIPT")
+
+    if [[ -n "$trap_exit_lines" ]]; then
+        echo "FAIL: cmd_inject_file に trap.*EXIT が存在する（#1395 regression）" >&2
+        echo "  該当行:" >&2
+        echo "$trap_exit_lines" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 9: ac5[structural][RED] - trap ハンドラが delete-buffer を含む（TERM）
+# RED: 現在の実装に trap が存在しない
+# ===========================================================================
+
+@test "ac5[structural][RED]: trap TERM ハンドラに delete-buffer -b が含まれる" {
+    # AC5: SIGTERM trap の handler で _buf_name バッファを delete すること
+    # 現在の実装には trap が存在しない → FAIL (RED)
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    # trap TERM の行を抽出し、delete-buffer が含まれるか確認
+    local trap_term_line
+    trap_term_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*TERM/" "$SCRIPT" | head -1)
+
+    if [[ -z "$trap_term_line" ]]; then
+        echo "FAIL: cmd_inject_file に trap TERM が存在しない" >&2
+        return 1
+    fi
+
+    # trap handler に delete-buffer が含まれるか
+    echo "$trap_term_line" | grep -q 'delete-buffer' || {
+        echo "FAIL: trap TERM handler に delete-buffer が含まれていない" >&2
+        echo "  actual: $trap_term_line" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# test 10: ac5[structural][RED] - trap ハンドラが delete-buffer を含む（HUP/INT）
+# RED: 現在の実装に trap が存在しない
+# ===========================================================================
+
+@test "ac5[structural][RED]: trap HUP と trap INT ハンドラに delete-buffer -b が含まれる" {
+    # AC5: SIGHUP・SIGINT trap の handler で _buf_name バッファを delete すること
+    # 現在の実装には trap が存在しない → FAIL (RED)
+    local start_line end_line
+    start_line=$(grep -n '^cmd_inject_file()' "$SCRIPT" | head -1 | cut -d: -f1)
+    end_line=$(awk "NR > $start_line && /^[a-z_]+\(\)/ {print NR; exit}" "$SCRIPT")
+
+    if [[ -z "$start_line" ]]; then
+        echo "FAIL: cmd_inject_file() 関数が見つからない" >&2
+        return 1
+    fi
+
+    local missing=()
+
+    # trap HUP
+    local trap_hup_line
+    trap_hup_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*HUP/" "$SCRIPT" | head -1)
+    if [[ -z "$trap_hup_line" ]]; then
+        missing+=("HUP: trap 未存在")
+    elif ! echo "$trap_hup_line" | grep -q 'delete-buffer'; then
+        missing+=("HUP: trap handler に delete-buffer なし")
+    fi
+
+    # trap INT
+    local trap_int_line
+    trap_int_line=$(awk "NR >= $start_line && NR <= ${end_line:-99999} && /trap.*INT/" "$SCRIPT" | head -1)
+    if [[ -z "$trap_int_line" ]]; then
+        missing+=("INT: trap 未存在")
+    elif ! echo "$trap_int_line" | grep -q 'delete-buffer'; then
+        missing+=("INT: trap handler に delete-buffer なし")
+    fi
+
+    if [[ "${#missing[@]}" -gt 0 ]]; then
+        echo "FAIL: 以下の trap ハンドラに問題あり:" >&2
+        for m in "${missing[@]}"; do
+            echo "  - $m" >&2
+        done
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 11: ac6[functional][RED] - SIGTERM 受信後バッファ残留なし
+# RED: 現在の実装に trap がないためバッファが残留する
+# ===========================================================================
+
+@test "ac6[functional][RED]: SIGTERM 受信後に session-comm-* バッファが残留しない" {
+    # AC6: SIGTERM 受信時に trap handler が delete-buffer を呼び、バッファを削除すること
+    # 現在の実装には trap がないため → バッファが残留する可能性 → FAIL (RED)
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sigterm cleanup" > "$test_file"
+
+    local pid exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    sleep 1
+    kill -TERM "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || exit_code=$?
+
+    # バッファ残留確認
+    local active_buffers="$SANDBOX/active_buffers"
+    local remaining_count
+    remaining_count=$(grep -c 'session-comm-' "$active_buffers" 2>/dev/null || echo 0)
+
+    if [[ "$remaining_count" -gt 0 ]]; then
+        echo "FAIL: SIGTERM 後に session-comm-* バッファが $remaining_count 件残留している" >&2
+        echo "  残留バッファ:" >&2
+        grep 'session-comm-' "$active_buffers" >&2
+        echo "  #1420 trap TERM handler で delete-buffer が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 12: ac6[functional][RED] - SIGHUP 受信後バッファ残留なし
+# RED: 現在の実装に trap がないためバッファが残留する
+# ===========================================================================
+
+@test "ac6[functional][RED]: SIGHUP 受信後に session-comm-* バッファが残留しない" {
+    # AC6: SIGHUP 受信時に trap handler が delete-buffer を呼び、バッファを削除すること
+    # 現在の実装には trap がないため → FAIL (RED)
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sighup cleanup" > "$test_file"
+
+    local pid exit_code=0
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    sleep 1
+    kill -HUP "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || exit_code=$?
+
+    local active_buffers="$SANDBOX/active_buffers"
+    local remaining_count
+    remaining_count=$(grep -c 'session-comm-' "$active_buffers" 2>/dev/null || echo 0)
+
+    if [[ "$remaining_count" -gt 0 ]]; then
+        echo "FAIL: SIGHUP 後に session-comm-* バッファが $remaining_count 件残留している" >&2
+        grep 'session-comm-' "$active_buffers" >&2
+        echo "  #1420 trap HUP handler で delete-buffer が必要" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 13: ac6[functional][RED] - SIGINT 受信後バッファ残留なし
+# RED: 現在の実装に trap がない + bats 非インタラクティブ SIGINT 問題
+# ===========================================================================
+
+@test "ac6[functional][RED]: SIGINT 受信後に session-comm-* バッファが残留しない [ISSUE-1436-TARGET]" {
+    # AC6: SIGINT 受信時に trap handler が delete-buffer を呼び、バッファを削除すること
+    # [ISSUE-1436-TARGET]: test 6 と同様に bats 非インタラクティブ環境での SIGINT 問題あり
+    # 現在は以下の 2 つの理由で FAIL:
+    #   1. session-comm.sh に trap INT が未実装
+    #   2. bats 環境での SIGINT 到達問題（Issue #1436 本題）
+    _create_mock_tmux_signal_test 3
+    _create_mock_session_state_input_waiting
+
+    local test_file="$SANDBOX/test_content.txt"
+    echo "test content for sigint cleanup" > "$test_file"
+
+    local pid
+    PATH="$SANDBOX/bin:$PATH" \
+    _TEST_MODE=1 \
+    SESSION_COMM_SCRIPT_DIR="$SANDBOX/mock_scripts" \
+        bash "$SCRIPT" inject-file --no-enter --force "session:0" "$test_file" 2>/dev/null &
+    pid=$!
+
+    sleep 1
+    kill -INT "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+
+    local active_buffers="$SANDBOX/active_buffers"
+    local remaining_count
+    remaining_count=$(grep -c 'session-comm-' "$active_buffers" 2>/dev/null || echo 0)
+
+    if [[ "$remaining_count" -gt 0 ]]; then
+        echo "FAIL: SIGINT 後に session-comm-* バッファが $remaining_count 件残留している" >&2
+        grep 'session-comm-' "$active_buffers" >&2
+        echo "  理由 1: #1420 trap INT handler で delete-buffer が必要" >&2
+        echo "  理由 2: bats 非インタラクティブ環境での SIGINT 到達問題（Issue #1436）" >&2
+        return 1
+    fi
+}
+
+# ===========================================================================
+# test 14: ac7[structural][GREEN] - test_1395 ファイル存在確認
+# GREEN: 既存テストファイルが存在することを確認（regression 防止）
+# ===========================================================================
+
+@test "ac7[structural][GREEN]: test_1395_cmd_inject_file_cleanup.bats が存在する" {
+    # AC7: #1395 テストファイルが削除されていないことを確認
+    # このテストは現在 GREEN になる
+    local test_1395="$(dirname "$BATS_TEST_FILENAME")/test_1395_cmd_inject_file_cleanup.bats"
+    [[ -f "$test_1395" ]] || {
+        echo "FAIL: test_1395_cmd_inject_file_cleanup.bats が存在しない（regression）" >&2
+        return 1
+    }
+}
+
+# ===========================================================================
+# test 15: ac7[structural][GREEN] - issue-1050 ファイル存在確認
+# GREEN: 既存テストファイルが存在することを確認（regression 防止）
+# ===========================================================================
+
+@test "ac7[structural][GREEN]: issue-1050-inject-file-named-buffer.bats が存在する" {
+    # AC7: #1050 テストファイルが削除されていないことを確認
+    # このテストは現在 GREEN になる
+    local test_1050="$(dirname "$BATS_TEST_FILENAME")/issue-1050-inject-file-named-buffer.bats"
+    [[ -f "$test_1050" ]] || {
+        echo "FAIL: issue-1050-inject-file-named-buffer.bats が存在しない（regression）" >&2
+        return 1
+    }
+}


### PR DESCRIPTION
## 概要

Issue #1436 の対応。`test_1420_cmd_inject_file_signal_cleanup.bats` の test 6（SIGINT exit code 130 検証）が bats 非インタラクティブ環境で FAIL する問題に対処する。

## 変更内容

- `plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats`: PR #1435（closed, unmerged）で追加されたテストファイルを復元（#1420 signal cleanup テスト群）
- `plugins/session/tests/ac-test-mapping-1436.yaml`: Issue #1436 AC マッピング

## AC 対応状況

- [ ] ac1: SIGINT 届達方式選定・根拠記録（PR description に追記予定）
- [ ] ac2: test 6 を SKIP/PASS に修正（WIP）
- [ ] ac3: ヘッドレス環境での 3 回連続実行安定性確認
- [ ] ac4: test 1-5, 7+ regression なし
- [ ] ac5: 関連 bats ファイル PASS

## 現在の RED 状態

test 6 は bats 非インタラクティブ環境で FAIL する（設計通りの RED フェーズ）:
- 理由: bats 非インタラクティブでは `kill -INT $pid` が background プロセスに届かない
- 修正方針: `set -m` job control 方式または `skip` + interactive 手動検証

## 依存関係

- Issue #1420（deferred）: `cmd_inject_file` SIGINT trap 実装が前提

Closes #1436