### PR TITLE
feat(autopilot): feature-dev fallback path 正規化 (#1620)

### DIFF
--- a/.autopilot/issues/issue-1620/ac-test-mapping.yaml
+++ b/.autopilot/issues/issue-1620/ac-test-mapping.yaml
@@ -1,0 +1,64 @@
+mappings:
+  - ac_index: 1
+    ac_text: "4 trigger (RED-only merge x1 / specialist NEEDS_WORK x3 / Worker chain failure x3 / P0 緊急) のいずれかを検知時、observer は user に fallback を提案する（observer log に detection event + Layer 2 Escalate 記録）"
+    test_file: "plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats"
+    test_names:
+      - "ac1: feature-dev-fallback-detect.sh が scripts/ に存在する"
+      - "ac1: feature-dev-fallback-detect.sh が実行可能権限を持つ"
+      - "ac1: feature-dev-fallback-detect.sh が RED-only merge trigger を検知して Layer 2 Escalate を記録する"
+      - "ac1: feature-dev-fallback-detect.sh が specialist NEEDS_WORK x3 trigger を検知して Layer 2 Escalate を記録する"
+      - "ac1: feature-dev-fallback-detect.sh が Worker chain failure x3 trigger を検知して Layer 2 Escalate を記録する"
+      - "ac1: feature-dev-fallback-detect.sh が P0 緊急 trigger を検知して Layer 2 Escalate を記録する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh"
+    # impl_files 推定: 新規作成対象ファイル（現在不在）
+
+  - ac_index: 2
+    ac_text: "observer は feature-dev fallback を自律 spawn してはならない (SU-3 連鎖、Layer 2 Escalate 経由必須) → spawn-controller.sh が feature-dev skill spawn を拒否 / SKIP_LAYER2=1 override のみ許可"
+    test_file: "plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats"
+    test_names:
+      - "ac2: spawn-controller.sh が feature-dev skill を拒否して非 0 で終了する"
+      - "ac2: SKIP_LAYER2=1 設定時は spawn-controller.sh が feature-dev を許可する"
+      - "ac2: spawn-controller.sh が feature-dev 拒否時に SKIP_LAYER2=1 を hint として出力する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+    # 注: feature-dev 拒否は L89 VALID_SKILLS 未登録で現状も達成済みだが、
+    #     SU-3/Layer 2 拒否メッセージおよび SKIP_LAYER2=1 override ロジックは未実装
+    # WARN: spawn-controller.sh に [[ "${BASH_SOURCE[0]}" == "${0}" ]] guard が不在。
+    #       source せず bash サブシェル直接実行で回避。実装者は source guard 追加を検討すること。
+
+  - ac_index: 3
+    ac_text: "spawn 命名規則: tmux window = wt-fd-<N>、worktree branch = wt-fd-<N>-<short> → intervention-catalog.md に記載"
+    test_file: "plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats"
+    test_names:
+      - "ac3: intervention-catalog.md に feature-dev fallback セクションが存在する"
+      - "ac3: intervention-catalog.md に tmux window 命名規則 wt-fd-<N> が記載されている"
+      - "ac3: intervention-catalog.md に worktree branch 命名規則 wt-fd-<N>-<short> が記載されている"
+    impl_files:
+      - "plugins/twl/refs/intervention-catalog.md"
+
+  - ac_index: 4
+    ac_text: "spawn prompt template が (a) refined Issue body + (b) co-autopilot 失敗経緯 + (c) AC + (d) DeltaSpec link を必ず含む → template ファイル存在 + 必須 4 sections check"
+    test_file: "plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats"
+    test_names:
+      - "ac4: feature-dev-fallback-prompt.md が templates/ に存在する"
+      - "ac4: template に section (a) refined Issue body が含まれる"
+      - "ac4: template に section (b) co-autopilot 失敗経緯が含まれる"
+      - "ac4: template に section (c) AC が含まれる"
+      - "ac4: template に section (d) DeltaSpec link が含まれる"
+    impl_files:
+      - "plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md"
+    # impl_files 推定: 新規作成対象ファイル（現在不在）
+
+  - ac_index: 5
+    ac_text: "完了後 .observation/interventions/<ts>-feature-dev-fallback.json に InterventionRecord、doobidoo に feature-dev-fallback tag で lesson 保存"
+    test_file: "plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats"
+    test_names:
+      - "ac5: record-feature-dev-fallback.sh が scripts/ に存在する"
+      - "ac5: record-feature-dev-fallback.sh が実行可能権限を持つ"
+      - "ac5: record-feature-dev-fallback.sh が .observation/interventions/ 配下に JSON を生成する"
+      - "ac5: 生成された InterventionRecord JSON が必須フィールドを含む"
+      - "ac5: record-feature-dev-fallback.sh が feature-dev-fallback tag での doobidoo lesson 保存コマンドを含む"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh"
+    # impl_files 推定: 新規作成対象ファイル（現在不在）

--- a/plugins/twl/refs/intervention-catalog.md
+++ b/plugins/twl/refs/intervention-catalog.md
@@ -208,6 +208,26 @@ Supervisor の介入判断ルール定義。Wave 1-5 の実績を反映した介
 - **実行制約**: Supervisor は実行しない。Issue 化を推奨
 - **リスク評価**: 高（影響範囲が広い。誤った修正は複数 Issue に影響する）
 
+### パターン 14: co-autopilot 失敗時の feature-dev fallback 提案（Issue #1620）
+
+- **検出条件**: 以下のいずれか 1 つが発生した場合:
+  1. **RED-only merge x1**: test only PR が merged（実装ゼロ、+N/-0 のみ）
+  2. **specialist NEEDS_WORK x3**: 同一 Issue に対し specialist が NEEDS_WORK を 3 回連続判定
+  3. **Worker chain failure x3**: Worker の chain が 3 回連続 failure（merge-gate REJECT）
+  4. **P0 緊急**: ユーザーの明示的 P0 指示
+- **情報提供内容**:
+  - trigger の種類と Issue 番号
+  - feature-dev fallback の手順（worktree 作成 → tmux window → cld 起動 → /feature-dev）
+  - Layer 2 Escalate である旨（ユーザー承認 MUST）
+- **命名規則**:
+  - tmux window: `wt-fd-<N>`（例: `wt-fd-1620`）
+  - worktree branch: `wt-fd-<N>-<short>`（例: `wt-fd-1620-fallback`）
+- **実行制約**: Supervisor は feature-dev を自律 spawn しない（SU-10）。ユーザーが手動で実行する
+  - 緊急時のみ: `SKIP_LAYER2=1 SKIP_LAYER2_REASON='<reason>'` で override 可能
+- **リスク評価**: 高（feature-dev は TDD ルール非強制、人間ドリブン実装）
+- **事後**: `record-feature-dev-fallback.sh` で InterventionRecord 保存 + doobidoo lesson 記録
+- **検知スクリプト**: `plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh`
+
 ### パターン 13: Claude Code classifier permission deny 2 回以上 → 即時 STOP（W5 連携）
 
 - **Wave 実績**: Wave 5 で Layer D refined-label-gate が 6 連続 permission 拒否。classifier の判断を無視した継続が問題を拡大させた教訓

--- a/plugins/twl/skills/su-observer/refs/su-observer-constraints.md
+++ b/plugins/twl/skills/su-observer/refs/su-observer-constraints.md
@@ -18,6 +18,7 @@
 | SU-7 | observed session への inject/send-keys は介入プロトコルに従う場合に許可（MAY） | OB-3 廃止に対応 |
 | SU-8 | supervisor hook は bare repo 構造（main/ がディレクトリとして存在すること）を前提とし、non-bare 検出時は no-op で exit 0 する（SHALL） | #728 |
 | SU-9 | supervisor hook は filename に埋め込む前に SESSION_ID を allow-list サニタイズ（[A-Za-z0-9_-]）しなければならず、サニタイズ前後で差分があれば stderr に警告を出力しなければならない（SHALL） | #729 |
+| SU-10 | feature-dev plugin の fallback spawn は Layer 2 Escalate 経由でユーザー承認後にのみ実行できる（SHALL NOT automate）。observer は feature-dev を自律 spawn してはならない。緊急時は SKIP_LAYER2=1 SKIP_LAYER2_REASON='<reason>' override のみ許可 | #1620 |
 
 ## 禁止事項（MUST NOT）
 
@@ -32,6 +33,7 @@
 - 検出結果をユーザー確認なしで自動 Issue 起票してはならない
 - **Issue 起票関連（不変条件 P / ADR-037）**: `gh issue create` を直接実行してはならない。新規 Issue の起票は必ず co-explore による explore-summary 作成後に co-issue 経由で行う。explore-summary なしの直接起票は `pre-bash-issue-create-gate.sh` で block される（bypass は `SKIP_ISSUE_GATE=1 SKIP_ISSUE_REASON='<reason>'` 明記時のみ）
 - `--with-chain --issue N` で co-autopilot を直接起動してはならない（ADR-026、SU-3 連鎖）
+- feature-dev plugin を自律 spawn してはならない（SU-10）。ユーザー承認後の Layer 2 Escalate 経由のみ許可
 
 ## Security gate (Layer A-D) 回避は MUST NOT
 

--- a/plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# feature-dev-fallback-detect.sh - co-autopilot 失敗時の feature-dev fallback 提案検知
+#
+# Usage:
+#   feature-dev-fallback-detect.sh --trigger <trigger-type> --issue <N> [--count N] [--log-dir <dir>]
+#
+# Trigger types:
+#   red-only-merge         RED-only merge が 1 回発生（test only PR が merged）
+#   specialist-needs-work  specialist NEEDS_WORK が N 回連続（--count 3）
+#   worker-chain-failure   Worker chain failure が N 回連続（--count 3）
+#   p0-urgent              P0 緊急（ユーザー判断）
+#
+# 動作:
+#   1. trigger を検知し Layer 2 Escalate を intervention-catalog.md パターン 14 に従い記録
+#   2. --log-dir に Layer 2 Escalate イベントログを書き出す
+#   3. ユーザーへ feature-dev fallback 提案メッセージを stdout に出力
+#
+# Issue #1620: feature-dev fallback path 正規化 (SU-10)
+
+set -euo pipefail
+
+TRIGGER=""
+ISSUE_NUM=""
+COUNT="1"
+LOG_DIR="${LOG_DIR:-.observation/events}"
+OBSERVATION_DIR="${OBSERVATION_DIR:-.observation}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --trigger)         TRIGGER="$2"; shift 2 ;;
+    --issue)           ISSUE_NUM="$2"; shift 2 ;;
+    --count)           COUNT="$2"; shift 2 ;;
+    --log-dir)         LOG_DIR="$2"; shift 2 ;;
+    --observation-dir) OBSERVATION_DIR="$2"; LOG_DIR="${OBSERVATION_DIR}/events"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$TRIGGER" ]]; then
+  echo "Error: --trigger required (red-only-merge|specialist-needs-work|worker-chain-failure|p0-urgent)" >&2
+  exit 2
+fi
+
+VALID_TRIGGERS=(red-only-merge specialist-needs-work worker-chain-failure p0-urgent)
+TRIGGER_FOUND=false
+for t in "${VALID_TRIGGERS[@]}"; do
+  [[ "$TRIGGER" == "$t" ]] && TRIGGER_FOUND=true && break
+done
+if [[ "$TRIGGER_FOUND" == "false" ]]; then
+  echo "Error: invalid trigger '$TRIGGER'. Valid: ${VALID_TRIGGERS[*]}" >&2
+  exit 2
+fi
+
+TIMESTAMP=$(date -u +"%Y%m%d-%H%M%S")
+
+# Layer 2 Escalate 記録（--log-dir に記録）
+mkdir -p "$LOG_DIR"
+EVENT_FILE="${LOG_DIR}/${TIMESTAMP}-feature-dev-fallback-detect.json"
+cat > "$EVENT_FILE" <<EOF
+{
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "event_type": "feature-dev-fallback-detect",
+  "trigger": "${TRIGGER}",
+  "count": ${COUNT},
+  "issue_num": ${ISSUE_NUM:-null},
+  "layer": "escalate",
+  "layer_label": "Layer 2 Escalate",
+  "pattern_id": "pattern-14-feature-dev-fallback",
+  "action": "propose-to-user",
+  "notes": "Layer 2 Escalate — ユーザー承認なしに feature-dev spawn 禁止 (SU-10)"
+}
+EOF
+
+# ユーザーへの fallback 提案メッセージ
+cat <<MSG
+================================================================================
+[FEATURE-DEV FALLBACK PROPOSAL] Layer 2 Escalate (パターン 14)
+================================================================================
+トリガー: ${TRIGGER} (count=${COUNT})
+Issue: ${ISSUE_NUM:-不明}
+
+co-autopilot が失敗状態を検知しました。
+feature-dev plugin による別実装ルートを提案します。
+
+【実行手順 (Layer 2 Escalate — ユーザー手動実行 MUST)】
+
+1. worktree 作成:
+   twl worktree create wt-fd-${ISSUE_NUM:-N} --branch "wt-fd-${ISSUE_NUM:-N}-<short>"
+
+2. cld セッション起動:
+   tmux new-window -n "wt-fd-${ISSUE_NUM:-N}"
+   cd worktrees/wt-fd-${ISSUE_NUM:-N}-<short>
+   cld
+
+3. /feature-dev を実行し feature-dev plugin の guided flow に従って実装
+
+4. 完了後 InterventionRecord を保存:
+   record-feature-dev-fallback.sh --issue ${ISSUE_NUM:-N}
+
+※ observer は feature-dev を自律 spawn しません (SU-10)
+   SKIP_LAYER2=1 SKIP_LAYER2_REASON='<reason>' で override 可能
+
+イベントログ: ${EVENT_FILE}
+================================================================================
+MSG
+
+exit 0

