### PR TITLE
feat(mcp): twl_validate_status_transition_handler 新設 (#1562)

### DIFF
--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1485,8 +1485,8 @@ def twl_validate_commit_handler(
             return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
 
 
-_STATUS_TARGET_OPTION_IDS = ("3d983780", "47fc9ee4")  # Refined, In Progress
-_STATUS_DENY_MESSAGES = {
+_STATUS_TARGET_OPTION_IDS: tuple[str, ...] = ("3d983780", "47fc9ee4")  # Refined, In Progress
+_STATUS_DENY_MESSAGES: dict[str, str] = {
     "3d983780": (
         "Status=Refined 直接遷移は禁止です。"
         " /twl:co-issue refine #N を実行して spec-review-session を完了させてください。"
@@ -1500,11 +1500,11 @@ _STATUS_DENY_MESSAGES = {
 
 def _check_status_transition_evidence(session_tmp_dir: str | None, controller_issue_dir: str | None) -> str | None:
     """spec-review-session 優先 → Phase4-complete.json の順で evidence を検索して返す。"""
-    stmp = Path(session_tmp_dir or os.environ.get("SESSION_TMP_DIR", "/tmp"))
+    stmp = Path(session_tmp_dir or os.environ.get("SESSION_TMP_DIR", "/tmp")).resolve()
     spec_files = sorted(stmp.glob(".spec-review-session-*.json"))
     if spec_files:
         return str(spec_files[0])
-    cidir = Path(controller_issue_dir or os.environ.get("CONTROLLER_ISSUE_DIR", ".controller-issue"))
+    cidir = Path(controller_issue_dir or os.environ.get("CONTROLLER_ISSUE_DIR", ".controller-issue")).resolve()
     phase4_files = sorted(cidir.glob("*/Phase4-complete.json"))
     if phase4_files:
         return str(phase4_files[0])
@@ -1533,6 +1533,10 @@ def twl_validate_status_transition_handler(
 
     Note: cross-repo R5 label fallback は本 handler 範囲外
           (autopilot-launch.sh の _check_label_fallback が担当)。
+
+    Note: timeout_sec は Sub-3 hook payload との API 一貫性のために定義。
+          本 handler は純粋 in-process ロジック（サブプロセス・ブロッキング I/O なし）のため
+          timeout は実施しない。
     """
     if tool_name != "Bash" or not command:
         return {"decision": "allow", "reason": "no-op: not target tool/command", "evidence_path": None, "matched_option_id": None}

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1485,6 +1485,69 @@ def twl_validate_commit_handler(
             return {"ok": False, "error": "timeout", "error_type": "timeout", "exit_code": 124}
 
 
+_STATUS_TARGET_OPTION_IDS = ("3d983780", "47fc9ee4")  # Refined, In Progress
+_STATUS_DENY_MESSAGES = {
+    "3d983780": (
+        "Status=Refined 直接遷移は禁止です。"
+        " /twl:co-issue refine #N を実行して spec-review-session を完了させてください。"
+    ),
+    "47fc9ee4": (
+        "Status=In Progress 直接遷移は禁止です。"
+        " autopilot/co-explore 経由で evidence を生成してください。"
+    ),
+}
+
+
+def _check_status_transition_evidence(session_tmp_dir: str | None, controller_issue_dir: str | None) -> str | None:
+    """spec-review-session 優先 → Phase4-complete.json の順で evidence を検索して返す。"""
+    stmp = Path(session_tmp_dir or os.environ.get("SESSION_TMP_DIR", "/tmp"))
+    spec_files = sorted(stmp.glob(".spec-review-session-*.json"))
+    if spec_files:
+        return str(spec_files[0])
+    cidir = Path(controller_issue_dir or os.environ.get("CONTROLLER_ISSUE_DIR", ".controller-issue"))
+    phase4_files = sorted(cidir.glob("*/Phase4-complete.json"))
+    if phase4_files:
+        return str(phase4_files[0])
+    return None
+
+
+def twl_validate_status_transition_handler(
+    command: str,
+    tool_name: str = "Bash",
+    session_tmp_dir: str | None = None,
+    controller_issue_dir: str | None = None,
+    timeout_sec: int | None = 10,
+) -> dict:
+    """validation module: gh project item-edit Status field transition gate.
+
+    Sub-1 (pre-bash-refined-status-gate.sh) の MCP-native 二重防御。
+    Sub-1 の In Progress gate に加え Refined gate と Phase4-complete.json evidence を追加する。
+
+    Returns:
+        {
+            "decision": "allow" | "deny",
+            "reason": str,
+            "evidence_path": str | None,
+            "matched_option_id": str | None,
+        }
+
+    Note: cross-repo R5 label fallback は本 handler 範囲外
+          (autopilot-launch.sh の _check_label_fallback が担当)。
+    """
+    if tool_name != "Bash" or not command:
+        return {"decision": "allow", "reason": "no-op: not target tool/command", "evidence_path": None, "matched_option_id": None}
+    if "gh project item-edit" not in command:
+        return {"decision": "allow", "reason": "no-op: not item-edit command", "evidence_path": None, "matched_option_id": None}
+    matched_id = next((oid for oid in _STATUS_TARGET_OPTION_IDS if re.search(rf"\b{oid}\b", command)), None)
+    if matched_id is None:
+        return {"decision": "allow", "reason": "no-op: target option ID not matched", "evidence_path": None, "matched_option_id": None}
+    evidence_path = _check_status_transition_evidence(session_tmp_dir, controller_issue_dir)
+    if evidence_path:
+        return {"decision": "allow", "reason": f"evidence found: {evidence_path}", "evidence_path": evidence_path, "matched_option_id": matched_id}
+    deny_reason = _STATUS_DENY_MESSAGES.get(matched_id, f"Status 遷移 option ID={matched_id} の直接遷移は禁止です。")
+    return {"decision": "deny", "reason": deny_reason, "evidence_path": None, "matched_option_id": matched_id}
+
+
 def twl_check_completeness_handler(manifest_context: str) -> dict:
     """validation module: specialist completeness check via flock-guarded manifest files."""
     import fcntl
@@ -2086,6 +2149,17 @@ try:
         return json.dumps(twl_validate_commit_handler(command=command, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
+    def twl_validate_status_transition(
+        command: str,
+        tool_name: str = "Bash",
+        session_tmp_dir: str | None = None,
+        controller_issue_dir: str | None = None,
+        timeout_sec: int | None = 10,
+    ) -> str:
+        """validation module: gh project item-edit Status field transition gate (MCP-native double defense)."""
+        return json.dumps(twl_validate_status_transition_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
     def twl_check_completeness(manifest_context: str) -> str:
         """validation module: specialist completeness check via flock-guarded manifest files."""
         return json.dumps(twl_check_completeness_handler(manifest_context=manifest_context), ensure_ascii=False)
@@ -2289,6 +2363,10 @@ except ImportError:
     def twl_validate_commit(command: str, files: list[str], timeout_sec: int | None = 300) -> str:  # type: ignore[misc]
         """validation module: commit message and file deps validation (in-process, no subprocess)."""
         return json.dumps(twl_validate_commit_handler(command=command, files=files, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_validate_status_transition(command: str, tool_name: str = "Bash", session_tmp_dir: str | None = None, controller_issue_dir: str | None = None, timeout_sec: int | None = 10) -> str:  # type: ignore[misc]
+        """validation module: gh project item-edit Status field transition gate (fastmcp not installed)."""
+        return json.dumps(twl_validate_status_transition_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
 
     def twl_check_completeness(manifest_context: str) -> str:  # type: ignore[misc]
         """validation module: specialist completeness check via flock-guarded manifest files."""

--- a/cli/twl/tests/ac-test-mapping.yaml
+++ b/cli/twl/tests/ac-test-mapping.yaml
@@ -488,3 +488,80 @@ mappings:
       - "TestAC6CliValueErrorHandling::test_ac7_stderr_single_line_no_traceback_on_invalid_command"
     impl_files:
       - "cli/twl/tests/test_mcp_lifecycle.py"
+
+  # ---------------------------------------------------------------------------
+  # Issue #1562: feat(twl/mcp): mcp twl_validate_status_transition
+  # ---------------------------------------------------------------------------
+
+  - ac_index: "1562-AC1"
+    ac_text: "tool が gh project item-edit + Refined option ID 3d983780 パターンマッチかつ evidence なしのとき {decision: 'deny', reason: <actionable>, evidence_path: null} を返す"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC5TruthTable::test_t3_refined_option_id_no_evidence_deny"
+      - "TestAC4OutputSchema::test_ac4_deny_result_has_required_keys"
+      - "TestAC5TruthTable::test_t5_in_progress_option_id_no_evidence_deny"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: "1562-AC2"
+    ac_text: "spec-review-session / Phase4-complete.json の evidence があるとき {decision: 'allow', reason: 'evidence found: <path>', evidence_path: <検出 path>} を返す（順序: spec-review-session 優先 → Phase4-complete）"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC5TruthTable::test_t1_refined_option_id_with_spec_review_session"
+      - "TestAC5TruthTable::test_t2_refined_option_id_with_phase4_complete"
+      - "TestAC4OutputSchema::test_ac4_allow_result_has_required_keys"
+      - "TestAC4OutputSchema::test_ac4_spec_review_evidence_priority_over_phase4"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: "1562-AC3"
+    ac_text: "本 tool 範囲外"
+    test_file: null
+    test_name: null
+    impl_files: []
+    note: "out-of-scope: AC3 は本 tool の範囲外のためテスト生成スキップ"
+
+  - ac_index: "1562-AC4"
+    ac_text: "output schema は {decision: 'allow'|'deny', reason: str, evidence_path: str|None} で固定。任意で matched_option_id を含めて良い"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC4OutputSchema::test_ac4_allow_result_has_required_keys"
+      - "TestAC4OutputSchema::test_ac4_deny_result_has_required_keys"
+      - "TestAC4OutputSchema::test_ac4_spec_review_evidence_priority_over_phase4"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: "1562-AC5"
+    ac_text: "pytest 単体テスト 11 件 (T1-T11 truth table) を追加"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC5TruthTable::test_t1_refined_option_id_with_spec_review_session"
+      - "TestAC5TruthTable::test_t2_refined_option_id_with_phase4_complete"
+      - "TestAC5TruthTable::test_t3_refined_option_id_no_evidence_deny"
+      - "TestAC5TruthTable::test_t4_in_progress_option_id_with_spec_review_session"
+      - "TestAC5TruthTable::test_t5_in_progress_option_id_no_evidence_deny"
+      - "TestAC5TruthTable::test_t6_partial_option_id_word_boundary_allow"
+      - "TestAC5TruthTable::test_t7_item_list_command_allow"
+      - "TestAC5TruthTable::test_t8_todo_option_id_allow"
+      - "TestAC5TruthTable::test_t9_edit_tool_allow"
+      - "TestAC5TruthTable::test_t10_empty_command_allow"
+      - "TestAC5TruthTable::test_t11_gh_api_graphql_allow"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: "1562-AC6"
+    ac_text: "tools.py の 3 箇所に entry 追加（handler function / @mcp.tool() decorator / fallback stub）"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC6FunctionExistsInToolsPy::test_ac6_handler_function_importable"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: "1562-AC7"
+    ac_text: "既存 In Progress option ID 47fc9ee4 の判定動作はリグレッションしない（T4/T5 で保証）"
+    test_file: "cli/twl/tests/test_issue_1562_validate_status_transition.py"
+    test_names:
+      - "TestAC5TruthTable::test_t4_in_progress_option_id_with_spec_review_session"
+      - "TestAC5TruthTable::test_t5_in_progress_option_id_no_evidence_deny"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"

--- a/cli/twl/tests/test_issue_1562_validate_status_transition.py
+++ b/cli/twl/tests/test_issue_1562_validate_status_transition.py
@@ -1,0 +1,348 @@
+"""Tests for Issue #1562: twl_validate_status_transition_handler MCP tool (RED フェーズ).
+
+TDD RED フェーズ用テストスタブ。実装前は全テストが FAIL する（意図的 RED）。
+
+AC 一覧:
+- AC1: tool が gh project item-edit + Refined option ID 3d983780 パターンマッチかつ
+       evidence なしのとき {decision: "deny", reason: <actionable>, evidence_path: null} を返す
+- AC2: spec-review-session / Phase4-complete.json の evidence があるとき
+       {decision: "allow", reason: "evidence found: <path>", evidence_path: <検出 path>} を返す
+- AC3: 本 tool 範囲外 → テスト生成スキップ（out-of-scope）
+- AC4: output schema は {decision: "allow"|"deny", reason: str, evidence_path: str|None}
+       任意で matched_option_id を含めて良い
+- AC5: pytest 単体テスト 11 件 (T1-T11 truth table) を追加
+- AC6: tools.py の 3 箇所に entry 追加
+       (handler function / @mcp.tool() decorator / fallback stub)
+- AC7: 既存 In Progress option ID 47fc9ee4 の判定動作はリグレッションしない (T4/T5)
+"""
+
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+
+
+# ---------------------------------------------------------------------------
+# AC1 / AC2 / AC4 / AC5 / AC7: Truth Table T1-T11
+# ---------------------------------------------------------------------------
+
+
+class TestAC5TruthTable:
+    """AC5: pytest 単体テスト 11 件 (T1-T11 truth table) を追加."""
+
+    # ------------------------------------------------------------------
+    # T1: Refined option ID + spec-review-session → allow
+    # ------------------------------------------------------------------
+
+    def test_t1_refined_option_id_with_spec_review_session(self, tmp_path):
+        # AC2: spec-review-session 存在時 → allow + evidence found: <path>
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        spec_file = tmp_path / ".spec-review-session-12345.json"
+        spec_file.write_text("{}", encoding="utf-8")
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d983780",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "evidence found:" in result["reason"]
+        assert result["evidence_path"] is not None
+        assert ".spec-review-session-12345.json" in result["evidence_path"]
+
+    # ------------------------------------------------------------------
+    # T2: Refined option ID + Phase4-complete.json → allow
+    # ------------------------------------------------------------------
+
+    def test_t2_refined_option_id_with_phase4_complete(self, tmp_path):
+        # AC2: Phase4-complete.json 存在時 → allow + evidence found: <path>
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        phase4_dir = tmp_path / "ci-dir" / "issue-1562"
+        phase4_dir.mkdir(parents=True)
+        phase4_file = phase4_dir / "Phase4-complete.json"
+        phase4_file.write_text("{}", encoding="utf-8")
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d983780",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "evidence found:" in result["reason"]
+        assert result["evidence_path"] is not None
+        assert "Phase4-complete.json" in result["evidence_path"]
+
+    # ------------------------------------------------------------------
+    # T3: Refined option ID + evidence なし → deny
+    # ------------------------------------------------------------------
+
+    def test_t3_refined_option_id_no_evidence_deny(self, tmp_path):
+        # AC1: evidence なし + Refined option ID → deny + actionable reason
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d983780",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "deny"
+        assert result["reason"]  # actionable な reason が存在する（空でない）
+        assert result["evidence_path"] is None
+
+    # ------------------------------------------------------------------
+    # T4: In Progress option ID + spec-review-session → allow (regression)
+    # ------------------------------------------------------------------
+
+    def test_t4_in_progress_option_id_with_spec_review_session(self, tmp_path):
+        # AC7: 既存 In Progress option ID 47fc9ee4 + evidence あり → allow（リグレッション保証）
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        spec_file = tmp_path / ".spec-review-session-99999.json"
+        spec_file.write_text("{}", encoding="utf-8")
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 47fc9ee4",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+
+    # ------------------------------------------------------------------
+    # T5: In Progress option ID + evidence なし → deny (regression)
+    # ------------------------------------------------------------------
+
+    def test_t5_in_progress_option_id_no_evidence_deny(self, tmp_path):
+        # AC7: 既存 In Progress option ID 47fc9ee4 + evidence なし → deny（リグレッション保証）
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 47fc9ee4",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "deny"
+        assert result["evidence_path"] is None
+
+    # ------------------------------------------------------------------
+    # T6: Partial match (3d9837801) → allow (word boundary: no match)
+    # ------------------------------------------------------------------
+
+    def test_t6_partial_option_id_word_boundary_allow(self, tmp_path):
+        # AC1: word boundary により 3d9837801 は Refined option ID にマッチしない → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d9837801",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+    # ------------------------------------------------------------------
+    # T7: item-list コマンド → allow (not item-edit)
+    # ------------------------------------------------------------------
+
+    def test_t7_item_list_command_allow(self, tmp_path):
+        # AC1: gh project item-list は item-edit でないため → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-list 6 --owner shuu5",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+    # ------------------------------------------------------------------
+    # T8: Todo option ID (f75ad846) → allow (対象外)
+    # ------------------------------------------------------------------
+
+    def test_t8_todo_option_id_allow(self, tmp_path):
+        # AC1: f75ad846 (Todo) は対象 option ID でないため → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id f75ad846",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+    # ------------------------------------------------------------------
+    # T9: tool_name が Edit → allow (対象外ツール)
+    # ------------------------------------------------------------------
+
+    def test_t9_edit_tool_allow(self, tmp_path):
+        # AC1: tool_name=Edit は Bash でないため → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="some arbitrary content",
+            tool_name="Edit",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+    # ------------------------------------------------------------------
+    # T10: 空コマンド → allow
+    # ------------------------------------------------------------------
+
+    def test_t10_empty_command_allow(self, tmp_path):
+        # AC1: 空コマンドは対象外 → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+    # ------------------------------------------------------------------
+    # T11: gh api graphql → allow (not item-edit)
+    # ------------------------------------------------------------------
+
+    def test_t11_gh_api_graphql_allow(self, tmp_path):
+        # AC1: gh api graphql は item-edit でないため → no-op allow
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command='gh api graphql -f query="{ viewer { login } }"',
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# AC4: output schema 検証
+# ---------------------------------------------------------------------------
+
+
+class TestAC4OutputSchema:
+    """AC4: output schema は {decision, reason, evidence_path} で固定."""
+
+    def test_ac4_allow_result_has_required_keys(self, tmp_path):
+        # AC4: allow 時のレスポンスに必須キーが含まれること
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-list 6 --owner shuu5",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert "decision" in result
+        assert "reason" in result
+        assert "evidence_path" in result
+        assert result["decision"] in ("allow", "deny")
+        assert isinstance(result["reason"], str)
+        # evidence_path は str または None
+        assert result["evidence_path"] is None or isinstance(result["evidence_path"], str)
+
+    def test_ac4_deny_result_has_required_keys(self, tmp_path):
+        # AC4: deny 時のレスポンスに必須キーが含まれること
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d983780",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path / "nonexistent-session-dir"),
+            controller_issue_dir=str(tmp_path / "nonexistent-ci-dir"),
+        )
+
+        assert "decision" in result
+        assert "reason" in result
+        assert "evidence_path" in result
+        assert result["decision"] == "deny"
+        assert isinstance(result["reason"], str)
+        assert result["reason"]  # non-empty actionable message
+        assert result["evidence_path"] is None
+
+    def test_ac4_spec_review_evidence_priority_over_phase4(self, tmp_path):
+        # AC2: spec-review-session が Phase4-complete より優先されること
+        # RED: twl_validate_status_transition_handler 未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        # 両方作成
+        spec_file = tmp_path / ".spec-review-session-77777.json"
+        spec_file.write_text("{}", encoding="utf-8")
+        phase4_dir = tmp_path / "ci-dir" / "issue-1562"
+        phase4_dir.mkdir(parents=True)
+        (phase4_dir / "Phase4-complete.json").write_text("{}", encoding="utf-8")
+
+        result = twl_validate_status_transition_handler(
+            command="gh project item-edit --project-id 6 --item-id abc --field-id XYZ --single-select-option-id 3d983780",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "ci-dir"),
+        )
+
+        assert result["decision"] == "allow"
+        # spec-review-session が優先されるため evidence_path に spec-review-session が含まれる
+        assert result["evidence_path"] is not None
+        assert ".spec-review-session-" in result["evidence_path"]
+
+
+# ---------------------------------------------------------------------------
+# AC6 (optional): tools.py に twl_validate_status_transition_handler が存在すること
+# ---------------------------------------------------------------------------
+
+
+class TestAC6FunctionExistsInToolsPy:
+    """AC6: tools.py に handler function が定義されていること."""
+
+    def test_ac6_handler_function_importable(self):
+        # AC6: tools.py に twl_validate_status_transition_handler 関数が存在する
+        # RED: 関数未実装のため ImportError で FAIL
+        from twl.mcp_server.tools import twl_validate_status_transition_handler
+
+        assert callable(twl_validate_status_transition_handler), (
+            "twl_validate_status_transition_handler は callable である必要があります"
+        )


### PR DESCRIPTION
## 概要

Issue #1562 の実装。`twl` MCP server に `validate_status_transition` tool を新設する。
Sub-1 (Bash hook #1561) の MCP-native 二重防御として、`gh project item-edit` 経由の Status=Refined / In Progress 直接遷移を evidence check で gate する。

## AC 対応

- **AC1**: Refined option ID (3d983780) + evidence なし → deny ✓
- **AC2**: spec-review-session / Phase4-complete.json 存在 → allow ✓
- **AC3**: 本 tool 範囲外（スコープ外）✓
- **AC4**: output schema {decision, reason, evidence_path} 固定 ✓
- **AC5**: pytest 15 件 (T1-T11 + AC4×3 + AC6×1) 全 GREEN ✓
- **AC6**: tools.py 3 箇所に entry 追加（handler / @mcp.tool() / fallback stub）✓
- **AC7**: In Progress option ID (47fc9ee4) リグレッションなし (T4/T5) ✓

## テスト結果

```
15 passed, 1 warning in 0.04s
```

Closes #1562