### PR TITLE
docs(arch): twill-integration.md Phase 2 Component Mapping に Tier 1+ 6 tool を追記 (#1527)

### DIFF
--- a/cli/twl/tests/ac-test-mapping-1527.yaml
+++ b/cli/twl/tests/ac-test-mapping-1527.yaml
@@ -2,36 +2,36 @@ mappings:
   - ac_index: 1
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_spawn_session が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac1_spawn_session_in_component_mapping"
+    test_name: "TestAC1SpawnSession::test_ac1_spawn_session_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"
   - ac_index: 2
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_spawn_controller が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac2_spawn_controller_in_component_mapping"
+    test_name: "TestAC2SpawnController::test_ac2_spawn_controller_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"
   - ac_index: 3
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_capture_pane が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac3_capture_pane_in_component_mapping"
+    test_name: "TestAC3CapturePane::test_ac3_capture_pane_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"
   - ac_index: 4
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_list_windows が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac4_list_windows_in_component_mapping"
+    test_name: "TestAC4ListWindows::test_ac4_list_windows_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"
   - ac_index: 5
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_get_session_state（拡張）が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac5_get_session_state_in_component_mapping"
+    test_name: "TestAC5GetSessionState::test_ac5_get_session_state_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"
   - ac_index: 6
     ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_get_budget が含む tool 群として記載されていること"
     test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
-    test_name: "test_ac6_get_budget_in_component_mapping"
+    test_name: "TestAC6GetBudget::test_ac6_get_budget_in_component_mapping"
     impl_files:
       - "plugins/twl/architecture/domain/contexts/twill-integration.md"

--- a/cli/twl/tests/ac-test-mapping-1527.yaml
+++ b/cli/twl/tests/ac-test-mapping-1527.yaml
@@ -1,0 +1,37 @@
+mappings:
+  - ac_index: 1
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_spawn_session が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac1_spawn_session_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"
+  - ac_index: 2
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_spawn_controller が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac2_spawn_controller_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"
+  - ac_index: 3
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_capture_pane が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac3_capture_pane_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"
+  - ac_index: 4
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_list_windows が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac4_list_windows_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"
+  - ac_index: 5
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_get_session_state（拡張）が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac5_get_session_state_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"
+  - ac_index: 6
+    ac_text: "twill-integration.md Phase 2 Component Mapping テーブルに twl_get_budget が含む tool 群として記載されていること"
+    test_file: "cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py"
+    test_name: "test_ac6_get_budget_in_component_mapping"
+    impl_files:
+      - "plugins/twl/architecture/domain/contexts/twill-integration.md"

--- a/cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py
+++ b/cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py
@@ -1,0 +1,110 @@
+"""TDD RED phase tests for Issue #1527.
+
+twill-integration.md Phase 2 Component Mapping テーブルに
+Tier 1+ 6 tool (spawn/observation/budget 系) を追記する。
+
+AC 1件につき 1テスト。全テストは実装前に FAIL（RED）する。
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).parents[3]
+TWILL_INTEGRATION_MD = (
+    REPO_ROOT / "plugins" / "twl" / "architecture" / "domain" / "contexts" / "twill-integration.md"
+)
+
+
+def _read_doc() -> str:
+    return TWILL_INTEGRATION_MD.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# AC1: Phase 2 Component Mapping テーブルに twl_spawn_session が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac1_spawn_session_in_component_mapping():
+    """AC1: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_spawn_session が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_spawn_session" in content, (
+        "Phase 2 Component Mapping に twl_spawn_session が未記載 (AC1 未実装)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC2: Phase 2 Component Mapping テーブルに twl_spawn_controller が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac2_spawn_controller_in_component_mapping():
+    """AC2: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_spawn_controller が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_spawn_controller" in content, (
+        "Phase 2 Component Mapping に twl_spawn_controller が未記載 (AC2 未実装)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC3: Phase 2 Component Mapping テーブルに twl_capture_pane が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac3_capture_pane_in_component_mapping():
+    """AC3: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_capture_pane が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_capture_pane" in content, (
+        "Phase 2 Component Mapping に twl_capture_pane が未記載 (AC3 未実装)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC4: Phase 2 Component Mapping テーブルに twl_list_windows が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac4_list_windows_in_component_mapping():
+    """AC4: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_list_windows が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_list_windows" in content, (
+        "Phase 2 Component Mapping に twl_list_windows が未記載 (AC4 未実装)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC5: Phase 2 Component Mapping テーブルに twl_get_session_state の拡張が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac5_get_session_state_in_component_mapping():
+    """AC5: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_get_session_state（拡張）が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_get_session_state" in content, (
+        "Phase 2 Component Mapping に twl_get_session_state が未記載 (AC5 未実装)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC6: Phase 2 Component Mapping テーブルに twl_get_budget が記載されていること
+# ---------------------------------------------------------------------------
+
+
+def test_ac6_get_budget_in_component_mapping():
+    """AC6: twill-integration.md の Phase 2 Component Mapping テーブルに
+    twl_get_budget が含む tool 群として記載されていること。
+    """
+    content = _read_doc()
+    assert "twl_get_budget" in content, (
+        "Phase 2 Component Mapping に twl_get_budget が未記載 (AC6 未実装)"
+    )

--- a/cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py
+++ b/cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py
@@ -1,13 +1,14 @@
-"""TDD RED phase tests for Issue #1527.
+"""TDD tests for Issue #1527.
 
 twill-integration.md Phase 2 Component Mapping テーブルに
 Tier 1+ 6 tool (spawn/observation/budget 系) を追記する。
 
-AC 1件につき 1テスト。全テストは実装前に FAIL（RED）する。
+AC 1件につき 1テスト。
 """
 
 from __future__ import annotations
 
+import pytest
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).parents[3]
@@ -15,9 +16,10 @@ TWILL_INTEGRATION_MD = (
     REPO_ROOT / "plugins" / "twl" / "architecture" / "domain" / "contexts" / "twill-integration.md"
 )
 
+if not TWILL_INTEGRATION_MD.exists():
+    pytest.skip(f"{TWILL_INTEGRATION_MD} not found", allow_module_level=True)
 
-def _read_doc() -> str:
-    return TWILL_INTEGRATION_MD.read_text(encoding="utf-8")
+_DOC_CONTENT = TWILL_INTEGRATION_MD.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -25,14 +27,13 @@ def _read_doc() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_ac1_spawn_session_in_component_mapping():
-    """AC1: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_spawn_session が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_spawn_session" in content, (
-        "Phase 2 Component Mapping に twl_spawn_session が未記載 (AC1 未実装)"
-    )
+class TestAC1SpawnSession:
+    """AC1: twill-integration.md Phase 2 Component Mapping に twl_spawn_session が記載されていること。"""
+
+    def test_ac1_spawn_session_in_component_mapping(self):
+        assert "twl_spawn_session" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_spawn_session が未記載 (AC1 未実装)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -40,14 +41,13 @@ def test_ac1_spawn_session_in_component_mapping():
 # ---------------------------------------------------------------------------
 
 
