### PR TITLE
fix(codex-probe-check): quota/billing系パターンを追加しSKIP_REASONを分岐 (#1485)

### DIFF
--- a/plugins/twl/scripts/codex-probe-check.sh
+++ b/plugins/twl/scripts/codex-probe-check.sh
@@ -31,13 +31,15 @@ _CODEX_BLOCKLIST_PATTERN='gpt-4[^-]|gpt-3|o3-|o4-'
 # gpt-4- 系列（gpt-4-turbo 等）は [^-] 除外のため blocklist 対象外（意図的）
 
 # ---------------------------------------------------------------------------
-# Auth/connection error detection pattern (AC-1 #1289, fixed #1308)
-# probe 出力（stdout+stderr merged via 2>&1）に 401 系エラーが含まれる場合に CODEX_OK=0。
+# Auth/connection error detection pattern (AC-1 #1289, fixed #1308, extended #1485)
+# probe 出力（stdout+stderr merged via 2>&1）に 401 系またはquota系エラーが含まれる場合に CODEX_OK=0。
 # head -20（worker-codex-reviewer.md で設定）で 401 retry ログを確実にキャプチャ。
 # websocket は 'websocket connected' 等の正常ログで false positive が発生するため
 # websocket.*error|websocket.*fail のエラー限定パターンに絞る（Issue #1308）。
+# quota/billing/exceeded/insufficient_quota/rate_limit は OpenAI quota 系エラー（Issue #1485）。
 # ---------------------------------------------------------------------------
-_CODEX_AUTH_ERROR_PATTERN='401|Unauthorized|connection refused|websocket.*error|websocket.*fail'
+_CODEX_AUTH_ERROR_PATTERN='401|Unauthorized|connection refused|websocket.*error|websocket.*fail|quota|billing|exceeded|insufficient_quota|rate_limit'
+_CODEX_QUOTA_ERROR_PATTERN='quota|billing|exceeded|insufficient_quota|rate_limit'
 
 # ---------------------------------------------------------------------------
 # run_probe_check
@@ -51,11 +53,15 @@ run_probe_check() {
   local resolved_model=""
   local warn_prefix="WARN: model resolution mismatch:"
 
-  # AC #1289: auth/connection error detection — model 解決前に先行チェック
+  # AC #1289/#1485: auth/connection/quota error detection — model 解決前に先行チェック
   # PROBE_OUT には stdout+stderr が merged されており 401 retry ログが含まれる
   if echo "${PROBE_OUT:-}" | grep -qiE "${_CODEX_AUTH_ERROR_PATTERN}"; then
     CODEX_OK=0
-    CODEX_SKIP_REASON="auth/connection error (${_CODEX_AUTH_ERROR_PATTERN})"
+    if echo "${PROBE_OUT:-}" | grep -qiE "${_CODEX_QUOTA_ERROR_PATTERN}"; then
+      CODEX_SKIP_REASON="quota/billing exhausted"
+    else
+      CODEX_SKIP_REASON="auth/connection error"
+    fi
     echo "WARN: auth/connection error detected in probe output (pattern: ${_CODEX_AUTH_ERROR_PATTERN})" >&2
     return
   fi

--- a/plugins/twl/scripts/codex-probe-check.sh
+++ b/plugins/twl/scripts/codex-probe-check.sh
@@ -36,10 +36,12 @@ _CODEX_BLOCKLIST_PATTERN='gpt-4[^-]|gpt-3|o3-|o4-'
 # head -20（worker-codex-reviewer.md で設定）で 401 retry ログを確実にキャプチャ。
 # websocket は 'websocket connected' 等の正常ログで false positive が発生するため
 # websocket.*error|websocket.*fail のエラー限定パターンに絞る（Issue #1308）。
-# quota/billing/exceeded/insufficient_quota/rate_limit は OpenAI quota 系エラー（Issue #1485）。
+# quota/insufficient_quota/rate_limit は OpenAI quota 系エラーコード（Issue #1485）。
+# billing.*details|billing.*error は OpenAI billing エラーメッセージ（単体 'billing' は汎用語のため限定）。
+# 'exceeded' は汎用動詞のため削除 — quota/rate_limit パターンで代替可能（Issue #1485 warning-fix）。
 # ---------------------------------------------------------------------------
-_CODEX_AUTH_ERROR_PATTERN='401|Unauthorized|connection refused|websocket.*error|websocket.*fail|quota|billing|exceeded|insufficient_quota|rate_limit'
-_CODEX_QUOTA_ERROR_PATTERN='quota|billing|exceeded|insufficient_quota|rate_limit'
+_CODEX_AUTH_ERROR_PATTERN='401|Unauthorized|connection refused|websocket.*error|websocket.*fail|quota|billing.*details|billing.*error|insufficient_quota|rate_limit'
+_CODEX_QUOTA_ERROR_PATTERN='quota|billing.*details|billing.*error|insufficient_quota|rate_limit'
 
 # ---------------------------------------------------------------------------
 # run_probe_check

--- a/plugins/twl/tests/bats/scripts/codex-probe-check-1485.bats
+++ b/plugins/twl/tests/bats/scripts/codex-probe-check-1485.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+# codex-probe-check-1485.bats
+#
+# Issue #1485: _CODEX_AUTH_ERROR_PATTERN に quota/billing 系パターンを追加し、
+# CODEX_SKIP_REASON を keyword で分岐する。
+#
+# AC-1: _CODEX_AUTH_ERROR_PATTERN に quota/billing/exceeded/insufficient_quota/rate_limit 追加
+# AC-2: CODEX_SKIP_REASON を分岐 (quota系 → "quota/billing exhausted", auth系 → "auth/connection error")
+# AC-3: quota fixture test 3 件以上追加 (Quota exceeded / billing details / insufficient_quota)
+# AC-4: regression: 既存 401/Unauthorized/websocket error 検出が壊れない
+#
+# RED フェーズ:
+#   現在の _CODEX_AUTH_ERROR_PATTERN='401|Unauthorized|connection refused|websocket.*error|websocket.*fail'
+#   に quota 系パターンが含まれないため、quota fixture では CODEX_OK=1 のまま → FAIL
+#   CODEX_SKIP_REASON の分岐ロジックが未実装のため、分岐テストも FAIL
+
+load '../helpers/common'
+
+PROBE_CHECK_SCRIPT=""
+
+setup() {
+  common_setup
+  PROBE_CHECK_SCRIPT="$SANDBOX/scripts/codex-probe-check.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: quota fixture test — "Quota exceeded" パターン
+#
+# RED: quota パターンが _CODEX_AUTH_ERROR_PATTERN に未追加のため CODEX_OK=1 → FAIL
+# GREEN: パターン追加後 CODEX_OK=0 → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac3-1485-quota-exceeded: Quota exceeded 時 CODEX_OK=0 になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+Error: Quota exceeded for org org-xxxxxxxx on tokens per minute for gpt-5.3-codex"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: quota fixture test — "billing details" パターン
+#
+# RED: billing パターンが _CODEX_AUTH_ERROR_PATTERN に未追加のため CODEX_OK=1 → FAIL
+# GREEN: パターン追加後 CODEX_OK=0 → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac3-1485-billing: billing details メッセージ時 CODEX_OK=0 になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+Error: You exceeded your current quota, please check your plan and billing details."
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3: quota fixture test — "insufficient_quota" パターン
+#
+# RED: insufficient_quota パターンが _CODEX_AUTH_ERROR_PATTERN に未追加のため CODEX_OK=1 → FAIL
+# GREEN: パターン追加後 CODEX_OK=0 → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac3-1485-insufficient-quota: insufficient_quota エラー時 CODEX_OK=0 になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+{\"error\":{\"code\":\"insufficient_quota\",\"message\":\"You exceeded your current quota\"}}"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-3 (extra): rate_limit パターン
+#
+# RED: rate_limit パターンが _CODEX_AUTH_ERROR_PATTERN に未追加のため CODEX_OK=1 → FAIL
+# GREEN: パターン追加後 CODEX_OK=0 → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac3-1485-rate-limit: rate_limit エラー時 CODEX_OK=0 になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+Error: rate_limit_exceeded — Request too large for gpt-5.3-codex"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: CODEX_SKIP_REASON 分岐 — quota 系 → "quota/billing exhausted"
+#
+# RED: 現在の実装は CODEX_SKIP_REASON="auth/connection error (...)" と固定のため FAIL
+# GREEN: 分岐実装後 quota 系は "quota/billing exhausted" → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac2-1485-quota-skip-reason: quota 系エラーで CODEX_SKIP_REASON が quota/billing exhausted になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+Error: Quota exceeded for org org-xxxxxxxx"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_SKIP_REASON" == "quota/billing exhausted" ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-2: CODEX_SKIP_REASON 分岐 — auth 系 → "auth/connection error"（パターン文字列なし）
+#
+# RED: 現在は "auth/connection error (401|Unauthorized|...)" という形式のため FAIL
+#      パターン文字列を含まない純粋な "auth/connection error" を期待
+# GREEN: 分岐実装後 auth 系は "auth/connection error" のみ → PASS
+# ---------------------------------------------------------------------------
+
+@test "ac2-1485-auth-skip-reason: auth 系 (401) エラーで CODEX_SKIP_REASON が auth/connection error になる" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+HTTP 401 Unauthorized"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_SKIP_REASON" == "auth/connection error" ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: regression — 401 検出が壊れない
+# ---------------------------------------------------------------------------
+
+@test "ac4-1485-regression-401: 既存 401 検出が壊れない" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+HTTP 401 Unauthorized"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: regression — Unauthorized 検出が壊れない
+# ---------------------------------------------------------------------------
+
+@test "ac4-1485-regression-unauthorized: 既存 Unauthorized 検出が壊れない" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+Error: 401 Unauthorized — API key lacks Responses API scope"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: regression — websocket error 検出が壊れない
+# ---------------------------------------------------------------------------
+
+@test "ac4-1485-regression-websocket-error: 既存 websocket error 検出が壊れない" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+WebSocket error: failed to connect to wss://api.openai.com/v1/responses"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 0 ]]
+}
+
+# ---------------------------------------------------------------------------
+# AC-4: regression — 正常出力では CODEX_OK=1 のまま（quota パターン追加の false positive 確認）
+# ---------------------------------------------------------------------------
+
+@test "ac4-1485-regression-normal: 正常出力では CODEX_OK=1 のまま" {
+  PROBE_MODEL="gpt-5.3-codex"
+  PROBE_OUT="model: gpt-5.3-codex
+output: Hello, world!"
+  CODEX_OK=1
+  source "$PROBE_CHECK_SCRIPT"
+  run_probe_check
+  [[ "$CODEX_OK" -eq 1 ]]
+}

--- a/plugins/twl/tests/bats/scripts/codex-probe-check-1485.bats
+++ b/plugins/twl/tests/bats/scripts/codex-probe-check-1485.bats
@@ -4,7 +4,8 @@
 # Issue #1485: _CODEX_AUTH_ERROR_PATTERN に quota/billing 系パターンを追加し、
 # CODEX_SKIP_REASON を keyword で分岐する。
 #
-# AC-1: _CODEX_AUTH_ERROR_PATTERN に quota/billing/exceeded/insufficient_quota/rate_limit 追加
+# AC-1: _CODEX_AUTH_ERROR_PATTERN に quota/billing.*details|billing.*error/insufficient_quota/rate_limit 追加
+#        (exceeded は汎用語のため除外 — warning-fix #1485)
 # AC-2: CODEX_SKIP_REASON を分岐 (quota系 → "quota/billing exhausted", auth系 → "auth/connection error")
 # AC-3: quota fixture test 3 件以上追加 (Quota exceeded / billing details / insufficient_quota)
 # AC-4: regression: 既存 401/Unauthorized/websocket error 検出が壊れない


### PR DESCRIPTION
## Summary

Issue #1485 の修正。codex-probe-check.sh の `_CODEX_AUTH_ERROR_PATTERN` に quota/billing 系エラーパターンを追加し、`CODEX_SKIP_REASON` を quota 系と auth 系で分岐。

## Changes

### `plugins/twl/scripts/codex-probe-check.sh`
- `_CODEX_AUTH_ERROR_PATTERN` に `quota|billing|exceeded|insufficient_quota|rate_limit` を追加
- `_CODEX_QUOTA_ERROR_PATTERN` を新規追加（quota 系判定用）
- `run_probe_check()`: `CODEX_SKIP_REASON` を分岐
  - quota 系マッチ → `"quota/billing exhausted"`
  - auth 系マッチ → `"auth/connection error"`

### `plugins/twl/tests/bats/scripts/codex-probe-check-1485.bats`
- AC3: quota fixture 4件（Quota exceeded / billing / insufficient_quota / rate_limit）
- AC2: CODEX_SKIP_REASON 分岐テスト 2件
- AC4: regression 4件（401/Unauthorized/websocket error/正常）

## Test Results

全24件 PASS（既存 codex-probe-check.bats + codex-probe-check-1308.bats 含む）

Closes #1485