### PR TITLE
fix(mergegate_ops): autopilot path に gh pr ready を追加 (#1500)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -115,6 +115,39 @@ issue_1015:
       test_file: "plugins/twl/tests/unit/chain-runner-trace-abspath/chain-runner-trace-abspath.bats"
       test_name: "trace-relpath[regression]: 相対パスの場合、trace ファイルが作成される"
       status: GREEN
+
+# --- Issue #1500 ---
+issue_1500:
+  issue: 1500
+  framework: pytest
+  test_file: "cli/twl/tests/autopilot/test_mergegate_ops.py"
+  mappings:
+    - ac_index: 1
+      ac_text: "mergegate_ops.py の _run_merge に gh pr ready を追加。gh pr merge 直前に gh pr ready を呼び出す。idempotent (既に ready なら no-op)。失敗時は明確なエラーで fail-fast。"
+      test_name: "test_ac1_gh_pr_ready_called_before_merge"
+      status: RED
+      red_mechanism: "_run_merge に gh pr ready 呼び出しが未追加のため call_log に ready が含まれず fail する"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/mergegate_ops.py"
+    - ac_index: 2
+      ac_text: "pytest 追加: gh pr ready 失敗時は fail-fast し gh pr merge を呼ばない"
+      test_name: "test_ac2_gh_pr_ready_fail_raises"
+      status: RED
+      red_mechanism: "gh pr ready が未実装のため returncode=1 でも merge が続行し result=True になりアサーション失敗"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/mergegate_ops.py"
+    - ac_index: 2
+      ac_text: "pytest 追加: idempotent ケース（既に ready）でも gh pr ready が呼ばれ、gh pr merge が継続すること"
+      test_name: "test_ac2_gh_pr_ready_idempotent_already_ready"
+      status: RED
+      red_mechanism: "gh pr ready が未実装のため call_log に ready が含まれず fail する"
+      impl_files:
+        - "cli/twl/src/twl/autopilot/mergegate_ops.py"
+    - ac_index: 3
+      ac_text: "ac-test-mapping 追加（本エントリ）"
+      test_name: "N/A (doc artifact)"
+      status: DONE
+      impl_files: []
       note: "回帰テスト。修正前後ともに PASS であること"
     - ac_index: 3
       ac_text: "TWL_CHAIN_TRACE に *..*（パストラバーサル）を含む場合、trace_event() はファイルを作成しない（既存動作）"

--- a/cli/twl/src/twl/autopilot/mergegate_ops.py
+++ b/cli/twl/src/twl/autopilot/mergegate_ops.py
@@ -391,6 +391,27 @@ class MergeGateOperationsMixin:
                 except (json.JSONDecodeError, ValueError):
                     pass  # precheck parse 失敗時は従来の merge flow に fallback
 
+        # #1500: draft → ready 変換（idempotent: already ready なら no-op）
+        ready_result = subprocess.run(
+            ["gh", "pr", "ready", self.pr_number, *gh_repo_flag],
+            capture_output=True,
+            text=True,
+        )
+        if ready_result.returncode != 0:
+            failure = json.dumps({
+                "reason": "draft_pr_ready_failed",
+                "details": ready_result.stderr[:500],
+                "step": "merge-gate",
+                "pr": f"#{self.pr_number}",
+            })
+            _state_write(self.issue, "pilot", status="failed", failure=failure)
+            print(
+                f"[merge-gate] Issue #{self.issue}: draft のまま merge は不可"
+                f" — gh pr ready 失敗: {ready_result.stderr[:200]}",
+                file=sys.stderr,
+            )
+            return False
+
         result = subprocess.run(
             ["gh", "pr", "merge", self.pr_number, *gh_repo_flag, "--squash"],
             capture_output=True,

--- a/cli/twl/src/twl/autopilot/mergegate_ops.py
+++ b/cli/twl/src/twl/autopilot/mergegate_ops.py
@@ -398,16 +398,20 @@ class MergeGateOperationsMixin:
             text=True,
         )
         if ready_result.returncode != 0:
+            raw_ready_err = ready_result.stderr
+            raw_ready_err = re.sub(r"ghp_[a-zA-Z0-9]+", "ghp_***MASKED***", raw_ready_err)
+            raw_ready_err = re.sub(r"Bearer\s+\S+", "Bearer ***MASKED***", raw_ready_err)
+            raw_ready_err = raw_ready_err[:500]
             failure = json.dumps({
                 "reason": "draft_pr_ready_failed",
-                "details": ready_result.stderr[:500],
+                "details": raw_ready_err,
                 "step": "merge-gate",
                 "pr": f"#{self.pr_number}",
             })
             _state_write(self.issue, "pilot", status="failed", failure=failure)
             print(
                 f"[merge-gate] Issue #{self.issue}: draft のまま merge は不可"
-                f" — gh pr ready 失敗: {ready_result.stderr[:200]}",
+                f" — gh pr ready 失敗: {raw_ready_err[:200]}",
                 file=sys.stderr,
             )
             return False

--- a/cli/twl/tests/autopilot/test_mergegate_ops.py
+++ b/cli/twl/tests/autopilot/test_mergegate_ops.py
@@ -1,0 +1,114 @@
+"""Unit tests for MergeGateOperationsMixin._run_merge() gh pr ready call (#1500).
+
+AC1: _run_merge に gh pr ready が追加されること。
+AC2: gh pr ready 呼び出しの mock 検証。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from twl.autopilot.mergegate import MergeGate
+
+
+@pytest.fixture
+def gate(tmp_path: Path) -> MergeGate:
+    autopilot_dir = tmp_path / ".autopilot"
+    (autopilot_dir / "issues").mkdir(parents=True)
+    (autopilot_dir / "checkpoints").mkdir()
+    scripts_root = tmp_path / "scripts"
+    scripts_root.mkdir()
+    return MergeGate(
+        issue="1500",
+        pr_number="1498",
+        branch="fix/1500-fixmergegateops-autopilot-path-gh-pr-r",
+        autopilot_dir=autopilot_dir,
+        scripts_root=scripts_root,
+    )
+
+
+class TestRunMergeGhPrReady:
+    """AC1/AC2: _run_merge は gh pr merge 直前に gh pr ready を呼び出す。"""
+
+    def test_ac1_gh_pr_ready_called_before_merge(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC1: gh pr merge 直前に gh pr ready が呼ばれること。"""
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
+        merge_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        call_log: list[list[str]] = []
+
+        def _fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            call_log.append(cmd)
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake_run):
+            result = gate._run_merge([])
+
+        assert result is True
+        # gh pr ready が呼ばれていること
+        ready_calls = [c for c in call_log if "ready" in c]
+        assert len(ready_calls) == 1, f"gh pr ready が呼ばれていない: calls={call_log}"
+        # gh pr ready が gh pr merge より先に呼ばれていること
+        ready_idx = next(i for i, c in enumerate(call_log) if "ready" in c)
+        merge_idx = next(i for i, c in enumerate(call_log) if "merge" in c)
+        assert ready_idx < merge_idx, "gh pr ready が gh pr merge より後に呼ばれている"
+
+    def test_ac2_gh_pr_ready_fail_raises(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC2: gh pr ready 失敗時は fail-fast し gh pr merge を呼ばない。"""
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+
+        ready_result = MagicMock(returncode=1, stdout="", stderr="some error")
+        merge_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        call_log: list[list[str]] = []
+
+        def _fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            call_log.append(cmd)
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake_run), \
+             patch("twl.autopilot.mergegate_ops._state_write"):
+            result = gate._run_merge([])
+
+        assert result is False, "gh pr ready 失敗時は False を返すべき"
+        merge_calls = [c for c in call_log if "merge" in c]
+        assert len(merge_calls) == 0, f"gh pr ready 失敗後に gh pr merge が呼ばれた: calls={call_log}"
+
+    def test_ac2_gh_pr_ready_idempotent_already_ready(
+        self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """AC2: PR が既に ready 状態でも gh pr ready は no-op (returncode=0) で継続する。"""
+        monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+
+        # "already ready" → returncode=0 と扱う
+        ready_result = MagicMock(returncode=0, stdout="", stderr="Pull request #1498 is already ready for review")
+        merge_result = MagicMock(returncode=0, stdout="", stderr="")
+
+        call_log: list[list[str]] = []
+
+        def _fake_run(cmd: list[str], **kwargs):  # noqa: ANN001
+            call_log.append(cmd)
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake_run):
+            result = gate._run_merge([])
+
+        assert result is True
+        ready_calls = [c for c in call_log if "ready" in c]
+        assert len(ready_calls) == 1, "already ready でも gh pr ready は呼ばれるべき"
+        merge_calls = [c for c in call_log if "merge" in c]
+        assert len(merge_calls) == 1, "already ready でも gh pr merge は呼ばれるべき"

--- a/cli/twl/tests/autopilot/test_mergegate_precheck.py
+++ b/cli/twl/tests/autopilot/test_mergegate_precheck.py
@@ -78,15 +78,25 @@ class TestPrecheckBranchProtection:
         self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
         merge_result = MagicMock(returncode=0, stdout="", stderr="")
 
-        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result) as mock_run:
+        call_log: list[list[str]] = []
+
+        def _fake(cmd: list[str], **kw):  # noqa: ANN001
+            call_log.append(cmd)
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake):
             ret = gate._run_merge([])
 
         assert ret is True
-        # precheck スキップされ、gh pr merge のみが直接呼ばれる
-        assert mock_run.call_count == 1
-        assert mock_run.call_args_list[0].args[0][:3] == ["gh", "pr", "merge"]
+        # precheck スキップ、gh pr ready → gh pr merge の順で呼ばれる
+        assert len(call_log) == 2
+        assert call_log[0][:3] == ["gh", "pr", "ready"]
+        assert call_log[1][:3] == ["gh", "pr", "merge"]
 
     def test_precheck_clean_proceeds_to_merge(
         self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
@@ -94,11 +104,12 @@ class TestPrecheckBranchProtection:
         """CLEAN 等 OK 状態なら precheck を通過して merge 実行."""
         monkeypatch.setenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", "true")
         precheck_result = MagicMock(returncode=0, stdout=json.dumps({"mergeStateStatus": "CLEAN"}))
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
         merge_result = MagicMock(returncode=0, stdout="", stderr="")
 
         with patch(
             "twl.autopilot.mergegate_ops.subprocess.run",
-            new=_mock_run_sequence([precheck_result, merge_result]),
+            new=_mock_run_sequence([precheck_result, ready_result, merge_result]),
         ):
             ret = gate._run_merge([])
 
@@ -117,9 +128,15 @@ class TestMergeConflictClassification:
         self, gate: MergeGate, stderr_msg: str, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
         merge_result = MagicMock(returncode=1, stdout="", stderr=stderr_msg)
 
-        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+        def _fake(cmd: list[str], **kw):  # noqa: ANN001
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake), \
              patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
             ret = gate._run_merge([])
 
@@ -135,11 +152,17 @@ class TestMergeConflictClassification:
         self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
         merge_result = MagicMock(
             returncode=1, stdout="", stderr="GraphQL: Required status check \"build\" is pending."
         )
 
-        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+        def _fake(cmd: list[str], **kw):  # noqa: ANN001
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake), \
              patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
             ret = gate._run_merge([])
 
@@ -154,11 +177,18 @@ class TestMergeConflictClassification:
         self, gate: MergeGate, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.delenv("DEV_AUTOPILOT_MERGEABILITY_PRECHECK", raising=False)
+        ready_result = MagicMock(returncode=0, stdout="", stderr="")
         merge_result = MagicMock(
             returncode=1, stdout="",
             stderr="auth failed with ghp_abcdef123456 not mergeable conflict",
         )
-        with patch("twl.autopilot.mergegate_ops.subprocess.run", return_value=merge_result), \
+
+        def _fake(cmd: list[str], **kw):  # noqa: ANN001
+            if "ready" in cmd:
+                return ready_result
+            return merge_result
+
+        with patch("twl.autopilot.mergegate_ops.subprocess.run", side_effect=_fake), \
              patch("twl.autopilot.mergegate_ops._state_write") as mock_write:
             gate._run_merge([])
 


### PR DESCRIPTION
## 概要

Issue #1500 の修正。autopilot path の `mergegate_ops.py:_run_merge` に `gh pr ready` 呼び出しを追加する。

## 変更内容

- `cli/twl/src/twl/autopilot/mergegate_ops.py`: `_run_merge` の `gh pr merge` 直前に `gh pr ready` を追加
  - idempotent: already ready なら returncode=0 で継続
  - 失敗時は `draft_pr_ready_failed` で fail-fast し `_state_write` で状態記録
- `cli/twl/tests/autopilot/test_mergegate_ops.py`: mock 検証テスト 3 件追加（AC2）
- `ac-test-mapping.yaml`: Issue #1500 エントリ追記（AC3）

## AC 対応

- AC1: `_run_merge` に `gh pr ready` 追加 ✅
- AC2: pytest mock 検証 ✅ (3 tests GREEN)
- AC3: ac-test-mapping 追加 ✅

Closes #1500