### PR TITLE
fix(specialist-audit): test-scaffold-only HARD FAIL を真に追加（#1535、observer 直接 implement）

### DIFF
--- a/plugins/twl/scripts/specialist-audit.sh
+++ b/plugins/twl/scripts/specialist-audit.sh
@@ -305,6 +305,30 @@ if [[ -n "$CONTROLLER_ISSUE_DIR" && -d "$CONTROLLER_ISSUE_DIR" ]]; then
   fi
 fi
 
+# --- test scaffold only HARD FAIL (Issue #1535、lesson 19 reproduction 防止) ---
+# Worker chain (Sonnet) が AC GREEN化を主張しても test scaffold だけで PR を merge する
+# pattern (Wave 68/70/71/72 で 4 連続発生) を構造的に防止する。
+# 現在の git diff (HEAD vs origin/main) の changed_files が test 系 path のみで、
+# impl path (cli/twl/src/, plugins/twl/scripts/, plugins/twl/skills/, plugins/twl/architecture/, etc) への
+# 変更がない場合 HARD FAIL → STATUS=FAIL, EXIT_CODE=1。
+if command -v git &>/dev/null; then
+  _current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+  if [[ -n "$_current_branch" && "$_current_branch" != "main" && "$_current_branch" != "HEAD" ]]; then
+    _changed_files=$(git diff --name-only origin/main..HEAD 2>/dev/null || echo "")
+    if [[ -n "$_changed_files" ]]; then
+      # test path 以外の変更カウント (impl/scripts/skill/architecture を含む)
+      _non_test_count=$(echo "$_changed_files" | grep -cvE '^(cli/twl/tests/|plugins/twl/tests/|plugins/session/tests/|tests/)' || true)
+      if [[ "$_non_test_count" -eq 0 ]]; then
+        echo "HARD FAIL: PR contains only test scaffold changes (no impl in src/scripts/skills/architecture paths) - lesson 19 reproduction 防止 (Issue #1535)" >&2
+        echo "  branch: ${_current_branch}" >&2
+        echo "  changed_files (test only): $(echo "$_changed_files" | head -5 | tr '\n' ' ')" >&2
+        STATUS="FAIL"
+        EXIT_CODE=1
+      fi
+    fi
+  fi
+fi
+
 # --- JSON 生成 ---
 issue_field="${ISSUE_NUM:-null}"
 


### PR DESCRIPTION
## 概要

本セッション 2026-05-07/08 で Wave 68/70/71/72 と **4 連続発生した lesson 19 (Refine Worker 非準拠) reproduction** を構造的に防止する。

## 真因

Worker chain (Sonnet) が AC GREEN化を主張しても **test scaffold だけで PR を merge する pattern** が定着:

| Wave | Issue | PR | 結果 |
|---|---|---|---|
| 68 | #1511 | #1529 | test scaffold のみ |
| 70 | #1530 (元 fix) | #1532 | "AC1-AC9 GREEN化" だが AC4 (specialist-audit fix) **false claim** |
| 71 | #1513 | #1534 | test scaffold のみ (Wave 70 fix 機能せず) |
| 72 | #1535 (真の fix) | #1536 | **また test scaffold のみ** (Worker が再帰的に lesson 19 reproduction) |

Wave 72 自身が lesson 19 victim → observer 直接 implement に切替。

## 修正

`plugins/twl/scripts/specialist-audit.sh` に test-scaffold-only HARD FAIL 検出を追加:

- `git diff origin/main..HEAD` の changed_files を検査
- test path のみで impl path (cli/twl/src/, plugins/twl/scripts/, plugins/twl/skills/, plugins/twl/architecture/, etc) への変更がゼロの場合
- `HARD FAIL` (STATUS=FAIL, EXIT_CODE=1) を返す
- specialist-audit が呼ばれる merge-gate 経路で **次 Wave 以降の test scaffold only PR を機械的に reject**

## 効果

- 次 Wave で Worker chain が test scaffold だけで merge 試行 → specialist-audit reject → chain workflow abort
- Worker は impl 本体実装まで完遂宣言できなくなる
- ADR-036 + Invariant N (lesson 構造化方針) の最初の structural verify が成立

## 制約

本 PR は最 minimal fix (24 lines)。following items は **次 Wave で別 Issue 起票して補完**:

- `tools.py` への `twl_list_windows_handler` 補完 (SUB-5 #1513)
- `worker-issue-pr-alignment` の AC unimpl CRITICAL 検出強化
- bats test (回帰防止)

## 関連

- 元 Issue: #1535 (meta-bug、本 PR は AC1 のみ実装)
- Wave 70 false claim: #1530 PR #1532
- test scaffold reproduction: #1511 (Wave 68), #1513 (Wave 71)
- ADR-036 + Invariant N (lesson 構造化方針 plugin 永続化)
- Wave 58 lesson 19 元

## scope / type

- scope: `plugins-twl`
- ctx: `autopilot`
- type: `fix`

observer 直接 implement (本セッション Worker chain が 4 連続 lesson 19 で失敗のため)。