### PR TITLE
feat(twl-mcp): twl mcp doctor サブコマンドを追加 (#1589)

### DIFF
--- a/cli/twl/src/twl/cli.py
+++ b/cli/twl/src/twl/cli.py
@@ -138,6 +138,9 @@ def main():
     mcp_parser = subparsers.add_parser('mcp', help='MCP server lifecycle 管理')
     mcp_subparsers = mcp_parser.add_subparsers(dest='mcp_subcommand', required=True)
     mcp_subparsers.add_parser('restart', help='Restart MCP server')
+    doctor_parser = mcp_subparsers.add_parser('doctor', help='Self-check .mcp.json configuration')
+    doctor_parser.add_argument('--probe', action='store_true', help='Run stdio handshake probe (timeout 5s)')
+    doctor_parser.add_argument('--format', choices=['human', 'json'], default='human', help='Output format')
 
     args = parser.parse_args()
 
@@ -149,6 +152,9 @@ def main():
             except ValueError as e:
                 print(f"Error: mcp restart failed — {e}", file=sys.stderr)
                 sys.exit(1)
+        elif args.mcp_subcommand == 'doctor':
+            from twl.mcp_server import doctor
+            sys.exit(doctor.run_doctor(args))
         else:
             mcp_parser.print_help(sys.stderr)
             sys.exit(1)

--- a/cli/twl/src/twl/mcp_server/doctor.py
+++ b/cli/twl/src/twl/mcp_server/doctor.py
@@ -1,0 +1,322 @@
+"""twl MCP doctor — self-check for .mcp.json configuration integrity."""
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from twl.mcp_server.lifecycle import _validate_command
+
+
+def _find_mcp_json() -> "Path | None":
+    """Find .mcp.json by walking up from CWD to git root."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return Path(result.stdout.strip()) / ".mcp.json"
+    except Exception:
+        pass
+    # Fallback: walk up from CWD
+    current = Path.cwd()
+    for parent in [current, *current.parents]:
+        candidate = parent / ".mcp.json"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _check_mcp_json_readable(mcp_json: "Path | None") -> dict[str, Any]:
+    if mcp_json is None:
+        return {
+            "name": "mcp_json_readable",
+            "result": "fail",
+            "detail": ".mcp.json not found in git root or any parent directory",
+            "fix": None,
+            "exit_code": 2,
+        }
+    try:
+        with open(mcp_json) as f:
+            config = json.load(f)
+        return {
+            "name": "mcp_json_readable",
+            "result": "pass",
+            "detail": f"Read {mcp_json}",
+            "fix": None,
+            "exit_code": 0,
+            "_config": config,
+        }
+    except Exception as e:
+        return {
+            "name": "mcp_json_readable",
+            "result": "fail",
+            "detail": f"Failed to read {mcp_json}: {e}",
+            "fix": None,
+            "exit_code": 2,
+        }
+
+
+def _check_validate_command(config: dict[str, Any]) -> tuple[dict[str, Any], str, list[str]]:
+    """Returns (check_result, command, args)."""
+    twl_server = config.get("mcpServers", {}).get("twl", {})
+    command = twl_server.get("command", "")
+    args = twl_server.get("args", [])
+
+    if not command:
+        return (
+            {
+                "name": "validate_command",
+                "result": "fail",
+                "detail": "mcpServers.twl.command is empty or missing",
+                "fix": "Set 'command' in .mcp.json under mcpServers.twl",
+                "exit_code": 2,
+            },
+            command,
+            args,
+        )
+
+    try:
+        _validate_command(command)
+        return (
+            {
+                "name": "validate_command",
+                "result": "pass",
+                "detail": f"command '{command}' is in allowlist",
+                "fix": None,
+                "exit_code": 0,
+            },
+            command,
+            args,
+        )
+    except ValueError as exc:
+        from twl.mcp_server.lifecycle import _format_fix_guidance
+        fix_msg = _format_fix_guidance(str(exc))
+        return (
+            {
+                "name": "validate_command",
+                "result": "fail",
+                "detail": str(exc),
+                "fix": fix_msg,
+                "exit_code": 2,
+            },
+            command,
+            args,
+        )
+
+
+def _check_binary_exists(command: str) -> dict[str, Any]:
+    if not command:
+        return {
+            "name": "binary_exists",
+            "result": "fail",
+            "detail": "No command to check",
+            "fix": None,
+            "exit_code": 1,
+        }
+
+    if os.path.isabs(command):
+        found = os.access(command, os.F_OK | os.X_OK)
+        if found:
+            return {
+                "name": "binary_exists",
+                "result": "pass",
+                "detail": f"Found executable at {command}",
+                "fix": None,
+                "exit_code": 0,
+            }
+        return {
+            "name": "binary_exists",
+            "result": "fail",
+            "detail": f"Absolute path '{command}' not found or not executable",
+            "fix": f"Ensure '{command}' exists and is executable",
+            "exit_code": 1,
+        }
+    else:
+        resolved = shutil.which(command)
+        if resolved:
+            return {
+                "name": "binary_exists",
+                "result": "pass",
+                "detail": f"Found '{command}' at {resolved}",
+                "fix": None,
+                "exit_code": 0,
+            }
+        return {
+            "name": "binary_exists",
+            "result": "fail",
+            "detail": f"'{command}' not found in PATH",
+            "fix": f"Install '{command}' or add its directory to PATH",
+            "exit_code": 1,
+        }
+
+
+def _check_stdio_probe(command: str, args: list[str]) -> dict[str, Any]:
+    """Perform a stdio handshake with timeout 5s."""
+    if not command:
+        return {
+            "name": "stdio_probe",
+            "result": "skipped",
+            "detail": "No command to probe",
+            "fix": None,
+            "exit_code": 0,
+        }
+
+    full_cmd = [command] + args
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            full_cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        # Send MCP initialize request
+        init_request = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {"protocolVersion": "2024-11-05", "capabilities": {}},
+        }) + "\n"
+        try:
+            stdout_data, _ = proc.communicate(
+                input=init_request.encode(),
+                timeout=5,
+            )
+            # Check for valid JSON-RPC response
+            for line in stdout_data.decode(errors="replace").splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                    if obj.get("jsonrpc") == "2.0":
+                        return {
+                            "name": "stdio_probe",
+                            "result": "pass",
+                            "detail": "Received valid JSON-RPC 2.0 response",
+                            "fix": None,
+                            "exit_code": 0,
+                        }
+                except json.JSONDecodeError:
+                    continue
+            return {
+                "name": "stdio_probe",
+                "result": "fail",
+                "detail": "No valid JSON-RPC 2.0 response received within 5s",
+                "fix": None,
+                "exit_code": 1,
+            }
+        except subprocess.TimeoutExpired:
+            return {
+                "name": "stdio_probe",
+                "result": "fail",
+                "detail": "Process did not respond within 5s (timeout)",
+                "fix": None,
+                "exit_code": 1,
+            }
+    except Exception as e:
+        return {
+            "name": "stdio_probe",
+            "result": "fail",
+            "detail": f"Failed to start process: {e}",
+            "fix": None,
+            "exit_code": 1,
+        }
+    finally:
+        if proc is not None and proc.poll() is None:
+            try:
+                proc.send_signal(signal.SIGTERM)
+                proc.wait(timeout=2)
+            except Exception:
+                pass
+
+
+def _compute_overall(checks: list[dict[str, Any]]) -> tuple[str, int]:
+    """Compute overall status and exit code from checks."""
+    max_exit = max((c["exit_code"] for c in checks), default=0)
+    if max_exit == 0:
+        return "ok", 0
+    if max_exit == 1:
+        return "warning", 1
+    return "critical", 2
+
+
+def _format_human(checks: list[dict[str, Any]], status: str) -> None:
+    STATUS_COLOR = {"ok": "\033[92m", "warning": "\033[93m", "critical": "\033[91m"}
+    RESULT_COLOR = {"pass": "\033[92m", "fail": "\033[91m", "skipped": "\033[90m"}
+    RESET = "\033[0m"
+
+    status_color = STATUS_COLOR.get(status, "")
+    print(f"\ntwl mcp doctor — {status_color}{status.upper()}{RESET}\n")
+    for check in checks:
+        result = check["result"]
+        color = RESULT_COLOR.get(result, "")
+        icon = {"pass": "✓", "fail": "✗", "skipped": "−"}.get(result, "?")
+        print(f"  {color}{icon} {check['name']}{RESET}: {check['detail']}")
+        if check.get("fix"):
+            print(f"    → Fix: {check['fix']}")
+    print()
+
+
+def run_doctor(args: Any) -> int:
+    """Entry point for twl mcp doctor. Returns exit code."""
+    probe = getattr(args, "probe", False)
+    fmt = getattr(args, "format", "human")
+
+    mcp_json = _find_mcp_json()
+    readable_check = _check_mcp_json_readable(mcp_json)
+    config = readable_check.pop("_config", {})
+    checks: list[dict[str, Any]] = [readable_check]
+
+    if readable_check["result"] == "pass":
+        validate_check, command, cmd_args = _check_validate_command(config)
+        checks.append(validate_check)
+
+        binary_check = _check_binary_exists(command)
+        checks.append(binary_check)
+
+        if probe:
+            probe_check = _check_stdio_probe(command, cmd_args)
+            checks.append(probe_check)
+        else:
+            checks.append({
+                "name": "stdio_probe",
+                "result": "skipped",
+                "detail": "Use --probe to run stdio handshake",
+                "fix": None,
+                "exit_code": 0,
+            })
+    else:
+        # Fill remaining checks as skipped
+        for name in ("validate_command", "binary_exists", "stdio_probe"):
+            checks.append({
+                "name": name,
+                "result": "skipped",
+                "detail": "Skipped due to .mcp.json read failure",
+                "fix": None,
+                "exit_code": 0,
+            })
+
+    status, exit_code = _compute_overall(checks)
+
+    clean_checks = [{k: v for k, v in c.items() if k != "exit_code"} for c in checks]
+
+    if fmt == "json":
+        output = {
+            "status": status,
+            "summary": f"{sum(1 for c in clean_checks if c['result'] == 'pass')} passed, "
+                       f"{sum(1 for c in clean_checks if c['result'] == 'fail')} failed, "
+                       f"{sum(1 for c in clean_checks if c['result'] == 'skipped')} skipped",
+            "checks": clean_checks,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        _format_human(checks, status)
+
+    return exit_code

--- a/cli/twl/src/twl/mcp_server/lifecycle.py
+++ b/cli/twl/src/twl/mcp_server/lifecycle.py
@@ -49,6 +49,19 @@ def _validate_command(command: str) -> None:
         )
 
 
+def _format_fix_guidance(reason: str) -> str:
+    """Return human-readable fix guidance for a validation failure reason."""
+    if "not in allowlist" in reason:
+        allowed = sorted(_ALLOWED_COMMANDS)
+        return f"{reason} — Use one of: {allowed}. Update .mcp.json 'command' field."
+    if "not in allowed prefixes" in reason:
+        prefixes = sorted(str(p) for p in _get_allowed_prefixes())
+        return f"{reason} — Use a command under: {prefixes}."
+    if "path resolution failed" in reason:
+        return f"{reason} — Check that the command path is valid and accessible."
+    return reason
+
+
 def _find_mcp_server_pids() -> "list[int]":
     """Find running twl MCP server PIDs via pgrep."""
     result = subprocess.run(
@@ -126,7 +139,7 @@ def restart_mcp_server() -> int:
     try:
         cmd = _find_mcp_server_cmd()
     except ValueError as exc:
-        print(f"Error: mcp restart aborted — {exc}", file=sys.stderr)
+        print(f"Error: mcp restart aborted — {_format_fix_guidance(str(exc))}", file=sys.stderr)
         return 1
     if cmd is None:
         print("Error: mcp restart aborted — could not determine startup command from .mcp.json", file=sys.stderr)

--- a/cli/twl/tests/ac-test-mapping-1589.yaml
+++ b/cli/twl/tests/ac-test-mapping-1589.yaml
@@ -1,0 +1,45 @@
+mappings:
+  - ac_index: 1
+    ac_text: "cli/twl/src/twl/cli.py に doctor サブパーサーを追加: mcp_subparsers.add_parser('doctor') に --probe と --format 引数を追加し、elif args.mcp_subcommand == 'doctor' ブロックで doctor.run_doctor(args) を呼び出す"
+    test_file: "cli/twl/tests/test_mcp_doctor.py"
+    test_name: "TestAC1CliDoctorSubparser"
+    impl_files:
+      - "cli/twl/src/twl/cli.py"
+
+  - ac_index: 2
+    ac_text: "doctor 本体を新規モジュール cli/twl/src/twl/mcp_server/doctor.py に実装: .mcp.json 独自読み込み → _validate_command 呼び出し → binary 存在確認 → --probe optional stdio handshake"
+    test_file: "cli/twl/tests/test_mcp_doctor.py"
+    test_name: "TestAC2DoctorModule / TestAC2ProbeFlag"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/doctor.py"
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+
+  - ac_index: 3
+    ac_text: "出力フォーマット 2 種類: human-readable（default）と --format json（status/summary/checks スキーマ）"
+    test_file: "cli/twl/tests/test_mcp_doctor.py"
+    test_name: "TestAC3OutputFormats"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/doctor.py"
+
+  - ac_index: 4
+    ac_text: "exit code 規約: 0=OK / 1=warning（binary_exists miss / stdio_probe fail）/ 2=critical（mcp_json_readable fail / validate_command fail）"
+    test_file: "cli/twl/tests/test_mcp_doctor.py"
+    test_name: "TestAC4ExitCodes"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/doctor.py"
+
+  - ac_index: 5
+    ac_text: "lifecycle.py に _format_fix_guidance(reason: str) -> str を追加し、restart_mcp_server() の except ValueError ブロックで使用する。doctor.py を import してはならない"
+    test_file: "cli/twl/tests/test_mcp_lifecycle.py"
+    test_name: "TestIssue1588AC3FailFastBehavior::test_ac5_fix_guidance_in_error_message"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+
+  - ac_index: 6
+    ac_text: "テスト追加: test_mcp_doctor.py 新規（OK/warning/critical 各ケース）と test_mcp_lifecycle.py の TestIssue1588AC3FailFastBehavior に test_ac5_fix_guidance_in_error_message を追加"
+    test_file: "cli/twl/tests/test_mcp_doctor.py"
+    test_name: "全クラス（TestAC1〜TestAC4, TestAC2ProbeFlag）"
+    impl_files:
+      - "cli/twl/src/twl/mcp_server/doctor.py"
+      - "cli/twl/src/twl/mcp_server/lifecycle.py"
+      - "cli/twl/src/twl/cli.py"

--- a/cli/twl/tests/test_mcp_doctor.py
+++ b/cli/twl/tests/test_mcp_doctor.py
@@ -1,0 +1,661 @@
+"""Tests for Issue #1589: twl mcp doctor command.
+
+TDD RED フェーズ用テスト。
+実装前は全テストが FAIL する（意図的 RED）。
+
+AC1: cli.py に doctor サブパーサーと --probe / --format 引数を追加
+AC2: doctor.py 新規モジュール（mcp.json 読み込み → _validate_command → binary 確認 → probe）
+AC3: 出力フォーマット human-readable / --format json
+AC4: exit code 規約（0=OK / 1=warning / 2=critical）
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+TWL_SRC = Path(__file__).resolve().parent.parent / "src"
+if str(TWL_SRC) not in sys.path:
+    sys.path.insert(0, str(TWL_SRC))
+
+
+# ---------------------------------------------------------------------------
+# AC1: cli.py に doctor サブパーサーが追加されていること
+# ---------------------------------------------------------------------------
+
+class TestAC1CliDoctorSubparser:
+    """AC1: cli.py の mcp_subparsers に 'doctor' が追加され、
+    --probe と --format 引数を持つこと。
+
+    RED: doctor サブパーサーが未実装のため、parse_args が fail する。
+    """
+
+    def test_ac1_doctor_module_importable(self):
+        # AC: twl.mcp_server.doctor が import 可能であること
+        # RED: doctor.py が存在しないため ImportError で FAIL する
+        try:
+            import twl.mcp_server.doctor  # noqa: F401
+        except ImportError as e:
+            pytest.fail(
+                f"twl.mcp_server.doctor が import できない (AC1/AC2 未実装): {e}"
+            )
+
+    def test_ac1_mcp_doctor_subparser_registered(self):
+        # AC: 'twl mcp doctor' が parse_args で認識されること
+        # RED: cli.py に doctor サブパーサーがないため parse_args が error で終了する
+        import twl.cli as cli_mod
+        import argparse
+
+        # cli.main() を parse_args 部分だけ再現するため、
+        # argparse の parser を再構築して doctor が登録されているかを検証する
+        cli_path = TWL_SRC / "twl" / "cli.py"
+        content = cli_path.read_text()
+        assert "doctor" in content, (
+            "cli.py に 'doctor' という文字列が存在しない (AC1 未実装 — doctor サブパーサー追加が必要)"
+        )
+
+    def test_ac1_doctor_subparser_has_probe_argument(self):
+        # AC: doctor サブパーサーに --probe 引数が定義されていること
+        # RED: doctor サブパーサーが未実装のため FAIL する
+        cli_path = TWL_SRC / "twl" / "cli.py"
+        content = cli_path.read_text()
+
+        # cli.py の doctor 周辺に --probe が定義されていること
+        doctor_idx = content.find("'doctor'")
+        if doctor_idx == -1:
+            pytest.fail("cli.py に 'doctor' サブパーサーが存在しない (AC1 未実装)")
+        # doctor 定義付近（前後500文字）に --probe があること
+        nearby = content[max(0, doctor_idx - 50):doctor_idx + 500]
+        assert "--probe" in nearby, (
+            f"cli.py の doctor サブパーサー付近に '--probe' 引数が定義されていない (AC1 未実装):\n{nearby}"
+        )
+
+    def test_ac1_doctor_subparser_has_format_argument(self):
+        # AC: doctor サブパーサーに --format 引数が定義されていること
+        # RED: doctor サブパーサーが未実装のため FAIL する
+        cli_path = TWL_SRC / "twl" / "cli.py"
+        content = cli_path.read_text()
+
+        doctor_idx = content.find("'doctor'")
+        if doctor_idx == -1:
+            pytest.fail("cli.py に 'doctor' サブパーサーが存在しない (AC1 未実装)")
+        nearby = content[max(0, doctor_idx - 50):doctor_idx + 600]
+        assert "--format" in nearby, (
+            f"cli.py の doctor サブパーサー付近に '--format' 引数が定義されていない (AC1 未実装):\n{nearby}"
+        )
+
+    def test_ac1_cli_dispatches_to_doctor_run_doctor(self):
+        # AC: cli.py の mcp_subcommand == 'doctor' ブロックで
+        #     doctor.run_doctor(args) が呼ばれること
+        # RED: dispatch ブロックが未実装のため FAIL する
+        cli_path = TWL_SRC / "twl" / "cli.py"
+        content = cli_path.read_text()
+        assert "run_doctor" in content, (
+            "cli.py に 'run_doctor' 呼び出しが存在しない (AC1 未実装)"
+        )
+        assert "mcp_subcommand == 'doctor'" in content or "mcp_subcommand==\"doctor\"" in content or \
+               "args.mcp_subcommand == 'doctor'" in content, (
+            "cli.py に doctor ディスパッチブロックが存在しない (AC1 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC2: doctor.py モジュール — 各 check 関数の存在と動作
+# ---------------------------------------------------------------------------
+
+class TestAC2DoctorModule:
+    """AC2: twl.mcp_server.doctor モジュールが存在し、run_doctor() が実装されていること。
+
+    RED: doctor.py が存在しないため ImportError で FAIL する。
+    """
+
+    def test_ac2_run_doctor_function_exists(self):
+        # AC: doctor.run_doctor 関数が存在すること
+        # RED: doctor.py が存在しないため ImportError で FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+        assert hasattr(doctor, "run_doctor") and callable(doctor.run_doctor), (
+            "doctor.run_doctor 関数が存在しない (AC2 未実装)"
+        )
+
+    def test_ac2_doctor_reads_mcp_json_directly(self):
+        # AC: doctor は .mcp.json を独自に読み込み、_find_mcp_server_cmd() を使わないこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+        import inspect
+        source = inspect.getsource(doctor)
+        # doctor は _find_mcp_server_cmd() を呼ばない
+        assert "_find_mcp_server_cmd" not in source, (
+            "doctor.py が _find_mcp_server_cmd() を呼んでいる (AC2 違反 — doctor は独自に .mcp.json を読む)"
+        )
+        # .mcp.json を読む処理が存在すること
+        assert ".mcp.json" in source or "mcp_json" in source, (
+            "doctor.py に .mcp.json 読み込み処理が存在しない (AC2 未実装)"
+        )
+
+    def test_ac2_doctor_calls_validate_command(self):
+        # AC: doctor が lifecycle._validate_command() を呼ぶこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+        import inspect
+        source = inspect.getsource(doctor)
+        assert "_validate_command" in source, (
+            "doctor.py で _validate_command() の呼び出しが見当たらない (AC2 未実装)"
+        )
+
+    def test_ac2_doctor_checks_binary_exists(self):
+        # AC: doctor が shutil.which または os.access でバイナリ存在確認すること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+        import inspect
+        source = inspect.getsource(doctor)
+        has_which = "shutil.which" in source or "which(" in source
+        has_access = "os.access" in source
+        assert has_which or has_access, (
+            "doctor.py に shutil.which / os.access によるバイナリ確認がない (AC2 未実装)"
+        )
+
+    def test_ac2_ok_case_all_checks_pass(self, make_mcp_json, tmp_path):
+        # AC: 正常な .mcp.json（command="uv"）で run_doctor() が 0 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", ["run", "--directory", str(tmp_path), "server.py"], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            result = doctor.run_doctor(args)
+
+        assert result == 0, (
+            f"正常ケースで run_doctor() が 0 を返さなかった: {result} (AC2/AC4 未実装)"
+        )
+
+    def test_ac2_critical_case_mcp_json_unreadable(self, tmp_path):
+        # AC: .mcp.json が読み取れない場合は run_doctor() が 2 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        # _find_mcp_json が None を返す → .mcp.json が見つからない
+        with patch("twl.mcp_server.doctor._find_mcp_json", return_value=None):
+            result = doctor.run_doctor(args)
+
+        assert result == 2, (
+            f".mcp.json 読み取り失敗時に run_doctor() が 2 を返さなかった: {result} (AC2/AC4 未実装)"
+        )
+
+    def test_ac2_critical_case_validate_command_fails(self, make_mcp_json, tmp_path):
+        # AC: _validate_command() が ValueError を raise した場合は 2 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+
+        mcp_json = make_mcp_json("bash", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")):
+            result = doctor.run_doctor(args)
+
+        assert result == 2, (
+            f"_validate_command 失敗時に run_doctor() が 2 を返さなかった: {result} (AC2/AC4 未実装)"
+        )
+
+    def test_ac2_warning_case_binary_not_found(self, make_mcp_json, tmp_path):
+        # AC: バイナリが見つからない場合は 1 を返すこと（warning）
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value=None):
+            result = doctor.run_doctor(args)
+
+        assert result == 1, (
+            f"binary_not_found 時に run_doctor() が 1 を返さなかった: {result} (AC2/AC4 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC3: 出力フォーマット — human と JSON
+# ---------------------------------------------------------------------------
+
+class TestAC3OutputFormats:
+    """AC3: --format json で機械可読 JSON を出力し、human（default）で色付き出力すること。
+
+    RED: doctor.py が存在しないため FAIL する。
+    """
+
+    def test_ac3_json_format_output_is_valid_json(self, make_mcp_json, tmp_path, capsys):
+        # AC: --format json 時に stdout に有効な JSON が出力されること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError as e:
+            pytest.fail(
+                f"--format json 時の stdout が有効な JSON でない (AC3 未実装): {e}\n"
+                f"stdout: {captured.out!r}"
+            )
+
+    def test_ac3_json_schema_has_required_keys(self, make_mcp_json, tmp_path, capsys):
+        # AC: JSON 出力が status / summary / checks キーを持つこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError:
+            pytest.fail("--format json の stdout が JSON でない (AC3 未実装)")
+
+        for key in ("status", "summary", "checks"):
+            assert key in output, (
+                f"JSON 出力に '{key}' キーが存在しない (AC3 未実装). keys={list(output.keys())}"
+            )
+
+    def test_ac3_json_checks_has_expected_names(self, make_mcp_json, tmp_path, capsys):
+        # AC: checks 配列に mcp_json_readable / validate_command / binary_exists / stdio_probe が含まれること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError:
+            pytest.fail("--format json の stdout が JSON でない (AC3 未実装)")
+
+        check_names = {c["name"] for c in output.get("checks", [])}
+        expected_names = {"mcp_json_readable", "validate_command", "binary_exists", "stdio_probe"}
+        assert expected_names <= check_names, (
+            f"checks に期待されるエントリが不足 (AC3 未実装). "
+            f"不足: {expected_names - check_names}"
+        )
+
+    def test_ac3_json_status_values_are_valid(self, make_mcp_json, tmp_path, capsys):
+        # AC: status は "ok" / "warning" / "critical" のいずれかであること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError:
+            pytest.fail("--format json の stdout が JSON でない (AC3 未実装)")
+
+        assert output.get("status") in ("ok", "warning", "critical"), (
+            f"status が有効値でない: {output.get('status')!r} (AC3 未実装)"
+        )
+
+    def test_ac3_json_check_result_values_are_valid(self, make_mcp_json, tmp_path, capsys):
+        # AC: 各 check の result は "pass" / "fail" / "skipped" のいずれかであること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError:
+            pytest.fail("--format json の stdout が JSON でない (AC3 未実装)")
+
+        valid_results = {"pass", "fail", "skipped"}
+        for check in output.get("checks", []):
+            assert check.get("result") in valid_results, (
+                f"check '{check.get('name')}' の result が無効値: {check.get('result')!r} "
+                f"(AC3 未実装)"
+            )
+
+    def test_ac3_stdio_probe_skipped_without_flag(self, make_mcp_json, tmp_path, capsys):
+        # AC: --probe なしの場合 stdio_probe の result は "skipped" であること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC3 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "json"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            doctor.run_doctor(args)
+
+        captured = capsys.readouterr()
+        try:
+            output = json.loads(captured.out)
+        except json.JSONDecodeError:
+            pytest.fail("--format json の stdout が JSON でない (AC3 未実装)")
+
+        probe_checks = [c for c in output.get("checks", []) if c.get("name") == "stdio_probe"]
+        assert probe_checks, "checks に stdio_probe エントリが存在しない (AC3 未実装)"
+        assert probe_checks[0].get("result") == "skipped", (
+            f"--probe なし時に stdio_probe が skipped でない: {probe_checks[0].get('result')!r} "
+            f"(AC3 未実装)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# AC4: exit code 規約（0=OK / 1=warning / 2=critical）
+# ---------------------------------------------------------------------------
+
+class TestAC4ExitCodes:
+    """AC4: run_doctor() の exit code が規約通りであること。
+
+    RED: doctor.py が存在しないため FAIL する。
+    """
+
+    def test_ac4_exit_0_all_checks_pass(self, make_mcp_json, tmp_path):
+        # AC: 全 check pass で 0 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"):
+            result = doctor.run_doctor(args)
+
+        assert result == 0, (
+            f"全 check pass 時に 0 を返さなかった: {result} (AC4 未実装)"
+        )
+
+    def test_ac4_exit_1_binary_not_found_warning(self, make_mcp_json, tmp_path):
+        # AC: binary_exists が fail（warning）の場合は 1 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value=None):
+            result = doctor.run_doctor(args)
+
+        assert result == 1, (
+            f"binary_not_found 時に 1 を返さなかった: {result} (AC4 未実装)"
+        )
+
+    def test_ac4_exit_2_mcp_json_unreadable_critical(self, tmp_path):
+        # AC: mcp_json_readable が fail（critical）の場合は 2 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("twl.mcp_server.doctor._find_mcp_json", return_value=None):
+            result = doctor.run_doctor(args)
+
+        assert result == 2, (
+            f".mcp.json 読み取り失敗時に 2 を返さなかった: {result} (AC4 未実装)"
+        )
+
+    def test_ac4_exit_2_validate_command_critical(self, make_mcp_json, tmp_path):
+        # AC: validate_command が fail（critical）の場合は 2 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        # allowlist 外コマンド
+        mcp_json = make_mcp_json("bash", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = False
+        args.format = "human"
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")):
+            result = doctor.run_doctor(args)
+
+        assert result == 2, (
+            f"validate_command 失敗（critical）時に 2 を返さなかった: {result} (AC4 未実装)"
+        )
+
+    def test_ac4_exit_1_probe_fail_warning(self, make_mcp_json, tmp_path):
+        # AC: stdio_probe が fail（warning）の場合は 1 を返すこと
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = True  # --probe 有効
+        args.format = "human"
+
+        # subprocess.Popen が即座に終了してしまう（probe 失敗）
+        mock_proc = MagicMock()
+        mock_proc.stdout.readline.return_value = b""  # 空 = JSON-RPC 応答なし
+        mock_proc.wait.return_value = 1
+        mock_proc.poll.return_value = 1
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("subprocess.Popen", return_value=mock_proc):
+            result = doctor.run_doctor(args)
+
+        assert result == 1, (
+            f"stdio_probe 失敗（warning）時に 1 を返さなかった: {result} (AC4 未実装)"
+        )
+
+    def test_ac4_cli_doctor_exits_with_correct_code(self, make_mcp_json, tmp_path):
+        # AC: cli.main() 経由で 'twl mcp doctor' が適切な exit code で終了すること
+        # RED: cli.py に doctor dispatch がないため SystemExit(2) ではなく
+        #     argparse error または KeyError で終了する
+        import twl.cli as cli_mod
+
+        try:
+            from twl.mcp_server import doctor as doctor_mod
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC4 未実装): {e}")
+
+        with patch("twl.mcp_server.doctor.run_doctor", return_value=0) as mock_run, \
+             patch.object(sys, "argv", ["twl", "mcp", "doctor"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli_mod.main()
+            assert exc_info.value.code == 0, (
+                f"twl mcp doctor (OK) の exit code が 0 でない: {exc_info.value.code} (AC4 未実装)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC2(b): --probe フラグが実際の stdio handshake を実施すること
+# ---------------------------------------------------------------------------
+
+class TestAC2ProbeFlag:
+    """AC2(d): --probe フラグ時に 5 秒 timeout で stdio handshake を実施すること。
+
+    RED: doctor.py が存在しないため FAIL する。
+    """
+
+    def test_ac2d_probe_succeeds_on_valid_jsonrpc_response(self, make_mcp_json, tmp_path):
+        # AC: プロセスが 5 秒以内に JSON-RPC 応答を返した場合は probe が pass であること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2d 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = True
+        args.format = "json"
+
+        # JSON-RPC 応答を返す mock プロセス（communicate ベース実装に合わせる）
+        mock_proc = MagicMock()
+        mock_proc.communicate.return_value = (b'{"jsonrpc": "2.0", "id": 1, "result": {}}\n', b'')
+        mock_proc.poll.return_value = None  # まだ実行中
+
+        with patch("twl.mcp_server.doctor._find_mcp_json", return_value=mcp_json), \
+             patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("subprocess.Popen", return_value=mock_proc):
+            result = doctor.run_doctor(args)
+
+        assert result == 0, (
+            f"有効な JSON-RPC 応答時に run_doctor() が 0 を返さなかった: {result} (AC2d 未実装)"
+        )
+
+    def test_ac2d_probe_sends_sigterm_on_failure(self, make_mcp_json, tmp_path):
+        # AC: probe 失敗時にプロセスを SIGTERM で後始末すること
+        # RED: doctor.py が存在しないため FAIL する
+        try:
+            from twl.mcp_server import doctor
+        except ImportError as e:
+            pytest.fail(f"twl.mcp_server.doctor が import できない (AC2d 未実装): {e}")
+
+        mcp_json = make_mcp_json("uv", [], tmp_path=tmp_path)
+
+        args = MagicMock()
+        args.probe = True
+        args.format = "human"
+
+        mock_proc = MagicMock()
+        mock_proc.stdout.readline.return_value = b""  # 空 = 応答なし
+        mock_proc.poll.return_value = None  # まだ実行中
+
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=str(tmp_path) + "\n")), \
+             patch("shutil.which", return_value="/usr/bin/uv"), \
+             patch("subprocess.Popen", return_value=mock_proc):
+            doctor.run_doctor(args)
+
+        # SIGTERM または terminate() が呼ばれていること
+        assert mock_proc.terminate.called or mock_proc.send_signal.called, (
+            "probe 失敗時にプロセスの terminate が呼ばれなかった (AC2d 未実装)"
+        )
+
+
+import contextlib
+
+@contextlib.contextmanager
+def capsys_workaround():
+    """capsys を使わないテストケースでの stdout キャプチャ回避用 no-op コンテキスト。"""
+    yield

--- a/cli/twl/tests/test_mcp_lifecycle.py
+++ b/cli/twl/tests/test_mcp_lifecycle.py
@@ -674,6 +674,24 @@ class TestIssue1588AC3FailFastBehavior:
             f"(Issue #1588 AC3 未実装)"
         )
 
+    def test_ac5_fix_guidance_in_error_message(self, capsys):
+        # AC: _format_fix_guidance が実装され、restart_mcp_server() の stderr に
+        #     その出力文字列が含まれること
+        # RED: _format_fix_guidance が未実装のため AttributeError または出力内容が変わらない
+        with patch.object(lifecycle_mod, "_find_mcp_server_pids", return_value=[]), \
+             patch.object(lifecycle_mod, "_find_mcp_server_cmd",
+                          side_effect=ValueError("command 'xxx' not in allowlist: ['uv', 'uvx']")):
+            result = lifecycle_mod.restart_mcp_server()
+        assert result == 1
+        captured = capsys.readouterr()
+        # _format_fix_guidance の出力が含まれることを確認
+        # 実装前は _format_fix_guidance が存在しないため fail する
+        assert hasattr(lifecycle_mod, "_format_fix_guidance"), \
+            "_format_fix_guidance が lifecycle.py に未実装 (AC5 RED)"
+        expected_guidance = lifecycle_mod._format_fix_guidance("command 'xxx' not in allowlist: ['uv', 'uvx']")
+        assert expected_guidance in captured.err, \
+            f"stderr に _format_fix_guidance の出力が含まれていない: {captured.err!r}"
+
 
 # ---------------------------------------------------------------------------
 # Issue #1588 AC4: ADR-0008 ファイルが存在すること

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -897,12 +897,12 @@ refs:
     description: "su-observer pitfalls catalog: cld-spawn / inject / explore / monitor / memory / recovery の失敗パターンと教訓集 + Memory Principles（doobidoo = cross-machine SSoT）+ externalize-state inline 手順 + Worker auto mode 確認 A/B。起動時 Step 0 で Read 必須"
 
   stuck-patterns-yaml:
-    type: ref
+    type: reference
     path: refs/stuck-patterns.yaml
     description: "全 stuck pattern の SSoT（#1582）: id/regex/recovery_action/owner_layer/confidence スキーマ。consumer は stuck-patterns-lib.sh 経由で参照。新規 pattern は必ずこの YAML に追加する。"
 
   stuck-patterns-md:
-    type: ref
+    type: reference
     path: refs/stuck-patterns.md
     description: "stuck-patterns.yaml の Markdown 参照ドキュメント（#1582）: 人間可読の pattern 一覧表 + consumer 一覧"
 
@@ -2906,6 +2906,11 @@ scripts:
     type: script
     path: ../../cli/twl/src/twl/autopilot/checkpoint.py
     description: "checkpoint ファイルから要約フィールドまたは CRITICAL findings を読み取る"
+
+  mcp-doctor:
+    type: script
+    path: ../../cli/twl/src/twl/mcp_server/doctor.py
+    description: "twl mcp doctor サブコマンド: .mcp.json の整合性 self-check（command allowlist 検証・binary 存在確認・stdio probe）(#1589)"
 
   observe-wrapper:
     type: script


### PR DESCRIPTION
## 概要

Issue #1589 の実装。`twl mcp doctor` サブコマンドを追加し、`.mcp.json` の整合性 self-check を提供する。

## 変更内容

- **doctor.py 新規作成**: .mcp.json 整合性 self-check
  - command allowlist 検証（`_validate_command` 利用）
  - binary 存在確認（PATH 探索 / 絶対パス確認）
  - stdio probe（`--probe` フラグ、timeout 5 秒、JSON-RPC 応答確認）
  - 出力: human-readable（色付き）/ `--format json`（CI 連携用）
  - exit code: 0=OK, 1=warning, 2=critical
- **lifecycle.py**: `_format_fix_guidance()` 追加、`restart_mcp_server()` の except ブロックに適用（AC5）
- **cli.py**: `mcp doctor` サブパーサー追加（`--probe`, `--format`）（AC1）
- **test_mcp_doctor.py 新規**: doctor 単体 unit test 27 件（AC2/AC3/AC4/AC6）
- **test_mcp_lifecycle.py**: `test_ac5_fix_guidance_in_error_message` 追加（AC6）
- **deps.yaml**: mcp-doctor エントリ追加、`stuck-patterns` type: ref → reference 修正

## テスト

67 テスト PASS（27 新規 + 40 既存）

Closes #1589