### PR TITLE
fix(#1476): merge-gate RED-only PR 検出 + issue-create-refined.sh 実装

### DIFF
--- a/plugins/twl/commands/merge-gate.md
+++ b/plugins/twl/commands/merge-gate.md
@@ -21,6 +21,16 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/merge-gate-check-pr.sh"
 
 PR が存在しない場合は即座に REJECT。Supervisor / Pilot が PR を作成（`intervene-auto --pattern pr-create`）してから再実行すること。
 
+### RED-only PR 検出（MUST — PR 存在確認の直後に実行）
+
+変更ファイルがテストファイルのみで実装ファイルを含まない "RED-only PR" を検出して REJECT する（Issue #1476）。
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/merge-gate-check-red-only.sh"
+```
+
+テストファイルのみの PR は AC が GREEN になる前に merge されるリスクがある。動的レビュアー構築より先に実行すること。
+
 ### 動的レビュアー構築
 
 ```bash

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2026,6 +2026,7 @@ commands:
       step: "8"
     calls:
       - script: merge-gate-check-pr
+      - script: merge-gate-check-red-only
       - script: merge-gate-build-manifest
       - script: merge-gate-check-spawn
       - script: merge-gate-checkpoint-merge
@@ -2882,6 +2883,16 @@ scripts:
     type: script
     path: scripts/merge-gate-check-pr.sh
     description: "PR 存在確認（merge-gate）: PR が存在しない場合は REJECT checkpoint を書き込んで exit 1"
+
+  merge-gate-check-red-only:
+    type: script
+    path: scripts/merge-gate-check-red-only.sh
+    description: "RED-only PR 検出（merge-gate）: PR diff がテストファイルのみで実装ファイルなしの場合に REJECT して exit 1（Issue #1476）"
+
+  issue-create-refined:
+    type: script
+    path: scripts/issue-create-refined.sh
+    description: "Issue 起票 + Status=Refined 自動遷移（Issue #1469）: gh issue create 後に board-status-update Refined を呼び出す"
 
   merge-gate-build-manifest:
     type: script

--- a/plugins/twl/scripts/issue-create-refined.sh
+++ b/plugins/twl/scripts/issue-create-refined.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# issue-create-refined.sh - Issue 起票 + Status=Refined 自動遷移
+#
+# gh issue create を呼び出した後 Project Board Status を Refined に設定する。
+# Issue #1469: bug Issue 起票後 Status=Todo のまま autopilot gate で reject される問題の修正。
+#
+# 引数:
+#   --title <title>    Issue タイトル
+#   --body <body>      Issue 本文
+#   --label <label>    ラベル（複数可、繰り返し）
+#   --repo <owner/repo> 対象リポジトリ
+#   --dry-run          実際の gh 呼び出しをスキップして終了コード 0 を返す
+
+set -euo pipefail
+
+TITLE=""
+BODY=""
+LABELS=()
+REPO=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --title)   TITLE="$2"; shift 2 ;;
+    --body)    BODY="$2"; shift 2 ;;
+    --label)   LABELS+=("$2"); shift 2 ;;
+    --repo)    REPO="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *)         shift ;;
+  esac
+done
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  exit 0
+fi
+
+# Issue 起票
+ISSUE_ARGS=(issue create)
+[[ -n "$TITLE" ]] && ISSUE_ARGS+=(--title "$TITLE")
+[[ -n "$BODY" ]]  && ISSUE_ARGS+=(--body "$BODY")
+for lbl in "${LABELS[@]:-}"; do
+  [[ -n "${lbl:-}" ]] && ISSUE_ARGS+=(--label "$lbl")
+done
+[[ -n "$REPO" ]]  && ISSUE_ARGS+=(--repo "$REPO")
+
+ISSUE_NUMBER=$(gh "${ISSUE_ARGS[@]}")
+
+# Status=Refined に遷移
+SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined

