### PR TITLE
fix(auto-merge): specialist-audit invoke を Layer 5 として追加 (#1540、lesson 19 真の bypass fix)

### DIFF
--- a/plugins/twl/scripts/auto-merge.sh
+++ b/plugins/twl/scripts/auto-merge.sh
@@ -187,6 +187,21 @@ if [[ "${DEV_AUTOPILOT_MERGEABILITY_PRECHECK:-false}" == "true" ]]; then
   esac
 fi
 
+# Layer 5 (Issue #1540 fix): specialist-audit による test-scaffold-only HARD FAIL 検出
+# Pilot merge-gate command (merge-gate.md) を経由しない直接 auto-merge.sh 呼び出し経路で
+# lesson 19 reproduction を防止する。本 invoke で specialist-audit が test path のみの
+# changed_files を検出した場合 HARD FAIL exit、merge を skip する。
+# (PR #1537 で specialist-audit.sh に追加した HARD FAIL を本経路で activate)
+_audit_script="${SCRIPT_DIR}/specialist-audit.sh"
+if [[ -f "$_audit_script" ]]; then
+  _audit_exit=0
+  bash "$_audit_script" --issue "${ISSUE_NUM:-}" --mode merge-gate 2>/dev/null || _audit_exit=$?
+  if [[ $_audit_exit -ne 0 ]]; then
+    echo "[auto-merge] REJECT: specialist-audit FAIL (exit=${_audit_exit}) — test scaffold only PR の可能性 (Issue #1540、lesson 19 reproduction 防止)" >&2
+    exit $_audit_exit
+  fi
+fi
+
 # #1497: merge 前に PR を ready に切り替える（draft → ready、idempotent）
 # #1499: "PR is not a draft" exit 1 は already-ready の no-op として扱う
 PR_READY_ERR=$(mktemp /tmp/auto-merge-ready-XXXXXX.log)


### PR DESCRIPTION
## 概要

本セッション Wave 73 で **5 連続 lesson 19 reproduction (Wave 68/70/71/72/73)** が発生した root cause を fix する。PR #1537 で specialist-audit.sh に test-scaffold-only HARD FAIL を追加したが、**chain workflow で active されていなかった**。

## 真因

`grep -rn 'specialist-audit' plugins/twl/` の結果:
- `merge-gate-check-spawn.sh:39` が specialist-audit を呼ぶ唯一の場所
- `merge-gate-check-spawn.sh` は `plugins/twl/commands/merge-gate.md:63` のみから呼ばれる
- `merge-gate.md` は **Pilot merge-gate phase で実行される command**

つまり Pilot が merge-gate command を経由せず直接 `auto-merge.sh` を呼ぶ経路では specialist-audit が **bypass** される。

Wave 73 PR #1539 close 時の確認: `.audit/` に `specialist-audit-1514-*` log が存在しない → specialist-audit が呼ばれていない確証。

## 修正

`plugins/twl/scripts/auto-merge.sh` の Layer guards 完了後・`gh pr ready` 直前 (line 188-190) に specialist-audit invoke を **Layer 5** として追加 (15 lines):

```bash
_audit_script="${SCRIPT_DIR}/specialist-audit.sh"
if [[ -f "$_audit_script" ]]; then
  _audit_exit=0
  bash "$_audit_script" --issue "${ISSUE_NUM:-}" --mode merge-gate 2>/dev/null || _audit_exit=$?
  if [[ $_audit_exit -ne 0 ]]; then
    echo "[auto-merge] REJECT: specialist-audit FAIL — test scaffold only PR の可能性 (Issue #1540)" >&2
    exit $_audit_exit
  fi
fi
```

## 効果

- 次 Wave 以降で Pilot が auto-merge.sh を直接呼ぶ経路でも specialist-audit が trigger される
- PR #1537 の test-scaffold-only HARD FAIL ロジックが本経路で **真に effective**
- ADR-036 + Invariant N (lesson 構造化方針) の **真の構造的勝利** が成立
- Wave 65 (chain.py SSOT に post-fix-verify 追加) と同 pattern の SSOT 不整合 fix

## 関連

- Issue: #1540 (specialist-audit bypass meta-bug)
- 元 fix: PR #1537 (specialist-audit.sh に HARD FAIL 追加)
- 元 lesson: #1535 (Wave 70 false claim) / Wave 58 lesson 19
- 同 SSOT pattern: Wave 65 #1507 (chain.py post-fix-verify)

## scope / type

- scope: `plugins-twl`
- ctx: `autopilot`
- type: `fix`

observer 直接 implement (本セッション 3 件目、Worker chain は同 lesson 19 で 5 連続失敗のため)。次 Wave で本 fix が active なら lesson 19 構造化が真に完成する。