--- a/plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh
+++ b/plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh
@@ -51,6 +51,18 @@ if [[ "$TRIGGER_FOUND" == "false" ]]; then
   exit 2
 fi
 
+# COUNT は正整数のみ許可（JSON インジェクション防止）
+if [[ ! "$COUNT" =~ ^[0-9]+$ ]]; then
+  echo "Error: --count は非負整数である必要があります: ${COUNT}" >&2
+  exit 2
+fi
+
+# LOG_DIR パストラバーサル防止（'..' を拒否）
+if [[ "$LOG_DIR" == *".."* ]]; then
+  echo "Error: --log-dir に '..' を含めることはできません: ${LOG_DIR}" >&2
+  exit 2
+fi
+
 TIMESTAMP=$(date -u +"%Y%m%d-%H%M%S")
 
 # Layer 2 Escalate 記録（--log-dir に記録）

--- a/plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh
@@ -34,6 +34,28 @@ if [[ -z "$ISSUE_NUM" ]]; then
   exit 2
 fi
 
+# 入力バリデーション（baseline-bash.md §11 準拠）
+if [[ ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --issue の値は正整数である必要があります: ${ISSUE_NUM}" >&2
+  exit 2
+fi
+
+VALID_TRIGGERS=(red-only-merge specialist-needs-work worker-chain-failure p0-urgent manual manual-override)
+TRIGGER_VALID=false
+for t in "${VALID_TRIGGERS[@]}"; do
+  [[ "$TRIGGER" == "$t" ]] && TRIGGER_VALID=true && break
+done
+if [[ "$TRIGGER_VALID" == "false" ]]; then
+  echo "Error: invalid trigger '${TRIGGER}'. Valid: ${VALID_TRIGGERS[*]}" >&2
+  exit 2
+fi
+
+# OUTPUT_DIR パストラバーサル防止（'..' を拒否）
+if [[ "$OUTPUT_DIR" == *".."* ]]; then
+  echo "Error: OUTPUT_DIR に '..' を含めることはできません: ${OUTPUT_DIR}" >&2
+  exit 2
+fi
+
 mkdir -p "$OUTPUT_DIR"
 TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
 RECORD_FILE="${OUTPUT_DIR}/${TIMESTAMP}-feature-dev-fallback.json"

--- a/plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh
+++ b/plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# record-feature-dev-fallback.sh - feature-dev fallback 完了後の InterventionRecord 記録
+#
+# Usage:
+#   record-feature-dev-fallback.sh --issue <N> [--output-dir <dir>] [--trigger <type>] [--result <success|failure>]
+#
+# 動作:
+#   1. .observation/interventions/<ts>-feature-dev-fallback.json に InterventionRecord を書き出す
+#   2. doobidoo に feature-dev-fallback タグで lesson 保存コマンドを出力（ユーザー手動実行）
+#
+# Issue #1620: feature-dev fallback path 正規化 (AC-5)
+
+set -euo pipefail
+
+ISSUE_NUM=""
+OUTPUT_DIR="${OBSERVATION_DIR:-.observation}/interventions"
+TRIGGER="${TRIGGER:-manual}"
+RESULT="${RESULT:-success}"
+BRANCH="$(git branch --show-current 2>/dev/null || echo "unknown")"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --issue)            ISSUE_NUM="$2"; shift 2 ;;
+    --output-dir)       OUTPUT_DIR="$2"; shift 2 ;;
+    --intervention-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --trigger)          TRIGGER="$2"; shift 2 ;;
+    --result)           RESULT="$2"; shift 2 ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$ISSUE_NUM" ]]; then
+  echo "Error: --issue <N> required" >&2
+  exit 2
+fi
+
+mkdir -p "$OUTPUT_DIR"
+TIMESTAMP=$(date -u +"%Y%m%dT%H%M%SZ")
+RECORD_FILE="${OUTPUT_DIR}/${TIMESTAMP}-feature-dev-fallback.json"
+
+cat > "$RECORD_FILE" <<EOF
+{
+  "timestamp": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "type": "intervention",
+  "pattern_id": "pattern-14-feature-dev-fallback",
+  "layer": "escalate",
+  "issue": ${ISSUE_NUM},
+  "issue_num": ${ISSUE_NUM},
+  "branch": "${BRANCH}",
+  "trigger": "${TRIGGER}",
+  "action_taken": "feature-dev fallback spawn (Layer 2 Escalate, user-approved)",
+  "result": "${RESULT}",
+  "tags": ["feature-dev-fallback"],
+  "notes": "co-autopilot 失敗後に feature-dev plugin による実装。SU-10 準拠。"
+}
+EOF
+
+echo "✓ InterventionRecord を書き出しました: ${RECORD_FILE}"
+
+# doobidoo lesson 保存コマンドをユーザーに提示（手動実行）
+cat <<MSG
+
+次のコマンドで doobidoo に lesson を保存してください（手動実行）:
+---
+mcp__doobidoo__memory_store \\
+  --content "Issue #${ISSUE_NUM}: co-autopilot 失敗後に feature-dev fallback で実装完了。trigger=${TRIGGER}。結果=${RESULT}" \\
+  --tags "feature-dev-fallback,wave,intervention" \\
+  --source "record-feature-dev-fallback.sh"
+---
+MSG
+
+exit 0

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -124,9 +124,35 @@ for s in "${VALID_SKILLS[@]}"; do
   fi
 done
 if [[ "$SKILL_FOUND" == "false" ]]; then
