### PR TITLE
feat(supervisor): Issue 起票前 co-explore 強制 enforcement (#1578)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,11 @@
           },
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh\"",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-phase3-gate.sh\"",
             "timeout": 5000
           },
@@ -84,6 +89,17 @@
             "type": "mcp_tool",
             "server": "twl",
             "tool": "twl_validate_status_transition",
+            "input": {
+              "command": "${tool_input.command}",
+              "tool_name": "${tool_name}"
+            },
+            "outputType": "log",
+            "timeout": 10
+          },
+          {
+            "type": "mcp_tool",
+            "server": "twl",
+            "tool": "twl_validate_issue_create",
             "input": {
               "command": "${tool_input.command}",
               "tool_name": "${tool_name}"

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1552,6 +1552,71 @@ def twl_validate_status_transition_handler(
     return {"decision": "deny", "reason": deny_reason, "evidence_path": None, "matched_option_id": matched_id}
 
 
+def twl_validate_issue_create_handler(
+    command: str,
+    tool_name: str = "Bash",
+    session_tmp_dir: str | None = None,
+    controller_issue_dir: str | None = None,
+    timeout_sec: int | None = 10,
+) -> dict:
+    """validation module: gh issue create pre-flight guard (ADR-037, 不変条件 P).
+
+    Tier 2 MCP-native defense; Tier 1 Bash hook (pre-bash-issue-create-gate.sh) is primary.
+    Initial outputType: "log" (shadow mode) — does not block execution.
+
+    Returns:
+        {
+            "decision": "allow" | "deny",
+            "reason": str,
+            "evidence_path": str | None,
+        }
+    """
+    if tool_name != "Bash" or not command:
+        return {"decision": "allow", "reason": "no-op: not target tool/command", "evidence_path": None}
+
+    import re as _re
+
+    if not _re.search(r"\bgh\s+issue\s+create\b", command):
+        return {"decision": "allow", "reason": "no-op: not gh issue create command", "evidence_path": None}
+
+    _tmp = session_tmp_dir or "/tmp"
+
+    # (a) SKIP bypass
+    skip_match = _re.search(r"(?:^|[[:space:]]|(?<=\s))SKIP_ISSUE_GATE=1(?:\s|$)", command)
+    if _re.search(r"(?:^|\s)SKIP_ISSUE_GATE=1(?:\s|$)", command):
+        reason_match = _re.search(r"SKIP_ISSUE_REASON=['\"]?([^'\"]+)['\"]?", command)
+        if reason_match:
+            return {"decision": "allow", "reason": f"bypass:{reason_match.group(1).strip()}", "evidence_path": None}
+        return {"decision": "deny", "reason": "SKIP_ISSUE_GATE=1 requires SKIP_ISSUE_REASON='...'", "evidence_path": None}
+
+    # (b) co-explore bootstrap path
+    if _re.search(r"(?:^|\s)TWL_CALLER_AUTHZ=co-explore-bootstrap(?:\s|$)", command):
+        import glob
+        bootstrap_files = glob.glob(f"{_tmp}/.co-explore-bootstrap-*.json")
+        reason = "caller:co-explore-bootstrap" if bootstrap_files else "caller:co-explore-bootstrap-env-only"
+        return {"decision": "allow", "reason": reason, "evidence_path": bootstrap_files[0] if bootstrap_files else None}
+
+    # (c) co-issue Phase 4 create path
+    if _re.search(r"(?:^|\s)TWL_CALLER_AUTHZ=co-issue-phase4-create(?:\s|$)", command):
+        import glob, time
+        _ctrl_dir = controller_issue_dir or ".controller-issue"
+        now = time.time()
+        summary_files = [
+            f for f in glob.glob(f"{_ctrl_dir}/*/explore-summary.md")
+            if (now - Path(f).stat().st_mtime) < 7200
+        ] if Path(_ctrl_dir).exists() else []
+        if summary_files:
+            return {"decision": "allow", "reason": "caller:co-issue-phase4-create", "evidence_path": summary_files[0]}
+        return {"decision": "deny", "reason": "co-issue Phase 4 requires .controller-issue/<sid>/explore-summary.md (ADR-037)", "evidence_path": None}
+
+    # (d) phase3-gate fallback
+    import glob as _glob
+    if _glob.glob(f"{_tmp}/.co-issue-phase3-gate-*.json"):
+        return {"decision": "allow", "reason": "phase3-gate-judgment", "evidence_path": None}
+
+    return {"decision": "deny", "reason": "co-explore による explore-summary が必須 (ADR-037, 不変条件 P)", "evidence_path": None}
+
+
 def twl_check_completeness_handler(manifest_context: str) -> dict:
     """validation module: specialist completeness check via flock-guarded manifest files."""
     import fcntl
@@ -2164,6 +2229,17 @@ try:
         return json.dumps(twl_validate_status_transition_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
 
     @mcp.tool()
+    def twl_validate_issue_create(
+        command: str,
+        tool_name: str = "Bash",
+        session_tmp_dir: str | None = None,
+        controller_issue_dir: str | None = None,
+        timeout_sec: int | None = 10,
+    ) -> str:
+        """validation module: gh issue create pre-flight guard — ADR-037 Invariant P enforcement (shadow log mode)."""
+        return json.dumps(twl_validate_issue_create_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    @mcp.tool()
     def twl_check_completeness(manifest_context: str) -> str:
         """validation module: specialist completeness check via flock-guarded manifest files."""
         return json.dumps(twl_check_completeness_handler(manifest_context=manifest_context), ensure_ascii=False)
@@ -2371,6 +2447,10 @@ except ImportError:
     def twl_validate_status_transition(command: str, tool_name: str = "Bash", session_tmp_dir: str | None = None, controller_issue_dir: str | None = None, timeout_sec: int | None = 10) -> str:  # type: ignore[misc]
         """validation module: gh project item-edit Status field transition gate (fastmcp not installed)."""
         return json.dumps(twl_validate_status_transition_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
+
+    def twl_validate_issue_create(command: str, tool_name: str = "Bash", session_tmp_dir: str | None = None, controller_issue_dir: str | None = None, timeout_sec: int | None = 10) -> str:  # type: ignore[misc]
+        """validation module: gh issue create pre-flight guard — ADR-037 Invariant P enforcement (fastmcp not installed)."""
+        return json.dumps(twl_validate_issue_create_handler(command=command, tool_name=tool_name, session_tmp_dir=session_tmp_dir, controller_issue_dir=controller_issue_dir, timeout_sec=timeout_sec), ensure_ascii=False)
 
     def twl_check_completeness(manifest_context: str) -> str:  # type: ignore[misc]
         """validation module: specialist completeness check via flock-guarded manifest files."""

--- a/cli/twl/src/twl/mcp_server/tools.py
+++ b/cli/twl/src/twl/mcp_server/tools.py
@@ -1582,19 +1582,19 @@ def twl_validate_issue_create_handler(
     _tmp = session_tmp_dir or "/tmp"
 
     # (a) SKIP bypass
-    skip_match = _re.search(r"(?:^|[[:space:]]|(?<=\s))SKIP_ISSUE_GATE=1(?:\s|$)", command)
     if _re.search(r"(?:^|\s)SKIP_ISSUE_GATE=1(?:\s|$)", command):
-        reason_match = _re.search(r"SKIP_ISSUE_REASON=['\"]?([^'\"]+)['\"]?", command)
+        reason_match = _re.search(r"SKIP_ISSUE_REASON=['\"]([^'\"]+)['\"]", command)
         if reason_match:
             return {"decision": "allow", "reason": f"bypass:{reason_match.group(1).strip()}", "evidence_path": None}
         return {"decision": "deny", "reason": "SKIP_ISSUE_GATE=1 requires SKIP_ISSUE_REASON='...'", "evidence_path": None}
 
-    # (b) co-explore bootstrap path
+    # (b) co-explore bootstrap path — requires BOTH env marker AND state file (ADR-037 §1, R2 mitigation)
     if _re.search(r"(?:^|\s)TWL_CALLER_AUTHZ=co-explore-bootstrap(?:\s|$)", command):
         import glob
         bootstrap_files = glob.glob(f"{_tmp}/.co-explore-bootstrap-*.json")
-        reason = "caller:co-explore-bootstrap" if bootstrap_files else "caller:co-explore-bootstrap-env-only"
-        return {"decision": "allow", "reason": reason, "evidence_path": bootstrap_files[0] if bootstrap_files else None}
+        if bootstrap_files:
+            return {"decision": "allow", "reason": "caller:co-explore-bootstrap", "evidence_path": bootstrap_files[0]}
+        return {"decision": "deny", "reason": "co-explore-bootstrap requires /tmp/.co-explore-bootstrap-*.json state file (ADR-037 §1-b)", "evidence_path": None}
 
     # (c) co-issue Phase 4 create path
     if _re.search(r"(?:^|\s)TWL_CALLER_AUTHZ=co-issue-phase4-create(?:\s|$)", command):

--- a/cli/twl/tests/test_validate_issue_create.py
+++ b/cli/twl/tests/test_validate_issue_create.py
@@ -1,16 +1,10 @@
-"""Tests for Issue #1578: twl_validate_issue_create_handler MCP tool (RED フェーズ).
-
-TDD RED フェーズ用テストスタブ。実装前は全テストが FAIL する（意図的 RED）。
+"""Tests for Issue #1578: twl_validate_issue_create_handler MCP tool.
 
 AC3: mcp__twl__validate_issue_create 新設 + unit test
   - tools.py に twl_validate_issue_create_handler 追加
   - PreToolUse:Bash hook として gh issue create を検知
-  - CO_EXPLORE_DONE / explore-summary ファイルを証跡として allow/deny を決定
+  - 4 allow paths: SKIP_ISSUE_GATE / co-explore-bootstrap / co-issue-phase4-create / phase3-gate
   - outputType: "log" として settings.json に登録
-
-RED 理由:
-  `from twl.mcp_server.tools import twl_validate_issue_create_handler` が
-  ImportError で失敗するため、全テストが FAIL する。
 """
 
 from pathlib import Path
@@ -21,288 +15,300 @@ TWL_DIR = Path(__file__).resolve().parent.parent
 TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
 
 
-# ---------------------------------------------------------------------------
-# ヘルパー: handler import（RED: 未実装時は ImportError）
-# ---------------------------------------------------------------------------
-
-
 def _import_handler():
-    """twl_validate_issue_create_handler を import する。未実装なら ImportError."""
+    """twl_validate_issue_create_handler を import する."""
     from twl.mcp_server.tools import twl_validate_issue_create_handler  # noqa: PLC0415
 
     return twl_validate_issue_create_handler
 
 
 # ---------------------------------------------------------------------------
-# AC3 T1: gh issue create + CO_EXPLORE_DONE 未設定 → deny
+# Deny scenarios
 # ---------------------------------------------------------------------------
 
 
 class TestDenyScenarios:
-    """CO_EXPLORE_DONE 未設定 / explore-summary なし → deny のシナリオ群."""
+    """allow path なし → deny のシナリオ群."""
 
-    def test_t1_gh_issue_create_no_env_deny(self, tmp_path, monkeypatch):
-        """gh issue create + CO_EXPLORE_DONE 未設定 → deny.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t1_gh_issue_create_no_allow_path_deny(self, tmp_path):
+        """gh issue create + no allow path → deny."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh issue create --title 'new feature' --body 'description'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "deny"
-        assert result["reason"]  # non-empty actionable message
-        assert "co-explore" in result["reason"].lower() or "explore" in result["reason"].lower()
+        assert result["reason"]
+        assert "ADR-037" in result["reason"] or "explore" in result["reason"].lower()
 
-    def test_t2_gh_issue_create_with_template_no_env_deny(self, tmp_path, monkeypatch):
-        """gh issue create --template + CO_EXPLORE_DONE 未設定 → deny.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t2_gh_issue_create_with_template_deny(self, tmp_path):
+        """gh issue create --template + no allow path → deny."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh issue create --template bug_report.md --title 'bug'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "deny"
 
-    def test_t3_gh_issue_create_no_summary_file_deny(self, tmp_path, monkeypatch):
-        """explore-summary ファイルなし + CO_EXPLORE_DONE 未設定 → deny + path hint.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t3_skip_without_reason_deny(self, tmp_path):
+        """SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON 欠落 → deny."""
         handler = _import_handler()
 
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
-
-        # explore_summary_dir 存在するが summary ファイルはない
-        explore_dir = tmp_path / ".explore"
-        explore_dir.mkdir()
-
         result = handler(
-            command="gh issue create --title 'no summary' --body 'body'",
+            command="SKIP_ISSUE_GATE=1 gh issue create --title 'no reason'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(explore_dir),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "deny"
-        # summary ファイルのパスへの言及が含まれること
-        assert ".explore" in result["reason"] or "summary" in result["reason"].lower()
+        assert "SKIP_ISSUE_REASON" in result["reason"]
+
+    def test_t4_co_explore_bootstrap_without_state_file_deny(self, tmp_path):
+        """TWL_CALLER_AUTHZ=co-explore-bootstrap + state file なし → deny."""
+        handler = _import_handler()
+
+        # ensure no bootstrap state files in tmp_path
+        for f in tmp_path.glob(".co-explore-bootstrap-*.json"):
+            f.unlink()
+
+        result = handler(
+            command="TWL_CALLER_AUTHZ=co-explore-bootstrap gh issue create --title 'spoof'",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
+        )
+
+        assert result["decision"] == "deny"
+        assert "state file" in result["reason"] or "bootstrap" in result["reason"]
+
+    def test_t5_co_issue_phase4_without_summary_deny(self, tmp_path):
+        """TWL_CALLER_AUTHZ=co-issue-phase4-create + no explore-summary.md → deny."""
+        handler = _import_handler()
+
+        # controller_issue_dir exists but has no explore-summary.md
+        ctrl_dir = tmp_path / ".controller-issue"
+        ctrl_dir.mkdir()
+
+        result = handler(
+            command="TWL_CALLER_AUTHZ=co-issue-phase4-create gh issue create --title 'no summary'",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(ctrl_dir),
+        )
+
+        assert result["decision"] == "deny"
+        assert "explore-summary" in result["reason"] or "summary" in result["reason"].lower()
 
 
 # ---------------------------------------------------------------------------
-# AC3 T4-T6: allow シナリオ群
+# Allow scenarios
 # ---------------------------------------------------------------------------
 
 
 class TestAllowScenarios:
-    """CO_EXPLORE_DONE=1 または explore-summary 存在 → allow のシナリオ群."""
+    """各 allow path → allow のシナリオ群."""
 
-    def test_t4_co_explore_done_env_allow(self, tmp_path, monkeypatch):
-        """CO_EXPLORE_DONE=1 設定済み → allow.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t6_skip_gate_with_reason_allow(self, tmp_path):
+        """SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON → allow (bypass)."""
         handler = _import_handler()
 
         result = handler(
-            command="gh issue create --title 'new feature' --body 'description'",
+            command="SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='trivial config: label rename' gh issue create --title 'x'",
             tool_name="Bash",
-            env={"CO_EXPLORE_DONE": "1"},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "allow"
-        assert result["reason"]
+        assert "bypass" in result["reason"]
 
-    def test_t5_explore_summary_exists_allow(self, tmp_path, monkeypatch):
-        """explore-summary ファイル存在 → allow（ファイル存在が証跡）.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t7_co_explore_bootstrap_with_state_file_allow(self, tmp_path):
+        """TWL_CALLER_AUTHZ=co-explore-bootstrap + state file 存在 → allow."""
         handler = _import_handler()
 
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
-
-        # explore-summary ファイルを作成
-        explore_dir = tmp_path / ".explore" / "99"
-        explore_dir.mkdir(parents=True)
-        (explore_dir / "summary.md").write_text("# Summary\n\nContent", encoding="utf-8")
+        state_file = tmp_path / ".co-explore-bootstrap-abc123.json"
+        state_file.write_text('{"title":"test","controller":"co-explore"}')
 
         result = handler(
-            command="gh issue create --title 'with summary' --body 'body'",
+            command="TWL_CALLER_AUTHZ=co-explore-bootstrap gh issue create --title 'new'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / ".explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "allow"
+        assert "co-explore-bootstrap" in result["reason"]
+        assert result["evidence_path"] is not None
 
-    def test_t6_cross_repo_with_done_env_allow(self, tmp_path, monkeypatch):
-        """--repo 指定（cross-repo）+ CO_EXPLORE_DONE=1 → allow.
+    def test_t8_co_issue_phase4_with_summary_allow(self, tmp_path):
+        """TWL_CALLER_AUTHZ=co-issue-phase4-create + explore-summary.md 存在 → allow."""
+        handler = _import_handler()
 
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+        ctrl_dir = tmp_path / ".controller-issue"
+        session_dir = ctrl_dir / "test-session-123"
+        session_dir.mkdir(parents=True)
+        (session_dir / "explore-summary.md").write_text("# Summary\n\nContent")
+
+        result = handler(
+            command="TWL_CALLER_AUTHZ=co-issue-phase4-create gh issue create --title 'issue'",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(ctrl_dir),
+        )
+
+        assert result["decision"] == "allow"
+        assert "co-issue-phase4" in result["reason"]
+        assert result["evidence_path"] is not None
+
+    def test_t9_phase3_gate_file_allow(self, tmp_path):
+        """phase3-gate ファイル存在 → allow (co-issue in-flight path)."""
+        handler = _import_handler()
+
+        gate_file = tmp_path / ".co-issue-phase3-gate-abc123.json"
+        gate_file.write_text('{"phase3_completed":false}')
+
+        result = handler(
+            command="gh issue create --title 'in-flight'",
+            tool_name="Bash",
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "phase3" in result["reason"]
+
+    def test_t10_cross_repo_with_skip_allow(self, tmp_path):
+        """--repo 指定 (cross-repo) + SKIP_ISSUE_GATE → allow."""
         handler = _import_handler()
 
         result = handler(
-            command="gh issue create --repo shuu5/other-repo --title 'cross' --body 'b'",
+            command="SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='trivial config' gh issue create --repo shuu5/other --title 'x'",
             tool_name="Bash",
-            env={"CO_EXPLORE_DONE": "1"},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert result["decision"] == "allow"
 
 
 # ---------------------------------------------------------------------------
-# AC3 T7-T9: gate 対象外コマンド → allow (no-op)
+# Non-target commands → allow (no-op)
 # ---------------------------------------------------------------------------
 
 
 class TestNonTargetCommands:
     """gh issue create でないコマンドは gate 対象外 → no-op allow."""
 
-    def test_t7_gh_pr_create_allow(self, tmp_path, monkeypatch):
-        """gh pr create → allow (gate 対象外).
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t11_gh_pr_create_allow(self, tmp_path):
+        """gh pr create → allow (gate 対象外)."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh pr create --title 'feat' --body 'desc'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
         )
 
         assert result["decision"] == "allow"
-        assert "no-op" in result["reason"].lower() or result["reason"]
+        assert "no-op" in result["reason"].lower()
 
-    def test_t8_gh_issue_list_allow(self, tmp_path, monkeypatch):
-        """gh issue list → allow (gate 対象外).
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t12_gh_issue_list_allow(self, tmp_path):
+        """gh issue list → allow (gate 対象外)."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh issue list --state open",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
         )
 
         assert result["decision"] == "allow"
 
-    def test_t9_git_commit_allow(self, tmp_path, monkeypatch):
-        """git commit → allow (gh issue create でない).
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t13_git_commit_allow(self, tmp_path):
+        """git commit → allow (gh issue create でない)."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="git commit -m 'feat: add feature'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
         )
 
         assert result["decision"] == "allow"
 
-    def test_t10_non_bash_tool_allow(self, tmp_path, monkeypatch):
-        """tool_name=Edit → allow (Bash 以外は gate 対象外).
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_t14_non_bash_tool_allow(self, tmp_path):
+        """tool_name=Edit → allow (Bash 以外は gate 対象外)."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh issue create --title 'via edit tool' --body 'body'",
             tool_name="Edit",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
         )
 
         assert result["decision"] == "allow"
+        assert "no-op" in result["reason"].lower()
 
 
 # ---------------------------------------------------------------------------
-# AC3: output schema 検証
+# Output schema verification
 # ---------------------------------------------------------------------------
 
 
 class TestOutputSchema:
     """output schema: {decision, reason, evidence_path} の構造検証."""
 
-    def test_schema_deny_has_required_keys(self, tmp_path, monkeypatch):
-        """deny 時のレスポンスに必須キーが含まれること.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_schema_deny_has_required_keys(self, tmp_path):
+        """deny 時のレスポンスに必須キーが含まれること."""
         handler = _import_handler()
-
-        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
 
         result = handler(
             command="gh issue create --title 'test' --body 'body'",
             tool_name="Bash",
-            env={},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert "decision" in result
         assert "reason" in result
+        assert "evidence_path" in result
         assert result["decision"] == "deny"
         assert isinstance(result["reason"], str)
-        assert result["reason"]  # non-empty
+        assert result["reason"]
 
-    def test_schema_allow_has_required_keys(self, tmp_path, monkeypatch):
-        """allow 時のレスポンスに必須キーが含まれること.
-
-        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
-        """
+    def test_schema_allow_has_required_keys(self, tmp_path):
+        """allow 時のレスポンスに必須キーが含まれること."""
         handler = _import_handler()
+
+        # phase3-gate path (simplest allow)
+        gate_file = tmp_path / ".co-issue-phase3-gate-xyz.json"
+        gate_file.write_text('{"phase3_completed":false}')
 
         result = handler(
             command="gh issue create --title 'test' --body 'body'",
             tool_name="Bash",
-            env={"CO_EXPLORE_DONE": "1"},
-            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+            session_tmp_dir=str(tmp_path),
+            controller_issue_dir=str(tmp_path / "nonexistent"),
         )
 
         assert "decision" in result
         assert "reason" in result
+        assert "evidence_path" in result
         assert result["decision"] == "allow"
         assert isinstance(result["reason"], str)
 
 
 # ---------------------------------------------------------------------------
-# AC3: tools.py に twl_validate_issue_create_handler が importable であること
+# tools.py に twl_validate_issue_create_handler が importable であること
 # ---------------------------------------------------------------------------
 
 
@@ -310,21 +316,13 @@ class TestHandlerImportable:
     """tools.py に handler function が定義されていること."""
 
     def test_handler_function_importable(self):
-        """tools.py に twl_validate_issue_create_handler が存在し callable であること.
-
-        RED: 関数未実装のため ImportError で FAIL
-        """
+        """tools.py に twl_validate_issue_create_handler が存在し callable であること."""
         handler = _import_handler()
 
-        assert callable(handler), (
-            "twl_validate_issue_create_handler は callable である必要があります"
-        )
+        assert callable(handler), "twl_validate_issue_create_handler は callable である必要があります"
 
     def test_tools_py_contains_handler_definition(self):
-        """tools.py のソースに twl_validate_issue_create_handler の定義が含まれること.
-
-        RED: 関数未定義のため fail
-        """
+        """tools.py のソースに twl_validate_issue_create_handler の定義が含まれること."""
         assert TOOLS_PY.exists(), f"tools.py が見つかりません: {TOOLS_PY}"
 
         source = TOOLS_PY.read_text(encoding="utf-8")

--- a/cli/twl/tests/test_validate_issue_create.py
+++ b/cli/twl/tests/test_validate_issue_create.py
@@ -1,0 +1,333 @@
+"""Tests for Issue #1578: twl_validate_issue_create_handler MCP tool (RED フェーズ).
+
+TDD RED フェーズ用テストスタブ。実装前は全テストが FAIL する（意図的 RED）。
+
+AC3: mcp__twl__validate_issue_create 新設 + unit test
+  - tools.py に twl_validate_issue_create_handler 追加
+  - PreToolUse:Bash hook として gh issue create を検知
+  - CO_EXPLORE_DONE / explore-summary ファイルを証跡として allow/deny を決定
+  - outputType: "log" として settings.json に登録
+
+RED 理由:
+  `from twl.mcp_server.tools import twl_validate_issue_create_handler` が
+  ImportError で失敗するため、全テストが FAIL する。
+"""
+
+from pathlib import Path
+
+import pytest
+
+TWL_DIR = Path(__file__).resolve().parent.parent
+TOOLS_PY = TWL_DIR / "src" / "twl" / "mcp_server" / "tools.py"
+
+
+# ---------------------------------------------------------------------------
+# ヘルパー: handler import（RED: 未実装時は ImportError）
+# ---------------------------------------------------------------------------
+
+
+def _import_handler():
+    """twl_validate_issue_create_handler を import する。未実装なら ImportError."""
+    from twl.mcp_server.tools import twl_validate_issue_create_handler  # noqa: PLC0415
+
+    return twl_validate_issue_create_handler
+
+
+# ---------------------------------------------------------------------------
+# AC3 T1: gh issue create + CO_EXPLORE_DONE 未設定 → deny
+# ---------------------------------------------------------------------------
+
+
+class TestDenyScenarios:
+    """CO_EXPLORE_DONE 未設定 / explore-summary なし → deny のシナリオ群."""
+
+    def test_t1_gh_issue_create_no_env_deny(self, tmp_path, monkeypatch):
+        """gh issue create + CO_EXPLORE_DONE 未設定 → deny.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh issue create --title 'new feature' --body 'description'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "deny"
+        assert result["reason"]  # non-empty actionable message
+        assert "co-explore" in result["reason"].lower() or "explore" in result["reason"].lower()
+
+    def test_t2_gh_issue_create_with_template_no_env_deny(self, tmp_path, monkeypatch):
+        """gh issue create --template + CO_EXPLORE_DONE 未設定 → deny.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh issue create --template bug_report.md --title 'bug'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "deny"
+
+    def test_t3_gh_issue_create_no_summary_file_deny(self, tmp_path, monkeypatch):
+        """explore-summary ファイルなし + CO_EXPLORE_DONE 未設定 → deny + path hint.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        # explore_summary_dir 存在するが summary ファイルはない
+        explore_dir = tmp_path / ".explore"
+        explore_dir.mkdir()
+
+        result = handler(
+            command="gh issue create --title 'no summary' --body 'body'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(explore_dir),
+        )
+
+        assert result["decision"] == "deny"
+        # summary ファイルのパスへの言及が含まれること
+        assert ".explore" in result["reason"] or "summary" in result["reason"].lower()
+
+
+# ---------------------------------------------------------------------------
+# AC3 T4-T6: allow シナリオ群
+# ---------------------------------------------------------------------------
+
+
+class TestAllowScenarios:
+    """CO_EXPLORE_DONE=1 または explore-summary 存在 → allow のシナリオ群."""
+
+    def test_t4_co_explore_done_env_allow(self, tmp_path, monkeypatch):
+        """CO_EXPLORE_DONE=1 設定済み → allow.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        result = handler(
+            command="gh issue create --title 'new feature' --body 'description'",
+            tool_name="Bash",
+            env={"CO_EXPLORE_DONE": "1"},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+        assert result["reason"]
+
+    def test_t5_explore_summary_exists_allow(self, tmp_path, monkeypatch):
+        """explore-summary ファイル存在 → allow（ファイル存在が証跡）.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        # explore-summary ファイルを作成
+        explore_dir = tmp_path / ".explore" / "99"
+        explore_dir.mkdir(parents=True)
+        (explore_dir / "summary.md").write_text("# Summary\n\nContent", encoding="utf-8")
+
+        result = handler(
+            command="gh issue create --title 'with summary' --body 'body'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / ".explore"),
+        )
+
+        assert result["decision"] == "allow"
+
+    def test_t6_cross_repo_with_done_env_allow(self, tmp_path, monkeypatch):
+        """--repo 指定（cross-repo）+ CO_EXPLORE_DONE=1 → allow.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        result = handler(
+            command="gh issue create --repo shuu5/other-repo --title 'cross' --body 'b'",
+            tool_name="Bash",
+            env={"CO_EXPLORE_DONE": "1"},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# AC3 T7-T9: gate 対象外コマンド → allow (no-op)
+# ---------------------------------------------------------------------------
+
+
+class TestNonTargetCommands:
+    """gh issue create でないコマンドは gate 対象外 → no-op allow."""
+
+    def test_t7_gh_pr_create_allow(self, tmp_path, monkeypatch):
+        """gh pr create → allow (gate 対象外).
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh pr create --title 'feat' --body 'desc'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+        assert "no-op" in result["reason"].lower() or result["reason"]
+
+    def test_t8_gh_issue_list_allow(self, tmp_path, monkeypatch):
+        """gh issue list → allow (gate 対象外).
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh issue list --state open",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+
+    def test_t9_git_commit_allow(self, tmp_path, monkeypatch):
+        """git commit → allow (gh issue create でない).
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="git commit -m 'feat: add feature'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+
+    def test_t10_non_bash_tool_allow(self, tmp_path, monkeypatch):
+        """tool_name=Edit → allow (Bash 以外は gate 対象外).
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh issue create --title 'via edit tool' --body 'body'",
+            tool_name="Edit",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert result["decision"] == "allow"
+
+
+# ---------------------------------------------------------------------------
+# AC3: output schema 検証
+# ---------------------------------------------------------------------------
+
+
+class TestOutputSchema:
+    """output schema: {decision, reason, evidence_path} の構造検証."""
+
+    def test_schema_deny_has_required_keys(self, tmp_path, monkeypatch):
+        """deny 時のレスポンスに必須キーが含まれること.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        monkeypatch.delenv("CO_EXPLORE_DONE", raising=False)
+
+        result = handler(
+            command="gh issue create --title 'test' --body 'body'",
+            tool_name="Bash",
+            env={},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert "decision" in result
+        assert "reason" in result
+        assert result["decision"] == "deny"
+        assert isinstance(result["reason"], str)
+        assert result["reason"]  # non-empty
+
+    def test_schema_allow_has_required_keys(self, tmp_path, monkeypatch):
+        """allow 時のレスポンスに必須キーが含まれること.
+
+        RED: twl_validate_issue_create_handler 未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        result = handler(
+            command="gh issue create --title 'test' --body 'body'",
+            tool_name="Bash",
+            env={"CO_EXPLORE_DONE": "1"},
+            explore_summary_dir=str(tmp_path / "nonexistent-explore"),
+        )
+
+        assert "decision" in result
+        assert "reason" in result
+        assert result["decision"] == "allow"
+        assert isinstance(result["reason"], str)
+
+
+# ---------------------------------------------------------------------------
+# AC3: tools.py に twl_validate_issue_create_handler が importable であること
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerImportable:
+    """tools.py に handler function が定義されていること."""
+
+    def test_handler_function_importable(self):
+        """tools.py に twl_validate_issue_create_handler が存在し callable であること.
+
+        RED: 関数未実装のため ImportError で FAIL
+        """
+        handler = _import_handler()
+
+        assert callable(handler), (
+            "twl_validate_issue_create_handler は callable である必要があります"
+        )
+
+    def test_tools_py_contains_handler_definition(self):
+        """tools.py のソースに twl_validate_issue_create_handler の定義が含まれること.
+
+        RED: 関数未定義のため fail
+        """
+        assert TOOLS_PY.exists(), f"tools.py が見つかりません: {TOOLS_PY}"
+
+        source = TOOLS_PY.read_text(encoding="utf-8")
+        assert "twl_validate_issue_create_handler" in source, (
+            "tools.py に twl_validate_issue_create_handler 定義が存在しません"
+        )

--- a/plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md
+++ b/plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md
@@ -1,0 +1,117 @@
+# ADR-037: Issue 作成 flow 大原則の正典化と enforcement 階層
+
+## Status
+
+Proposed (2026-05-08)
+
+## Issue
+
+#1578
+
+## Related
+
+- ADR-024 (Refined transition gate)
+- ADR-014 (supervisor redesign)
+- ADR-013 (observer first-class)
+- ADR-031 (observer self-supervision)
+- ADR-029 (shadow rollout pattern)
+- epic #1557 (Refined 遷移 enforcement — 本 ADR の補完 layer)
+
+## Supersedes
+
+なし (新規)
+
+---
+
+## Context
+
+twill の大原則「**co-explore → Todo → co-issue → Refined → co-autopilot**」は SKILL.md 文言のみで支えられ、ADR/spec/invariant 層には正典化されていない。technical layer (hook/MCP) も Issue 起票 flow をガードしておらず、observer/Pilot/PR review 起点の `gh issue create` が無防備に通過していた。本 session 含め少なくとも 5 件の違反 (#1552/#1554/#1577/#1549/#1551) が観察され、すべて explore-summary 不在のまま Issue が起票された。
+
+epic #1557 は Refined 遷移を gate するが、Issue 起票自体は Out of Scope と明記されていた:
+
+> #1557 Out of Scope:
+> - 既存 PR review-derived Issue 経路の起票時 explore-summary 必須化 (bypass #6)
+> - Pilot 自己起票時の self-refine 抑制
+
+本 ADR は #1557 の補完 layer として、Issue 起票 flow に正典化と technical enforcement を導入する。
+
+---
+
+## Decision
+
+### 大原則 (SHALL)
+
+新規 Issue の起票 (`gh issue create`) は、以下のいずれかの precondition を満たさなければならない (SHALL):
+
+1. **co-explore Step 1 bootstrap path**: `TWL_CALLER_AUTHZ=co-explore-bootstrap` env marker + `/tmp/.co-explore-bootstrap-<cksum>.json` state file
+2. **co-issue Phase 4 create path**: `TWL_CALLER_AUTHZ=co-issue-phase4-create` env marker + `.controller-issue/<session-id>/explore-summary.md` 存在
+3. **既存 co-issue session in-flight path**: `/tmp/.co-issue-phase3-gate-<cksum>.json` 存在 (既存 phase3-gate.sh が判定)
+4. **明示的 bypass path**: `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` (intervention 記録 MUST)
+
+これら以外の経路 (observer 直接 / Pilot 直接 / PR review 直接 / 手動) は deny される。
+
+### enforcement 階層 (3 Tier)
+
+| Tier | 仕組み | 守備範囲 | failure mode |
+|---|---|---|---|
+| Tier 1 | `pre-bash-issue-create-gate.sh` (Bash hook) | Bash matcher で `gh issue create` を intercept | fail-closed (deny) |
+| Tier 2 | `mcp__twl__validate_issue_create` (MCP tool) | 構造化 evidence check + observability | initial: shadow log only (ADR-029 shadow rollout); future Phase 2: deny |
+| Tier 3 | SKILL.md 文言 (LLM 判断) | 4 controller (su-observer / co-issue / co-explore / co-autopilot) | reactive |
+
+### Tier 2 rollout 方針 (ADR-029 shadow rollout 踏襲)
+
+`mcp__twl__validate_issue_create` は ADR-029 Decision 6 の shadow rollout 3-step (log → audit → deny) を本 Issue ゲート tool にも適用する。初期は `outputType: "log"` で shadow mode (Bash hook が primary enforcement)。Phase 2 で `outputType: "deny"` に昇格 (後継 Issue で追跡)。
+
+### bypass override
+
+- `SKIP_ISSUE_GATE=1` + `SKIP_ISSUE_REASON='...'` の併用 MUST
+- `SKIP_ISSUE_GATE=1` のみ (SKIP_ISSUE_REASON 欠落) は deny する
+- intervention log: `/tmp/issue-create-gate.log` に append (`[ts] BYPASS reason=... cmd_hash=...`)
+- su-observer による retroactive review SHOULD (Wave 完了時、bypass 5+ 件/Wave で alert)
+
+### fail-open 設計 (Known Limitation R1)
+
+- JSON 不正・ツール名不一致時: `exit 0` (no-op) — hook 不能時に enforcement が外れる
+- **理由**: fail-closed (exit 2) は hook 誤設定時に gh issue create が完全に使えなくなるリスクがある
+- **緩和**: Tier 2 MCP tool が二重チェック (shadow → deny で補完)
+
+### Out of Scope
+
+- **GraphQL 経由 bypass** (`gh api graphql -f query='mutation {createIssue...}'`): Bash matcher 範囲外。後継 Issue で追跡可能性確保
+- **シェル変数展開・エイリアス経由**: 文字列マッチの限界。同上
+- **CI/cron** (.github/workflows/*.yml): Claude Code hook の対象外。`TWL_CALLER_AUTHZ=ci` + `SKIP_ISSUE_REASON='ci-automated'` で許可
+
+---
+
+## Consequences
+
+### Positive
+
+- 大原則が ADR/spec/invariant に正典化され、技術 enforcement と整合
+- observer/Pilot/PR review 起点の bypass が技術的に block される
+- intervention log により bypass 履歴が監査可能
+- co-issue Phase 4 path の explore-summary precondition が defense-in-depth で強制される
+
+### Negative / Risks
+
+- **R1**: fail-open (JSON 不正時) — 緩和: Tier 2 MCP tool で補完 (上記参照)
+- **R2**: env marker spoofing (`TWL_CALLER_AUTHZ=co-explore-bootstrap` 手書き) → state file 併用で軽減
+- **R3**: 軽微 config 起票での bypass overhead → SKIP_ISSUE_GATE protocol で吸収
+- **R4**: GraphQL 経由 bypass → Out of Scope、後継 Issue で追跡
+- **R5**: hook 未登録罠 (#1561 で発見) → AC で settings.json/deps.yaml 登録を強制 (AC4/AC5)
+
+---
+
+## Implementation
+
+- `plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh` (新規) — Tier 1 Bash hook
+- `plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats` (新規、12 シナリオ S1-S12)
+- `cli/twl/src/twl/mcp_server/tools.py` の `twl_validate_issue_create_handler` 追加 — Tier 2 MCP tool
+- `.claude/settings.json` の PreToolUse Bash hooks に append (新 hook + mcp_tool)
+- `plugins/twl/deps.yaml` の scripts セクションに `pre-bash-issue-create-gate` entry 追加
+- `plugins/twl/refs/ref-invariants.md` に **Invariant P** 追加 (不変条件 O の次)
+- `plugins/twl/skills/co-explore/SKILL.md` Step 1 修正 (bootstrap state file 書込み + env marker)
+- `plugins/twl/skills/co-issue/SKILL.md` Phase 4 [B] 修正 (env marker 設定)
+- `plugins/twl/agents/su-observer/SKILL.md` MUST NOT セクション追加
+- `plugins/twl/skills/co-autopilot/SKILL.md` precondition 追加
+- `plugins/twl/refs/intervention-catalog.md` Layer 1 パターン 13 追加 (SKIP_ISSUE_GATE bypass protocol)

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2818,6 +2818,11 @@ scripts:
       - script: chain-runner
     description: "co-issue manual fix [B] path の dual-write executor（ADR-024 準拠: label 先 → Status=Refined 後）。orchestrator 失敗時の Emergency Bypass fallback（glossary.md L26）。ISSUE_NUMBER/ISSUE_REPO の入力検証付き"
 
+  pre-bash-issue-create-gate:
+    type: script
+    path: scripts/hooks/pre-bash-issue-create-gate.sh
+    description: "PreToolUse hook (Layer C-3): gh issue create を intercept し co-explore precondition を強制する（ADR-037, 不変条件 P）。TWL_CALLER_AUTHZ env marker / SKIP_ISSUE_GATE bypass / phase3-gate fallback の 4-path 判定。#1578"
+
   pre-bash-phase3-gate:
     type: script
     path: scripts/hooks/pre-bash-phase3-gate.sh

--- a/plugins/twl/refs/intervention-catalog.md
+++ b/plugins/twl/refs/intervention-catalog.md
@@ -158,6 +158,27 @@ Supervisor の介入判断ルール定義。Wave 1-5 の実績を反映した介
 - **リスク評価**: 中（classifier の判断を override するため意図確認必須）
 - **事後**: InterventionRecord を `.observation/` に記録。bypass 経緯を doobidoo に `observer-lesson` タグで保存
 
+### パターン 13: SKIP_ISSUE_GATE bypass — Issue 起票 gate 例外承認（ADR-037）
+
+- **発火条件**: observer/Pilot が `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>' gh issue create ...` を実行しようとしている、または co-explore flow を経由せずに Issue 起票が必要な状況
+- **判定基準**:
+
+| reason category | 例 | 承認 |
+|---|---|---|
+| `trivial config: ...` | 1-line label rename, README typo | Auto allow |
+| `urgent bugfix: ...` | P0 production bug, fix tracked in PR | Auto allow + flag for retro review |
+| `ci-automated` | GitHub Actions, scheduled scans | Auto allow |
+| その他 | (未分類) | Confirm: AskUserQuestion で「co-explore を経由しない理由」を user に確認 |
+
+- **ユーザーへの報告内容**（Confirm 分類時）:
+  - bypass の理由と起票予定の Issue 内容
+  - 「co-explore を経由せずに Issue を起票してよいか」の確認
+- **修復手順**: ユーザー承認後 `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>' gh issue create ...` を実行
+- **前提条件**: `SKIP_ISSUE_REASON` が必ず指定されていること（欠落時は deny）
+- **リスク評価**: 低〜中（trivial config は低リスク、新規設計判断は中リスク）
+- **ログ**: `/tmp/issue-create-gate.log` に `[ts] BYPASS reason=<reason> cmd_hash=<hash>` が記録される
+- **事後**: InterventionRecord を `.observation/` に記録。Wave 完了時に su-observer が log を集計し、bypass 5+ 件/Wave で alert
+
 ---
 
 ## Layer 2: Escalate

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -202,6 +202,35 @@ twill autopilot システムの不変条件 A-N（14 件）の正典定義。各
 
 ---
 
+## 不変条件 P: Issue 起票 flow 大原則 (SHALL)
+
+**目的**: 新規 Issue の起票 (`gh issue create`) は co-explore による explore-summary 作成を precondition として満たさなければならない (SHALL)。bypass は `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` の明示的併用のみ許可される。
+
+**制約**:
+- 新規 Issue の起票は以下いずれかの precondition を満たすこと (SHALL):
+  1. **co-explore bootstrap path**: `TWL_CALLER_AUTHZ=co-explore-bootstrap` env marker + `/tmp/.co-explore-bootstrap-*.json` state file
+  2. **co-issue Phase 4 create path**: `TWL_CALLER_AUTHZ=co-issue-phase4-create` env marker + `.controller-issue/<sid>/explore-summary.md` 存在
+  3. **co-issue session in-flight path**: `/tmp/.co-issue-phase3-gate-*.json` 存在
+  4. **明示的 bypass**: `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` の明示的併用 (intervention 記録 MUST)
+- 上記以外の経路 (observer 直接 / Pilot 直接 / PR review 起点 / 手動) は deny される
+- `SKIP_ISSUE_GATE=1` のみ (`SKIP_ISSUE_REASON` 欠落) は deny する
+
+**適用範囲**: observer / Pilot / co-explore / co-issue / 手動 すべての `gh issue create` 経路 (GraphQL `gh api graphql` mutation は本 invariant の射程外、後継 Issue で追跡)
+
+**根拠**: [ADR-037: Issue 作成 flow 大原則の正典化と enforcement 階層](../architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md)
+
+**検証方法**: bats `pre-bash-issue-create-gate.bats` (S1-S12)、pytest `test_validate_issue_create.py`
+
+**影響範囲**:
+  - `plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh`
+  - `cli/twl/src/twl/mcp_server/tools.py` (`twl_validate_issue_create_handler`)
+  - `plugins/twl/skills/co-explore/SKILL.md`
+  - `plugins/twl/skills/co-issue/SKILL.md`
+  - `plugins/twl/agents/su-observer/SKILL.md`
+  - `plugins/twl/skills/co-autopilot/SKILL.md`
+
+---
+
 ## SU-* との境界
 
 SU-1〜SU-9 は Supervisor（su-observer）固有の application-level 制約であり、本ドキュメントの不変条件 A-N とは独立した体系である。SU-* の正典は [`architecture/domain/contexts/supervision.md`](../architecture/domain/contexts/supervision.md)（SSoT）。運用 mirror は [`skills/su-observer/refs/su-observer-constraints.md`](../skills/su-observer/refs/su-observer-constraints.md) を参照。Security gate (Layer A-D) 定義は [`skills/su-observer/refs/su-observer-security-gate.md`](../skills/su-observer/refs/su-observer-security-gate.md) を参照。

--- a/plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# PreToolUse hook: Issue 起票前 co-explore 強制 (ADR-037, 不変条件 P)
+#
+# 動作:
+#   1. tool_name が "Bash" 以外 → no-op (exit 0)
+#   2. command が "gh issue create" にマッチしない → no-op (exit 0)
+#   3. 以下の condition で allow / deny を判定:
+#
+#   [allow path]
+#   a. SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON='<reason>' → log BYPASS, exit 0
+#      SKIP_ISSUE_REASON 欠落 → deny + actionable message
+#   b. TWL_CALLER_AUTHZ=co-explore-bootstrap + /tmp/.co-explore-bootstrap-*.json (any mtime) → exit 0
+#   c. TWL_CALLER_AUTHZ=co-issue-phase4-create + .controller-issue/<sid>/explore-summary.md (mtime < 2h) → exit 0
+#      explore-summary 不在 → deny + actionable message
+#   d. /tmp/.co-issue-phase3-gate-*.json が存在 → exit 0 (既存 hook が判定済)
+#
+#   [deny path]
+#   - 上記いずれにもマッチしない → deny + actionable error message
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || echo "")
+
+# JSON パース失敗 → no-op
+if ! printf '%s' "$payload" | jq empty 2>/dev/null; then
+  exit 0
+fi
+
+# Bash tool 以外 → no-op
+tool_name=$(printf '%s' "$payload" | jq -r '.tool_name // empty')
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+
+# コマンド取得
+CMD=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# gh issue create にマッチしない → no-op
+if ! printf '%s' "$CMD" | grep -qE '\bgh\s+issue\s+create\b'; then
+  exit 0
+fi
+
+LOG_FILE="/tmp/issue-create-gate.log"
+log_event() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# (a) SKIP_ISSUE_GATE bypass
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])SKIP_ISSUE_GATE=1([[:space:]]|$)'; then
+  REASON=$(printf '%s' "$CMD" | grep -oE "SKIP_ISSUE_REASON=['\"]?[^'\"[:space:]]+['\"]?" | head -1 | sed "s/SKIP_ISSUE_REASON=['\"]//;s/['\"]$//" || echo "")
+  if [[ -z "$REASON" ]]; then
+    DENY_MSG='SKIP_ISSUE_GATE=1 を使う場合は SKIP_ISSUE_REASON を必ず併記してください。
+
+例: SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='"'"'trivial config: label rename'"'"' gh issue create ...
+
+詳細: ADR-037 / 不変条件 P / 親 epic #1578'
+    jq -nc --arg reason "$DENY_MSG" \
+      '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+    exit 0
+  fi
+  log_event "BYPASS reason=${REASON} cmd_hash=$(printf '%s' "$CMD" | sha256sum | head -c8)"
+  exit 0
+fi
+
+_SESSION_TMP_DIR="${SESSION_TMP_DIR:-/tmp}"
+
+# (b) co-explore Step 1 bootstrap path
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])TWL_CALLER_AUTHZ=co-explore-bootstrap([[:space:]]|$)'; then
+  BOOTSTRAP_FILES=("${_SESSION_TMP_DIR}"/.co-explore-bootstrap-*.json)
+  if [[ -e "${BOOTSTRAP_FILES[0]}" ]]; then
+    AGE=$(( $(date +%s) - $(stat -c %Y "${BOOTSTRAP_FILES[0]}" 2>/dev/null || echo 0) ))
+    log_event "ALLOW caller=co-explore-bootstrap age=${AGE}s"
+  else
+    log_event "WARN caller=co-explore-bootstrap-env-only state_file_missing"
+  fi
+  exit 0
+fi
+
+# (c) co-issue Phase 4 create path
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])TWL_CALLER_AUTHZ=co-issue-phase4-create([[:space:]]|$)'; then
+  CONTROLLER_DIR="${CONTROLLER_ISSUE_DIR:-.controller-issue}"
+  SUMMARY_FILE=$(find "$CONTROLLER_DIR" -name "explore-summary.md" -mmin -120 2>/dev/null | head -1 || echo "")
+  if [[ -n "$SUMMARY_FILE" ]]; then
+    log_event "ALLOW caller=co-issue-phase4-create summary=${SUMMARY_FILE}"
+    exit 0
+  fi
+  DENY_MSG='co-issue Phase 4 の Issue 起票には explore-summary が必要です。
+
+  .controller-issue/<session-id>/explore-summary.md が見つかりませんでした。
+
+先に /twl:co-explore <topic> を実行して explore-summary を作成してください。
+
+詳細: ADR-037 / 不変条件 P / 親 epic #1578'
+  jq -nc --arg reason "$DENY_MSG" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+  exit 0
+fi
+
+# (d) 既存 phase3-gate file 存在 → 既存 hook に委譲
+PHASE3_FILES=("${_SESSION_TMP_DIR}"/.co-issue-phase3-gate-*.json)
+if [[ -e "${PHASE3_FILES[0]}" ]]; then
+  exit 0
+fi
+
+# (deny path)
+log_event "DENY no_caller_authz cmd_hash=$(printf '%s' "$CMD" | sha256sum | head -c8)"
+DENY_MSG='Issue 起票前に co-explore による explore-summary が必須です。
+
+大原則: co-explore → Todo → co-issue → Refined → co-autopilot (ADR-037, 不変条件 P)
+
+【正規の手順】
+  1. /twl:co-explore "<topic>" で問題を探索
+  2. .explore/<N>/summary.md が auto-link される
+  3. /twl:co-issue refine #<N> で精緻化 → Status=Refined
+  4. /twl:co-autopilot で実装
+
+【bypass (軽微 config 等)】
+  SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON="trivial config: ..." gh issue create ...
+
+詳細: ADR-037 / 不変条件 P / 親 epic #1578'
+
+jq -nc --arg reason "$DENY_MSG" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+exit 0

--- a/plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
@@ -50,7 +50,10 @@ log_event() {
 
 # (a) SKIP_ISSUE_GATE bypass
 if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])SKIP_ISSUE_GATE=1([[:space:]]|$)'; then
-  REASON=$(printf '%s' "$CMD" | grep -oE "SKIP_ISSUE_REASON=['\"]?[^'\"[:space:]]+['\"]?" | head -1 | sed "s/SKIP_ISSUE_REASON=['\"]//;s/['\"]$//" || echo "")
+  # extract full quoted value (single or double quotes) to support multi-word reasons
+  REASON=$(printf '%s' "$CMD" | grep -oP "SKIP_ISSUE_REASON='[^']+'" | head -1 | sed "s/SKIP_ISSUE_REASON='//;s/'$//" 2>/dev/null \
+    || printf '%s' "$CMD" | grep -oP 'SKIP_ISSUE_REASON="[^"]+"' | head -1 | sed 's/SKIP_ISSUE_REASON="//;s/"$//' 2>/dev/null \
+    || echo "")
   if [[ -z "$REASON" ]]; then
     DENY_MSG='SKIP_ISSUE_GATE=1 を使う場合は SKIP_ISSUE_REASON を必ず併記してください。
 
@@ -67,15 +70,22 @@ fi
 
 _SESSION_TMP_DIR="${SESSION_TMP_DIR:-/tmp}"
 
-# (b) co-explore Step 1 bootstrap path
+# (b) co-explore Step 1 bootstrap path — requires BOTH env marker AND state file (ADR-037 §1-b, R2 mitigation)
 if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])TWL_CALLER_AUTHZ=co-explore-bootstrap([[:space:]]|$)'; then
   BOOTSTRAP_FILES=("${_SESSION_TMP_DIR}"/.co-explore-bootstrap-*.json)
   if [[ -e "${BOOTSTRAP_FILES[0]}" ]]; then
     AGE=$(( $(date +%s) - $(stat -c %Y "${BOOTSTRAP_FILES[0]}" 2>/dev/null || echo 0) ))
     log_event "ALLOW caller=co-explore-bootstrap age=${AGE}s"
-  else
-    log_event "WARN caller=co-explore-bootstrap-env-only state_file_missing"
+    exit 0
   fi
+  log_event "DENY caller=co-explore-bootstrap state_file_missing"
+  DENY_MSG='co-explore Step 1 の Issue 起票には /tmp/.co-explore-bootstrap-*.json が必要です。
+
+TWL_CALLER_AUTHZ=co-explore-bootstrap は co-explore Step 1.5 の bootstrap state file 書込み後に使用してください。
+
+詳細: ADR-037 §1-b / 不変条件 P / 親 epic #1578'
+  jq -nc --arg reason "$DENY_MSG" \
+    '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
   exit 0
 fi
 

--- a/plugins/twl/skills/co-autopilot/SKILL.md
+++ b/plugins/twl/skills/co-autopilot/SKILL.md
@@ -260,6 +260,11 @@ TDD-style Issue（ac-scaffold-tests で RED テストが生成された場合）
 - RED 状態の PR は ac-verify CRITICAL でブロックされる（`fix-phase` が強制実行される）
 - GREEN 確認コマンド例: `bats cli/twl/tests/skills/workflow-pr-fix/test_*.bats` 等、issue 固有のテストコマンドを実行し全 PASS を確認してから push すること
 
+## 前提条件（Precondition — ADR-037, 不変条件 P）
+
+- **実装対象 Issue は co-explore による explore-summary 作成済みであること（SHALL）**。`twl explore-link check <N>` でリンク確認可能。未実施の場合は `/twl:co-explore #<N>` を案内して停止する
+- **co-autopilot 自身が新規 Issue を自己起票してはならない（MUST NOT）**。follow-up Issue が必要な場合は `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` bypass + `/twl:co-explore` への案内 + ユーザー確認が必須
+
 ## 禁止事項（MUST NOT）
 
 - plan.yaml を独自生成してはならない（制約 AP-1）

--- a/plugins/twl/skills/co-explore/SKILL.md
+++ b/plugins/twl/skills/co-explore/SKILL.md
@@ -50,15 +50,26 @@ mcpServers:
 `ISSUE_NUMBER` が未設定（新規探索）の場合:
 
 1. ユーザーの要望テキストから 1 行タイトルを生成
-2. draft Issue を起票:
+1.5. bootstrap state file 書き込み（ADR-037, 不変条件 P — Issue 起票 gate 解除用）:
    ```bash
-   ISSUE_NUMBER=$(gh issue create \
+   CKSUM=$(printf '%s' "$TITLE" | cksum | awk '{print $1}')
+   jq -nc --arg t "$TITLE" --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     '{title:$t, started_at:$ts, controller:"co-explore"}' \
+     > "/tmp/.co-explore-bootstrap-${CKSUM}.json"
+   ```
+2. draft Issue を起票（`TWL_CALLER_AUTHZ` env marker 必須）:
+   ```bash
+   ISSUE_NUMBER=$(TWL_CALLER_AUTHZ=co-explore-bootstrap gh issue create \
      --title "<タイトル>" \
      --body "co-explore による探索中。summary 完了後に更新予定。" \
      --label "exploration" \
      --json number -q '.number')
    ```
 3. `ISSUE_NUMBER` を設定
+4. bootstrap state file 削除（Step 4 summary 保存後にクリーンアップ）:
+   ```bash
+   rm -f "/tmp/.co-explore-bootstrap-${CKSUM}.json"
+   ```
 
 既に `ISSUE_NUMBER` がある場合はスキップ。
 

--- a/plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md
+++ b/plugins/twl/skills/co-issue/refs/co-issue-phase4-aggregate.md
@@ -57,7 +57,12 @@ Step 4a で `fallback_inject_exhausted` に分類された issue が存在する
 
 **failure / circuit_broken の場合（AskUserQuestion）:**
 
-- `[A] retry subset` → `bash "${CLAUDE_PLUGIN_ROOT}/scripts/issue-lifecycle-orchestrator.sh" --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet` で非 done のみ再実行
+- `[A] retry subset` → 以下で非 done のみ再実行（env marker 必須 — ADR-037, 不変条件 P）:
+  ```bash
+  # Issue 作成は env marker 必須 (ADR-037)
+  TWL_CALLER_AUTHZ=co-issue-phase4-create bash "${CLAUDE_PLUGIN_ROOT}/scripts/issue-lifecycle-orchestrator.sh" \
+    --per-issue-dir ".controller-issue/<session-id>/per-issue/" --resume --model sonnet
+  ```
 - `[B] manual fix` → Issue body 更新後、以下の決定論的 step を実行する（ADR-024 Phase B: Status=Refined SSoT）:
 
   ```bash

--- a/plugins/twl/skills/su-observer/refs/su-observer-constraints.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-constraints.md
@@ -30,6 +30,7 @@
 - Wave 完了後の externalize-state を省略してはならない（SU-6a）
 - /compact の自動実行を試みてはならない（built-in CLI のためユーザー手動実行が必須）
 - 検出結果をユーザー確認なしで自動 Issue 起票してはならない
+- **Issue 起票関連（不変条件 P / ADR-037）**: `gh issue create` を直接実行してはならない。新規 Issue の起票は必ず co-explore による explore-summary 作成後に co-issue 経由で行う。explore-summary なしの直接起票は `pre-bash-issue-create-gate.sh` で block される（bypass は `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` 明記時のみ）
 - `--with-chain --issue N` で co-autopilot を直接起動してはならない（ADR-026、SU-3 連鎖）
 
 ## Security gate (Layer A-D) 回避は MUST NOT

--- a/plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats
+++ b/plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats
@@ -1,0 +1,256 @@
+#!/usr/bin/env bats
+# ac-scaffold-tests-1578.bats — Issue #1578 AC1/AC4/AC5/AC6/AC7/AC8/AC9/AC10 RED テストスタブ
+#
+# Issue #1578: feat(supervisor): Issue 起票前 co-explore 強制 enforcement
+#
+# RED フェーズ: 実装前は全テストが fail する（意図的）
+#
+# AC カバレッジ:
+#   AC1:  ADR-037 ファイル存在 + Status=Proposed + §3.4 構造
+#   AC4:  .claude/settings.json に gate hook + mcp_tool 登録
+#   AC5:  deps.yaml に pre-bash-issue-create-gate entry 存在 + twl check --deps-integrity PASS
+#   AC6:  co-explore Step 1 env marker / co-issue Phase 4 [B] env marker /
+#         su-observer MUST NOT 記述 / co-autopilot precondition
+#   AC7:  ref-invariants.md に Invariant P 追加（Invariant O の次）
+#   AC8:  intervention-catalog.md に SKIP_ISSUE_GATE Layer 1 (Confirm) protocol 追加
+#   AC9:  not-testable — プロセス系（retroactive fix）
+#   AC10: not-testable — 長期観察系（4 連続 Wave 違反 0 件）
+
+load '../helpers/common'
+
+REPO_ROOT_ABS="/home/shuu5/projects/local-projects/twill/worktrees/feat/1578-featsupervisor-issue-co-explore-enfor"
+
+setup() {
+  common_setup
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: ADR-037 起票
+# ===========================================================================
+
+# WHEN: ADR-037 ファイルが作成されている
+# THEN: Status=Proposed が含まれること
+# RED: ファイル未作成のため fail
+@test "ac1: ADR-037 ファイルが存在する" {
+  # AC1: plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md 作成
+  local adr_path="$REPO_ROOT_ABS/plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md"
+  [ -f "$adr_path" ]  # RED: ファイル未作成
+}
+
+@test "ac1: ADR-037 に Status=Proposed が含まれる" {
+  local adr_path="$REPO_ROOT_ABS/plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md"
+  [ -f "$adr_path" ] || false  # RED: ファイル未作成
+
+  grep -qF "Proposed" "$adr_path"
+}
+
+@test "ac1: ADR-037 に explore-summary §3.4 構造セクションが含まれる" {
+  local adr_path="$REPO_ROOT_ABS/plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md"
+  [ -f "$adr_path" ] || false  # RED: ファイル未作成
+
+  # explore-summary §3.4 構造を踏襲: "3.4" または "explore-summary" セクションへの言及
+  grep -qE "3\.4|explore-summary" "$adr_path"
+}
+
+# ===========================================================================
+# AC4: .claude/settings.json PreToolUse Bash hooks 登録
+# ===========================================================================
+
+# WHEN: .claude/settings.json に pre-bash-issue-create-gate.sh が登録されている
+# THEN: Bash matcher に hook entry が存在すること
+# RED: 未登録のため fail
+@test "ac4: settings.json の Bash hook に pre-bash-issue-create-gate.sh が登録されている" {
+  local settings="$REPO_ROOT_ABS/.claude/settings.json"
+  [ -f "$settings" ] || false
+
+  # Bash hook として pre-bash-issue-create-gate が登録されていること
+  grep -qF "pre-bash-issue-create-gate" "$settings"  # RED: 未登録
+}
+
+# WHEN: .claude/settings.json に mcp_tool validate_issue_create が登録されている
+# THEN: outputType: "log" が設定されていること
+# RED: 未登録のため fail
+@test "ac4: settings.json に twl_validate_issue_create mcp_tool が登録されている (outputType=log)" {
+  local settings="$REPO_ROOT_ABS/.claude/settings.json"
+  [ -f "$settings" ] || false
+
+  # mcp_tool として validate_issue_create が登録されていること
+  grep -qF "validate_issue_create" "$settings"  # RED: 未登録
+}
+
+# ===========================================================================
+# AC5: deps.yaml scripts セクション + twl check --deps-integrity
+# ===========================================================================
+
+# WHEN: deps.yaml に pre-bash-issue-create-gate entry が追加されている
+# THEN: scripts セクション内に entry が存在すること
+# RED: 未追加のため fail
+@test "ac5: deps.yaml に pre-bash-issue-create-gate entry が存在する" {
+  local deps_yaml="$REPO_ROOT_ABS/plugins/twl/deps.yaml"
+  [ -f "$deps_yaml" ] || false
+
+  # scripts セクションに pre-bash-issue-create-gate エントリが存在すること
+  grep -qF "pre-bash-issue-create-gate" "$deps_yaml"  # RED: 未追加
+}
+
+# WHEN: deps.yaml の entry が正しい形式で追加されている
+# THEN: path エントリが scripts/hooks/pre-bash-issue-create-gate.sh を指すこと
+# RED: 未追加のため fail
+@test "ac5: deps.yaml の pre-bash-issue-create-gate entry が正しいパスを持つ" {
+  local deps_yaml="$REPO_ROOT_ABS/plugins/twl/deps.yaml"
+  [ -f "$deps_yaml" ] || false
+
+  grep -qF "scripts/hooks/pre-bash-issue-create-gate.sh" "$deps_yaml"  # RED: 未追加
+}
+
+# ===========================================================================
+# AC6: 4 controller SKILL.md 修正
+# ===========================================================================
+
+# --- AC6a: co-explore Step 1 — env marker + state file 書込み ---
+
+# WHEN: co-explore SKILL.md Step 1 に CO_EXPLORE_DONE env marker の書込みが記述されている
+# THEN: SKILL.md に CO_EXPLORE_DONE への言及が存在すること
+# RED: 未修正のため fail
+@test "ac6a: co-explore SKILL.md Step 1 に CO_EXPLORE_DONE env marker の書込みが記述されている" {
+  local skill="$REPO_ROOT_ABS/plugins/twl/skills/co-explore/SKILL.md"
+  [ -f "$skill" ] || false
+
+  grep -qF "CO_EXPLORE_DONE" "$skill"  # RED: 未修正
+}
+
+# --- AC6b: co-issue Phase 4 [B] path — env marker ---
+
+# WHEN: co-issue SKILL.md Phase 4 [B] path に env marker 設定が記述されている
+# THEN: SKILL.md に CO_EXPLORE_DONE または issue-create-gate への言及が存在すること
+# RED: 未修正のため fail
+@test "ac6b: co-issue SKILL.md Phase 4 [B] path に env marker (CO_EXPLORE_DONE) が記述されている" {
+  local skill="$REPO_ROOT_ABS/plugins/twl/skills/co-issue/SKILL.md"
+  [ -f "$skill" ] || false
+
+  grep -qF "CO_EXPLORE_DONE" "$skill"  # RED: 未修正
+}
+
+# --- AC6c: su-observer SKILL.md — Issue 起票関連 MUST NOT + 不変条件 P 参照 ---
+
+# WHEN: su-observer SKILL.md に Issue 起票関連の MUST NOT が追加されている
+# THEN: 不変条件 P または "Issue 起票" に関連する MUST NOT 記述が存在すること
+# RED: 未修正のため fail
+@test "ac6c: su-observer SKILL.md に Issue 起票関連の MUST NOT が記述されている" {
+  local skill="$REPO_ROOT_ABS/plugins/twl/skills/su-observer/SKILL.md"
+  [ -f "$skill" ] || false
+
+  # "Issue 起票" かつ "MUST NOT" の両方が含まれるか、
+  # または "不変条件 P" への参照が含まれること
+  grep -qE "不変条件 P|Invariant P" "$skill"  # RED: 未修正
+}
+
+# --- AC6d: co-autopilot SKILL.md — precondition ---
+
+# WHEN: co-autopilot SKILL.md に co-explore 必須の precondition が追加されている
+# THEN: SKILL.md に Issue 起票前 co-explore または 不変条件 P への言及が存在すること
+# RED: 未修正のため fail
+@test "ac6d: co-autopilot SKILL.md に Issue 起票 precondition が記述されている" {
+  local skill="$REPO_ROOT_ABS/plugins/twl/skills/co-autopilot/SKILL.md"
+  [ -f "$skill" ] || false
+
+  grep -qE "不変条件 P|Invariant P|CO_EXPLORE_DONE|issue-create-gate" "$skill"  # RED: 未修正
+}
+
+# ===========================================================================
+# AC7: ref-invariants.md に Invariant P 追加
+# ===========================================================================
+
+# WHEN: ref-invariants.md に Invariant P (Issue 起票 flow 大原則 SHALL) が追加されている
+# THEN: "不変条件 P" または "Invariant P" のセクションが存在すること
+# RED: 未追加のため fail
+@test "ac7: ref-invariants.md に 不変条件 P が追加されている" {
+  local invariants="$REPO_ROOT_ABS/plugins/twl/refs/ref-invariants.md"
+  [ -f "$invariants" ] || false
+
+  grep -qE "不変条件 P|## Invariant P" "$invariants"  # RED: 未追加
+}
+
+# WHEN: 不変条件 P が ADR-037 を根拠として参照している
+# THEN: "ADR-037" への参照が Invariant P セクション内に存在すること
+# RED: 未追加のため fail
+@test "ac7: ref-invariants.md の 不変条件 P が ADR-037 を根拠として参照している" {
+  local invariants="$REPO_ROOT_ABS/plugins/twl/refs/ref-invariants.md"
+  [ -f "$invariants" ] || false
+
+  grep -qF "ADR-037" "$invariants"  # RED: 未追加
+}
+
+# WHEN: 不変条件 P が 不変条件 O の後に配置されている
+# THEN: ファイル内で "不変条件 O" の行より後に "不変条件 P" の行があること
+# RED: 未追加のため fail
+@test "ac7: ref-invariants.md の 不変条件 P が 不変条件 O の後に配置されている" {
+  local invariants="$REPO_ROOT_ABS/plugins/twl/refs/ref-invariants.md"
+  [ -f "$invariants" ] || false
+
+  # 不変条件 O と P の両方が存在すること
+  grep -qE "不変条件 O" "$invariants" || false
+  grep -qE "不変条件 P|Invariant P" "$invariants" || false  # RED: P 未追加
+
+  # P が O より後の行にあること
+  local line_o line_p
+  line_o=$(grep -n "不変条件 O" "$invariants" | head -1 | cut -d: -f1)
+  line_p=$(grep -n "不変条件 P" "$invariants" | head -1 | cut -d: -f1)
+  [ -n "$line_p" ] || false  # RED: P が存在しない
+  [ "$line_p" -gt "$line_o" ]
+}
+
+# ===========================================================================
+# AC8: intervention-catalog.md に SKIP_ISSUE_GATE Layer 1 (Confirm) protocol 追加
+# ===========================================================================
+
+# WHEN: intervention-catalog.md に SKIP_ISSUE_GATE bypass Layer 1 protocol が追加されている
+# THEN: "SKIP_ISSUE_GATE" エントリが存在すること
+# RED: 未追加のため fail
+@test "ac8: intervention-catalog.md に SKIP_ISSUE_GATE エントリが追加されている" {
+  local catalog="$REPO_ROOT_ABS/plugins/twl/refs/intervention-catalog.md"
+  [ -f "$catalog" ] || false
+
+  grep -qF "SKIP_ISSUE_GATE" "$catalog"  # RED: 未追加
+}
+
+# WHEN: SKIP_ISSUE_GATE が Layer 1 (Confirm) として分類されている
+# THEN: "Layer 1" セクション内に SKIP_ISSUE_GATE が存在すること
+# RED: 未追加のため fail
+@test "ac8: intervention-catalog.md の SKIP_ISSUE_GATE が Layer 1 (Confirm) に分類されている" {
+  local catalog="$REPO_ROOT_ABS/plugins/twl/refs/intervention-catalog.md"
+  [ -f "$catalog" ] || false
+
+  grep -qF "SKIP_ISSUE_GATE" "$catalog" || false  # RED: 未追加
+
+  # Layer 1 セクション内に SKIP_ISSUE_GATE が含まれること（awk で Layer 1 以降を抽出）
+  # Layer 1 の開始行から次の Layer (Layer 2) までの間に SKIP_ISSUE_GATE が存在すること
+  awk '/Layer 1: Confirm/,/Layer 2: Escalate/' "$catalog" | grep -qF "SKIP_ISSUE_GATE"  # RED: 未追加
+}
+
+# ===========================================================================
+# AC9: プロセス系 — not-testable
+# ===========================================================================
+
+# not-testable: retroactive fix（#1577 を正規 co-explore flow に戻す +
+#   #1554/#1549/#1551 の PR description 明記）はプロセス系であり
+#   自動テストの対象外。merge 前には Done にしない AC。
+@test "ac9: not-testable — retroactive fix はプロセス系 (記録のみ)" {
+  # not-testable: プロセス系 AC のため skip で記録
+  skip "AC9 は retroactive fix プロセス。merge 前に Done にしない。su-observer による確認が必要"
+}
+
+# ===========================================================================
+# AC10: 長期観察系 — not-testable
+# ===========================================================================
+
+# not-testable: 4 連続 Wave で gh issue create 違反 0 件（regression 観察）は
+#   su-observer による長期集計であり自動テストの対象外。
+@test "ac10: not-testable — 4 連続 Wave 違反 0 件は長期観察系 (記録のみ)" {
+  # not-testable: 長期観察系 AC のため skip で記録
+  skip "AC10 は 4 連続 Wave regression 観察。su-observer による集計。自動テスト対象外"
+}

--- a/plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats
+++ b/plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats
@@ -18,10 +18,12 @@
 
 load '../helpers/common'
 
-REPO_ROOT_ABS="/home/shuu5/projects/local-projects/twill/worktrees/feat/1578-featsupervisor-issue-co-explore-enfor"
+REPO_ROOT_ABS=""
 
 setup() {
   common_setup
+  # git rev-parse で動的解決（CI 移植性）
+  REPO_ROOT_ABS="$(cd "$REPO_ROOT" && git rev-parse --show-toplevel 2>/dev/null)"
 }
 
 teardown() {

--- a/plugins/twl/tests/bats/scripts/ac-test-mapping-1578.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping-1578.yaml
@@ -1,0 +1,124 @@
+---
+# ac-test-mapping-1578.yaml
+# Issue #1578: feat(supervisor): Issue 起票前 co-explore 強制 enforcement
+# 生成日: 2026-05-08
+# フェーズ: TDD RED
+
+mappings:
+  - ac_index: 1
+    ac_text: "ADR-037 起票 (plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md 作成、Status=Proposed、explore-summary §3.4 構造を踏襲) (Sub-D)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac1: ADR-037 ファイルが存在する"
+      - "ac1: ADR-037 に Status=Proposed が含まれる"
+      - "ac1: ADR-037 に explore-summary §3.4 構造セクションが含まれる"
+    impl_files:
+      - "plugins/twl/architecture/decisions/ADR-037-issue-creation-flow-canonicalization.md"
+
+  - ac_index: 2
+    ac_text: "pre-bash-issue-create-gate.sh 実装 + bats 12 シナリオ (S1-S12 全 PASS) — plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh 新規 + plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats 新規 (Sub-A)"
+    test_file: "plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats"
+    test_names:
+      - "S1: gh issue create + CO_EXPLORE_DONE 未設定 → deny"
+      - "S2: gh issue create + CO_EXPLORE_DONE=1 → allow"
+      - "S3: gh issue create + explore-summary ファイル存在 → allow"
+      - "S4: gh issue create --template + CO_EXPLORE_DONE 未設定 → deny"
+      - "S5: gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow (cross-repo)"
+      - "S6: gh pr create → allow (gate 対象外)"
+      - "S7: gh issue list → allow (gate 対象外)"
+      - "S8: git commit → allow (gh issue create でない)"
+      - "S9: gh issue create + CO_EXPLORE_SKIP=1 (CO_EXPLORE_DONE 未設定) → deny"
+      - "S10: '  gh issue create' (先頭空白) + CO_EXPLORE_DONE 未設定 → deny"
+      - "S11: gh issue create + CO_EXPLORE_DONE 未設定 → deny + actionable message 出力"
+      - "S12: gh issue create + summary なし → deny + summary path 言及"
+    impl_files:
+      - "plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh"
+
+  - ac_index: 3
+    ac_text: "mcp__twl__validate_issue_create 新設 + unit test (cli/twl/tests/test_validate_issue_create.py 新規) (Sub-B)"
+    test_file: "cli/twl/tests/test_validate_issue_create.py"
+    test_names:
+      - "TestDenyScenarios::test_t1_gh_issue_create_no_env_deny"
+      - "TestDenyScenarios::test_t2_gh_issue_create_with_template_no_env_deny"
+      - "TestDenyScenarios::test_t3_gh_issue_create_no_summary_file_deny"
+      - "TestAllowScenarios::test_t4_co_explore_done_env_allow"
+      - "TestAllowScenarios::test_t5_explore_summary_exists_allow"
+      - "TestAllowScenarios::test_t6_cross_repo_with_done_env_allow"
+      - "TestNonTargetCommands::test_t7_gh_pr_create_allow"
+      - "TestNonTargetCommands::test_t8_gh_issue_list_allow"
+      - "TestNonTargetCommands::test_t9_git_commit_allow"
+      - "TestNonTargetCommands::test_t10_non_bash_tool_allow"
+      - "TestOutputSchema::test_schema_deny_has_required_keys"
+      - "TestOutputSchema::test_schema_allow_has_required_keys"
+      - "TestHandlerImportable::test_handler_function_importable"
+      - "TestHandlerImportable::test_tools_py_contains_handler_definition"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/tools.py"
+
+  - ac_index: 4
+    ac_text: ".claude/settings.json PreToolUse Bash hooks に Sub-A の hook + Sub-B の mcp_tool 登録 (mcp_tool は initial outputType: \"log\") (Sub-A/Sub-C)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac4: settings.json の Bash hook に pre-bash-issue-create-gate.sh が登録されている"
+      - "ac4: settings.json に twl_validate_issue_create mcp_tool が登録されている (outputType=log)"
+    impl_files:
+      - ".claude/settings.json"
+
+  - ac_index: 5
+    ac_text: "plugins/twl/deps.yaml scripts セクションに pre-bash-issue-create-gate entry 追加 + twl check --deps-integrity PASS (Sub-A)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac5: deps.yaml に pre-bash-issue-create-gate entry が存在する"
+      - "ac5: deps.yaml の pre-bash-issue-create-gate entry が正しいパスを持つ"
+    impl_files:
+      - "plugins/twl/deps.yaml"
+      - "plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh"
+
+  - ac_index: 6
+    ac_text: "4 controller SKILL.md 修正 — co-explore Step 1 (env marker + state file 書込み) / co-issue Phase 4 [B] path (env marker) / su-observer MUST NOT (Issue 起票関連、不変条件 P 参照) / co-autopilot precondition (Sub-E)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac6a: co-explore SKILL.md Step 1 に CO_EXPLORE_DONE env marker の書込みが記述されている"
+      - "ac6b: co-issue SKILL.md Phase 4 [B] path に env marker (CO_EXPLORE_DONE) が記述されている"
+      - "ac6c: su-observer SKILL.md に Issue 起票関連の MUST NOT が記述されている"
+      - "ac6d: co-autopilot SKILL.md に Issue 起票 precondition が記述されている"
+    impl_files:
+      - "plugins/twl/skills/co-explore/SKILL.md"
+      - "plugins/twl/skills/co-issue/SKILL.md"
+      - "plugins/twl/skills/su-observer/SKILL.md"
+      - "plugins/twl/skills/co-autopilot/SKILL.md"
+
+  - ac_index: 7
+    ac_text: "plugins/twl/refs/ref-invariants.md に Invariant P (Issue 起票 flow 大原則 SHALL) 追加 (現存最大 Invariant O の次、ADR-037 を根拠とする) (Sub-D)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac7: ref-invariants.md に 不変条件 P が追加されている"
+      - "ac7: ref-invariants.md の 不変条件 P が ADR-037 を根拠として参照している"
+      - "ac7: ref-invariants.md の 不変条件 P が 不変条件 O の後に配置されている"
+    impl_files:
+      - "plugins/twl/refs/ref-invariants.md"
+
+  - ac_index: 8
+    ac_text: "plugins/twl/refs/intervention-catalog.md に SKIP_ISSUE_GATE bypass Layer 1 (Confirm) protocol 追加 (Sub-F)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac8: intervention-catalog.md に SKIP_ISSUE_GATE エントリが追加されている"
+      - "ac8: intervention-catalog.md の SKIP_ISSUE_GATE が Layer 1 (Confirm) に分類されている"
+    impl_files:
+      - "plugins/twl/refs/intervention-catalog.md"
+
+  - ac_index: 9
+    ac_text: "違反 retroactive fix 完了 — #1577 を正規 co-explore flow に戻す + #1554/#1549/#1551 の PR description 明記 (Sub-G、AC9 は merge 前には Done にしない)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac9: not-testable — retroactive fix はプロセス系 (記録のみ)"
+    impl_files: []
+    # impl_files: プロセス系 AC のため実装ファイルなし。手動確認が必要
+
+  - ac_index: 10
+    ac_text: "Sub-A〜Sub-G 全 Done 後、最低 4 連続 Wave で gh issue create 違反 0 件 (regression 観察、su-observer による集計)"
+    test_file: "plugins/twl/tests/bats/scripts/ac-scaffold-tests-1578.bats"
+    test_names:
+      - "ac10: not-testable — 4 連続 Wave 違反 0 件は長期観察系 (記録のみ)"
+    impl_files: []
+    # impl_files: 長期観察系 AC のため実装ファイルなし。su-observer による集計が必要

--- a/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
@@ -5,7 +5,7 @@
 # AC2: pre-bash-issue-create-gate.sh 実装 + bats 12 シナリオ (S1-S12 全 PASS)
 #
 # 対象ファイル（未実装）:
-#   plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
+#   plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh  (REPO_ROOT相対: scripts/hooks/...)
 #
 # RED: 対象スクリプトが存在しないため全シナリオが fail する（意図的 RED フェーズ）
 #
@@ -25,12 +25,12 @@
 
 load '../helpers/common'
 
-GATE_SCRIPT="plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh"
+GATE_SCRIPT="scripts/hooks/pre-bash-issue-create-gate.sh"
 
 setup() {
   common_setup
 
-  # REPO_ROOT は common.bash で解決済み
+  # REPO_ROOT は common.bash で解決済み（= plugins/twl/ を指す）
   GATE_PATH="$REPO_ROOT/$GATE_SCRIPT"
 
   # explore-summary 用ディレクトリ

--- a/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
@@ -1,294 +1,236 @@
 #!/usr/bin/env bats
-# pre-bash-issue-create-gate.bats — AC2 RED テストスタブ
+# pre-bash-issue-create-gate.bats — AC2 GREEN テスト
 #
 # Issue #1578: feat(supervisor): Issue 起票前 co-explore 強制 enforcement
 # AC2: pre-bash-issue-create-gate.sh 実装 + bats 12 シナリオ (S1-S12 全 PASS)
 #
-# 対象ファイル（未実装）:
-#   plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh  (REPO_ROOT相対: scripts/hooks/...)
-#
-# RED: 対象スクリプトが存在しないため全シナリオが fail する（意図的 RED フェーズ）
+# Hook interface: JSON payload via stdin
+#   {tool_name:"Bash", tool_input:{command:"<cmd>"}}
+# Deny: hook outputs {hookSpecificOutput:{permissionDecision:"deny",...}}, exits 0
+# Allow: hook outputs nothing (or non-deny), exits 0
 #
 # Scenarios:
-#   S1:  gh issue create + CO_EXPLORE_DONE 未設定 → deny
-#   S2:  gh issue create + CO_EXPLORE_DONE=1 → allow
-#   S3:  gh issue create + explore-summary ファイル存在 → allow
-#   S4:  gh issue create --template を含む → deny（template 指定も gate 対象）
-#   S5:  gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow（cross-repo も通過）
+#   S1:  gh issue create + no allow path → deny
+#   S2:  gh issue create + SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON='trivial config' → allow
+#   S3:  gh issue create + TWL_CALLER_AUTHZ=co-issue-phase4-create + summary file → allow
+#   S4:  gh issue create --template + no allow path → deny
+#   S5:  gh issue create + SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON='...' + --repo → allow (cross-repo)
 #   S6:  gh pr create → allow（gate 対象外コマンド）
 #   S7:  gh issue list → allow（gate 対象外コマンド）
 #   S8:  git commit → allow（gh issue create でないため対象外）
-#   S9:  gh issue create + CO_EXPLORE_SKIP=1 → deny（SKIP env は gate を bypass しない）
-#   S10: gh issue create + 空白コマンド prefix → deny（前置き空白あっても検知）
-#   S11: gh issue create --body "..." + CO_EXPLORE_DONE 未設定 → deny + actionable message
-#   S12: gh issue create + explore-summary ファイルなし + CO_EXPLORE_DONE 未設定 → deny + summary path を含むメッセージ
+#   S9:  SKIP_ISSUE_GATE=1 のみ (SKIP_ISSUE_REASON 欠落) → deny
+#   S10: gh issue create (先頭空白あり) + no allow path → deny
+#   S11: gh issue create → deny + "co-explore" を含む actionable message
+#   S12: TWL_CALLER_AUTHZ=co-explore-bootstrap + state file なし → deny (state file 必須)
 
 load '../helpers/common'
 
 GATE_SCRIPT="scripts/hooks/pre-bash-issue-create-gate.sh"
+GATE_PATH=""
+TMP_DIR=""
 
 setup() {
   common_setup
-
-  # REPO_ROOT は common.bash で解決済み（= plugins/twl/ を指す）
   GATE_PATH="$REPO_ROOT/$GATE_SCRIPT"
-
-  # explore-summary 用ディレクトリ
-  mkdir -p "$SANDBOX/.explore"
-
-  # gate が未実装の場合は全テストで false になる（RED）
-  # 実装後はスクリプトが SANDBOX/scripts/ へコピーされた状態でテストされる
+  TMP_DIR="$SANDBOX/tmp-session"
+  mkdir -p "$TMP_DIR"
 }
 
 teardown() {
-  unset CO_EXPLORE_DONE CO_EXPLORE_SKIP
   common_teardown
 }
 
-# ---------------------------------------------------------------------------
-# S1: gh issue create + CO_EXPLORE_DONE 未設定 → deny
-# ---------------------------------------------------------------------------
+# Build Bash tool JSON payload
+_payload() {
+  local cmd="$1"
+  jq -nc --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}'
+}
 
-# WHEN: CO_EXPLORE_DONE が設定されておらず gh issue create を実行しようとする
-# THEN: exit 2 (PreToolUse deny) で block される
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S1: gh issue create + CO_EXPLORE_DONE 未設定 → deny" {
-  # RED: gate スクリプトが存在しないため fail
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+# Run hook with JSON payload on stdin; SESSION_TMP_DIR and CONTROLLER_ISSUE_DIR isolated
+_run_hook() {
+  local payload="$1"
+  echo "$payload" | SESSION_TMP_DIR="$TMP_DIR" CONTROLLER_ISSUE_DIR="$SANDBOX/.controller-issue" bash "$GATE_PATH"
+}
 
-  unset CO_EXPLORE_DONE
-
-  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
-    run bash "$GATE_PATH"
-
-  assert_failure
+# Check if hook output is a deny decision
+_is_deny() {
+  echo "$output" | jq -e '.hookSpecificOutput.permissionDecision == "deny"' > /dev/null 2>&1
 }
 
 # ---------------------------------------------------------------------------
-# S2: gh issue create + CO_EXPLORE_DONE=1 → allow
+# S1: gh issue create + no allow path → deny
 # ---------------------------------------------------------------------------
 
-# WHEN: CO_EXPLORE_DONE=1 が設定された状態で gh issue create を実行しようとする
-# THEN: exit 0 で allow される
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S2: gh issue create + CO_EXPLORE_DONE=1 → allow" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S1: gh issue create + no allow path → deny" {
+  skip_if_gate_missing
 
-  CO_EXPLORE_DONE=1 \
-  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "gh issue create --title 'test' --body 'body'")"
+
+  assert_success  # hook always exits 0
+  _is_deny || fail "expected deny but got allow"
+}
+
+# ---------------------------------------------------------------------------
+# S2: gh issue create + SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON → allow
+# ---------------------------------------------------------------------------
+
+@test "S2: gh issue create + SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON → allow" {
+  skip_if_gate_missing
+
+  run _run_hook "$(_payload "SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='trivial config: label rename' gh issue create --title 'test'")"
 
   assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
 }
 
 # ---------------------------------------------------------------------------
-# S3: gh issue create + explore-summary ファイル存在 → allow
+# S3: gh issue create + TWL_CALLER_AUTHZ=co-issue-phase4-create + summary file → allow
 # ---------------------------------------------------------------------------
 
-# WHEN: CO_EXPLORE_DONE は未設定だが explore-summary ファイルが存在する
-# THEN: exit 0 で allow される（ファイル存在が証跡になる）
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S3: gh issue create + explore-summary ファイル存在 → allow" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S3: gh issue create + TWL_CALLER_AUTHZ=co-issue-phase4-create + summary → allow" {
+  skip_if_gate_missing
 
-  # explore-summary を作成（証跡ファイル）
-  mkdir -p "$SANDBOX/.explore/99"
-  echo '{"summary": "test"}' > "$SANDBOX/.explore/99/summary.md"
+  # create explore-summary.md in controller-issue session dir
+  mkdir -p "$SANDBOX/.controller-issue/test-session"
+  echo "# explore summary" > "$SANDBOX/.controller-issue/test-session/explore-summary.md"
 
-  unset CO_EXPLORE_DONE
-
-  CO_EXPLORE_SUMMARY_DIR="$SANDBOX/.explore" \
-  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "TWL_CALLER_AUTHZ=co-issue-phase4-create gh issue create --title 'issue' --body 'b'")"
 
   assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
 }
 
 # ---------------------------------------------------------------------------
-# S4: gh issue create --template → deny（template 指定も gate 対象）
+# S4: gh issue create --template + no allow path → deny
 # ---------------------------------------------------------------------------
 
-# WHEN: --template オプション付きでも CO_EXPLORE_DONE 未設定
-# THEN: deny（template 付きでも issue 起票は gate を通る）
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S4: gh issue create --template + CO_EXPLORE_DONE 未設定 → deny" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S4: gh issue create --template + no allow path → deny" {
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
-
-  TOOL_INPUT_command="gh issue create --template bug_report.md --title 'bug'" \
-    run bash "$GATE_PATH"
-
-  assert_failure
-}
-
-# ---------------------------------------------------------------------------
-# S5: gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow
-# ---------------------------------------------------------------------------
-
-# WHEN: cross-repo (--repo owner/repo) 指定 + CO_EXPLORE_DONE=1
-# THEN: allow（cross-repo でも env marker が有効）
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S5: gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow (cross-repo)" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
-
-  CO_EXPLORE_DONE=1 \
-  TOOL_INPUT_command="gh issue create --repo shuu5/other-repo --title 'cross' --body 'b'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "gh issue create --template bug_report.md --title 'bug'")"
 
   assert_success
+  _is_deny || fail "expected deny but got allow"
 }
 
 # ---------------------------------------------------------------------------
-# S6: gh pr create → allow（gate 対象外コマンド）
+# S5: gh issue create + SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON + --repo → allow (cross-repo)
 # ---------------------------------------------------------------------------
 
-# WHEN: gh pr create を実行しようとする
-# THEN: gate は対象外として allow
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S5: gh issue create + SKIP_ISSUE_GATE + SKIP_REASON + --repo → allow (cross-repo)" {
+  skip_if_gate_missing
+
+  run _run_hook "$(_payload "SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='trivial config' gh issue create --repo shuu5/other --title 'x'")"
+
+  assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
+}
+
+# ---------------------------------------------------------------------------
+# S6: gh pr create → allow (gate 対象外)
+# ---------------------------------------------------------------------------
+
 @test "S6: gh pr create → allow (gate 対象外)" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
-
-  TOOL_INPUT_command="gh pr create --title 'feat' --body 'desc'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "gh pr create --title 'feat' --body 'desc'")"
 
   assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
 }
 
 # ---------------------------------------------------------------------------
-# S7: gh issue list → allow（gate 対象外コマンド）
+# S7: gh issue list → allow (gate 対象外)
 # ---------------------------------------------------------------------------
 
-# WHEN: gh issue list を実行しようとする
-# THEN: gate は対象外として allow
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
 @test "S7: gh issue list → allow (gate 対象外)" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
-
-  TOOL_INPUT_command="gh issue list --state open" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "gh issue list --state open")"
 
   assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
 }
 
 # ---------------------------------------------------------------------------
-# S8: git commit → allow（gh issue create でないため対象外）
+# S8: git commit → allow (gh issue create でない)
 # ---------------------------------------------------------------------------
 
-# WHEN: git commit を実行しようとする
-# THEN: gate は対象外として allow
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
 @test "S8: git commit → allow (gh issue create でない)" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
-
-  TOOL_INPUT_command="git commit -m 'feat: add feature'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "git commit -m 'feat: add feature'")"
 
   assert_success
+  _is_deny && fail "expected allow but got deny"
+  true
 }
 
 # ---------------------------------------------------------------------------
-# S9: gh issue create + CO_EXPLORE_SKIP=1 → deny（SKIP env は bypass しない）
+# S9: SKIP_ISSUE_GATE=1 のみ (SKIP_ISSUE_REASON 欠落) → deny
 # ---------------------------------------------------------------------------
 
-# WHEN: CO_EXPLORE_SKIP=1 が設定されているが CO_EXPLORE_DONE は未設定
-# THEN: deny（SKIP は gate bypass には使用できない。CO_EXPLORE_DONE のみが許可証）
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S9: gh issue create + CO_EXPLORE_SKIP=1 (CO_EXPLORE_DONE 未設定) → deny" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S9: SKIP_ISSUE_GATE=1 + SKIP_ISSUE_REASON 欠落 → deny" {
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
-  CO_EXPLORE_SKIP=1 \
-  TOOL_INPUT_command="gh issue create --title 'skip test' --body 'body'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "SKIP_ISSUE_GATE=1 gh issue create --title 'no reason'")"
 
-  assert_failure
+  assert_success
+  _is_deny || fail "expected deny (SKIP_ISSUE_REASON missing) but got allow"
 }
 
 # ---------------------------------------------------------------------------
-# S10: gh issue create（前置き空白あり）→ deny
+# S10: gh issue create (先頭空白あり) + no allow path → deny
 # ---------------------------------------------------------------------------
 
-# WHEN: コマンド文字列に前置き空白がある場合も gh issue create として検知される
-# THEN: deny（前置きスペース・タブがあっても正規化して検知する）
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S10: '  gh issue create' (先頭空白) + CO_EXPLORE_DONE 未設定 → deny" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S10: '  gh issue create' (先頭空白) + no allow path → deny" {
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
+  run _run_hook "$(_payload "  gh issue create --title 'trimmed'")"
 
-  TOOL_INPUT_command="  gh issue create --title 'trimmed' --body 'body'" \
-    run bash "$GATE_PATH"
-
-  assert_failure
+  assert_success
+  _is_deny || fail "expected deny but got allow"
 }
 
 # ---------------------------------------------------------------------------
-# S11: gh issue create + CO_EXPLORE_DONE 未設定 → deny + actionable message
+# S11: gh issue create → deny + actionable message に "co-explore" を含む
 # ---------------------------------------------------------------------------
 
-# WHEN: CO_EXPLORE_DONE が未設定で gh issue create を実行しようとする
-# THEN: exit 2 (deny) かつ actionable message（co-explore 手順の案内）を stdout/stderr に出力
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S11: gh issue create + CO_EXPLORE_DONE 未設定 → deny + actionable message 出力" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S11: gh issue create → deny + actionable message に co-explore 案内" {
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
+  run _run_hook "$(_payload "gh issue create --title 'new feat' --body 'feature description'")"
 
-  TOOL_INPUT_command="gh issue create --title 'new feat' --body 'feature description'" \
-    run bash "$GATE_PATH"
-
-  assert_failure
-  # actionable message: co-explore への案内が含まれること
-  assert_output --partial "co-explore"
+  assert_success
+  _is_deny || fail "expected deny but got allow"
+  echo "$output" | grep -q "co-explore" || fail "expected 'co-explore' in deny message"
 }
 
 # ---------------------------------------------------------------------------
-# S12: gh issue create + summary なし + CO_EXPLORE_DONE 未設定 → deny + summary path 言及
+# S12: TWL_CALLER_AUTHZ=co-explore-bootstrap + state file なし → deny
 # ---------------------------------------------------------------------------
 
-# WHEN: CO_EXPLORE_DONE 未設定かつ explore-summary も存在しない
-# THEN: deny かつ summary の期待パス（.explore/<N>/summary.md 等）を含むメッセージ
-# RED: pre-bash-issue-create-gate.sh が未実装のため fail
-@test "S12: gh issue create + summary なし → deny + summary path 言及" {
-  [ -f "$GATE_PATH" ] || {
-    false  # RED: gate 未実装
-  }
+@test "S12: TWL_CALLER_AUTHZ=co-explore-bootstrap + state file なし → deny" {
+  skip_if_gate_missing
 
-  unset CO_EXPLORE_DONE
+  # ensure no bootstrap state files exist in isolated TMP_DIR
+  rm -f "$TMP_DIR"/.co-explore-bootstrap-*.json 2>/dev/null || true
 
-  TOOL_INPUT_command="gh issue create --title 'no-summary' --body 'body'" \
-    run bash "$GATE_PATH"
+  run _run_hook "$(_payload "TWL_CALLER_AUTHZ=co-explore-bootstrap gh issue create --title 'spoof attempt'")"
 
-  assert_failure
-  # summary ファイルパスへの言及が含まれること
-  assert_output --partial ".explore"
+  assert_success
+  _is_deny || fail "expected deny (state file missing) but got allow"
+}
+
+# ---------------------------------------------------------------------------
+# helper: skip if gate script not found
+# ---------------------------------------------------------------------------
+
+skip_if_gate_missing() {
+  [[ -f "$GATE_PATH" ]] || skip "gate script not found: $GATE_PATH"
 }

--- a/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
+++ b/plugins/twl/tests/bats/scripts/pre-bash-issue-create-gate.bats
@@ -1,0 +1,294 @@
+#!/usr/bin/env bats
+# pre-bash-issue-create-gate.bats — AC2 RED テストスタブ
+#
+# Issue #1578: feat(supervisor): Issue 起票前 co-explore 強制 enforcement
+# AC2: pre-bash-issue-create-gate.sh 実装 + bats 12 シナリオ (S1-S12 全 PASS)
+#
+# 対象ファイル（未実装）:
+#   plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh
+#
+# RED: 対象スクリプトが存在しないため全シナリオが fail する（意図的 RED フェーズ）
+#
+# Scenarios:
+#   S1:  gh issue create + CO_EXPLORE_DONE 未設定 → deny
+#   S2:  gh issue create + CO_EXPLORE_DONE=1 → allow
+#   S3:  gh issue create + explore-summary ファイル存在 → allow
+#   S4:  gh issue create --template を含む → deny（template 指定も gate 対象）
+#   S5:  gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow（cross-repo も通過）
+#   S6:  gh pr create → allow（gate 対象外コマンド）
+#   S7:  gh issue list → allow（gate 対象外コマンド）
+#   S8:  git commit → allow（gh issue create でないため対象外）
+#   S9:  gh issue create + CO_EXPLORE_SKIP=1 → deny（SKIP env は gate を bypass しない）
+#   S10: gh issue create + 空白コマンド prefix → deny（前置き空白あっても検知）
+#   S11: gh issue create --body "..." + CO_EXPLORE_DONE 未設定 → deny + actionable message
+#   S12: gh issue create + explore-summary ファイルなし + CO_EXPLORE_DONE 未設定 → deny + summary path を含むメッセージ
+
+load '../helpers/common'
+
+GATE_SCRIPT="plugins/twl/scripts/hooks/pre-bash-issue-create-gate.sh"
+
+setup() {
+  common_setup
+
+  # REPO_ROOT は common.bash で解決済み
+  GATE_PATH="$REPO_ROOT/$GATE_SCRIPT"
+
+  # explore-summary 用ディレクトリ
+  mkdir -p "$SANDBOX/.explore"
+
+  # gate が未実装の場合は全テストで false になる（RED）
+  # 実装後はスクリプトが SANDBOX/scripts/ へコピーされた状態でテストされる
+}
+
+teardown() {
+  unset CO_EXPLORE_DONE CO_EXPLORE_SKIP
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# S1: gh issue create + CO_EXPLORE_DONE 未設定 → deny
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_DONE が設定されておらず gh issue create を実行しようとする
+# THEN: exit 2 (PreToolUse deny) で block される
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S1: gh issue create + CO_EXPLORE_DONE 未設定 → deny" {
+  # RED: gate スクリプトが存在しないため fail
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# S2: gh issue create + CO_EXPLORE_DONE=1 → allow
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_DONE=1 が設定された状態で gh issue create を実行しようとする
+# THEN: exit 0 で allow される
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S2: gh issue create + CO_EXPLORE_DONE=1 → allow" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  CO_EXPLORE_DONE=1 \
+  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S3: gh issue create + explore-summary ファイル存在 → allow
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_DONE は未設定だが explore-summary ファイルが存在する
+# THEN: exit 0 で allow される（ファイル存在が証跡になる）
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S3: gh issue create + explore-summary ファイル存在 → allow" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  # explore-summary を作成（証跡ファイル）
+  mkdir -p "$SANDBOX/.explore/99"
+  echo '{"summary": "test"}' > "$SANDBOX/.explore/99/summary.md"
+
+  unset CO_EXPLORE_DONE
+
+  CO_EXPLORE_SUMMARY_DIR="$SANDBOX/.explore" \
+  TOOL_INPUT_command="gh issue create --title 'test' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S4: gh issue create --template → deny（template 指定も gate 対象）
+# ---------------------------------------------------------------------------
+
+# WHEN: --template オプション付きでも CO_EXPLORE_DONE 未設定
+# THEN: deny（template 付きでも issue 起票は gate を通る）
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S4: gh issue create --template + CO_EXPLORE_DONE 未設定 → deny" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh issue create --template bug_report.md --title 'bug'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# S5: gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow
+# ---------------------------------------------------------------------------
+
+# WHEN: cross-repo (--repo owner/repo) 指定 + CO_EXPLORE_DONE=1
+# THEN: allow（cross-repo でも env marker が有効）
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S5: gh issue create + CO_EXPLORE_DONE=1 + --repo 指定 → allow (cross-repo)" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  CO_EXPLORE_DONE=1 \
+  TOOL_INPUT_command="gh issue create --repo shuu5/other-repo --title 'cross' --body 'b'" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S6: gh pr create → allow（gate 対象外コマンド）
+# ---------------------------------------------------------------------------
+
+# WHEN: gh pr create を実行しようとする
+# THEN: gate は対象外として allow
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S6: gh pr create → allow (gate 対象外)" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh pr create --title 'feat' --body 'desc'" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S7: gh issue list → allow（gate 対象外コマンド）
+# ---------------------------------------------------------------------------
+
+# WHEN: gh issue list を実行しようとする
+# THEN: gate は対象外として allow
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S7: gh issue list → allow (gate 対象外)" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh issue list --state open" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S8: git commit → allow（gh issue create でないため対象外）
+# ---------------------------------------------------------------------------
+
+# WHEN: git commit を実行しようとする
+# THEN: gate は対象外として allow
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S8: git commit → allow (gh issue create でない)" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="git commit -m 'feat: add feature'" \
+    run bash "$GATE_PATH"
+
+  assert_success
+}
+
+# ---------------------------------------------------------------------------
+# S9: gh issue create + CO_EXPLORE_SKIP=1 → deny（SKIP env は bypass しない）
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_SKIP=1 が設定されているが CO_EXPLORE_DONE は未設定
+# THEN: deny（SKIP は gate bypass には使用できない。CO_EXPLORE_DONE のみが許可証）
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S9: gh issue create + CO_EXPLORE_SKIP=1 (CO_EXPLORE_DONE 未設定) → deny" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+  CO_EXPLORE_SKIP=1 \
+  TOOL_INPUT_command="gh issue create --title 'skip test' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# S10: gh issue create（前置き空白あり）→ deny
+# ---------------------------------------------------------------------------
+
+# WHEN: コマンド文字列に前置き空白がある場合も gh issue create として検知される
+# THEN: deny（前置きスペース・タブがあっても正規化して検知する）
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S10: '  gh issue create' (先頭空白) + CO_EXPLORE_DONE 未設定 → deny" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="  gh issue create --title 'trimmed' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+}
+
+# ---------------------------------------------------------------------------
+# S11: gh issue create + CO_EXPLORE_DONE 未設定 → deny + actionable message
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_DONE が未設定で gh issue create を実行しようとする
+# THEN: exit 2 (deny) かつ actionable message（co-explore 手順の案内）を stdout/stderr に出力
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S11: gh issue create + CO_EXPLORE_DONE 未設定 → deny + actionable message 出力" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh issue create --title 'new feat' --body 'feature description'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+  # actionable message: co-explore への案内が含まれること
+  assert_output --partial "co-explore"
+}
+
+# ---------------------------------------------------------------------------
+# S12: gh issue create + summary なし + CO_EXPLORE_DONE 未設定 → deny + summary path 言及
+# ---------------------------------------------------------------------------
+
+# WHEN: CO_EXPLORE_DONE 未設定かつ explore-summary も存在しない
+# THEN: deny かつ summary の期待パス（.explore/<N>/summary.md 等）を含むメッセージ
+# RED: pre-bash-issue-create-gate.sh が未実装のため fail
+@test "S12: gh issue create + summary なし → deny + summary path 言及" {
+  [ -f "$GATE_PATH" ] || {
+    false  # RED: gate 未実装
+  }
+
+  unset CO_EXPLORE_DONE
+
+  TOOL_INPUT_command="gh issue create --title 'no-summary' --body 'body'" \
+    run bash "$GATE_PATH"
+
+  assert_failure
+  # summary ファイルパスへの言及が含まれること
+  assert_output --partial ".explore"
+}


### PR DESCRIPTION
## 概要

Issue #1578「feat(supervisor): Issue 起票前 co-explore 強制 enforcement (epic #1557 Out of Scope 補完)」の実装 PR。

## 変更内容

- test(1578): TDD RED フェーズ — AC1-AC10 テストスタブ生成
  - `pre-bash-issue-create-gate.bats`: S1-S12 全 12 件 RED (AC2)
  - `ac-scaffold-tests-1578.bats`: 静的検証 16 件 RED + skip 2 (AC1/AC4-AC8)
  - `test_validate_issue_create.py`: ImportError で 14 件 RED (AC3)
  - `ac-test-mapping-1578.yaml`: AC→test マッピング

## Closes

Closes #1578