### PR TITLE
fix(#1495): autopilot-orchestrator resume safety + cleanup_worker PR open check (Wave 57 incident)

### DIFF
--- a/plugins/twl/scripts/autopilot-orchestrator.sh
+++ b/plugins/twl/scripts/autopilot-orchestrator.sh
@@ -183,6 +183,21 @@ get_phase_issues() {
   fi
 }
 
+# bare_root_dir を解決する (#1495 fix)
+# bare repo worktree mode では main/.git がファイルで、worktrees/ は main の親 (= bare_root) 直下にある。
+# PROJECT_DIR ($effective_project_dir) は main/ を指すため、worktrees/ 検索には親ディレクトリが必要。
+# Python 側 (cli/twl/src/twl/autopilot/worktree.py:_resolve_git_common_dir) と同等のパス解決ロジック。
+_resolve_bare_root_dir() {
+  local _project_dir="$1"
+  if [[ -f "$_project_dir/.git" ]]; then
+    # bare repo worktree mode: main/.git is a file → parent is bare_root
+    dirname "$_project_dir"
+  else
+    # standalone repo or non-worktree mode
+    echo "$_project_dir"
+  fi
+}
+
 # Worker の tmux window 名を解決する
 # autopilot-launch.sh が state に保存した window 名を優先し、未設定時はレガシーパターンにフォールバック
 resolve_worker_window() {
@@ -250,6 +265,25 @@ filter_active_issues() {
       continue
     fi
 
+    # #1495 fix: status=running/merge-ready で worktree が bare_root/worktrees/ に存在する場合は
+    # resume と判定して spawn skip (orchestrator crash → resume シナリオの safety guard)
+    if [[ "$status" == "running" || "$status" == "merge-ready" ]]; then
+      local _ff_branch
+      _ff_branch=$(python3 -m twl.autopilot.state read --type issue --issue "$ISSUE" --field branch 2>/dev/null || echo "")
+      if [[ -n "$_ff_branch" && "$_ff_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
+        local _ff_effective_dir="$PROJECT_DIR"
+        if [[ -n "${ISSUE_REPO_PATH:-}" ]]; then
+          _ff_effective_dir="$ISSUE_REPO_PATH"
+        fi
+        local _ff_bare_root
+        _ff_bare_root=$(_resolve_bare_root_dir "$_ff_effective_dir")
+        if [[ -d "$_ff_bare_root/worktrees/$_ff_branch" ]]; then
+          echo "[orchestrator] Issue #${ISSUE}: skip (status=${status}, worktree active in bare_root: ${_ff_bare_root}/worktrees/${_ff_branch})" >&2
+          continue
+        fi
+      fi
+    fi
+
     if bash "$SCRIPTS_ROOT/autopilot-should-skip.sh" "$PLAN_FILE" "$ISSUE" 2>/dev/null; then
       echo "[orchestrator] Issue #${ISSUE}: skip (dependency failed)" >&2
       python3 -m twl.autopilot.state write --type issue --issue "$ISSUE" --role pilot \
@@ -284,13 +318,17 @@ launch_worker() {
   local -a _repo_args=()
   [[ "$ISSUE_REPO_ID" != "_default" ]] && _repo_args=(--repo "$ISSUE_REPO_ID")
 
+  # #1495 fix: bare_root_dir を解決 (worktree mode の main の親ディレクトリ = bare_root)
+  local _bare_root_dir
+  _bare_root_dir=$(_resolve_bare_root_dir "$effective_project_dir")
+
   # ADR-018 SSOT: 既存 Worker 検出時の重複起動防止ガード（status=running/merge-ready）
   local existing_status
   existing_status=$(python3 -m twl.autopilot.state read --type issue "${_repo_args[@]}" --issue "$ISSUE" --field status 2>/dev/null || echo "")
   if [[ "$existing_status" == "running" || "$existing_status" == "merge-ready" ]]; then
     local existing_branch_for_skip
     existing_branch_for_skip=$(python3 -m twl.autopilot.state read --type issue "${_repo_args[@]}" --issue "$ISSUE" --field branch 2>/dev/null || echo "")
-    local skip_candidate_dir="$effective_project_dir/worktrees/$existing_branch_for_skip"
+    local skip_candidate_dir="$_bare_root_dir/worktrees/$existing_branch_for_skip"
     if [[ -n "$existing_branch_for_skip" && "$existing_branch_for_skip" =~ ^[a-zA-Z0-9_/\-]+$ && -d "$skip_candidate_dir" ]]; then
       # spawn skip: window 不在 → crash-detect.sh に委譲（failure フィールド保持、直接書き込み禁止）
       local spawn_skip_window
@@ -312,8 +350,9 @@ launch_worker() {
   local existing_branch
   existing_branch=$(python3 -m twl.autopilot.state read --type issue "${_repo_args[@]}" --issue "$ISSUE" --field branch 2>/dev/null || echo "")
   # ブランチ名バリデーション: `.` 除外の統一 regex（L288/L418/L1270 + autopilot-cleanup.sh L186 + orchestrator-cleanup-sequence.bats test double）
+  # #1495 fix: bare_root_dir/worktrees/ で検索 (PROJECT_DIR は main を指すため worktrees/ を検出できなかった bug)
   if [[ -n "$existing_branch" && "$existing_branch" =~ ^[a-zA-Z0-9_/\-]+$ ]]; then
-    local candidate_dir="$effective_project_dir/worktrees/$existing_branch"
+    local candidate_dir="$_bare_root_dir/worktrees/$existing_branch"
     if [[ -d "$candidate_dir" ]]; then
       worktree_dir="$candidate_dir"
       echo "[orchestrator] Issue #${ISSUE}: 既存 worktree を使用: $worktree_dir" >&2
@@ -457,10 +496,18 @@ cleanup_worker() {
       $_wt_ok || echo "[orchestrator] Issue #${issue}: ⚠️ worktree削除失敗（クリーンアップは続行）: ${_wt_del_out}" >&2
     fi
 
-    # Step 3: リモートブランチ削除（クロスリポ対応）
+    # Step 3: リモートブランチ削除（クロスリポ対応）+ #1495 fix: PR open check
     resolve_issue_repo_context "$entry"
-    # ISSUE_REPO_PATH パストラバーサル防止: 絶対パスかつ ".." を含まないことを確認
-    if [[ -n "$ISSUE_REPO_PATH" && "$ISSUE_REPO_PATH" == /* && "$ISSUE_REPO_PATH" != *..* ]]; then
+    # #1495 fix: open PR があるブランチは削除しない (autopilot-cleanup.sh:283-299 と同一パターン)
+    local _cw_pr_count=0
+    if command -v gh &>/dev/null; then
+      _cw_pr_count=$(gh pr list --head "$branch" --state open --json number --jq 'length' 2>/dev/null || echo "0")
+      _cw_pr_count=$(echo "$_cw_pr_count" | tr -cd '0-9')
+    fi
+    if [[ "${_cw_pr_count:-0}" -gt 0 ]]; then
+      echo "[orchestrator] Issue #${issue}: WARN: open PR あり — リモートブランチ削除スキップ: ${branch} (PR count=${_cw_pr_count})" >&2
+    elif [[ -n "$ISSUE_REPO_PATH" && "$ISSUE_REPO_PATH" == /* && "$ISSUE_REPO_PATH" != *..* ]]; then
+      # ISSUE_REPO_PATH パストラバーサル防止: 絶対パスかつ ".." を含まないことを確認
       git -C "$ISSUE_REPO_PATH" push origin --delete "$branch" 2>/dev/null || true
     else
       git push origin --delete "$branch" 2>/dev/null || true

--- a/plugins/twl/tests/bats/scripts/orchestrator-cleanup-pr-check.bats
+++ b/plugins/twl/tests/bats/scripts/orchestrator-cleanup-pr-check.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# orchestrator-cleanup-pr-check.bats — Issue #1495
+#
+# Spec: cleanup_worker が `git push origin --delete <branch>` を実行する前に
+#       `gh pr list --head <branch> --state open` で open PR を check し、
+#       open PR がある場合はリモートブランチ削除を skip する。
+#       これにより、orchestrator が status=failed で cleanup を実行しても、
+#       open PR の head ref を保護する (Wave 57 incident 再発防止)。
+#
+# Coverage:
+#   AC3-a: open PR が存在する場合は git push origin --delete が呼ばれない
+#   AC3-b: open PR が存在しない場合 (count=0) はリモートブランチ削除実行
+#   AC3-c: gh CLI が unavailable な場合は安全側 (default _cw_pr_count=0、削除は実行)
+#          ただし PR check 不可の場合はリモート削除がそのまま実行される (regression: cleanup-sequence と同等)
+#
+# §9 heredoc チェック: heredoc 内で外部変数を参照しない。
+# §10 source guard チェック: orchestrator.sh は source guard を持たない。直接 source 禁止。
+
+load '../helpers/common'
+
+ORCHESTRATOR_SH=""
+
+setup() {
+  common_setup
+  ORCHESTRATOR_SH="${REPO_ROOT}/scripts/autopilot-orchestrator.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC3-a/b: 静的 grep — cleanup_worker 内の PR check 実装
+# ---------------------------------------------------------------------------
+
+@test "AC3-a: cleanup_worker 内に gh pr list による open PR check が存在する (静的 grep)" {
+  # 静的検証: cleanup_worker 関数内に `gh pr list --head` がある
+  run grep -E 'gh pr list --head .*--state open' "$ORCHESTRATOR_SH"
+  assert_success
+  assert_output --partial 'gh pr list --head'
+  assert_output --partial '--state open'
+}
+
+@test "AC3-b: cleanup_worker 内で _cw_pr_count > 0 のとき WARN ログを出力 (静的 grep)" {
+  # 静的検証: 「open PR あり — リモートブランチ削除スキップ」のメッセージが存在
+  run grep -E 'open PR あり.*リモートブランチ削除スキップ' "$ORCHESTRATOR_SH"
+  assert_success
+  assert_output --partial 'open PR あり'
+}
+
+@test "AC3-c: cleanup_worker 内で gh unavailable 時の fallback ロジック (command -v gh)" {
+  # 静的検証: `command -v gh` で gh の存在を check してから pr list を呼ぶ
+  # (cleanup_worker 内、autopilot-cleanup.sh:289 と同一パターン)
+  run grep -E 'command -v gh' "$ORCHESTRATOR_SH"
+  assert_success
+}
+
+@test "AC3-d: cleanup_worker の PR check が `git push origin --delete` の前に位置する (静的順序)" {
+  # cleanup_worker 関数の `Step 3` セクション内で、PR check が delete より前にあることを確認
+  # awk で関数内を抽出し、`gh pr list` が `git push origin --delete` より先に出現することを検証
+  run bash -c "
+    awk '/^cleanup_worker\\(\\)/,/^}/' '$ORCHESTRATOR_SH' | grep -nE 'gh pr list|git push origin --delete' | head -2
+  "
+  assert_success
+  # 1 行目は gh pr list、2 行目は git push origin --delete のはず
+  assert_output --partial 'gh pr list'
+  assert_output --partial 'git push origin --delete'
+
+  # 順序検証: gh pr list の行番号 < git push origin --delete の行番号
+  run bash -c "
+    awk '/^cleanup_worker\\(\\)/,/^}/' '$ORCHESTRATOR_SH' | grep -nE 'gh pr list|git push origin --delete' | awk -F: '{print \$1, \$2}' | head -2
+  "
+  # 期待: 先頭が gh pr list、続いて git push
+  [[ "${lines[0]}" == *'gh pr list'* ]] || {
+    echo "Expected first match to be 'gh pr list', got: ${lines[0]}"
+    return 1
+  }
+}
+
+# ---------------------------------------------------------------------------
+# AC3 sentinel: 修正前の脆弱な path が完全に置換されていること
+# ---------------------------------------------------------------------------
+
+@test "AC3-sentinel: cleanup_worker 内の git push origin --delete に PR check 前置きがある" {
+  # 静的検証: cleanup_worker 関数内の git push origin --delete が条件分岐内 (elif/else)
+  # にあること = 直前に PR check がある
+  # `if [[ "${_cw_pr_count:-0}" -gt 0 ]]` 分岐があれば OK
+  run grep -E '_cw_pr_count.*-gt 0' "$ORCHESTRATOR_SH"
+  assert_success
+}
+
+@test "AC3-sentinel: #1495 fix のコメントが存在する" {
+  # 静的検証: 修正コミットのトレーサビリティ
+  run grep -E '#1495 fix.*PR open check' "$ORCHESTRATOR_SH"
+  assert_success
+}

--- a/plugins/twl/tests/bats/scripts/orchestrator-resume-worktree.bats
+++ b/plugins/twl/tests/bats/scripts/orchestrator-resume-worktree.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+# orchestrator-resume-worktree.bats — Issue #1495
+#
+# Spec: orchestrator が exit 144 等で異常終了 → resume mode で再起動した際、
+#       既存 worktree (bare_root/worktrees/) を「resume」として正しく認識し、
+#       status=running/merge-ready を上書きせず Worker spawn を skip する。
+#
+# Coverage:
+#   AC1: launch_worker の bare_root_dir 解決 helper `_resolve_bare_root_dir` が main/.git ファイル
+#        worktree mode を検出し、親ディレクトリ (= bare_root) を返す
+#   AC2: filter_active_issues で status=running + worktree existing in bare_root → ACTIVE_ENTRIES から除外
+#
+# §9 heredoc チェック: heredoc 内で外部変数を参照しない。
+# §10 source guard チェック: orchestrator.sh は source guard を持たない。直接 source 禁止。
+
+load '../helpers/common'
+
+ORCHESTRATOR_SH=""
+
+setup() {
+  common_setup
+  ORCHESTRATOR_SH="${REPO_ROOT}/scripts/autopilot-orchestrator.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# AC1: _resolve_bare_root_dir helper の動作検証
+# ---------------------------------------------------------------------------
+
+@test "AC1-a: _resolve_bare_root_dir が main/.git ファイル worktree mode で親ディレクトリを返す" {
+  # Given: bare repo worktree 構造
+  mkdir -p "$SANDBOX/twill-test/main"
+  mkdir -p "$SANDBOX/twill-test/.bare"
+  echo "gitdir: $SANDBOX/twill-test/.bare" > "$SANDBOX/twill-test/main/.git"
+
+  # When: helper を呼ぶ (bash 関数を抽出して直接 source)
+  run bash -c "source <(grep -A 9 '^_resolve_bare_root_dir()' '$ORCHESTRATOR_SH'); _resolve_bare_root_dir '$SANDBOX/twill-test/main'"
+
+  # Then: 親ディレクトリ (bare_root) が返る
+  assert_success
+  assert_output "$SANDBOX/twill-test"
+}
+
+@test "AC1-b: _resolve_bare_root_dir が standalone repo (.git ディレクトリ) で同ディレクトリを返す" {
+  # Given: standalone repo (.git はディレクトリ)
+  mkdir -p "$SANDBOX/standalone/.git"
+
+  # When
+  run bash -c "source <(grep -A 9 '^_resolve_bare_root_dir()' '$ORCHESTRATOR_SH'); _resolve_bare_root_dir '$SANDBOX/standalone'"
+
+  # Then: 同ディレクトリが返る (worktrees/ は project_dir 直下)
+  assert_success
+  assert_output "$SANDBOX/standalone"
+}
+
+# ---------------------------------------------------------------------------
+# AC2: filter_active_issues の resume フィルタ
+# ---------------------------------------------------------------------------
+
+@test "AC2-a: orchestrator.sh が L293 で _bare_root_dir/worktrees/ を参照する (静的 grep)" {
+  # 静的検証: L293 周辺で _bare_root_dir を使用していること
+  run grep -E 'skip_candidate_dir="\$_bare_root_dir/worktrees/' "$ORCHESTRATOR_SH"
+  assert_success
+  assert_output --partial '_bare_root_dir/worktrees/'
+}
+
+@test "AC2-b: orchestrator.sh が L316 で _bare_root_dir/worktrees/ を参照する (静的 grep)" {
+  # 静的検証: L316 周辺で _bare_root_dir を使用していること
+  run grep -E 'candidate_dir="\$_bare_root_dir/worktrees/\$existing_branch"' "$ORCHESTRATOR_SH"
+  assert_success
+  assert_output --partial '_bare_root_dir/worktrees/'
+}
+
+@test "AC2-c: filter_active_issues 内に running/merge-ready resume フィルタが存在する (静的 grep)" {
+  # 静的検証: filter_active_issues 関数内に「resume worktree skip」logic が存在
+  run grep -E 'status.*running.*merge-ready.*' "$ORCHESTRATOR_SH"
+  assert_success
+
+  # 「worktree active in bare_root」のメッセージが存在
+  run grep -E 'worktree active in bare_root' "$ORCHESTRATOR_SH"
+  assert_success
+}
+
+@test "AC2-d: filter_active_issues 修正前と異なる挙動 (regression sentinel)" {
+  # 静的検証: effective_project_dir/worktrees/ への参照が完全に削除されていること
+  # (もし残っていれば bug 1-A が再発)
+  run grep -nE 'effective_project_dir/worktrees/' "$ORCHESTRATOR_SH"
+  assert_failure  # 参照が無いことを確認
+}
+
+# ---------------------------------------------------------------------------
+# AC1+AC2 統合: helper 関数定義の存在確認
+# ---------------------------------------------------------------------------
+
+@test "AC-helper: _resolve_bare_root_dir 関数が定義されている" {
+  run grep -E '^_resolve_bare_root_dir\(\)' "$ORCHESTRATOR_SH"
+  assert_success
+  assert_output --partial '_resolve_bare_root_dir()'
+}
+
+@test "AC-helper: _resolve_bare_root_dir が main/.git ファイル分岐を持つ" {
+  # _resolve_bare_root_dir 関数本体に `[[ -f "$_project_dir/.git" ]]` のチェックがあること
+  run grep -E '\-f "\$_project_dir/\.git"' "$ORCHESTRATOR_SH"
+  assert_success
+}


### PR DESCRIPTION
Closes #1495

Wave 57 incident (PR #1492/#1493/#1494 全 CLOSED UNMERGED + 3 worktree/branch 削除) の root cause を 3 つ同時に修正。

## 真因 (Phase B code-explorer 調査で確定)

### Bug 1-A: bare_root パス不一致 (CRITICAL)
\`effective_project_dir = PROJECT_DIR = .../twill/main\` だが、worktree は \`.../twill/worktrees/\` (bare_root 直下) に存在。L293/L316 が \`\$effective_project_dir/worktrees/\` を見ていたため常に false → resume guard 非発動 → status=failed 上書き。

### Bug 1-B: filter_active_issues が running/merge-ready をフィルタしない
\`done\` のみスキップ、\`running\`/\`merge-ready\` は再 launch_worker 対象 → Bug 1-A と相まって「既に存在」エラー → status=failed 連鎖。

### Bug 2: cleanup_worker (L408-469) の PR open check 不在
\`git push origin --delete\` の前に PR の open check 一切なし。autopilot-cleanup.sh:283-299 には実装済みだが orchestrator.sh は抜けていた → open PR の head ref を強制削除 → PR が CLOSED 化。

## 修正内容

1. \`_resolve_bare_root_dir()\` helper 追加 (worktree mode で main の親 = bare_root を返す)
2. filter_active_issues に resume フィルタ: status=running/merge-ready + worktree existing in bare_root → ACTIVE_ENTRIES から除外
3. launch_worker L293/L316 を \`\$_bare_root_dir/worktrees/\` に変更
4. cleanup_worker: \`git push origin --delete\` の前に \`gh pr list --head\` count > 0 確認、open なら削除スキップ (autopilot-cleanup.sh と同一パターン)

## regression test (新規 bats)

- \`orchestrator-resume-worktree.bats\`: AC1/AC2 全 8 件 (helper 動作 + 静的 grep)
- \`orchestrator-cleanup-pr-check.bats\`: AC3 全 6 件 (gh check 順序 + sentinel)

## verification

| test | result |
|---|---|
| 新 \`orchestrator-resume-worktree.bats\` | 8/8 pass |
| 新 \`orchestrator-cleanup-pr-check.bats\` | 6/6 pass |
| 既存 \`orchestrator-cleanup-sequence.bats\` | 16/16 pass (regression なし) |
| 既存 \`orchestrator-branch-regex.bats\` | 16/16 pass |
| \`twl check --deps-integrity\` | All files exist (315/315) |

## 関連

- 復旧 PR: #1492 / #1493 / #1494 (Phase A で reopen 済、merge 待ち)
- 事故 log: \`.autopilot/trace/orchestrator-phase-1-7a53b30f-wave57.log\`
- Phase B 真因調査 hash (doobidoo): \`c9a22c1f\`