### PR TITLE
docs(glossary): Tier 1+ / shadow rollout pattern 用語を追加 (#1526)

### DIFF
--- a/cli/twl/tests/ac-test-mapping-1526.yaml
+++ b/cli/twl/tests/ac-test-mapping-1526.yaml
@@ -1,0 +1,13 @@
+mappings:
+  - ac_index: 1
+    ac_text: "Tier 1+ 用語が glossary.md の MUST 用語テーブルに登録されている（ADR-029 Decision 6）"
+    test_file: "cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats"
+    test_name: "ac1: glossary.md に Tier 1+ が登録されている"
+    impl_files:
+      - "plugins/twl/architecture/domain/glossary.md"
+  - ac_index: 2
+    ac_text: "shadow rollout pattern 用語が glossary.md に登録されている（ADR-029 Decision 5/6）"
+    test_file: "cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats"
+    test_name: "ac2: glossary.md に shadow rollout pattern が登録されている"
+    impl_files:
+      - "plugins/twl/architecture/domain/glossary.md"

--- a/cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats
+++ b/cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats
@@ -22,8 +22,13 @@ setup() {
     [[ -f "$GLOSSARY_MD" ]] \
         || skip "glossary.md が見つかりません: $GLOSSARY_MD"
 
+    # 用語列限定マッチ（PR #1357 推奨パターン）
     grep -qF '| Tier 1+ |' "$GLOSSARY_MD" \
         || { echo "FAIL: glossary.md に '| Tier 1+ |' が見つかりません"; false; }
+
+    # 行形式検証: 定義列・Context 列を含む完全な 3 列形式であること
+    grep -qE '^\| Tier 1\+ \| .+ \| .+ \|' "$GLOSSARY_MD" \
+        || { echo "FAIL: Tier 1+ の行が定義列・Context 列を含む完全な形式ではありません"; false; }
 }
 
 # ===========================================================================
@@ -36,6 +41,11 @@ setup() {
     [[ -f "$GLOSSARY_MD" ]] \
         || skip "glossary.md が見つかりません: $GLOSSARY_MD"
 
+    # 用語列限定マッチ（PR #1357 推奨パターン）
     grep -qF '| shadow rollout pattern |' "$GLOSSARY_MD" \
         || { echo "FAIL: glossary.md に '| shadow rollout pattern |' が見つかりません"; false; }
+
+    # 行形式検証: 定義列・Context 列を含む完全な 3 列形式であること
+    grep -qE '^\| shadow rollout pattern \| .+ \| .+ \|' "$GLOSSARY_MD" \
+        || { echo "FAIL: shadow rollout pattern の行が定義列・Context 列を含む完全な形式ではありません"; false; }
 }

--- a/cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats
+++ b/cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+# test_issue1526_glossary_tier1plus_shadow.bats - Tier 1+ / shadow rollout pattern glossary 登録テスト
+#
+# Issue: #1526 tech-debt: glossary.md に Tier 1+ / shadow rollout pattern 用語を追加
+#
+# 検証する仕様:
+#   AC-1: glossary.md に Tier 1+ が MUST テーブルに登録されていること
+#   AC-2: glossary.md に shadow rollout pattern が登録されていること
+
+setup() {
+    REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../.." && pwd)"
+    GLOSSARY_MD="$REPO_ROOT/plugins/twl/architecture/domain/glossary.md"
+}
+
+# ===========================================================================
+# AC-1: MUST テーブルに "Tier 1+" が登録されていること
+# 検証: テーブル行 `| Tier 1+ |` の列境界を含むパターンで用語列限定マッチ
+# ===========================================================================
+
+@test "ac1: glossary.md に Tier 1+ が登録されている" {
+    # AC: Tier 1+ は ADR-029 Decision 6 で定義された次層改善カテゴリ（observer/controller MCP 化 6 tool 群）
+    [[ -f "$GLOSSARY_MD" ]] \
+        || skip "glossary.md が見つかりません: $GLOSSARY_MD"
+
+    grep -qF '| Tier 1+ |' "$GLOSSARY_MD" \
+        || { echo "FAIL: glossary.md に '| Tier 1+ |' が見つかりません"; false; }
+}
+
+# ===========================================================================
+# AC-2: MUST テーブルに "shadow rollout pattern" が登録されていること
+# 検証: テーブル行 `| shadow rollout pattern |` の列境界を含むパターンで用語列限定マッチ
+# ===========================================================================
+
+@test "ac2: glossary.md に shadow rollout pattern が登録されている" {
+    # AC: shadow rollout pattern は ADR-029 Decision 5/6 で validated 済の 3-step migration pattern
+    [[ -f "$GLOSSARY_MD" ]] \
+        || skip "glossary.md が見つかりません: $GLOSSARY_MD"
+
+    grep -qF '| shadow rollout pattern |' "$GLOSSARY_MD" \
+        || { echo "FAIL: glossary.md に '| shadow rollout pattern |' が見つかりません"; false; }
+}

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -55,7 +55,7 @@
 | SHA pin | 可変参照（tag/branch）を避け、40-char commit SHA で依存を固定すること。再現性と一貫性を保証する（ADR-033） | Cross-Repo Protocol |
 | Drift Detection | SHA ピンと実際の Provider HEAD を定期比較してずれを検出する運用。cron・GitHub Actions・手動レビューのいずれかで実施する（ADR-033） | Cross-Repo Protocol |
 | Tier 1+ | ADR-029 Decision 6 で定義された次層改善カテゴリ。Tier 2 caller migration（Decision 5）完遂後に着手する observer/controller の bash 呼び出し依存を解消する 6 MCP tool 群の総称（epic #1271）。spawn/observation/budget の 3 分類で構成される | TWiLL Integration |
-| shadow rollout pattern | ADR-029 Decision 5/6 で validated 済の 3-step migration pattern。Step 1: bash hook 保持 + MCP tool log-only 並走（mcp-shadow-compare.sh で整合検証）、Step 2: 1 週間 mismatch 0 件確認後 blocking 切替、Step 3: 既存 bash hook 削除（#1225 pattern 踏襲） | TWiLL Integration |
+| shadow rollout pattern | ADR-029 Decision 5/6 で validated 済の 3-step migration pattern。Step 1: bash hook 保持 + MCP tool log-only 並走（shadow 整合検証）、Step 2: mismatch 0 件確認後 blocking 切替、Step 3: 既存 bash hook 削除（詳細は ADR-029 §shadow rollout pattern 参照） | TWiLL Integration |
 
 ## 照合ポリシー
 

--- a/plugins/twl/architecture/domain/glossary.md
+++ b/plugins/twl/architecture/domain/glossary.md
@@ -54,6 +54,8 @@
 | protocols/ | クロスリポジトリ知識転送プロトコルを格納するディレクトリ（`architecture/protocols/`）。contracts/（同一リポジトリ内 Context 間）とは直交する概念であり、外部リポジトリの Pinned Reference を管理する（ADR-033） | Cross-Repo Protocol |
 | SHA pin | 可変参照（tag/branch）を避け、40-char commit SHA で依存を固定すること。再現性と一貫性を保証する（ADR-033） | Cross-Repo Protocol |
 | Drift Detection | SHA ピンと実際の Provider HEAD を定期比較してずれを検出する運用。cron・GitHub Actions・手動レビューのいずれかで実施する（ADR-033） | Cross-Repo Protocol |
+| Tier 1+ | ADR-029 Decision 6 で定義された次層改善カテゴリ。Tier 2 caller migration（Decision 5）完遂後に着手する observer/controller の bash 呼び出し依存を解消する 6 MCP tool 群の総称（epic #1271）。spawn/observation/budget の 3 分類で構成される | TWiLL Integration |
+| shadow rollout pattern | ADR-029 Decision 5/6 で validated 済の 3-step migration pattern。Step 1: bash hook 保持 + MCP tool log-only 並走（mcp-shadow-compare.sh で整合検証）、Step 2: 1 週間 mismatch 0 件確認後 blocking 切替、Step 3: 既存 bash hook 削除（#1225 pattern 踏襲） | TWiLL Integration |
 
 ## 照合ポリシー
 


### PR DESCRIPTION
## 変更概要

ADR-029 Decision 6 で定義された2用語を `glossary.md` の MUST 用語テーブルに登録する。

## 追加用語

| 用語 | 定義 | Context |
|------|------|---------|
| Tier 1+ | ADR-029 Decision 6 で定義された次層改善カテゴリ。observer/controller の bash 呼び出し依存を解消する 6 MCP tool 群の総称（epic #1271） | TWiLL Integration |
| shadow rollout pattern | Decision 5/6 で validated 済の 3-step migration pattern（bash 並走 → blocking 切替 → bash 削除） | TWiLL Integration |

## 検出元

PR #1525 (Issue #1509) の worker-architecture レビューで検出。

## テスト

- `cli/twl/tests/architecture/test_issue1526_glossary_tier1plus_shadow.bats` 追加（2 AC → 2 RED→GREEN）
- `cli/twl/tests/ac-test-mapping-1526.yaml` 追加

Closes #1526