### PR TITLE
fix(autopilot-init): AUTOPILOT_DIR 解決の SCRIPT_DIR 汚染 fix（#1543、Wave 75 で観察）

### DIFF
--- a/plugins/twl/scripts/autopilot-init.sh
+++ b/plugins/twl/scripts/autopilot-init.sh
@@ -5,8 +5,25 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # プロジェクトルートを特定（main/ worktree を前提）
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-# AUTOPILOT_DIR 環境変数によるオーバーライドをサポート（テスト用）
-AUTOPILOT_DIR="${AUTOPILOT_DIR:-$PROJECT_ROOT/.autopilot}"
+# AUTOPILOT_DIR 解決 (#1543 fix: SCRIPT_DIR ベース default は plugin install 先を汚染するため避ける)
+# 優先順位:
+#   1. env var で明示指定 (export AUTOPILOT_DIR=<path>)
+#   2. git worktree list から main worktree を探して main/.autopilot を使用
+#   3. fallback: $(pwd)/.autopilot (caller の cwd ベース、SCRIPT_DIR 経由しない)
+if [[ -z "${AUTOPILOT_DIR:-}" ]]; then
+  _autopilot_main_wt=$(git worktree list --porcelain 2>/dev/null | awk '
+    /^worktree /{ wt=substr($0,10) }
+    /^HEAD 0{40}$/{ wt="" }
+    /^bare$/{ wt="" }
+    /^branch refs\/heads\/main$/{ if(wt!="") { print wt; exit } }
+  ' || true)
+  if [[ -n "$_autopilot_main_wt" && -d "$_autopilot_main_wt" ]]; then
+    AUTOPILOT_DIR="${_autopilot_main_wt}/.autopilot"
+  else
+    AUTOPILOT_DIR="$(pwd)/.autopilot"
+  fi
+  unset _autopilot_main_wt
+fi
 if [[ "$AUTOPILOT_DIR" == *".."* ]]; then
   echo "ERROR: AUTOPILOT_DIR にパストラバーサル文字 '..' が含まれています: $AUTOPILOT_DIR" >&2
   exit 1


### PR DESCRIPTION
## 概要

ユーザー指摘により発覚した bug fix。`autopilot-init.sh` line 9 の `AUTOPILOT_DIR=\${AUTOPILOT_DIR:-\$PROJECT_ROOT/.autopilot}` 経路で SCRIPT_DIR がグローバル plugin install 先 (`~/.claude/plugins/twl/scripts/`) にある場合、`PROJECT_ROOT=~/.claude/plugins/twl/` → `AUTOPILOT_DIR=~/.claude/plugins/twl/.autopilot/` で**グローバル汚染**。

## 観察 (Wave 75、2026-05-08 07:37)

Pilot が AUTOPILOT_DIR env var 未 export 状態で subshell 経由で `autopilot-init.sh` を呼んだ → 汚染。Pilot 自己 recovery (echo unset 確認 + rm -rf + AUTOPILOT_DIR= prefix で再実行) で進行したが、root fix 必要。

## 修正

AUTOPILOT_DIR 解決を以下の優先順位に変更:

1. env var 明示指定 (現状維持)
2. **git worktree list から main worktree 検出 → main/.autopilot** (新規、SCRIPT_DIR 経由しない)
3. fallback: $(pwd)/.autopilot (cwd ベース)

`autopilot-orchestrator.sh` の `resolve_autopilot_dir` と整合する logic。

## 効果

- SCRIPT_DIR ベース default を完全削除
- グローバル plugin install 先の汚染を機械的に防止
- AUTOPILOT_DIR env var lose しても安全な default

## 関連

- Issue: #1543
- 観察: Wave 75 (#1515 spawn 時)、ユーザー指摘で発覚

observer 直接 implement (本セッション 4 件目、Wave 75 active 中の並列 fix)。