### PR TITLE
fix(#1475): detect Sonnet 4.6 auto-compaction, suppress false STAGNATE-300

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -943,3 +943,65 @@ issue_1451:
       red_mechanism: "§12 未存在のため非インタラクティブ/SIG_IGN キーワード grep が失敗する"
       impl_files:
         - "plugins/twl/refs/baseline-bash.md"
+
+- issue: 1475
+  title: "bug(cld-observe-any): Sonnet 4.6 auto-compaction 中の Worker を STAGNATE-300 として誤検知"
+  framework: bats
+  test_file: "plugins/session/tests/test_1475_compaction_detect.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "LLM_INDICATORS に Compacting/Snapshotting/Externalizing/Restoring/Summarizing を明示追加する"
+      test_names:
+        - "ac1(#1475): Compacting が llm-indicators.sh に明示登録されていること (RED)"
+        - "ac1(#1475): Snapshotting が llm-indicators.sh に明示登録されていること (RED)"
+        - "ac1(#1475): Externalizing が llm-indicators.sh に明示登録されていること (RED)"
+        - "ac1(#1475): Restoring が llm-indicators.sh に明示登録されていること (RED)"
+        - "ac1(#1475): Summarizing が llm-indicators.sh に明示登録されていること (RED)"
+        - "ac1(#1475): detect_thinking が 'Compacting' (サフィックスなし) を検知すること (RED)"
+        - "ac1(#1475): detect_thinking が 'Snapshotting' (サフィックスなし) を検知すること (RED)"
+      status: RED
+      red_mechanism: "llm-indicators.sh に compaction 系キーワードが未登録のため grep/indicator loop が失敗する"
+      impl_files:
+        - "plugins/session/scripts/lib/llm-indicators.sh"
+
+    - ac_index: 2
+      ac_text: "cld-observe-any が compaction 中 pane を検知し [COMPACTION-DETECTED] を emit する"
+      test_name: "ac2(#1475): 'Compacting…' pane で COMPACTION-DETECTED が emit されること (RED)"
+      status: RED
+      red_mechanism: "cld-observe-any に COMPACTION-DETECTED emit ロジックが存在しないため出力に含まれない"
+      impl_files:
+        - "plugins/session/scripts/cld-observe-any"
+
+    - ac_index: 3
+      ac_text: "COMPACTION-DETECTED 発火後フラグを持続し次サイクルで STAGNATE を抑止する"
+      test_names:
+        - "ac3(#1475): COMPACTION-DETECTED 発火後にフラグ持続して次サイクルで STAGNATE を抑止すること (RED)"
+        - "ac3(#1475): Compacting キーワード含む pane で detect_thinking が 'Compacting' を返すこと (RED)"
+      status: RED
+      red_mechanism: "COMPACTION_ACTIVE フラグ機構が未実装のため compaction 完了後もSTAGNATE-300が発火する"
+      impl_files:
+        - "plugins/session/scripts/cld-observe-any"
+
+    - ac_index: 4
+      ac_text: "observer-idle-check C3 が Compacting/Snapshotting (サフィックスなし) で IDLE-COMPLETED を抑制する"
+      test_names:
+        - "ac4(#1475): observer-idle-check C3 が 'Compacting' (サフィックスなし) で IDLE-COMPLETED を抑制すること (RED)"
+        - "ac4(#1475): observer-idle-check C3 が 'Snapshotting' (サフィックスなし) で IDLE-COMPLETED を抑制すること (RED)"
+      status: RED
+      red_mechanism: "llm-indicators.sh に明示登録なしのため汎用 regex がサフィックスなし単語を捕捉できずC3不発"
+      impl_files:
+        - "plugins/session/scripts/lib/llm-indicators.sh"
+        - "plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+    - ac_index: 5
+      ac_text: "compaction 状態を検知し STAGNATE false positive を防止する統合確認"
+      test_names:
+        - "ac5(#1475): cld-observe-any が compaction 状態を検知して COMPACTION-DETECTED を emit すること (RED)"
+        - "ac5(#1475): Externalizing (サフィックスなし) が detect_thinking で検知されること (RED)"
+        - "ac5(#1475): Restoring (サフィックスなし) が detect_thinking で検知されること (RED)"
+        - "ac5(#1475): Summarizing (サフィックスなし) が detect_thinking で検知されること (RED)"
+      status: RED
+      red_mechanism: "Externalizing/Restoring/Summarizing が未登録かつ COMPACTION-DETECTED 未実装"
+      impl_files:
+        - "plugins/session/scripts/lib/llm-indicators.sh"
+        - "plugins/session/scripts/cld-observe-any"

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -419,6 +419,16 @@ evaluate_window() {
         return
     fi
 
+    # [COMPACTION-DETECTED]: Sonnet 4.6 auto-compaction フェーズ検知（#1475）
+    # thinking guard 前に配置 — compaction は LLM active 状態のため即時 emit
+    local _ci
+    for _ci in Compacting Snapshotting Externalizing Restoring Summarizing; do
+        if echo "$tail15" | grep -qiE "$_ci"; then
+            emit_event "COMPACTION-DETECTED" "$win" "$_ci" "$log_age" "$state" "$budget_min"
+            return
+        fi
+    done
+
     # 以下: thinking がある場合は絶対 emit しない
     if [[ -n "$thinking" ]]; then
         return
@@ -465,7 +475,8 @@ evaluate_window() {
     fi
 
     # [STAGNATE]
-    if [[ "$log_age" -ge "$STAGNATE_SEC" ]]; then
+    # COMPACTION_ACTIVE=1: compaction 完了後の pane 静止時に誤発火を抑止（#1475）
+    if [[ "${COMPACTION_ACTIVE:-0}" != "1" ]] && [[ "$log_age" -ge "$STAGNATE_SEC" ]]; then
         emit_event "STAGNATE-${STAGNATE_SEC}" "$win" "$thinking" "$log_age" "$state" "$budget_min"
         return
     fi

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -423,8 +423,7 @@ evaluate_window() {
     # thinking guard 前に配置 — compaction は LLM active 状態のため即時 emit
     # COMPACTION_INDICATORS SSOT: lib/llm-indicators.sh 参照
     local _ci=""
-    for _ci in "${COMPACTION_INDICATORS[@]:-}"; do
-        if [[ -z "$_ci" ]]; then continue; fi
+    for _ci in "${COMPACTION_INDICATORS[@]}"; do
         if echo "$tail15" | grep -qiE "$_ci"; then
             COMPACTION_DETECTED_TS["$win"]=$(date +%s)
             emit_event "COMPACTION-DETECTED" "$win" "$_ci" "$log_age" "$state" "$budget_min"
@@ -515,7 +514,8 @@ LAST_HB_TS=0
 declare -A IDLE_COMPLETED_TS
 
 # [COMPACTION-DETECTED] 状態管理 — daemon mode でのサイクル間 STAGNATE 抑止（#1475）
-# COMPACTION-DETECTED emit 後 COMPACTION_SUPPRESS_SEC 秒間 STAGNATE を抑止する
+# IDLE_COMPLETED_TS と異なり evaluate_window() 内部で書き込む（compaction 検知がそこで発生するため）。
+# --once mode では呼び出し元が COMPACTION_ACTIVE=1 env var で引き継ぐ設計。
 declare -A COMPACTION_DETECTED_TS
 COMPACTION_SUPPRESS_SEC="${COMPACTION_SUPPRESS_SEC:-2700}"
 # #1457: timeout-based fallback — phrase 非マッチでも IDLE_COMPLETED_TIMEOUT_SEC 秒経過後に auto-kill

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -421,9 +421,12 @@ evaluate_window() {
 
     # [COMPACTION-DETECTED]: Sonnet 4.6 auto-compaction フェーズ検知（#1475）
     # thinking guard 前に配置 — compaction は LLM active 状態のため即時 emit
-    local _ci
-    for _ci in Compacting Snapshotting Externalizing Restoring Summarizing; do
+    # COMPACTION_INDICATORS SSOT: lib/llm-indicators.sh 参照
+    local _ci=""
+    for _ci in "${COMPACTION_INDICATORS[@]:-}"; do
+        if [[ -z "$_ci" ]]; then continue; fi
         if echo "$tail15" | grep -qiE "$_ci"; then
+            COMPACTION_DETECTED_TS["$win"]=$(date +%s)
             emit_event "COMPACTION-DETECTED" "$win" "$_ci" "$log_age" "$state" "$budget_min"
             return
         fi
@@ -475,8 +478,17 @@ evaluate_window() {
     fi
 
     # [STAGNATE]
-    # COMPACTION_ACTIVE=1: compaction 完了後の pane 静止時に誤発火を抑止（#1475）
-    if [[ "${COMPACTION_ACTIVE:-0}" != "1" ]] && [[ "$log_age" -ge "$STAGNATE_SEC" ]]; then
+    # 抑止条件（#1475）:
+    #   A) COMPACTION_ACTIVE=1 env var (caller が設定、--once mode での cycle 間引き継ぎ)
+    #   B) 直近 COMPACTION_SUPPRESS_SEC 以内に COMPACTION-DETECTED を emit した (daemon internal state)
+    local _compaction_suppress=0
+    if [[ "${COMPACTION_ACTIVE:-0}" == "1" ]]; then
+        _compaction_suppress=1
+    elif [[ -n "${COMPACTION_DETECTED_TS[$win]+_}" ]]; then
+        local _elapsed=$(( $(date +%s) - ${COMPACTION_DETECTED_TS[$win]} ))
+        [[ "$_elapsed" -le "${COMPACTION_SUPPRESS_SEC:-2700}" ]] && _compaction_suppress=1
+    fi
+    if [[ "$_compaction_suppress" != "1" ]] && [[ "$log_age" -ge "$STAGNATE_SEC" ]]; then
         emit_event "STAGNATE-${STAGNATE_SEC}" "$win" "$thinking" "$log_age" "$state" "$budget_min"
         return
     fi
@@ -501,6 +513,11 @@ LAST_HB_TS=0
 # [IDLE-COMPLETED] 状態管理 — メインループスコープで宣言 (AC-5, Issue #1117)
 # evaluate_window() は stateless 設計を維持するため、連想配列はここで管理する
 declare -A IDLE_COMPLETED_TS
+
+# [COMPACTION-DETECTED] 状態管理 — daemon mode でのサイクル間 STAGNATE 抑止（#1475）
+# COMPACTION-DETECTED emit 後 COMPACTION_SUPPRESS_SEC 秒間 STAGNATE を抑止する
+declare -A COMPACTION_DETECTED_TS
+COMPACTION_SUPPRESS_SEC="${COMPACTION_SUPPRESS_SEC:-2700}"
 # #1457: timeout-based fallback — phrase 非マッチでも IDLE_COMPLETED_TIMEOUT_SEC 秒経過後に auto-kill
 # IDLE_COMPLETED_TIMEOUT_SEC=0 (default) で無効化。env var で override 可能
 IDLE_COMPLETED_TIMEOUT_SEC="${IDLE_COMPLETED_TIMEOUT_SEC:-0}"

--- a/plugins/session/scripts/lib/llm-indicators.sh
+++ b/plugins/session/scripts/lib/llm-indicators.sh
@@ -40,6 +40,14 @@ LLM_INDICATORS=(
     "Churned"
     "Skedaddling"
     "Orchestrating"
+
+    # --- compaction phase indicators: Sonnet 4.6 auto-compaction (#1475) ---
+    "Compacting"
+    "Snapshotting"
+    "Externalizing"
+    "Restoring"
+    "Summarizing"
+
     "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \\([0-9])"
 
     # --- AC: EN 9 new indicators (#1454) ---

--- a/plugins/session/scripts/lib/llm-indicators.sh
+++ b/plugins/session/scripts/lib/llm-indicators.sh
@@ -11,6 +11,10 @@
 [[ -n "${_LLM_INDICATORS_LOADED:-}" ]] && return 0
 _LLM_INDICATORS_LOADED=1
 
+# COMPACTION_INDICATORS: Sonnet 4.6 auto-compaction フェーズ名（#1475 SSOT）
+# cld-observe-any の [COMPACTION-DETECTED] ループも本配列を参照する
+COMPACTION_INDICATORS=("Compacting" "Snapshotting" "Externalizing" "Restoring" "Summarizing")
+
 LLM_INDICATORS=(
     # --- existing EN indicators ---
     "Thinking"
@@ -42,11 +46,8 @@ LLM_INDICATORS=(
     "Orchestrating"
 
     # --- compaction phase indicators: Sonnet 4.6 auto-compaction (#1475) ---
-    "Compacting"
-    "Snapshotting"
-    "Externalizing"
-    "Restoring"
-    "Summarizing"
+    # SSOT: COMPACTION_INDICATORS 配列に定義し、LLM_INDICATORS は参照する
+    "${COMPACTION_INDICATORS[@]}"
 
     "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \\([0-9])"
 

--- a/plugins/session/tests/test_1475_compaction_detect.bats
+++ b/plugins/session/tests/test_1475_compaction_detect.bats
@@ -1,0 +1,392 @@
+#!/usr/bin/env bats
+# test_1475_compaction_detect.bats — Issue #1475: auto-compaction 中の誤介入防止
+# RED テスト: 実装前は fail する。実装後 GREEN になる。
+#
+# 設計注意:
+#   LLM_INDICATORS の汎用 regex "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \([0-9])"
+#   が既存するため、"Compacting…" 等は現状でも detect_thinking にマッチする。
+#   しかし、以下は現状で RED（fail）になる:
+#     - AC1: llm-indicators.sh に明示的な文字列が存在しない（grep fail）
+#     - AC2: COMPACTION-DETECTED イベントが emit されない（emit ロジック未実装）
+#   これらが実装後に GREEN になることを確認する。
+
+SCRIPT_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/../scripts" && pwd)"
+LLM_INDICATORS_LIB="$SCRIPT_DIR/lib/llm-indicators.sh"
+CLD_OBSERVE_ANY="$SCRIPT_DIR/cld-observe-any"
+export SCRIPT_DIR LLM_INDICATORS_LIB CLD_OBSERVE_ANY
+
+setup() {
+    TMPDIR_TEST="$(mktemp -d)"
+}
+
+teardown() {
+    [[ -n "${TMPDIR_TEST:-}" && -d "$TMPDIR_TEST" ]] && rm -rf "$TMPDIR_TEST"
+}
+
+# ---------------------------------------------------------------------------
+# AC1: LLM_INDICATORS に Compacting/Snapshotting/Externalizing/Restoring/Summarizing
+#       を明示的に追加する（Approach A）
+# RED: 現状これらは llm-indicators.sh に明示登録されていない → grep fail
+#
+# 重要: 汎用 regex "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \([0-9])" が既存するため
+#        detect_thinking 自体は現状でもマッチする場合があるが、
+#        明示登録なしでは以下が問題になる:
+#        - 汎用 regex は末尾に特定サフィックス (…, for N, (N) が必須
+#        - "Compacting" 単体（サフィックスなし）は検知できない
+#        - 明示登録により確実に検知できることを保証する
+# ---------------------------------------------------------------------------
+
+@test "ac1(#1475): Compacting が llm-indicators.sh に明示登録されていること (RED)" {
+    # RED: 現状 "Compacting" という文字列が llm-indicators.sh に存在しない
+    grep -q "Compacting" "$LLM_INDICATORS_LIB"
+}
+
+@test "ac1(#1475): Snapshotting が llm-indicators.sh に明示登録されていること (RED)" {
+    # RED: 現状 "Snapshotting" という文字列が llm-indicators.sh に存在しない
+    grep -q "Snapshotting" "$LLM_INDICATORS_LIB"
+}
+
+@test "ac1(#1475): Externalizing が llm-indicators.sh に明示登録されていること (RED)" {
+    # RED: 現状 "Externalizing" という文字列が llm-indicators.sh に存在しない
+    grep -q "Externalizing" "$LLM_INDICATORS_LIB"
+}
+
+@test "ac1(#1475): Restoring が llm-indicators.sh に明示登録されていること (RED)" {
+    # RED: 現状 "Restoring" という文字列が llm-indicators.sh に存在しない
+    grep -q "Restoring" "$LLM_INDICATORS_LIB"
+}
+
+@test "ac1(#1475): Summarizing が llm-indicators.sh に明示登録されていること (RED)" {
+    # RED: 現状 "Summarizing" という文字列が llm-indicators.sh に存在しない
+    grep -q "Summarizing" "$LLM_INDICATORS_LIB"
+}
+
+@test "ac1(#1475): detect_thinking が 'Compacting' (サフィックスなし) を検知すること (RED)" {
+    # RED: "Compacting" 単体は汎用 regex "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \([0-9])" に
+    #      マッチしない（サフィックス必須）
+    # 実装後: "Compacting" を明示登録 → サフィックスなしでも検知可能
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Compacting"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
+        detected="\$ind"
+        break
+    fi
+done
+[[ -n "\$detected" ]] && echo "PASS: \$detected" || { echo "FAIL: Compacting (no suffix) not detected"; exit 1; }
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac1(#1475): detect_thinking が 'Snapshotting' (サフィックスなし) を検知すること (RED)" {
+    # RED: "Snapshotting" 単体は汎用 regex にマッチしない（サフィックス必須）
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Snapshotting"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
+        detected="\$ind"
+        break
+    fi
+done
+[[ -n "\$detected" ]] && echo "PASS: \$detected" || { echo "FAIL: Snapshotting (no suffix) not detected"; exit 1; }
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC2: cld-observe-any で [COMPACTION-DETECTED] event 発火、stagnate 判定から除外
+# RED: 現状 COMPACTION-DETECTED emit ロジックが存在しない → output に含まれない
+# ---------------------------------------------------------------------------
+
+@test "ac2(#1475): 'Compacting…' pane で COMPACTION-DETECTED が emit されること (RED)" {
+    local script_dir="$SCRIPT_DIR"
+    local cld_observe_any="$CLD_OBSERVE_ANY"
+
+    # RED: 現状 cld-observe-any に COMPACTION-DETECTED emit ロジックが存在しない
+    # 実装後: "Compacting" を pane 内容から検知して [COMPACTION-DETECTED] を emit する
+    run bash <<EOF
+win="ap-test-win-1475-ac2"
+capture="Compacting…"
+export win capture
+
+tmux() {
+    case "\$1" in
+        list-windows)
+            if [[ "\${2:-}" == "-a" ]]; then
+                printf 'test-session:0 %s\n' "\$win"
+                return
+            fi
+            echo "test-session:0 \$win"
+            ;;
+        display-message)
+            echo "0 claude"
+            ;;
+        capture-pane)
+            printf '%s\n' "\$capture"
+            ;;
+        *)
+            return 0 ;;
+    esac
+}
+export -f tmux
+
+output=\$(_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$script_dir" \
+    bash "$cld_observe_any" --window "\$win" --once \
+    --complete-regex "PHASE_COMPLETE" --stagnate-sec 10 2>/dev/null)
+echo "\$output"
+echo "\$output" | grep -q "COMPACTION-DETECTED"
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC3: bats test で Worker pane に "Compacting…" 出力 → STAGNATE-300 false positive 回避を検証
+# RED テストは「汎用 regex が届かない状況」= pane 静止後（compaction 完了直後）を模倣する
+#
+# 現状の問題の本質:
+#   compaction 中の "Compacting…" 表示時 → 汎用 regex で detect → thinking 非空 → STAGNATE 抑止
+#   compaction 完了後に pane が静止 → 表示は変わらず "Compacting completed" 等が残る
+#   → log_age が伸びて STAGNATE 発火
+#
+# AC3 の RED テスト: COMPACTION-DETECTED フラグが持続して stagnate を除外するか確認
+# 現状フラグなし → pane 静止時に STAGNATE が発火する
+# ---------------------------------------------------------------------------
+
+@test "ac3(#1475): COMPACTION-DETECTED 発火後にフラグ持続して次サイクルで STAGNATE を抑止すること (RED)" {
+    local script_dir="$SCRIPT_DIR"
+    local cld_observe_any="$CLD_OBSERVE_ANY"
+
+    # RED: 現状 COMPACTION-DETECTED の状態フラグ機構が存在しない
+    # → pane に "Compacting…" が存在しなくなった後もフラグを維持して STAGNATE 抑止が必要
+    # 実装後: COMPACTION_ACTIVE フラグ or event-dir への書き込みで持続する
+    run bash <<EOF
+win="ap-test-win-1475-ac3"
+
+# pane 静止後（compaction 完了後）を模倣: pane に indicator 文字列なし
+# detect_thinking は空 → 現状は STAGNATE 発火 → RED
+capture="Claude compacted your context."
+export win capture
+
+tmux() {
+    case "\$1" in
+        list-windows)
+            if [[ "\${2:-}" == "-a" ]]; then
+                printf 'test-session:0 %s\n' "\$win"
+                return
+            fi
+            echo "test-session:0 \$win"
+            ;;
+        display-message)
+            echo "0 claude"
+            ;;
+        capture-pane)
+            printf '%s\n' "\$capture"
+            ;;
+        *)
+            return 0 ;;
+    esac
+}
+export -f tmux
+
+output=\$(_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$script_dir" \
+    COMPACTION_ACTIVE=1 \
+    bash "$cld_observe_any" --window "\$win" --once \
+    --complete-regex "PHASE_COMPLETE" --stagnate-sec 10 2>/dev/null)
+echo "\$output"
+# 実装後: COMPACTION_ACTIVE フラグで STAGNATE 抑止 → STAGNATE-10 が emit されない
+if echo "\$output" | grep -q "STAGNATE-10"; then
+    echo "FAIL: STAGNATE-10 was emitted despite COMPACTION_ACTIVE=1"
+    exit 1
+fi
+echo "PASS: STAGNATE-10 not emitted when COMPACTION_ACTIVE=1"
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac3(#1475): Compacting キーワード含む pane で detect_thinking が 'Compacting' を返すこと (RED)" {
+    # RED: 汎用 regex は "Compacting…" や "Compacting for 3m" にはマッチするが
+    #      grep -q "Compacting" での明示確認が必要
+    # このテストは AC1 の補強: detect_thinking の返値が "Compacting" (明示 indicator) であること
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Compacting for 9m 19s · max effort"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "^\${ind}\$" 2>/dev/null; then
+        # 完全一致（行全体）で detect
+        detected="\$ind"
+        break
+    fi
+done
+# 汎用 regex ではなく明示登録の "Compacting" だけにマッチすることを確認
+if [[ "\$detected" == "Compacting" ]]; then
+    echo "PASS: detected by explicit 'Compacting' entry"
+else
+    echo "FAIL: Compacting not detected by explicit entry (detected='\$detected')"
+    exit 1
+fi
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC4: observer の log_age stagnate 判定でも同様の exclude が効くことを確認
+# observer-idle-check.sh C3 が Compacting/Snapshotting を明示的に検知して
+# _check_idle_completed を return 1 させること
+# RED: 明示登録なし → 一部のフォーマットで C3 が機能しない
+# ---------------------------------------------------------------------------
+
+@test "ac4(#1475): observer-idle-check C3 が 'Compacting' (サフィックスなし) で IDLE-COMPLETED を抑制すること (RED)" {
+    local script_dir="$SCRIPT_DIR"
+    local idle_check_lib
+    idle_check_lib="$script_dir/../../twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+    # RED: "Compacting" 単体は汎用 regex にマッチしない → C3 が機能しない
+    # 実装後: "Compacting" を明示登録 → C3 → return 1 → IDLE-COMPLETED 抑制
+    run bash <<EOF
+source "$idle_check_lib"
+
+# C2 を通過させるための完了フレーズ + Compacting（サフィックスなし）
+pane_content="\$(printf "Wave 56 co-autopilot complete\nCompacting")"
+first_seen_ts=\$(( \$(date +%s) - 120 ))
+now_ts=\$(date +%s)
+
+if _check_idle_completed "\$pane_content" "\$first_seen_ts" "\$now_ts" 60; then
+    echo "FAIL: IDLE-COMPLETED triggered despite Compacting (no suffix) in pane"
+    exit 1
+else
+    echo "PASS: Compacting (no suffix) suppressed IDLE-COMPLETED"
+fi
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac4(#1475): observer-idle-check C3 が 'Snapshotting' (サフィックスなし) で IDLE-COMPLETED を抑制すること (RED)" {
+    local script_dir="$SCRIPT_DIR"
+    local idle_check_lib
+    idle_check_lib="$script_dir/../../twl/skills/su-observer/scripts/lib/observer-idle-check.sh"
+
+    # RED: "Snapshotting" 単体は汎用 regex にマッチしない → C3 が機能しない
+    run bash <<EOF
+source "$idle_check_lib"
+
+pane_content="\$(printf "Wave 56 co-autopilot complete\nSnapshotting")"
+first_seen_ts=\$(( \$(date +%s) - 120 ))
+now_ts=\$(date +%s)
+
+if _check_idle_completed "\$pane_content" "\$first_seen_ts" "\$now_ts" 60; then
+    echo "FAIL: IDLE-COMPLETED triggered despite Snapshotting (no suffix) in pane"
+    exit 1
+else
+    echo "PASS: Snapshotting (no suffix) suppressed IDLE-COMPLETED"
+fi
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC5: Wave 56+ で Worker auto-compaction 中の誤介入が発生しないことを確認
+# AC1+AC2 組み合わせ統合確認
+# RED: COMPACTION-DETECTED イベントが実装されていない
+# ---------------------------------------------------------------------------
+
+@test "ac5(#1475): cld-observe-any が compaction 状態を検知して COMPACTION-DETECTED を emit すること (RED)" {
+    local script_dir="$SCRIPT_DIR"
+    local cld_observe_any="$CLD_OBSERVE_ANY"
+
+    # RED: COMPACTION-DETECTED emit ロジック未実装
+    # 実装後: Compacting/Snapshotting/Externalizing/Restoring/Summarizing のいずれかを
+    #         pane で検知した場合に [COMPACTION-DETECTED] を emit する
+    run bash <<EOF
+win="ap-test-win-1475-ac5"
+capture="Snapshotting…"
+export win capture
+
+tmux() {
+    case "\$1" in
+        list-windows)
+            if [[ "\${2:-}" == "-a" ]]; then
+                printf 'test-session:0 %s\n' "\$win"
+                return
+            fi
+            echo "test-session:0 \$win"
+            ;;
+        display-message)
+            echo "0 claude"
+            ;;
+        capture-pane)
+            printf '%s\n' "\$capture"
+            ;;
+        *)
+            return 0 ;;
+    esac
+}
+export -f tmux
+
+output=\$(_TEST_MODE=1 CLD_OBSERVE_ANY_SCRIPT_DIR="$script_dir" \
+    bash "$cld_observe_any" --window "\$win" --once \
+    --complete-regex "PHASE_COMPLETE" --stagnate-sec 10 2>/dev/null)
+echo "\$output"
+# 実装後: COMPACTION-DETECTED が含まれること
+echo "\$output" | grep -q "COMPACTION-DETECTED"
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac5(#1475): Externalizing (サフィックスなし) が detect_thinking で検知されること (RED)" {
+    # RED: "Externalizing" 単体は汎用 regex にマッチしない
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Externalizing"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
+        detected="\$ind"
+        break
+    fi
+done
+[[ -n "\$detected" ]] && echo "PASS: \$detected" \
+    || { echo "FAIL: Externalizing (no suffix) not detected"; exit 1; }
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac5(#1475): Restoring (サフィックスなし) が detect_thinking で検知されること (RED)" {
+    # RED: "Restoring" 単体は汎用 regex にマッチしない
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Restoring"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
+        detected="\$ind"
+        break
+    fi
+done
+[[ -n "\$detected" ]] && echo "PASS: \$detected" \
+    || { echo "FAIL: Restoring (no suffix) not detected"; exit 1; }
+EOF
+    [[ "$status" -eq 0 ]]
+}
+
+@test "ac5(#1475): Summarizing (サフィックスなし) が detect_thinking で検知されること (RED)" {
+    # RED: "Summarizing" 単体は汎用 regex にマッチしない
+    run bash <<EOF
+source "$LLM_INDICATORS_LIB"
+pane_text="Summarizing"
+detected=""
+for ind in "\${LLM_INDICATORS[@]}"; do
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
+        detected="\$ind"
+        break
+    fi
+done
+[[ -n "\$detected" ]] && echo "PASS: \$detected" \
+    || { echo "FAIL: Summarizing (no suffix) not detected"; exit 1; }
+EOF
+    [[ "$status" -eq 0 ]]
+}

--- a/plugins/session/tests/test_1475_compaction_detect.bats
+++ b/plugins/session/tests/test_1475_compaction_detect.bats
@@ -208,21 +208,21 @@ EOF
 }
 
 @test "ac3(#1475): Compacting キーワード含む pane で detect_thinking が 'Compacting' を返すこと (RED)" {
-    # RED: 汎用 regex は "Compacting…" や "Compacting for 3m" にはマッチするが
-    #      grep -q "Compacting" での明示確認が必要
-    # このテストは AC1 の補強: detect_thinking の返値が "Compacting" (明示 indicator) であること
+    # detect_thinking は grep -qiE で部分マッチ（アンカーなし）。
+    # "Compacting" 明示登録が generic regex より先に並ぶため、
+    # "Compacting for 9m 19s · max effort" を与えると "Compacting" が最初にマッチする。
+    # → 返値が "Compacting" であることを確認。
     run bash <<EOF
 source "$LLM_INDICATORS_LIB"
 pane_text="Compacting for 9m 19s · max effort"
 detected=""
 for ind in "\${LLM_INDICATORS[@]}"; do
-    if echo "\$pane_text" | grep -qiE "^\${ind}\$" 2>/dev/null; then
-        # 完全一致（行全体）で detect
+    if echo "\$pane_text" | grep -qiE "\$ind" 2>/dev/null; then
         detected="\$ind"
         break
     fi
 done
-# 汎用 regex ではなく明示登録の "Compacting" だけにマッチすることを確認
+# 明示登録 "Compacting" が generic regex より先に反応することを確認
 if [[ "\$detected" == "Compacting" ]]; then
     echo "PASS: detected by explicit 'Compacting' entry"
 else


### PR DESCRIPTION
## 概要

Sonnet 4.6 auto-compaction（コンテキスト78%超で発動）中の Worker pane が10-30分静止し、`cld-observe-any` が誤って STAGNATE-300 を emit する問題を修正。

## 変更点

### AC1: `llm-indicators.sh` に compaction phase キーワードを追加
- Compacting, Snapshotting, Externalizing, Restoring, Summarizing
- 汎用 regex より先に配置し、サフィックスなし形式も検知可能に

### AC2: `cld-observe-any` に `[COMPACTION-DETECTED]` event を追加
- thinking guard より前でチェック（compaction は LLM active 状態）
- 呼び出し元が COMPACTION_ACTIVE フラグを設定するための signal

### AC3: `COMPACTION_ACTIVE=1` env var で STAGNATE 抑止
- COMPACTION-DETECTED 発火後、呼び出し元が設定するフラグを参照
- compaction 完了後の pane 静止時の誤 STAGNATE-300 を防止

### AC4: observer-idle-check C3 対応
- AC1 の明示登録により、サフィックスなし compaction キーワードでも C3 が機能

## テスト

`plugins/session/tests/test_1475_compaction_detect.bats` 16/16 GREEN

Closes #1475