-def test_ac2_spawn_controller_in_component_mapping():
-    """AC2: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_spawn_controller が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_spawn_controller" in content, (
-        "Phase 2 Component Mapping に twl_spawn_controller が未記載 (AC2 未実装)"
-    )
+class TestAC2SpawnController:
+    """AC2: twill-integration.md Phase 2 Component Mapping に twl_spawn_controller が記載されていること。"""
+
+    def test_ac2_spawn_controller_in_component_mapping(self):
+        assert "twl_spawn_controller" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_spawn_controller が未記載 (AC2 未実装)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -55,14 +55,13 @@ def test_ac2_spawn_controller_in_component_mapping():
 # ---------------------------------------------------------------------------
 
 
-def test_ac3_capture_pane_in_component_mapping():
-    """AC3: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_capture_pane が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_capture_pane" in content, (
-        "Phase 2 Component Mapping に twl_capture_pane が未記載 (AC3 未実装)"
-    )
+class TestAC3CapturePane:
+    """AC3: twill-integration.md Phase 2 Component Mapping に twl_capture_pane が記載されていること。"""
+
+    def test_ac3_capture_pane_in_component_mapping(self):
+        assert "twl_capture_pane" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_capture_pane が未記載 (AC3 未実装)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -70,14 +69,13 @@ def test_ac3_capture_pane_in_component_mapping():
 # ---------------------------------------------------------------------------
 
 
