### PR TITLE
[Self-Improve] rule-gap: bats 非インタラクティブ環境での SIGINT 到達方法（set -m + kill -INT -$pgid）

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -899,3 +899,47 @@ mappings:
     red_mechanism: "allowlist チェックが未実装のため (a)(b) の Warning grep が失敗する"
     impl_files:
       - "plugins/session/scripts/session-comm-backend-mcp.sh"
+
+# --- Issue #1451 ---
+issue_1451:
+  issue: 1451
+  framework: bats
+  test_file: "plugins/twl/tests/bats/baseline-bash-section12.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "refs/baseline-bash.md に ## 12. bats 非インタラクティブ SIGINT 送信 セクションが §11 の直後に存在する"
+      test_name: "baseline-bash-section12: AC1 section '## 12.' exists"
+      status: RED
+      red_mechanism: "§12 セクションが未存在のため grep が失敗する"
+      impl_files:
+        - "plugins/twl/refs/baseline-bash.md"
+
+    - ac_index: 2
+      ac_text: "§12 は推奨パターン（set -m, kill -INT -$pgid, trap 'set +m' RETURN, pgid 数値検証）を含む"
+      test_names:
+        - "baseline-bash-section12: AC2 mentions 'set -m'"
+        - "baseline-bash-section12: AC2 mentions 'kill -INT' with process group"
+        - "baseline-bash-section12: AC2 mentions 'trap' for set +m cleanup"
+        - "baseline-bash-section12: AC2 includes pgid numeric validation"
+      status: RED
+      red_mechanism: "§12 未存在のため sed コマンドが空を返し全パターン grep が失敗する"
+      impl_files:
+        - "plugins/twl/refs/baseline-bash.md"
+
+    - ac_index: 3
+      ac_text: "§12 は BAD/GOOD ブロック構造を持つ（既存セクションのパターンに準拠）"
+      test_names:
+        - "baseline-bash-section12: AC3 has BAD block for kill -INT without process group"
+        - "baseline-bash-section12: AC3 has GOOD block with recommended pattern"
+      status: RED
+      red_mechanism: "§12 未存在のため BAD/GOOD heading grep が失敗する"
+      impl_files:
+        - "plugins/twl/refs/baseline-bash.md"
+
+    - ac_index: 4
+      ac_text: "§12 は POSIX 規定（非インタラクティブシェルでの SIG_IGN）の説明を含む"
+      test_name: "baseline-bash-section12: AC4 mentions non-interactive shell or POSIX constraint"
+      status: RED
+      red_mechanism: "§12 未存在のため非インタラクティブ/SIG_IGN キーワード grep が失敗する"
+      impl_files:
+        - "plugins/twl/refs/baseline-bash.md"

--- a/plugins/twl/refs/baseline-bash.md
+++ b/plugins/twl/refs/baseline-bash.md
@@ -501,3 +501,47 @@ fi
 | `plugins/twl/skills/su-observer/scripts/step0-monitor-bootstrap.sh` | L18 | `SUPERVISOR_DIR`: allowlist `^[a-zA-Z0-9./_-]+$` + `*..* ` blocklist の混在 |
 
 **対応方針**: mixed 方式は allowlist で網羅できているため blocklist 部分を削除するだけで改善可能。後続 Issue で個別対応予定。
+
+## 12. bats 非インタラクティブ SIGINT 送信
+
+bats は**非インタラクティブシェル**として実行されるため、POSIX 規定により `kill -INT $pid` でバックグラウンドプロセスに SIGINT を送ると **SIG_IGN**（無視）が設定されて届かない。非インタラクティブシェルのバックグラウンドプロセスは SIGINT が SIG_IGN になる（POSIX 規定）。
+
+### BAD: 非インタラクティブ環境で kill -INT $pid を直接送信
+
+```bash
+# BAD: bats（非インタラクティブ）環境では SIGINT がバックグラウンドプロセスに届かない
+run_target &
+pid=$!
+sleep 0.1
+kill -INT "$pid"  # SIG_IGN のため無効 — プロセスが停止しない
+```
+
+### GOOD: set -m + kill -INT -$pgid でプロセスグループに送信
+
+```bash
+# GOOD: set -m でジョブ制御を有効化 → バックグラウンドプロセスが独立した process group に配置
+# kill -INT -$pgid でプロセスグループ全体に SIGINT が届く
+set -m
+trap 'set +m' RETURN  # スコープ漏れを防止
+
+run_target &
+pid=$!
+pgid=$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')
+if [[ "$pgid" =~ ^[1-9][0-9]*$ ]]; then
+    kill -INT "-$pgid" 2>/dev/null || kill -INT "$pid" 2>/dev/null || true
+else
+    kill -INT "$pid" 2>/dev/null || true
+fi
+```
+
+### ポイント
+
+| 要素 | 役割 |
+|---|---|
+| `set -m` | ジョブ制御を有効化。バックグラウンドプロセスが独立した process group に配置される |
+| `trap 'set +m' RETURN` | 関数終了時に `set -m` を解除しスコープ漏れを防止 |
+| `kill -INT -$pgid` | プロセスグループ全体に SIGINT を送信（`-$pgid` の `-` がグループ指定） |
+| `[[ "$pgid" =~ ^[1-9][0-9]*$ ]]` | pgid の数値検証（allowlist regex）。空文字 `kill -INT ""` による事故を防止 |
+| `|| kill -INT "$pid"` | pgid 送信失敗時の fallback（プロセス個別送信） |
+
+**レビュー観点**: bats テスト内でバックグラウンドプロセスに `kill -INT "$pid"` を送信している箇所を見つけた場合、`set -m` が有効かつ `kill -INT "-$pgid"` 形式（プロセスグループ指定）が使われているかを確認する。非インタラクティブ環境での SIGINT 未到達は MEDIUM（confidence ≥ 80）として報告する。