--- a/plugins/twl/scripts/issue-create-refined.sh
+++ b/plugins/twl/scripts/issue-create-refined.sh
@@ -42,6 +42,7 @@ for lbl in "${LABELS[@]:-}"; do
   [[ -n "${lbl:-}" ]] && ISSUE_ARGS+=(--label "$lbl")
 done
 [[ -n "$REPO" ]]  && ISSUE_ARGS+=(--repo "$REPO")
+ISSUE_ARGS+=(--json number -q .number)
 
 ISSUE_NUMBER=$(gh "${ISSUE_ARGS[@]}")
 

--- a/plugins/twl/scripts/issue-create-refined.sh
+++ b/plugins/twl/scripts/issue-create-refined.sh
@@ -45,6 +45,12 @@ done
 
 ISSUE_NUMBER=$(gh "${ISSUE_ARGS[@]}")
 
+# ISSUE_NUMBER は正の整数のみ許可（chain-runner.sh と同一規約）
+if [[ ! "$ISSUE_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+  echo "ERROR: gh issue create returned unexpected output: ${ISSUE_NUMBER}" >&2
+  exit 1
+fi
+
 # Status=Refined に遷移
 SCRIPTS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 bash "${SCRIPTS_ROOT}/chain-runner.sh" board-status-update "$ISSUE_NUMBER" Refined

--- a/plugins/twl/scripts/merge-gate-check-red-only.sh
+++ b/plugins/twl/scripts/merge-gate-check-red-only.sh
@@ -27,7 +27,7 @@ _is_test_file() {
   [[ "$f" == *.spec.js ]] && return 0
   [[ "$f" == */tests/* ]] && return 0
   [[ "$f" == */test/* ]] && return 0
-  [[ "$f" == ac-test-mapping*.yaml ]] && return 0
+  [[ "$f" == *ac-test-mapping*.yaml ]] && return 0
   return 1
 }
 

--- a/plugins/twl/scripts/merge-gate-check-red-only.sh
+++ b/plugins/twl/scripts/merge-gate-check-red-only.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# merge-gate-check-red-only.sh - RED-only PR 検出チェック（merge-gate Step）
+#
+# PR の変更ファイルがテストファイルのみ（実装ファイルなし）の場合を検出して REJECT する。
+# Issue #1476: PR #1470 が test のみで実装欠落のまま merge された問題の再発防止。
+#
+# 呼び出し: bash "${CLAUDE_PLUGIN_ROOT}/scripts/merge-gate-check-red-only.sh"
+
+set -euo pipefail
+
+# 変更ファイルリストを取得
+CHANGED_FILES=$(git diff --name-only origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null || true)
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  exit 0
+fi
+
+# テストファイルパターン判定
+_is_test_file() {
+  local f="$1"
+  [[ "$f" == *.bats ]] && return 0
+  [[ "$f" == *test_*.py ]] && return 0
+  [[ "$f" == *_test.py ]] && return 0
+  [[ "$f" == *.test.ts ]] && return 0
+  [[ "$f" == *.spec.ts ]] && return 0
+  [[ "$f" == *.test.js ]] && return 0
+  [[ "$f" == *.spec.js ]] && return 0
+  [[ "$f" == */tests/* ]] && return 0
+  [[ "$f" == */test/* ]] && return 0
+  [[ "$f" == ac-test-mapping*.yaml ]] && return 0
+  return 1
+}
+
+# 実装ファイルが1つでも含まれるか確認
+has_impl_file=false
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  if ! _is_test_file "$file"; then
+    has_impl_file=true
+    break
+  fi
+done <<< "$CHANGED_FILES"
+
+if [[ "$has_impl_file" == "false" ]]; then
+  echo "REJECT: RED-only PR を検出しました。変更ファイルがテストファイルのみで実装ファイルが含まれていません" >&2
+  echo "変更ファイル:" >&2
+  echo "$CHANGED_FILES" | sed 's/^/  /' >&2
+  exit 1
+fi
+
+exit 0

--- a/plugins/twl/tests/bats/scripts/ac-test-mapping-1476.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping-1476.yaml
@@ -1,0 +1,55 @@
+mappings:
+  - ac_index: 1
+    ac_text: "merge-gate specialist で \"RED-only PR\" を検出して reject (Approach 1)"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats"
+    test_names:
+      - "ac1: merge-gate-check-red-only.sh が scripts/ に存在する"
+      - "ac1: merge-gate-check-red-only.sh が実行可能である"
+      - "ac1: merge-gate-check-red-only.sh が bash 構文チェック pass"
+      - "ac1: diff がテストファイルのみの場合 REJECT メッセージを出力する"
+      - "ac1: diff がテストファイルのみの場合 exit 1 を返す"
+      - "ac1: diff に実装ファイルが含まれる場合は exit 0 を返す"
+      - "ac1: diff が実装ファイルのみ（テストなし）の場合は exit 0 を返す（テストなし自体は reject しない）"
+    impl_files:
+      - plugins/twl/scripts/merge-gate-check-red-only.sh
+    # NOTE: merge-gate-check-red-only.sh は未実装（新規作成が必要）。
+    # merge-gate-check-phase-review.sh（既存）を参考に実装する。
+
+  - ac_index: 2
+    ac_text: "bats test で diff = test only PR を simulate → reject 動作確認"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats"
+    test_names:
+      - "ac2: テストファイルのみの diff で RED-only を検出できる"
+      - "ac2: .bats ファイル群のみを含む diff で RED-only と判定される"
+      - "ac2: テスト + 実装ファイルを含む diff では RED-only と判定されない"
+    impl_files:
+      - plugins/twl/scripts/merge-gate-check-red-only.sh
+
+  - ac_index: 3
+    ac_text: "別途 follow-up Issue (#1469 fix) を起票し issue-create-refined.sh 実装 (Approach 3)"
+    test_file: ""
+    test_names: []
+    impl_files: []
+    # プロセス系 AC（Issue 起票）のため自動テスト不要。
+    # impl_files は [] — 手動起票で達成を確認する。
+
+  - ac_index: 4
+    ac_text: "PR #1470 でmerged された bats test の expected 実装が main に存在することを確認"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats"
+    test_names:
+      - "ac4: issue-create-refined.sh が scripts/ に存在する"
+      - "ac4: issue-create-refined.sh が実行可能である"
+      - "ac4: issue-create-refined.sh が bash 構文チェック pass"
+      - "ac4: issue-create-refined.sh が gh issue create と Refined 遷移を実行する"
+    impl_files:
+      - plugins/twl/scripts/issue-create-refined.sh
+    # NOTE: issue-create-refined.sh は未実装（PR #1470 で bats test のみ追加、実装欠落）。
+    # 既存 issue-create-refined.bats との共存に注意（#1469 分の RED テストが既に存在する）。
+
+  - ac_index: 5
+    ac_text: "Wave 56+ で同症状 (RED-only merge) が再発しないことを確認"
+    test_file: ""
+    test_names: []
+    impl_files: []
+    # AC1/AC2 の達成で担保されるため独立したテスト不要。
+    # impl_files は [] — AC1 の merge-gate-check-red-only.sh 実装により回帰防止される。

--- a/plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats
+++ b/plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats
@@ -303,6 +303,12 @@ teardown() {
 
   local call_log="$SANDBOX/gh_calls.log"
   stub_command "gh" "echo \"\$*\" >> '$call_log'; echo '1469'"
+  # chain-runner.sh を inline スタブに置き換え（board-status-update Refined を call_log に記録）
+  cat > "$SANDBOX/scripts/chain-runner.sh" <<EOF
+#!/usr/bin/env bash
+echo "chain: \$*" >> "${SANDBOX}/gh_calls.log" || true
+EOF
+  chmod +x "$SANDBOX/scripts/chain-runner.sh"
 
   run bash "$script" \
     --title "test bug" \

--- a/plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats
+++ b/plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats
@@ -1,0 +1,322 @@
+#!/usr/bin/env bats
+# issue-1476-red-only-merge.bats — RED-phase tests for Issue #1476
+#
+# Issue #1476: Wave 54 でmerged されたPR #1470 (closes #1469) は RED bats test のみを追加し、
+# issue-create-refined.sh の実装が完全に欠落したまま merge された。
+# merge-gate が "RED-only PR"（テストファイルのみで実装ファイルなし）を検出して reject する。
+#
+# AC coverage:
+#   AC1 - merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+#   AC2 - bats test で diff = test only PR を simulate → reject 動作確認
+#   AC4 - PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+  export CLAUDE_PLUGIN_ROOT="$SANDBOX"
+  export ISSUE_NUM="1476"
+
+  stub_command "git" '
+    case "$*" in
+      *"rev-parse --show-toplevel"*) echo "$SANDBOX" ;;
+      *"rev-parse --git-dir"*) echo ".git" ;;
+      *"branch --show-current"*) echo "feat/1476-test" ;;
+      *"diff --name-only"*)
+        # デフォルト: テストファイルのみ（RED-only PR を simulate）
+        echo "plugins/twl/tests/bats/scripts/issue-create-refined.bats"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  stub_command "gh" '
+    case "$*" in
+      *"pr view"*"--json number"*) echo "1470" ;;
+      *) exit 0 ;;
+    esac
+  '
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC1: merge-gate specialist で "RED-only PR" を検出して reject
+# ---------------------------------------------------------------------------
+
+@test "ac1: merge-gate-check-red-only.sh が scripts/ に存在する" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: 実装前は fail する（ファイル未作成）
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+}
+
+@test "ac1: merge-gate-check-red-only.sh が実行可能である" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+  [[ -x "$script" ]] || {
+    echo "FAIL: $script が実行可能でない" >&2
+    return 1
+  }
+}
+
+@test "ac1: merge-gate-check-red-only.sh が bash 構文チェック pass" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: ファイル未存在のため fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+  bash -n "$script"
+}
+
+@test "ac1: diff がテストファイルのみの場合 REJECT メッセージを出力する" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+
+  # テストファイルのみの diff を simulate
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        echo "plugins/twl/tests/bats/scripts/issue-create-refined.bats"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script" 2>&1
+
+  assert_output --partial "REJECT"
+}
+
+@test "ac1: diff がテストファイルのみの場合 exit 1 を返す" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        echo "plugins/twl/tests/bats/scripts/issue-create-refined.bats"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script"
+
+  assert_failure
+}
+
+@test "ac1: diff に実装ファイルが含まれる場合は exit 0 を返す" {
+  # AC: merge-gate specialist で "RED-only PR" を検出して reject (Approach 1)
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  # テストファイル + 実装ファイルの diff を simulate
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        echo "plugins/twl/tests/bats/scripts/issue-create-refined.bats"
+        echo "plugins/twl/scripts/issue-create-refined.sh"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script"
+
+  assert_success
+}
+
+@test "ac1: diff が実装ファイルのみ（テストなし）の場合は exit 0 を返す（テストなし自体は reject しない）" {
+  # AC: 実装ファイルのみの場合は問題なし
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        echo "plugins/twl/scripts/issue-create-refined.sh"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC2: bats test で diff = test only PR を simulate → reject 動作確認
+# ---------------------------------------------------------------------------
+
+@test "ac2: テストファイルのみの diff で RED-only を検出できる" {
+  # AC: bats test で diff = test only PR を simulate → reject 動作確認
+  # RED: 実装前は fail する（スクリプト未存在）
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない。RED-only PR 検出機能が未実装" >&2
+    return 1
+  }
+
+  # .bats ファイルのみの diff を simulate（PR #1470 相当）
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        printf "plugins/twl/tests/bats/scripts/issue-create-refined.bats\n"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script" 2>&1
+
+  assert_failure
+  assert_output --partial "REJECT"
+}
+
+@test "ac2: .bats ファイル群のみを含む diff で RED-only と判定される" {
+  # AC: bats test で diff = test only PR を simulate → reject 動作確認
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  # 複数の bats ファイルのみの diff
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        printf "plugins/twl/tests/bats/scripts/foo.bats\nplugins/twl/tests/bats/scripts/bar.bats\n"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script"
+
+  assert_failure
+}
+
+@test "ac2: テスト + 実装ファイルを含む diff では RED-only と判定されない" {
+  # AC: bats test で diff = test only PR を simulate → reject 動作確認
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/merge-gate-check-red-only.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  stub_command "git" '
+    case "$*" in
+      *"diff --name-only"*|*"diff HEAD"*)
+        printf "plugins/twl/tests/bats/scripts/issue-create-refined.bats\nplugins/twl/scripts/issue-create-refined.sh\n"
+        ;;
+      *) exit 0 ;;
+    esac
+  '
+
+  run bash "$script"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# AC4: PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+# ---------------------------------------------------------------------------
+
+@test "ac4: issue-create-refined.sh が scripts/ に存在する" {
+  # AC: PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+  # RED: issue-create-refined.sh が未実装のため fail する
+  local script="$REPO_ROOT/scripts/issue-create-refined.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない" >&2
+    echo "INFO: PR #1470 は issue-create-refined.bats を追加したが、実装 issue-create-refined.sh は merge されていない" >&2
+    return 1
+  }
+}
+
+@test "ac4: issue-create-refined.sh が実行可能である" {
+  # AC: PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+  # RED: 実装前は fail する
+  local script="$REPO_ROOT/scripts/issue-create-refined.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+  [[ -x "$script" ]] || {
+    echo "FAIL: $script が実行可能でない" >&2
+    return 1
+  }
+}
+
+@test "ac4: issue-create-refined.sh が bash 構文チェック pass" {
+  # AC: PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+  # RED: 実装前は fail する
+  local script="$REPO_ROOT/scripts/issue-create-refined.sh"
+  [[ -f "$script" ]] || {
+    echo "FAIL: $script が存在しない（未実装）" >&2
+    return 1
+  }
+  bash -n "$script"
+}
+
+@test "ac4: issue-create-refined.sh が gh issue create と Refined 遷移を実行する" {
+  # AC: PR #1470 でmerged された bats test の expected 実装が main に存在することを確認
+  # RED: 実装前は fail する
+  local script="$SANDBOX/scripts/issue-create-refined.sh"
+  [[ -f "$script" ]] || {
+    false
+    return
+  }
+
+  local call_log="$SANDBOX/gh_calls.log"
+  stub_command "gh" "echo \"\$*\" >> '$call_log'; echo '1469'"
+
+  run bash "$script" \
+    --title "test bug" \
+    --body "bug body" \
+    --label "bug" \
+    --repo "shuu5/twill"
+
+  assert_success
+  grep -q "issue create" "$call_log" || {
+    echo "FAIL: gh issue create が呼ばれていない" >&2
+    return 1
+  }
+  grep -q "Refined" "$call_log" || {
+    echo "FAIL: board-status-update Refined が呼ばれていない" >&2
+    return 1
+  }
+}


### PR DESCRIPTION
Closes #1476

## 変更概要

- merge-gate に RED-only PR 検出機能を追加（AC1/AC2）
- issue-create-refined.sh 実装追加（AC4）
- AC3: follow-up Issue 起票（#1469 fix）
- AC5: Wave 56+ 再発防止確認（AC1/AC2 達成で担保）

## RED テスト（TDD フェーズ）

現在 RED フェーズ。実装前のテスト確認済み:
- `plugins/twl/tests/bats/scripts/issue-1476-red-only-merge.bats` (14 RED tests)
- `plugins/twl/tests/bats/scripts/ac-test-mapping-1476.yaml`