-  echo "Error: invalid skill name '$SKILL'." >&2
-  echo "Valid: ${VALID_SKILLS[*]}" >&2
-  exit 2
+  # Issue #1620: feature-dev は Layer 2 Escalate 経由必須（SU-10）
+  # SKIP_LAYER2=1 override 時のみ許可（SKIP_LAYER2_REASON 必須）
+  if [[ "$SKILL_NORMALIZED" == "feature-dev" ]]; then
+    if [[ "${SKIP_LAYER2:-0}" == "1" ]]; then
+      if [[ -z "${SKIP_LAYER2_REASON:-}" ]]; then
+        echo "[spawn-controller] WARN: SKIP_LAYER2=1 — SKIP_LAYER2_REASON 未設定（設定推奨）" >&2
+      fi
+      echo "[spawn-controller] WARN: SKIP_LAYER2=1 — feature-dev fallback spawn を許可（SU-10 bypass、理由: ${SKIP_LAYER2_REASON:-未設定}）" >&2
+      # feature-dev は人間ドリブン実装のため、cld-spawn は呼ばず手順を出力して exit 0
+      # ユーザーが手動で cld セッションを起動し /feature-dev を実行する
+      SCRIPT_DIR_FD="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+      DETECT_SCRIPT_FD="${SCRIPT_DIR_FD}/feature-dev-fallback-detect.sh"
+      if [[ -x "$DETECT_SCRIPT_FD" ]]; then
+        bash "$DETECT_SCRIPT_FD" --trigger "manual-override" --issue "${CHAIN_ISSUE:-unknown}" 2>/dev/null || true
+      else
+        echo "[spawn-controller] feature-dev fallback: ユーザーが手動で cld セッション → /feature-dev を実行してください" >&2
+      fi
+      exit 0
+    else
+      echo "Error: 'feature-dev' は自律 spawn 禁止 (SU-10, Issue #1620)。" >&2
+      echo "  feature-dev fallback は Layer 2 Escalate 経由でユーザー承認後に実行してください。" >&2
+      echo "  緊急時: SKIP_LAYER2=1 SKIP_LAYER2_REASON='<reason>' を設定して再実行" >&2
+      exit 1
+    fi
+  else
+    echo "Error: invalid skill name '$SKILL'." >&2
+    echo "Valid: ${VALID_SKILLS[*]}" >&2
+    exit 2
+  fi
 fi
 
 # prompt file 存在確認

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -132,12 +132,20 @@ if [[ "$SKILL_FOUND" == "false" ]]; then
         echo "[spawn-controller] WARN: SKIP_LAYER2=1 — SKIP_LAYER2_REASON 未設定（設定推奨）" >&2
       fi
       echo "[spawn-controller] WARN: SKIP_LAYER2=1 — feature-dev fallback spawn を許可（SU-10 bypass、理由: ${SKIP_LAYER2_REASON:-未設定}）" >&2
