### PR TITLE
feat(observer): #1457 IDLE_COMPLETED_PHRASE_REGEX に idle 待機 phrase 追加と timeout fallback 実装

### DIFF
--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -490,6 +490,10 @@ LAST_HB_TS=0
 # [IDLE-COMPLETED] 状態管理 — メインループスコープで宣言 (AC-5, Issue #1117)
 # evaluate_window() は stateless 設計を維持するため、連想配列はここで管理する
 declare -A IDLE_COMPLETED_TS
+# #1457: timeout-based fallback — phrase 非マッチでも IDLE_COMPLETED_TIMEOUT_SEC 秒経過後に auto-kill
+# IDLE_COMPLETED_TIMEOUT_SEC=0 (default) で無効化。env var で override 可能
+IDLE_COMPLETED_TIMEOUT_SEC="${IDLE_COMPLETED_TIMEOUT_SEC:-0}"
+declare -A IDLE_TIMEOUT_FIRST_ACTIVE_TS
 
 # _check_idle_completed() の SSOT を source する
 # BASH_SOURCE[0] = plugins/session/scripts/cld-observe-any → ../twl/ = plugins/twl/
@@ -622,6 +626,25 @@ while true; do
                    [[ -z "$_idle_thinking" ]] && \
                    echo "$PANE_CONTENT" | grep -qE "${IDLE_COMPLETED_PHRASE_REGEX:-nothing pending}"; then
                     IDLE_COMPLETED_TS[$WIN]=$NOW
+                fi
+                # #1457 Approach B: timeout-based fallback — phrase 非マッチでも TIMEOUT_SEC 経過で auto-kill
+                if [[ "${IDLE_COMPLETED_TIMEOUT_SEC:-0}" -gt 0 ]] && \
+                   [[ -n "$PANE_CONTENT" ]] && \
+                   [[ -z "$_idle_thinking" ]]; then
+                    if [[ "${IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]:-0}" -eq 0 ]]; then
+                        IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]=$NOW
+                    elif (( NOW - IDLE_TIMEOUT_FIRST_ACTIVE_TS[WIN] >= IDLE_COMPLETED_TIMEOUT_SEC )); then
+                        echo "[IDLE-COMPLETED] $WIN: timeout-based auto-kill (IDLE_COMPLETED_TIMEOUT_SEC=${IDLE_COMPLETED_TIMEOUT_SEC}s)"
+                        if [[ "${IDLE_COMPLETED_AUTO_KILL:-0}" == "1" ]]; then
+                            SAFE_WIN="${WIN//[^a-zA-Z0-9_-]/_}"
+                            KILL_TARGET=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null \
+                                | awk -v n="$WIN" '$2 == n { print $1; exit }')
+                            if [[ -n "$KILL_TARGET" ]] && tmux kill-window -t "$KILL_TARGET" 2>/dev/null; then
+                                echo "[IDLE-COMPLETED] $WIN: killed (timeout=${IDLE_COMPLETED_TIMEOUT_SEC}s)"
+                                unset 'IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]'
+                            fi
+                        fi
+                    fi
                 fi
             fi
         done

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -633,15 +633,16 @@ while true; do
                    [[ -z "$_idle_thinking" ]]; then
                     if [[ "${IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]:-0}" -eq 0 ]]; then
                         IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]=$NOW
-                    elif (( NOW - IDLE_TIMEOUT_FIRST_ACTIVE_TS[WIN] >= IDLE_COMPLETED_TIMEOUT_SEC )); then
+                    elif (( NOW - IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN] >= IDLE_COMPLETED_TIMEOUT_SEC )); then
                         echo "[IDLE-COMPLETED] $WIN: timeout-based auto-kill (IDLE_COMPLETED_TIMEOUT_SEC=${IDLE_COMPLETED_TIMEOUT_SEC}s)"
+                        # タイムスタンプリセット: AUTO_KILL 有無に関わらず次サイクル spam を防止
+                        unset 'IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]'
                         if [[ "${IDLE_COMPLETED_AUTO_KILL:-0}" == "1" ]]; then
                             SAFE_WIN="${WIN//[^a-zA-Z0-9_-]/_}"
                             KILL_TARGET=$(tmux list-windows -a -F '#{session_name}:#{window_index} #{window_name}' 2>/dev/null \
                                 | awk -v n="$WIN" '$2 == n { print $1; exit }')
                             if [[ -n "$KILL_TARGET" ]] && tmux kill-window -t "$KILL_TARGET" 2>/dev/null; then
                                 echo "[IDLE-COMPLETED] $WIN: killed (timeout=${IDLE_COMPLETED_TIMEOUT_SEC}s)"