-def test_ac4_list_windows_in_component_mapping():
-    """AC4: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_list_windows が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_list_windows" in content, (
-        "Phase 2 Component Mapping に twl_list_windows が未記載 (AC4 未実装)"
-    )
+class TestAC4ListWindows:
+    """AC4: twill-integration.md Phase 2 Component Mapping に twl_list_windows が記載されていること。"""
+
+    def test_ac4_list_windows_in_component_mapping(self):
+        assert "twl_list_windows" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_list_windows が未記載 (AC4 未実装)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -85,14 +83,13 @@ def test_ac4_list_windows_in_component_mapping():
 # ---------------------------------------------------------------------------
 
 
-def test_ac5_get_session_state_in_component_mapping():
-    """AC5: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_get_session_state（拡張）が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_get_session_state" in content, (
-        "Phase 2 Component Mapping に twl_get_session_state が未記載 (AC5 未実装)"
-    )
+class TestAC5GetSessionState:
+    """AC5: twill-integration.md Phase 2 Component Mapping に twl_get_session_state（拡張）が記載されていること。"""
+
+    def test_ac5_get_session_state_in_component_mapping(self):
+        assert "twl_get_session_state" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_get_session_state が未記載 (AC5 未実装)"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -100,11 +97,10 @@ def test_ac5_get_session_state_in_component_mapping():
 # ---------------------------------------------------------------------------
 
 
-def test_ac6_get_budget_in_component_mapping():
-    """AC6: twill-integration.md の Phase 2 Component Mapping テーブルに
-    twl_get_budget が含む tool 群として記載されていること。
-    """
-    content = _read_doc()
-    assert "twl_get_budget" in content, (
-        "Phase 2 Component Mapping に twl_get_budget が未記載 (AC6 未実装)"
-    )
+class TestAC6GetBudget:
+    """AC6: twill-integration.md Phase 2 Component Mapping に twl_get_budget が記載されていること。"""
+
+    def test_ac6_get_budget_in_component_mapping(self):
+        assert "twl_get_budget" in _DOC_CONTENT, (
+            "Phase 2 Component Mapping に twl_get_budget が未記載 (AC6 未実装)"
+        )

--- a/plugins/twl/architecture/domain/contexts/twill-integration.md
+++ b/plugins/twl/architecture/domain/contexts/twill-integration.md
@@ -233,6 +233,7 @@ Phase 2 は既存 Phase 0/1 の 5 MCP tool に加え、`cli/twl/src/twl/autopilo
 | `tools.py` (既存 + Phase 2 統合) | twl_validate / twl_audit / twl_check / twl_state_read / twl_state_write + Phase 2 全 handler (validation 5, state 3, autopilot 12+) | Phase 0/1 + #1101 統合 | ✅ 実装済（27 handler） |
 | `tools_comm.py` | twl_send_msg / twl_recv_msg / twl_notify_supervisor | 子 5（`#1101` epic CLOSED 2026-04-30） | ✅ 実装済（別ファイル extract） |
 | ~~`tools_validation.py` / `tools_state.py` / `tools_autopilot.py`~~ | （ファイル分割は当初計画。実装上は `tools.py` 内に統合された） | （N/A） | 🚫 未実施（モジュール分割は子 1 拡充計画から外れたが、handler は `tools.py` 内に実装済。Tier 2 caller migration（ADR-029 Decision 5）には影響なし） |
+| `tools.py` (Tier 1+ 拡張 / ADR-029 Decision 6) | twl_spawn_session / twl_spawn_controller / twl_capture_pane / twl_list_windows / twl_get_session_state（拡張） / twl_get_budget | epic #1271 子 Issue 6 件（spawn 系 2 / observation 系 3 / budget 系 1） | ✅ 実装済（6 handler） |
 
 ### Key Workflows (Phase 2 完了後に更新)
 


### PR DESCRIPTION
## 概要

ADR-029 Decision 6 の Tier 1+ 6 tool（spawn/observation/budget 系）を `twill-integration.md` の Phase 2 Component Mapping テーブルに追記する。

## 変更内容

- `plugins/twl/architecture/domain/contexts/twill-integration.md`: Phase 2 Component Mapping テーブルに新行を追加

| tools_*.py ファイル | 含む tool 群 |
|---|---|
| `tools.py` (Tier 1+ 拡張 / ADR-029 Decision 6) | twl_spawn_session / twl_spawn_controller / twl_capture_pane / twl_list_windows / twl_get_session_state（拡張） / twl_get_budget |

## テスト

- `cli/twl/tests/test_issue_1527_twill_integration_component_mapping.py` — 6 PASS（RED → GREEN）

## 関連

- Closes #1527
- epic #1271
- ADR-029 Decision 6（検出元: PR #1525 / Issue #1509）