+      # SKIP_LAYER2=1 bypass を intervention-log に記録（SKIP_PARALLEL_CHECK=1 と同等）
+      _layer2_reason="${SKIP_LAYER2_REASON:-未設定}"
+      # 改行・CR を除去（ログインジェクション防止）
+      _layer2_reason="${_layer2_reason//$'\n'/ }"
+      _layer2_reason="${_layer2_reason//$'\r'/ }"
+      echo "[spawn-controller] SKIP_LAYER2=1 bypass: SU-10 override, reason=${_layer2_reason}, skill=feature-dev" >> "${SUPERVISOR_DIR:-.supervisor}/intervention-log.md" 2>/dev/null || true
       # feature-dev は人間ドリブン実装のため、cld-spawn は呼ばず手順を出力して exit 0
       # ユーザーが手動で cld セッションを起動し /feature-dev を実行する
       SCRIPT_DIR_FD="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
       DETECT_SCRIPT_FD="${SCRIPT_DIR_FD}/feature-dev-fallback-detect.sh"
+      # CHAIN_ISSUE は L166 以降で初期化されるため、ここでは環境変数または空文字を使う
+      _fd_issue="${CHAIN_ISSUE:-}"
       if [[ -x "$DETECT_SCRIPT_FD" ]]; then
-        bash "$DETECT_SCRIPT_FD" --trigger "manual-override" --issue "${CHAIN_ISSUE:-unknown}" 2>/dev/null || true
+        bash "$DETECT_SCRIPT_FD" --trigger "manual-override" ${_fd_issue:+--issue "$_fd_issue"} 2>/dev/null || true
       else
         echo "[spawn-controller] feature-dev fallback: ユーザーが手動で cld セッション → /feature-dev を実行してください" >&2
       fi