--- a/plugins/twl/tests/bats/baseline-bash-section12.bats
+++ b/plugins/twl/tests/bats/baseline-bash-section12.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# baseline-bash-section12.bats - Verify Issue #1451: baseline-bash.md に
+# ## 12. bats 非インタラクティブ SIGINT 送信 セクションが追加されていること
+# RED: §12 はまだ存在しないため全テストが FAIL する
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  TESTS_DIR="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${TESTS_DIR}/.." && pwd)"
+  BASELINE="${REPO_ROOT}/refs/baseline-bash.md"
+  export REPO_ROOT BASELINE
+}
+
+# ===========================================================================
+# AC1: ## 12. bats 非インタラクティブ SIGINT 送信 セクションが §11 の直後に存在する
+# ===========================================================================
+
+@test "baseline-bash-section12: AC1 section '## 12.' exists" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 12\.' "${BASELINE}"
+}
+
+@test "baseline-bash-section12: AC1 section heading includes 'SIGINT'" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 12\..*SIGINT' "${BASELINE}"
+}
+
+@test "baseline-bash-section12: AC1 section heading includes 'bats'" {
+  [ -f "${BASELINE}" ]
+  grep -qE '^## 12\..*bats' "${BASELINE}"
+}
+
+@test "baseline-bash-section12: AC1 §12 appears after §11 in file" {
+  [ -f "${BASELINE}" ]
+  local line_11 line_12
+  line_11=$(grep -n '^## 11\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_11}" ]
+  [ -n "${line_12}" ]
+  [ "${line_12}" -gt "${line_11}" ]
+}
+
+# ===========================================================================
+# AC2: §12 は推奨パターンの核心要素を含む
+# - set -m (job control) の説明
+# - kill -INT -$pgid (プロセスグループ指定) のパターン
+# - trap 'set +m' RETURN によるスコープ漏れ防止
+# - pgid 数値検証による空文字 kill 事故防止
+# ===========================================================================
+
+@test "baseline-bash-section12: AC2 mentions 'set -m'" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qF 'set -m'
+}
+
+@test "baseline-bash-section12: AC2 mentions 'kill -INT' with process group" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE 'kill -INT.*-\$pgid|kill.*-INT.*pgid'
+}
+
+@test "baseline-bash-section12: AC2 mentions 'trap' for set +m cleanup" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE "trap.*set \+m|trap.*RETURN"
+}
+
+@test "baseline-bash-section12: AC2 includes pgid numeric validation" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE '\^\[1-9\]\[0-9\]\*\$|pgid.*=~.*\^.*\[0-9\]'
+}
+
+# ===========================================================================
+# AC3: §12 は BAD/GOOD ブロック構造を持つ（既存セクションのパターンに準拠）
+# ===========================================================================
+
+@test "baseline-bash-section12: AC3 has BAD block for kill -INT without process group" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE '^### BAD:|^#### BAD'
+}
+
+@test "baseline-bash-section12: AC3 has GOOD block with recommended pattern" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE '^### GOOD:|^#### GOOD'
+}
+
+# ===========================================================================
+# AC4: §12 はトリガー条件（POSIX 規定）の説明を含む
+# bats 非インタラクティブシェルでは SIGINT が SIG_IGN になる原因
+# ===========================================================================
+
+@test "baseline-bash-section12: AC4 mentions non-interactive shell or POSIX constraint" {
+  [ -f "${BASELINE}" ]
+  local line_12
+  line_12=$(grep -n '^## 12\.' "${BASELINE}" | head -1 | cut -d: -f1)
+  [ -n "${line_12}" ]
+  tail -n +"${line_12}" "${BASELINE}" | grep -qE '非インタラクティブ|non-interactive|SIG_IGN|POSIX'
+}


### PR DESCRIPTION
## 概要

Issue #1451 対応。bats 非インタラクティブ環境での SIGINT 送信パターンを `refs/baseline-bash.md` §12 として規約化。

## 変更内容

### `plugins/twl/refs/baseline-bash.md`
- §12「bats 非インタラクティブ SIGINT 送信」セクションを追加
  - POSIX 規定（非インタラクティブシェルのバックグラウンドプロセスは SIG_IGN）の説明
  - BAD: `kill -INT $pid` 直接送信（届かない）
  - GOOD: `set -m` + `trap 'set +m' RETURN` + `kill -INT -$pgid`（プロセスグループ）
  - pgid 数値検証 `[[ "$pgid" =~ ^[1-9][0-9]*$ ]]` で空文字 kill 事故防止
  - レビュー観点を追記（MEDIUM / confidence ≥ 80）

### `plugins/twl/tests/bats/baseline-bash-section12.bats`（新規）
- 11テスト（全件 GREEN 確認済み）
  - AC1: §12 セクション存在確認（見出し・順序）
  - AC2: 推奨パターン要素の網羅確認（set -m, kill -INT -pgid, trap, pgid 数値検証）
  - AC3: BAD/GOOD ブロック構造
  - AC4: POSIX 規定・非インタラクティブ説明の存在

### `ac-test-mapping.yaml`
- Issue #1451 エントリを追記

## 検証

```
bats plugins/twl/tests/bats/baseline-bash-section12.bats
1..11
ok 1..11 （全件 GREEN）
```

## 関連

- Issue: #1451
- 検出 PR: #1450
- 対象 specialist: worker-code-reviewer

Closes #1451
