### PR TITLE
fix(#1499): auto-merge.sh の gh pr ready idempotency 対応（already-ready PR で失敗するケース）

### DIFF
--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -190,6 +190,7 @@ fi
 # #1497: merge 前に PR を ready に切り替える（draft → ready、idempotent）
 # #1499: "PR is not a draft" exit 1 は already-ready の no-op として扱う
 PR_READY_ERR=$(mktemp /tmp/auto-merge-ready-XXXXXX.log)
+trap 'rm -f "${PR_READY_ERR:-}"' EXIT
 if ! gh pr ready "$PR_NUMBER" 2>"$PR_READY_ERR"; then
   READY_ERR_RAW=$(sed -E 's/ghp_[a-zA-Z0-9]+/ghp_***MASKED***/g; s/Bearer [^ ]+/Bearer ***MASKED***/g' "$PR_READY_ERR" | head -c 300)
   if echo "$READY_ERR_RAW" | grep -qiE '(not a draft)'; then

--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -188,12 +188,18 @@ if [[ "${DEV_AUTOPILOT_MERGEABILITY_PRECHECK:-false}" == "true" ]]; then
 fi
 
 # #1497: merge 前に PR を ready に切り替える（draft → ready、idempotent）
+# #1499: "PR is not a draft" exit 1 は already-ready の no-op として扱う
 PR_READY_ERR=$(mktemp /tmp/auto-merge-ready-XXXXXX.log)
 if ! gh pr ready "$PR_NUMBER" 2>"$PR_READY_ERR"; then
   READY_ERR_RAW=$(sed -E 's/ghp_[a-zA-Z0-9]+/ghp_***MASKED***/g; s/Bearer [^ ]+/Bearer ***MASKED***/g' "$PR_READY_ERR" | head -c 300)
-  echo "[auto-merge] Error: PR #${PR_NUMBER} draft → ready 切替失敗。draft のまま merge は不可。ready 切替を要。詳細: ${READY_ERR_RAW}" >&2
-  rm -f "$PR_READY_ERR"
-  exit 1
+  if echo "$READY_ERR_RAW" | grep -qiE '(not a draft)'; then
+    echo "[auto-merge] Issue #${ISSUE_NUM}: PR #${PR_NUMBER} は already-ready（no-op）" >&2
+    rm -f "$PR_READY_ERR"
+  else
+    echo "[auto-merge] Error: PR #${PR_NUMBER} draft → ready 切替失敗。draft のまま merge は不可。ready 切替を要。詳細: ${READY_ERR_RAW}" >&2
+    rm -f "$PR_READY_ERR"
+    exit 1
+  fi
 fi
 rm -f "$PR_READY_ERR"
 

--- a/plugins/twl/tests/bats/scripts/auto-merge-pr-ready.bats
+++ b/plugins/twl/tests/bats/scripts/auto-merge-pr-ready.bats
@@ -36,8 +36,9 @@ PYSTUB
   chmod +x "$STUB_BIN/python3"
 
   # gh stub: 呼び出しをログに記録する（各テストで PR_READY_FAIL / PR_ALREADY_READY を override 可能）
-  # PR_READY_FAIL=true  → gh pr ready が失敗する
-  # PR_ALREADY_READY=true → gh pr ready が "already ready" 系の exit 0 を返す（idempotent 検証用）
+  # PR_READY_FAIL=true    → gh pr ready が真のエラーで失敗する（例: GraphQL 権限エラー）
+  # PR_ALREADY_READY=true → gh pr ready が "PR is not a draft" で exit 1 を返す
+  #                         （実際の GitHub CLI 動作: already-ready な PR への gh pr ready は exit 1）
   GH_CALL_LOG="$SANDBOX/gh-calls.log"
   : > "$GH_CALL_LOG"
   export GH_CALL_LOG
@@ -47,8 +48,12 @@ PYSTUB
 echo "gh $*" >> "${GH_CALL_LOG}"
 case "$*" in
   *"pr ready "*)
+    if [[ "${PR_ALREADY_READY:-false}" == "true" ]]; then
+      echo "PR is not a draft" >&2
+      exit 1
+    fi
     if [[ "${PR_READY_FAIL:-false}" == "true" ]]; then
-      echo "failed to mark PR as ready for review: PR is not a draft" >&2
+      echo "GraphQL: Unresolved review request" >&2
       exit 1
     fi
     exit 0 ;;