--- a/plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md
+++ b/plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md
@@ -1,0 +1,70 @@
+# feature-dev Fallback Prompt Template
+
+このテンプレートは co-autopilot 失敗時の feature-dev fallback spawn で使用する。
+`feature-dev-fallback-detect.sh` がトリガーを検知し、ユーザーが Layer 2 Escalate を承認した後に使用する。
+
+---
+
+## (a) Refined Issue Body
+
+```
+<!-- ここに refined Issue body を貼り付ける -->
+<!-- gh issue view <N> でコピーし、最新の refinement 内容を含めること -->
+Issue #<N>: <title>
+
+## 概要
+<issue body>
+
+## AC
+<acceptance criteria>
+```
+
+## (b) co-autopilot 失敗経緯
+
+```
+<!-- ここに co-autopilot の失敗経緯を記載する -->
+トリガー: <red-only-merge | needs-work-x3 | chain-failure-x3 | p0-emergency>
+失敗した PR: #<PR番号>（<失敗の内容: RED-only / NEEDS_WORK / chain failure>）
+Pilot 判断: <なぜ feature-dev fallback を選択したか>
+```
+
+## (c) Acceptance Criteria (AC)
+
+```
+<!-- ここに Issue の AC を列挙する -->
+- AC-1: ...
+- AC-2: ...
+...
+```
+
+## (d) DeltaSpec Link
+
+```
+<!-- ここに DeltaSpec へのリンクを記載する -->
+DeltaSpec: plugins/twl/deltaspec/changes/<deltaspec-slug>.md
+（不在の場合は「DeltaSpec なし」と記載）
+```
+
+---
+
+## 使用方法
+
+1. このテンプレートを worktree にコピーする:
+   ```bash
+   cp plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md \
+      /tmp/feature-dev-prompt-<N>.md
+   ```
+
+2. (a)-(d) の各セクションを埋める
+
+3. cld セッションで `/feature-dev` を実行し、プロンプト内容を貼り付ける
+
+4. feature-dev の Phase 3 (Clarifying Questions) と Phase 5 (Implementation) でユーザーが承認判断を行う
+
+---
+
+## 制約事項
+
+- observer は このプロンプトを自律的に使用して feature-dev を spawn してはならない（SU-10）
+- ユーザーが手動で feature-dev セッションを起動し、このプロンプトを渡すこと
+- TDD ルール（RED → GREEN）は feature-dev では強制されないため、実装者が意識して守ること