-                                unset 'IDLE_TIMEOUT_FIRST_ACTIVE_TS[$WIN]'
                             fi
                         fi
                     fi

--- a/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md
@@ -69,6 +69,21 @@ Wave 文脈 / 並列タスク境界: Wave <N>、並列 <M> Issue 中 <K> 番目
 
 **例外**: `--force-large` を spawn-controller.sh に渡し、prompt 冒頭に `REASON:` 行で正当化することで 30 行超を許容できる。
 
+## Wave 完遂時の出力規約（#1457）
+
+Pilot (co-autopilot) は Wave 完了時に以下の形式で必ず出力すること（MUST）。これにより `cld-observe-any` の `IDLE_COMPLETED_PHRASE_REGEX` が確実に検知し auto-kill が発火する。
+
+```text
+>>> Wave N 完遂: <完了内容の要約>
+```
+
+例:
+```text
+>>> Wave 51 完遂: PR #1234, #1235 マージ完了。次の指示をお待ちします。
+```
+
+**注意**: この形式なしに「observer の次の指示を待機」「次の Wave 指示まで休止」等の自然言語表現だけで完了を示すと、`IDLE_COMPLETED_PHRASE_REGEX` が一致しない場合に auto-kill が不発火になる（Issue #1457 pitfall）。`>>> Wave N 完遂:` は machine-readable な completion marker として使うこと。
+
 ## Worker 起動時の auto mode 確認方針
 
 Worker pane に `⏵⏵ auto mode on` が出ない場合でも auto mode は有効である（`refs/pitfalls-catalog.md` §4.7-4.8 参照）。確認方法 A（heartbeat ファイル存在確認）/ 確認方法 B（pane capture grep）の詳細は同 §4.7-4.8 を参照。

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -11,7 +11,7 @@
 
 # COMPLETION_PHRASE_REGEX — SSOT (AC-1)
 # 行単位 grep -qE で機能する。A2+A3+A4 の他条件 AND により false positive を抑制。
-readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|Wave [0-9]+ co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=)'
+readonly IDLE_COMPLETED_PHRASE_REGEX='(refined ラベル付与|Status=Refined|nothing pending|recap: Goal|>>> 実装完了|Phase 4 完了|merge-gate.*成功|spec-review marker cleanup|explore-summary saved|\.explore/[0-9]+/summary\.md|次のステップ:|co-autopilot complete|Wave [0-9]+ co-autopilot complete|hand control back to su-observer|observer 側で次の|Step [0-9]+ 完了処理|orchestrator --summary（done=|observer.*(待機|休止|介入を待)|次の.*Wave.*(指示|まで)|Wave [0-9]+.*完(遂|了)|これ以上.*(処理|追加).*不要)'
 
 # IDLE_COMPLETED_DEBOUNCE_SEC — デフォルト 60s、env var で override 可能 (AC-2)
 IDLE_COMPLETED_DEBOUNCE_SEC="${IDLE_COMPLETED_DEBOUNCE_SEC:-60}"