@@ -261,6 +266,83 @@ teardown() {
   # "merge_failed" に関する記述が存在すること
   grep -qi "merge_failed\|merge.*draft\|draft.*merge" "$PITFALLS_CATALOG" || {
     echo "FAIL: pitfalls-catalog.md に 'merge_failed' / draft merge 関連の記述がない"
+    false
+  }
+}
+
+# ---------------------------------------------------------------------------
+# AC-idempotency: "PR is not a draft" exit 1 を no-op 扱いにして merge を続行する
+# Issue #1499: GitHub CLI の一部バージョンでは already-ready な PR への gh pr ready は exit 1 を返す
+# ---------------------------------------------------------------------------
+
+@test "ac-idempotency: gh pr ready が 'PR is not a draft' で exit 1 を返しても merge を続行する" {
+  # AC: gh pr ready が exit 1 + "PR is not a draft" を返す場合、
+  #     already-ready（no-op）と判断して merge を続行する（成功）
+  # RED: 現在の実装（L192-196）は exit 1 を一律エラーとして扱うため FAIL する
+  export PR_ALREADY_READY=true
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 1497 --pr 1498 --branch fix/1497-draft-ready
+
+  # "PR is not a draft" は no-op: auto-merge.sh は成功（exit 0）すること
+  assert_success
+
+  # gh pr ready が呼ばれていること
+  grep -qF "gh pr ready 1498" "$GH_CALL_LOG" || {
+    echo "FAIL: gh pr ready 1498 が呼ばれていない"
+    cat "$GH_CALL_LOG"
+    false
+  }
+
+  # "PR is not a draft" を受けても merge が続行されていること
+  grep -qF "gh pr merge 1498 --squash" "$GH_CALL_LOG" || {
+    echo "FAIL: gh pr merge 1498 --squash が呼ばれていない（already-ready の no-op 後に merge が続行されるべき）"
+    cat "$GH_CALL_LOG"
+    false
+  }
+
+  assert_output --partial "merge 成功"
+}
+
+# ---------------------------------------------------------------------------
+# AC-stub-distinct: PR_READY_FAIL=true と PR_ALREADY_READY=true が異なるエラーを返す
+# Issue #1499: スタブを更新して idempotency 分岐テストが正確に動作することを確認する
+# ---------------------------------------------------------------------------
+
+@test "ac-stub-distinct: PR_READY_FAIL=true は 'GraphQL' エラーを返し draft/ready メッセージを出力する" {
+  # AC: PR_READY_FAIL=true（真のエラー）と PR_ALREADY_READY=true（already-ready）を区別する
+  #     PR_READY_FAIL=true → 別エラーメッセージ（GraphQL 系）で失敗
+  #     PR_ALREADY_READY=true → "PR is not a draft" で exit 1 → no-op 扱い（別テスト AC-idempotency）
+  # RED（AC-stub-distinct の観点）:
+  #     auto-merge.sh に idempotency 分岐がないため、
+  #     PR_ALREADY_READY=true のケースで merge が続行されない（ac-idempotency と連動）
+  export PR_READY_FAIL=true
+
+  run bash "$SANDBOX/scripts/auto-merge.sh" --issue 1497 --pr 1498 --branch fix/1497-draft-ready
+
+  # 真のエラー（GraphQL 系）時は失敗すること
+  assert_failure
+
+  # auto-merge.sh のエラーメッセージに "draft" と "ready" が含まれること
+  # （スタブが "GraphQL" エラーを返しても、auto-merge.sh の固定メッセージが出力される）
+  echo "$output" | grep -qi "draft" || {
+    echo "FAIL: 出力に 'draft' が含まれていない（auto-merge.sh エラーメッセージ要確認）"
+    echo "--- output ---"
+    echo "$output"
+    false
+  }
+  echo "$output" | grep -qi "ready" || {
+    echo "FAIL: 出力に 'ready' が含まれていない（auto-merge.sh エラーメッセージ要確認）"
+    echo "--- output ---"
+    echo "$output"
+    false
+  }
+
+  # スタブが "GraphQL" エラーを出力していること（PR_READY_FAIL が PR_ALREADY_READY と別扱いになっていること）
+  echo "$output" | grep -qi "graphql\|unresolved\|review" || {
+    echo "FAIL: PR_READY_FAIL=true 時に 'GraphQL' 系メッセージが出力されていない"
+    echo "FAIL: スタブが PR_READY_FAIL と PR_ALREADY_READY を区別できていない可能性"
+    echo "--- output ---"
+    echo "$output"
     false
   }
 }


### PR DESCRIPTION
## 概要

Closes #1499

Issue #1497 fix (PR #1498) で auto-merge.sh に `gh pr ready` を追加したが、GitHub CLI の一部バージョンでは already-ready な PR に `gh pr ready` を実行すると `exit 1`（"PR is not a draft" 系メッセージ）を返すため、already-ready な PR のマージが失敗するケースがある。

## 変更内容

### テストスタブ更新（TDD RED scaffold）
- `PR_ALREADY_READY=true` スタブ: exit 0 → exit 1 + "PR is not a draft"（実 GitHub CLI 動作を正確に模擬）
- `PR_READY_FAIL=true` スタブ: "not a draft" メッセージ → "GraphQL: Unresolved review request"（区別可能な別エラー）

### 新規 RED テスト
- `ac-idempotency`: `gh pr ready` が exit 1 + "PR is not a draft" 返却時に merge を続行すること
- `ac-stub-distinct`: `PR_READY_FAIL=true` が別エラーを返すことの確認

## 参照
- Issue #1497, PR #1498
- 検出元: PR #1498 post-fix-verify（worker-code-reviewer, confidence 82）