--- a/plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats
+++ b/plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats
@@ -1,0 +1,401 @@
+#!/usr/bin/env bats
+# issue-1620-feature-dev-fallback.bats
+# RED tests for Issue #1620: feat(autopilot): feature-dev fallback path 正規化
+#
+# AC coverage:
+#   AC-1 - observer が 4 trigger 検知時に fallback 提案 + Layer 2 Escalate 記録を行う
+#           → feature-dev-fallback-detect.sh の存在 + 動作確認
+#   AC-2 - observer は feature-dev fallback を自律 spawn してはならない
+#           → spawn-controller.sh が feature-dev skill を拒否する
+#           → SKIP_LAYER2=1 override のみ許可する
+#   AC-3 - spawn 命名規則: tmux window = wt-fd-<N>、worktree branch = wt-fd-<N>-<short>
+#           → intervention-catalog.md に記載
+#   AC-4 - spawn prompt template が必須 4 sections を含む
+#           → template ファイル存在 + sections 確認
+#   AC-5 - 完了後に InterventionRecord JSON + doobidoo lesson 保存スクリプトが存在する
+#           → record-feature-dev-fallback.sh の存在 + 動作確認
+#
+# テスト設計:
+#   - feature-dev-fallback-detect.sh は未実装のため存在チェックが RED で fail する
+#   - spawn-controller.sh の VALID_SKILLS に feature-dev がないため拒否確認は GREEN だが、
+#     SKIP_LAYER2=1 override ロジックは未実装のため RED
+#   - intervention-catalog.md に wt-fd-<N> 命名規則が未記載のため RED
+#   - feature-dev-fallback-prompt.md は未実装のため存在チェックが RED で fail する
+#   - record-feature-dev-fallback.sh は未実装のため存在チェックが RED で fail する
+#
+# WARN: source guard 確認結果:
+#   spawn-controller.sh に [[ "${BASH_SOURCE[0]}" == "${0}" ]] guard が存在しない。
+#   set -euo pipefail 環境で source すると main 到達前に exit に巻き込まれるリスクあり。
+#   本テストでは source せず、static grep 検査 および bash サブシェルで直接実行する設計で回避済み。
+#   実装者は spawn-controller.sh への source guard 追加を検討すること（impl_files 参照）。
+
+load 'helpers/common'
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown
+# ---------------------------------------------------------------------------
+
+setup() {
+  common_setup
+
+  SPAWN_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/spawn-controller.sh"
+  DETECT_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/feature-dev-fallback-detect.sh"
+  TEMPLATE_FILE="${REPO_ROOT}/skills/su-observer/templates/feature-dev-fallback-prompt.md"
+  RECORD_SCRIPT="${REPO_ROOT}/skills/su-observer/scripts/record-feature-dev-fallback.sh"
+  CATALOG_FILE="${REPO_ROOT}/refs/intervention-catalog.md"
+
+  export SPAWN_SCRIPT DETECT_SCRIPT TEMPLATE_FILE RECORD_SCRIPT CATALOG_FILE
+
+  # cld-spawn stub（実際の tmux spawn をスキップ）
+  stub_command "cld-spawn" 'echo "cld-spawn-stub: $*"; exit 0'
+
+  # tmux stub（副作用を回避）
+  stub_command "tmux" 'echo "tmux-stub: $*"; exit 0'
+
+  # プロンプトファイルをサンドボックスに作成
+  echo "test prompt content" > "$SANDBOX/test-prompt.txt"
+
+  export SKIP_PARALLEL_CHECK=1
+  export SKIP_PARALLEL_REASON="bats test issue-1620 RED phase"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC-1: feature-dev-fallback-detect.sh の存在と動作確認
+#
+# 4 trigger:
+#   (a) RED-only merge x1
+#   (b) specialist NEEDS_WORK x3
+#   (c) Worker chain failure x3
+#   (d) P0 緊急
+#
+# RED: ファイルが未実装のため fail する
+# PASS 条件（実装後）:
+#   - plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh が存在する
+#   - 実行可能権限がある
+#   - 4 trigger を検知して observer log に detection event + Layer 2 Escalate を記録する
+# ===========================================================================
+
+@test "ac1: feature-dev-fallback-detect.sh が scripts/ に存在する" {
+  # AC-1: 4 trigger 検知スクリプトが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ]
+}
+
+@test "ac1: feature-dev-fallback-detect.sh が実行可能権限を持つ" {
+  # AC-1: スクリプトが実行可能であること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ] || {
+    echo "RED: feature-dev-fallback-detect.sh 未実装"
+    false
+  }
+  [ -x "${DETECT_SCRIPT}" ]
+}
+
+@test "ac1: feature-dev-fallback-detect.sh が RED-only merge trigger を検知して Layer 2 Escalate を記録する" {
+  # AC-1: RED-only merge x1 trigger → observer log に detection event + Layer 2 Escalate
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ] || {
+    echo "RED: feature-dev-fallback-detect.sh 未実装"
+    false
+  }
+
+  local log_dir="$SANDBOX/observation"
+  mkdir -p "$log_dir"
+
+  run bash "${DETECT_SCRIPT}" \
+    --trigger red-only-merge \
+    --count 1 \
+    --log-dir "$log_dir"
+  [ "$status" -eq 0 ]
+  # Layer 2 Escalate が記録されていること
+  grep -r "Layer 2 Escalate\|layer_2_escalate\|LAYER2_ESCALATE" "$log_dir"
+}
+
+@test "ac1: feature-dev-fallback-detect.sh が specialist NEEDS_WORK x3 trigger を検知して Layer 2 Escalate を記録する" {
+  # AC-1: specialist NEEDS_WORK x3 trigger → observer log に detection event + Layer 2 Escalate
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ] || {
+    echo "RED: feature-dev-fallback-detect.sh 未実装"
+    false
+  }
+
+  local log_dir="$SANDBOX/observation"
+  mkdir -p "$log_dir"
+
+  run bash "${DETECT_SCRIPT}" \
+    --trigger specialist-needs-work \
+    --count 3 \
+    --log-dir "$log_dir"
+  [ "$status" -eq 0 ]
+  grep -r "Layer 2 Escalate\|layer_2_escalate\|LAYER2_ESCALATE" "$log_dir"
+}
+
+@test "ac1: feature-dev-fallback-detect.sh が Worker chain failure x3 trigger を検知して Layer 2 Escalate を記録する" {
+  # AC-1: Worker chain failure x3 trigger → observer log に detection event + Layer 2 Escalate
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ] || {
+    echo "RED: feature-dev-fallback-detect.sh 未実装"
+    false
+  }
+
+  local log_dir="$SANDBOX/observation"
+  mkdir -p "$log_dir"
+
+  run bash "${DETECT_SCRIPT}" \
+    --trigger worker-chain-failure \
+    --count 3 \
+    --log-dir "$log_dir"
+  [ "$status" -eq 0 ]
+  grep -r "Layer 2 Escalate\|layer_2_escalate\|LAYER2_ESCALATE" "$log_dir"
+}
+
+@test "ac1: feature-dev-fallback-detect.sh が P0 緊急 trigger を検知して Layer 2 Escalate を記録する" {
+  # AC-1: P0 緊急 trigger → observer log に detection event + Layer 2 Escalate
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${DETECT_SCRIPT}" ] || {
+    echo "RED: feature-dev-fallback-detect.sh 未実装"
+    false
+  }
+
+  local log_dir="$SANDBOX/observation"
+  mkdir -p "$log_dir"
+
+  run bash "${DETECT_SCRIPT}" \
+    --trigger p0-urgent \
+    --log-dir "$log_dir"
+  [ "$status" -eq 0 ]
+  grep -r "Layer 2 Escalate\|layer_2_escalate\|LAYER2_ESCALATE" "$log_dir"
+}
+
+# ===========================================================================
+# AC-2: spawn-controller.sh が feature-dev skill の spawn を拒否する
+#       SKIP_LAYER2=1 override のみ許可する
+#
+# RED（一部）: feature-dev 拒否は L89 VALID_SKILLS に含まれないため現状 PASS だが、
+#              SKIP_LAYER2=1 override ロジックは未実装のため RED
+# PASS 条件（実装後）:
+#   - feature-dev を skill として渡すと exit 非 0（拒否）
+#   - SKIP_LAYER2=1 を設定すると spawn が許可される（VALID_SKILLS 拡張 or override）
+#   - 拒否時に SU-3 連鎖・Layer 2 Escalate 経由必須のメッセージが stderr に出力される
+# ===========================================================================
+
+@test "ac2: spawn-controller.sh が feature-dev skill を拒否して非 0 で終了する" {
+  # AC-2: spawn-controller.sh が feature-dev skill spawn を拒否すること
+  # 現状は VALID_SKILLS に含まれないため拒否されるが、拒否理由が SU-3/Layer 2 明示ではない
+  # RED: SU-3 連鎖メッセージが出力されないため fail する
+  local prompt_file="$SANDBOX/test-prompt.txt"
+
+  run bash "${SPAWN_SCRIPT}" feature-dev "$prompt_file" 2>&1
+  # 拒否されること（非 0 終了）
+  [ "$status" -ne 0 ]
+  # SU-3 / Layer 2 Escalate 経由必須メッセージが stderr に含まれること
+  [[ "$output" == *"SU-3"* || "$output" == *"Layer 2"* || "$output" == *"SKIP_LAYER2"* ]]
+}
+
+@test "ac2: SKIP_LAYER2=1 設定時は spawn-controller.sh が feature-dev を許可する" {
+  # AC-2: SKIP_LAYER2=1 override のみ feature-dev spawn を許可すること
+  # RED: SKIP_LAYER2=1 override ロジックが未実装のため fail する
+  local prompt_file="$SANDBOX/test-prompt.txt"
+
+  run env SKIP_LAYER2=1 SKIP_PARALLEL_CHECK=1 SKIP_PARALLEL_REASON="test" \
+    bash "${SPAWN_SCRIPT}" feature-dev "$prompt_file" 2>&1
+  # SKIP_LAYER2=1 設定時は spawn が通ること（exit 0 または cld-spawn-stub 出力あり）
+  [ "$status" -eq 0 ]
+}
+
+@test "ac2: spawn-controller.sh が feature-dev 拒否時に SKIP_LAYER2=1 を hint として出力する" {
+  # AC-2: 拒否メッセージに SKIP_LAYER2=1 の override 方法が含まれること
+  # RED: hint メッセージが未実装のため fail する
+  local prompt_file="$SANDBOX/test-prompt.txt"
+
+  run bash "${SPAWN_SCRIPT}" feature-dev "$prompt_file" 2>&1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SKIP_LAYER2"* ]]
+}
+
+# ===========================================================================
+# AC-3: spawn 命名規則が intervention-catalog.md に記載されている
+#       tmux window = wt-fd-<N>、worktree branch = wt-fd-<N>-<short>
+#
+# RED: intervention-catalog.md に命名規則が未記載のため fail する
+# PASS 条件（実装後）:
+#   - intervention-catalog.md の用語列（テーブル）に wt-fd-<N> が記載されている
+#   - worktree branch 命名規則 wt-fd-<N>-<short> が記載されている
+#   - feature-dev fallback のセクションが存在する
+# ===========================================================================
+
+@test "ac3: intervention-catalog.md に feature-dev fallback セクションが存在する" {
+  # AC-3: intervention-catalog.md に feature-dev fallback の命名規則が記載されていること
+  # RED: 実装前は fail する（セクション未記載）
+  [ -f "${CATALOG_FILE}" ]
+  grep -q "feature-dev fallback\|feature-dev-fallback" "${CATALOG_FILE}"
+}
+
+@test "ac3: intervention-catalog.md に tmux window 命名規則 wt-fd-<N> が記載されている" {
+  # AC-3: tmux window 命名規則 wt-fd-<N> が intervention-catalog.md に記載されていること
+  # RED: 実装前は fail する（命名規則未記載）
+  # Markdown テーブル用語列マッチ（PR #1357 / commit 532d6e20）: '| term |' パターン使用
+  [ -f "${CATALOG_FILE}" ]
+  # テーブル以外でも命名規則として記載があることを確認（grep -q で存在チェック）
+  grep -q "wt-fd-" "${CATALOG_FILE}"
+}
+
+@test "ac3: intervention-catalog.md に worktree branch 命名規則 wt-fd-<N>-<short> が記載されている" {
+  # AC-3: worktree branch 命名規則 wt-fd-<N>-<short> が記載されていること
+  # RED: 実装前は fail する（命名規則未記載）
+  [ -f "${CATALOG_FILE}" ]
+  grep -q "wt-fd-.*-\(<short>\|<N>-\)" "${CATALOG_FILE}"
+}
+
+# ===========================================================================
+# AC-4: spawn prompt template が必須 4 sections を含む
+#       (a) refined Issue body
+#       (b) co-autopilot 失敗経緯
+#       (c) AC
+#       (d) DeltaSpec link
+#
+# RED: template ファイルが未実装のため fail する
+# PASS 条件（実装後）:
+#   - plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md が存在する
+#   - 4 つの必須 sections がすべて含まれる
+# ===========================================================================
+
+@test "ac4: feature-dev-fallback-prompt.md が templates/ に存在する" {
+  # AC-4: spawn prompt template ファイルが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${TEMPLATE_FILE}" ]
+}
+
+@test "ac4: template に section (a) refined Issue body が含まれる" {
+  # AC-4(a): refined Issue body のセクションが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${TEMPLATE_FILE}" ] || {
+    echo "RED: feature-dev-fallback-prompt.md 未実装"
+    false
+  }
+  # section (a): refined Issue body を示すヘッダーが含まれること
+  grep -qi "refined issue body\|## issue\|# issue body\|refined_issue\|issue_body" "${TEMPLATE_FILE}"
+}
+
+@test "ac4: template に section (b) co-autopilot 失敗経緯が含まれる" {
+  # AC-4(b): co-autopilot 失敗経緯のセクションが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${TEMPLATE_FILE}" ] || {
+    echo "RED: feature-dev-fallback-prompt.md 未実装"
+    false
+  }
+  grep -qi "co-autopilot\|autopilot.*fail\|failure.*history\|失敗経緯\|chain.*failure" "${TEMPLATE_FILE}"
+}
+
+@test "ac4: template に section (c) AC が含まれる" {
+  # AC-4(c): AC（Acceptance Criteria）のセクションが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${TEMPLATE_FILE}" ] || {
+    echo "RED: feature-dev-fallback-prompt.md 未実装"
+    false
+  }
+  grep -qi "acceptance criteria\|## ac\|# ac\|## AC\|acceptance_criteria" "${TEMPLATE_FILE}"
+}
+
+@test "ac4: template に section (d) DeltaSpec link が含まれる" {
+  # AC-4(d): DeltaSpec link のセクションが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${TEMPLATE_FILE}" ] || {
+    echo "RED: feature-dev-fallback-prompt.md 未実装"
+    false
+  }
+  grep -qi "deltaspec\|delta.*spec\|DeltaSpec" "${TEMPLATE_FILE}"
+}
+
+# ===========================================================================
+# AC-5: 完了後に InterventionRecord + doobidoo lesson 保存スクリプトが存在する
+#       .observation/interventions/<ts>-feature-dev-fallback.json に InterventionRecord
+#       doobidoo に feature-dev-fallback tag で lesson 保存
+#
+# RED: record-feature-dev-fallback.sh が未実装のため fail する
+# PASS 条件（実装後）:
+#   - plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh が存在する
+#   - 実行可能権限がある
+#   - .observation/interventions/<ts>-feature-dev-fallback.json を生成する
+#   - doobidoo への lesson 保存コマンドを含む
+# ===========================================================================
+
+@test "ac5: record-feature-dev-fallback.sh が scripts/ に存在する" {
+  # AC-5: InterventionRecord 記録スクリプトが存在すること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${RECORD_SCRIPT}" ]
+}
+
+@test "ac5: record-feature-dev-fallback.sh が実行可能権限を持つ" {
+  # AC-5: スクリプトが実行可能であること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${RECORD_SCRIPT}" ] || {
+    echo "RED: record-feature-dev-fallback.sh 未実装"
+    false
+  }
+  [ -x "${RECORD_SCRIPT}" ]
+}
+
+@test "ac5: record-feature-dev-fallback.sh が .observation/interventions/ 配下に JSON を生成する" {
+  # AC-5: .observation/interventions/<ts>-feature-dev-fallback.json が生成されること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${RECORD_SCRIPT}" ] || {
+    echo "RED: record-feature-dev-fallback.sh 未実装"
+    false
+  }
+
+  local intervention_dir="$SANDBOX/observation/interventions"
+  mkdir -p "$intervention_dir"
+
+  run bash "${RECORD_SCRIPT}" \
+    --issue 1620 \
+    --trigger "red-only-merge" \
+    --intervention-dir "$intervention_dir"
+  [ "$status" -eq 0 ]
+
+  # <ts>-feature-dev-fallback.json が生成されていること
+  local json_count
+  json_count=$(find "$intervention_dir" -name "*-feature-dev-fallback.json" | wc -l)
+  [ "$json_count" -ge 1 ]
+}
+
+@test "ac5: 生成された InterventionRecord JSON が必須フィールドを含む" {
+  # AC-5: InterventionRecord JSON が type/trigger/timestamp/issue_number を含むこと
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${RECORD_SCRIPT}" ] || {
+    echo "RED: record-feature-dev-fallback.sh 未実装"
+    false
+  }
+
+  local intervention_dir="$SANDBOX/observation/interventions"
+  mkdir -p "$intervention_dir"
+
+  bash "${RECORD_SCRIPT}" \
+    --issue 1620 \
+    --trigger "red-only-merge" \
+    --intervention-dir "$intervention_dir" 2>/dev/null
+
+  local json_file
+  json_file=$(find "$intervention_dir" -name "*-feature-dev-fallback.json" | head -1)
+  [ -n "$json_file" ]
+
+  # JSON に type フィールドが含まれること
+  grep -q '"type"\|"trigger"\|"timestamp"\|"issue"' "$json_file"
+}
+
+@test "ac5: record-feature-dev-fallback.sh が feature-dev-fallback tag での doobidoo lesson 保存コマンドを含む" {
+  # AC-5: doobidoo に feature-dev-fallback tag で lesson 保存するロジックが含まれること
+  # RED: 実装前は fail する（ファイル不在）
+  [ -f "${RECORD_SCRIPT}" ] || {
+    echo "RED: record-feature-dev-fallback.sh 未実装"
+    false
+  }
+
+  # スクリプトに doobidoo / mcp__doobidoo + feature-dev-fallback tag が含まれること
+  grep -q "doobidoo\|mcp__doobidoo" "${RECORD_SCRIPT}"
+  grep -q "feature-dev-fallback" "${RECORD_SCRIPT}"
+}