--- a/plugins/twl/tests/bats/ac-test-mapping-1457.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1457.yaml
@@ -1,0 +1,77 @@
+mappings:
+  - ac_index: 1
+    ac_text: "上記 4 件 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加され、bats test で match 確認"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains 'observer.*(待機|休止|介入を待)' pattern"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 1
+    ac_text: "上記 4 件 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加され、bats test で match 確認 (次の Wave)"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains '次の.*Wave.*(指示|まで)' pattern"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 1
+    ac_text: "上記 4 件 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加され、bats test で match 確認 (Wave 完遂)"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX matches 'Wave 50 完遂確認' phrase"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 1
+    ac_text: "上記 4 件 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加され、bats test で match 確認 (これ以上)"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains 'これ以上.*(処理|追加).*不要' pattern"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 1
+    ac_text: "上記 4 件 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加され、bats test で match 確認 (behavioral)"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac1(#1457): _check_idle_completed detects 'observer の次の指示を待機'"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 2
+    ac_text: "timeout-based fallback (Approach B) 実装、IDLE_COMPLETED_TIMEOUT_SEC env で制御"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac2(#1457): cld-observe-any references IDLE_COMPLETED_TIMEOUT_SEC env var"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: 2
+    ac_text: "timeout-based fallback (Approach B) 実装、IDLE_COMPLETED_TIMEOUT_SEC default 0"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac2(#1457): IDLE_COMPLETED_TIMEOUT_SEC default is 0 (disabled)"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"
+
+  - ac_index: 3
+    ac_text: "spawn prompt 規約 (Approach C) を spawn-controller-playbook.md に追加"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac3(#1457): su-observer-controller-spawn-playbook.md contains Wave completion output convention"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/su-observer-controller-spawn-playbook.md"
+
+  - ac_index: 4
+    ac_text: "Wave 完遂シナリオ再現テスト: regex match → kill"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac4(#1457): scenario — regex match phrase 検出 → _check_idle_completed returns 0 after debounce"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 4
+    ac_text: "Wave 完遂シナリオ再現テスト: 通常 thinking → kill しない (regression)"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac4(#1457): scenario — LLM thinking indicator あり → _check_idle_completed returns 1 (no kill)"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+  - ac_index: 4
+    ac_text: "Wave 完遂シナリオ再現テスト: phrase なし + timeout → kill"
+    test_file: "plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats"
+    test_name: "ac4(#1457): scenario — IDLE_COMPLETED_TIMEOUT_SEC=1800 で phrase なし + 経過 → auto-kill パス存在"
+    impl_files:
+      - "plugins/session/scripts/cld-observe-any"

--- a/plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats
+++ b/plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats
@@ -1,0 +1,246 @@
+#!/usr/bin/env bats
+# issue-1457-idle-phrase-extend.bats — Issue #1457 TDD RED フェーズ
+#
+# tech-debt(cld-observe-any): IDLE_COMPLETED_PHRASE_REGEX が idle 待機 phrase に未対応で AUTO_KILL 不発火
+#
+# AC coverage:
+#   AC1 — 4件 idle 待機 phrase を IDLE_COMPLETED_PHRASE_REGEX に追加 + bats match 確認
+#   AC2 — timeout-based fallback: IDLE_COMPLETED_TIMEOUT_SEC env で制御
+#   AC3 — spawn prompt 規約を su-observer-controller-spawn-playbook.md に追加
+#   AC4 — Wave 完遂シナリオ再現テスト (regex match / timeout / thinking の 3 ケース)
+#
+# 全テストは実装前（RED）状態で fail する。実装後に GREEN になる。
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${this_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  OBSERVER_LIB="${REPO_ROOT}/skills/su-observer/scripts/lib/observer-idle-check.sh"
+  CLD_OBSERVE_ANY="${REPO_ROOT}/../session/scripts/cld-observe-any"
+  SPAWN_PLAYBOOK="${REPO_ROOT}/skills/su-observer/refs/su-observer-controller-spawn-playbook.md"
+
+  export OBSERVER_LIB CLD_OBSERVE_ANY SPAWN_PLAYBOOK
+
+  TMPDIR_TEST="$(mktemp -d)"
+  export TMPDIR_TEST
+}
+
+teardown() {
+  rm -rf "${TMPDIR_TEST}"
+}
+
+# ===========================================================================
+# AC1: 4件 idle 待機 phrase が IDLE_COMPLETED_PHRASE_REGEX に追加される
+# ===========================================================================
+
+@test "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains 'observer.*(待機|休止|介入を待)' pattern" {
+  # AC: "observer の次の指示を待機" 等の phrase を catch するパターンが追加される
+  # RED: 現在の regex にこのパターンがないため fail
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    echo \"\${IDLE_COMPLETED_PHRASE_REGEX}\" | grep -qE 'observer.*(待機|休止|介入を待)'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains '次の.*Wave.*(指示|まで)' pattern" {
+  # AC: "次の Wave 指示まで休止" 等の phrase を catch するパターンが追加される
+  # RED: 現在の regex にこのパターンがないため fail
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    echo \"\${IDLE_COMPLETED_PHRASE_REGEX}\" | grep -qE '次の.*Wave.*(指示|まで)'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX matches 'Wave 50 完遂確認' phrase" {
+  # AC: "Wave 50 完遂確認" 等の phrase を catch するパターンが追加される
+  # RED: 現在の regex にこのパターンがないため fail
+  # NOTE: "Wave [0-9]+ co-autopilot complete" は既存。"Wave N 完遂/完了" が未追加
+  # NOTE: 構造テスト（regex文字列自体をgrep）は .* が | を跨いで false positive を生じる
+  #       ため、サンプルフレーズで動作確認する
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    echo 'Wave 50 完遂確認' | grep -qE \"\${IDLE_COMPLETED_PHRASE_REGEX}\"
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): IDLE_COMPLETED_PHRASE_REGEX contains 'これ以上.*(処理|追加).*不要' pattern" {
+  # AC: "これ以上の処理は不要" 等の phrase を catch するパターンが追加される
+  # RED: 現在の regex にこのパターンがないため fail
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    echo \"\${IDLE_COMPLETED_PHRASE_REGEX}\" | grep -qE 'これ以上.*(処理|追加).*不要'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): _check_idle_completed detects 'observer の次の指示を待機'" {
+  # AC: 実際に Pilot が出す "observer の次の指示を待機" フレーズで idle と判定される
+  # 出典: Wave 51 closing (doobidoo 926469a2)
+  # RED: IDLE_COMPLETED_PHRASE_REGEX にパターンがないため return 1
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='Wave 51 の実装が完了しました。
+observer の次の指示を待機しています。
+> '
+    _check_idle_completed \"\${pane_content}\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): _check_idle_completed detects '次の Wave 指示まで休止'" {
+  # AC: "次の Wave 指示まで休止" フレーズで idle と判定される
+  # 出典: Wave 50 closing (doobidoo dfc653b8)
+  # RED: IDLE_COMPLETED_PHRASE_REGEX にパターンがないため return 1
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='全 Issue のマージが完了しました。
+次の Wave 指示まで休止します。
+> '
+    _check_idle_completed \"\${pane_content}\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): _check_idle_completed detects 'Wave 50 完遂確認'" {
+  # AC: "Wave 50 完遂確認" フレーズで idle と判定される
+  # RED: IDLE_COMPLETED_PHRASE_REGEX にパターンがないため return 1
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='Wave 50 完遂確認 / Pilot session は idle 状態で待機
+> '
+    _check_idle_completed \"\${pane_content}\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac1(#1457): _check_idle_completed detects 'observer の介入を待機'" {
+  # AC: "observer の介入を待機" フレーズで idle と判定される
+  # RED: IDLE_COMPLETED_PHRASE_REGEX にパターンがないため return 1
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane_content='全タスクが完了しました。observer の介入を待機しています。
+> '
+    _check_idle_completed \"\${pane_content}\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC2: timeout-based fallback — IDLE_COMPLETED_TIMEOUT_SEC env で制御
+# ===========================================================================
+
+@test "ac2(#1457): cld-observe-any references IDLE_COMPLETED_TIMEOUT_SEC env var" {
+  # AC: cld-observe-any に IDLE_COMPLETED_TIMEOUT_SEC による timeout 判定が追加される
+  # RED: 現在 IDLE_COMPLETED_TIMEOUT_SEC が cld-observe-any に存在しないため fail
+  [ -f "${CLD_OBSERVE_ANY}" ]
+  run grep -qE 'IDLE_COMPLETED_TIMEOUT_SEC' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2(#1457): IDLE_COMPLETED_TIMEOUT_SEC default is 0 (disabled)" {
+  # AC: デフォルト値 0 = 無効化（既存動作に影響しない）
+  # RED: 変数が実装されていないため fail
+  [ -f "${CLD_OBSERVE_ANY}" ]
+  run grep -qE 'IDLE_COMPLETED_TIMEOUT_SEC.*:-.*0|IDLE_COMPLETED_TIMEOUT_SEC.*=.*0' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac2(#1457): observer-idle-check.sh or cld-observe-any handles timeout-based kill path" {
+  # AC: phrase regex 非マッチ状態で IDLE_COMPLETED_TIMEOUT_SEC 秒経過後に auto-kill が発火する
+  # RED: timeout パスが実装されていないため fail
+  run bash -c "
+    grep -qE 'IDLE_COMPLETED_TIMEOUT_SEC' '${CLD_OBSERVE_ANY}' && \
+    grep -qE 'TIMEOUT|timeout.*kill|timeout.*auto.kill|TIMEOUT.*SEC' '${CLD_OBSERVE_ANY}'
+  "
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC3: spawn prompt 規約を su-observer-controller-spawn-playbook.md に追加
+# ===========================================================================
+
+@test "ac3(#1457): su-observer-controller-spawn-playbook.md contains Wave completion output convention" {
+  # AC: spawn prompt 規約として「Wave完了時は >>> Wave N 完遂: を必ず出力する」が追加される
+  # RED: 現在 playbook にこの規約が存在しないため fail
+  [ -f "${SPAWN_PLAYBOOK}" ]
+  run grep -qE '>>> Wave|Wave.*完遂.*出力|完遂.*MUST|Wave.*完遂.*必須' "${SPAWN_PLAYBOOK}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac3(#1457): spawn-playbook Wave convention includes literal '>>> Wave N 完遂:' example" {
+  # AC: spawn prompt 規約に実際の出力例 ">>> Wave N 完遂:" が記載される
+  # RED: 現在記載がないため fail
+  [ -f "${SPAWN_PLAYBOOK}" ]
+  run grep -qF '>>> Wave' "${SPAWN_PLAYBOOK}"
+  [ "${status}" -eq 0 ]
+}
+
+# ===========================================================================
+# AC4: Wave 完遂シナリオ再現テスト
+# ===========================================================================
+
+@test "ac4(#1457): scenario — regex match phrase 検出 → _check_idle_completed returns 0 after debounce" {
+  # AC: 新 phrase "observer の次の指示を待機" を含む pane で debounce 経過後に 0 を返す
+  # RED: 現在の regex にパターンがないため return 1
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane='Wave 51 の全 PR がマージされました。
+observer の次の指示を待機中
+> '
+    # debounce 経過シミュレーション (first_seen=100, now=161, debounce=60)
+    _check_idle_completed \"\$pane\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4(#1457): scenario — LLM thinking indicator あり → _check_idle_completed returns 1 (no kill)" {
+  # AC: LLM が思考中（Brewing/Thinking）の場合は idle 判定しない
+  # GREEN: この挙動は既実装（_check_idle_completed C3 条件）。regression として保全
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane='Brewing for 2m 30s · max effort
+Wave 51 の次の指示を待機しています。'
+    # first_seen=100, now=161: debounce 経過済みだが Brewing あり
+    _check_idle_completed \"\$pane\" 100 161
+  "
+  [ "${status}" -ne 0 ]
+}
+
+@test "ac4(#1457): scenario — IDLE_COMPLETED_TIMEOUT_SEC=1800 で phrase なし + 経過 → auto-kill パス存在" {
+  # AC: phrase regex 非マッチかつ IDLE_COMPLETED_TIMEOUT_SEC 秒経過でも auto-kill が発火する
+  # RED: IDLE_COMPLETED_TIMEOUT_SEC が cld-observe-any に実装されていないため fail
+  [ -f "${CLD_OBSERVE_ANY}" ]
+  run grep -qE 'IDLE_COMPLETED_TIMEOUT_SEC' "${CLD_OBSERVE_ANY}"
+  [ "${status}" -eq 0 ]
+}
+
+@test "ac4(#1457): scenario — 通常 phrase 'nothing pending' は引き続き match する (regression)" {
+  # AC: 既存の regex パターンが新 phrase 追加後も動作することを確認
+  # GREEN: 既実装のパターンが壊れていないことを確認する regression テスト
+  [ -f "${OBSERVER_LIB}" ]
+  run bash -c "
+    source '${OBSERVER_LIB}'
+    pane='Tasks completed.
+nothing pending
+> '
+    _check_idle_completed \"\$pane\" 100 161
+  "
+  [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
## 概要

Issue #1457 の修正。Pilot が Wave 完遂後に「observer 待機」系フレーズを出した場合に `IDLE_COMPLETED_AUTO_KILL` が不発火になる問題を解消。

## 変更内容

### AC1: IDLE_COMPLETED_PHRASE_REGEX に 4件の idle 待機 phrase を追加
- `observer.*(待機|休止|介入を待)`: "observer の次の指示を待機" 等
- `次の.*Wave.*(指示|まで)`: "次の Wave 指示まで休止" 等  
- `Wave [0-9]+.*完(遂|了)`: "Wave 50 完遂確認" 等
- `これ以上.*(処理|追加).*不要`: "これ以上の処理は不要" 等

### AC2: timeout-based fallback (Approach B)
- `IDLE_COMPLETED_TIMEOUT_SEC` env var 追加（default 0 = 無効）
- phrase 非マッチかつ TIMEOUT_SEC 経過後に `IDLE_COMPLETED_AUTO_KILL=1` で auto-kill

### AC3: spawn prompt 規約 (Approach C)
- `su-observer-controller-spawn-playbook.md` に Wave 完遂時の出力規約を追加
- Pilot は `>>> Wave N 完遂:` を必ず出力する

## テスト

`plugins/twl/tests/bats/issue-1457-idle-phrase-extend.bats`: 17/17 PASS

## 関連
- Closes #1457