### PR TITLE
tech-debt(twl-mcp): co-explore/co-autopilot SKILL.md に mcpServers frontmatter を追記

### DIFF
--- a/cli/twl/tests/skills/co-explore/ac-test-mapping.yaml
+++ b/cli/twl/tests/skills/co-explore/ac-test-mapping.yaml
@@ -1,0 +1,32 @@
+mappings:
+  - ac_index: "AC-1"
+    ac_text: "co-explore/SKILL.md frontmatter に mcpServers キーが存在する"
+    test_file: "cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats"
+    test_names:
+      - "ac1: co-explore/SKILL.md frontmatter に mcpServers キーが存在する"
+    impl_files:
+      - "plugins/twl/skills/co-explore/SKILL.md"
+
+  - ac_index: "AC-2"
+    ac_text: "co-explore/SKILL.md の mcpServers に twl エントリがある"
+    test_file: "cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats"
+    test_names:
+      - "ac2: co-explore/SKILL.md の mcpServers に twl エントリがある"
+    impl_files:
+      - "plugins/twl/skills/co-explore/SKILL.md"
+
+  - ac_index: "AC-3"
+    ac_text: "co-autopilot/SKILL.md frontmatter に mcpServers キーが存在する"
+    test_file: "cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats"
+    test_names:
+      - "ac3: co-autopilot/SKILL.md frontmatter に mcpServers キーが存在する"
+    impl_files:
+      - "plugins/twl/skills/co-autopilot/SKILL.md"
+
+  - ac_index: "AC-4"
+    ac_text: "co-autopilot/SKILL.md の mcpServers に twl エントリがある"
+    test_file: "cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats"
+    test_names:
+      - "ac4: co-autopilot/SKILL.md の mcpServers に twl エントリがある"
+    impl_files:
+      - "plugins/twl/skills/co-autopilot/SKILL.md"

--- a/cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats
+++ b/cli/twl/tests/skills/co-explore/test_1519_mcp_frontmatter.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# test_1519_mcp_frontmatter.bats
+#
+# Issue #1519: tech-debt(twl-mcp): co-explore/co-autopilot SKILL.md に
+#              mcpServers frontmatter を追記して subagent MCP 継承を明示する
+#
+# 対象 AC:
+#   AC-1: co-explore/SKILL.md frontmatter に mcpServers キーが存在する
+#   AC-2: co-explore/SKILL.md の mcpServers に twl エントリがある
+#   AC-3: co-autopilot/SKILL.md frontmatter に mcpServers キーが存在する
+#   AC-4: co-autopilot/SKILL.md の mcpServers に twl エントリがある
+#
+# 全テストは実装前に fail (RED) する。
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../../../" && pwd)"
+    CO_EXPLORE_SKILL_MD="${REPO_ROOT}/plugins/twl/skills/co-explore/SKILL.md"
+    CO_AUTOPILOT_SKILL_MD="${REPO_ROOT}/plugins/twl/skills/co-autopilot/SKILL.md"
+}
+
+# ===========================================================================
+# AC-1: co-explore/SKILL.md frontmatter に mcpServers キーが存在する
+# RED: 現状 co-explore/SKILL.md に mcpServers の記述がないため FAIL する
+# ===========================================================================
+
+@test "ac1: co-explore/SKILL.md frontmatter に mcpServers キーが存在する" {
+    [[ -f "$CO_EXPLORE_SKILL_MD" ]] \
+        || { echo "FAIL: co-explore SKILL.md が見つかりません: $CO_EXPLORE_SKILL_MD"; false; }
+
+    grep -qE '^mcpServers:' "$CO_EXPLORE_SKILL_MD" \
+        || { echo "FAIL: co-explore/SKILL.md frontmatter に mcpServers キーがありません"; false; }
+}
+
+# ===========================================================================
+# AC-2: co-explore/SKILL.md の mcpServers に twl エントリがある
+# RED: 現状 mcpServers 自体が存在しないため FAIL する
+# ===========================================================================
+
+@test "ac2: co-explore/SKILL.md の mcpServers に twl エントリがある" {
+    [[ -f "$CO_EXPLORE_SKILL_MD" ]] \
+        || { echo "FAIL: co-explore SKILL.md が見つかりません: $CO_EXPLORE_SKILL_MD"; false; }
+
+    grep -qE '^  twl:' "$CO_EXPLORE_SKILL_MD" \
+        || { echo "FAIL: co-explore/SKILL.md の mcpServers に twl エントリがありません"; false; }
+}
+
+# ===========================================================================
+# AC-3: co-autopilot/SKILL.md frontmatter に mcpServers キーが存在する
+# RED: 現状 co-autopilot/SKILL.md に mcpServers の記述がないため FAIL する
+# ===========================================================================
+
+@test "ac3: co-autopilot/SKILL.md frontmatter に mcpServers キーが存在する" {
+    [[ -f "$CO_AUTOPILOT_SKILL_MD" ]] \
+        || { echo "FAIL: co-autopilot SKILL.md が見つかりません: $CO_AUTOPILOT_SKILL_MD"; false; }
+
+    grep -qE '^mcpServers:' "$CO_AUTOPILOT_SKILL_MD" \
+        || { echo "FAIL: co-autopilot/SKILL.md frontmatter に mcpServers キーがありません"; false; }
+}
+
+# ===========================================================================
+# AC-4: co-autopilot/SKILL.md の mcpServers に twl エントリがある
+# RED: 現状 mcpServers 自体が存在しないため FAIL する
+# ===========================================================================
+
+@test "ac4: co-autopilot/SKILL.md の mcpServers に twl エントリがある" {
+    [[ -f "$CO_AUTOPILOT_SKILL_MD" ]] \
+        || { echo "FAIL: co-autopilot SKILL.md が見つかりません: $CO_AUTOPILOT_SKILL_MD"; false; }
+
+    grep -qE '^  twl:' "$CO_AUTOPILOT_SKILL_MD" \
+        || { echo "FAIL: co-autopilot/SKILL.md の mcpServers に twl エントリがありません"; false; }
+}

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -16,6 +16,12 @@ tools:
 spawnable_by:
 - user
 - su-observer
+mcpServers:
+  twl:
+    command: /home/shuu5/projects/local-projects/twill/main/cli/twl/.venv/bin/fastmcp
+    args:
+      - run
+      - /home/shuu5/projects/local-projects/twill/main/cli/twl/src/twl/mcp_server/server.py
 ---
 
 # co-autopilot

--- a/plugins/twl/skills/co-explore/SKILL.md
+++ b/plugins/twl/skills/co-explore/SKILL.md
@@ -17,6 +17,12 @@ tools:
 - Glob
 spawnable_by:
 - user
+mcpServers:
+  twl:
+    command: /home/shuu5/projects/local-projects/twill/main/cli/twl/.venv/bin/fastmcp
+    args:
+      - run
+      - /home/shuu5/projects/local-projects/twill/main/cli/twl/src/twl/mcp_server/server.py
 ---
 
 # co-explore


### PR DESCRIPTION
## 概要
Issue #1519 の対応。co-explore および co-autopilot の SKILL.md frontmatter に `mcpServers: twl` を追記し、subagent が `mcp__twl__*` ツールを自動的に利用できることを明示する。

## 変更内容
- `plugins/twl/skills/co-explore/SKILL.md`: `mcpServers` frontmatter 追記
- `plugins/twl/skills/co-autopilot/SKILL.md`: `mcpServers` frontmatter 追記

## 参照
- ADR-035-subagent-mcp-server-inheritance.md Decision 2
- .claude/subagent-mcp.json (reference config)

Closes #1519