### PR DESCRIPTION
## 概要

co-autopilot 失敗時の feature-dev fallback path を正規化し、Layer 2 Escalate として定義する。

## AC 対応

| AC | 内容 | 実装 |
|----|------|------|
| AC-1 | 4 trigger 検知時に observer が user に fallback を提案 | `feature-dev-fallback-detect.sh` 新規作成 |
| AC-2 | observer が feature-dev を自律 spawn 禁止 (SU-10) | `spawn-controller.sh` に拒否ロジック追加 |
| AC-3 | 命名規則 `wt-fd-<N>` 記載 | `intervention-catalog.md` パターン 14 追加 |
| AC-4 | spawn prompt template に必須 4 sections | `templates/feature-dev-fallback-prompt.md` 新規作成 |
| AC-5 | InterventionRecord + doobidoo lesson 保存 | `record-feature-dev-fallback.sh` 新規作成 |

## 変更ファイル

- `plugins/twl/skills/su-observer/scripts/feature-dev-fallback-detect.sh` — AC-1
- `plugins/twl/skills/su-observer/scripts/record-feature-dev-fallback.sh` — AC-5
- `plugins/twl/skills/su-observer/templates/feature-dev-fallback-prompt.md` — AC-4
- `plugins/twl/skills/su-observer/scripts/spawn-controller.sh` — AC-2 (feature-dev 拒否 + SKIP_LAYER2=1 override)
- `plugins/twl/refs/intervention-catalog.md` — AC-1/AC-3 (パターン 14 追加)
- `plugins/twl/skills/su-observer/refs/su-observer-constraints.md` — SU-10 追加
- `plugins/twl/tests/bats/issue-1620-feature-dev-fallback.bats` — 22件 GREEN
- `.autopilot/issues/issue-1620/ac-test-mapping.yaml`

## テスト

```
22/22 PASS (issue-1620-feature-dev-fallback.bats)
```

Closes #1620