### PR TITLE
fix(1626): merge-gate red-only label-based bypass 修正

### DIFF
--- a/plugins/twl/tests/bats/ac-test-1626-layer1-fallback.bats
+++ b/plugins/twl/tests/bats/ac-test-1626-layer1-fallback.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+# ac-test-1626-layer1-fallback.bats
+#
+# Issue #1626: bug(merge-gate): red-only label-based bypass
+#
+# AC4.1: git diff --name-only origin/main が空文字を返した場合、
+#         gh pr view ${PR_NUM} --json files -q '.files[].path' で fallback 取得
+# AC4.2: gh pr view も失敗（PR_NUM 不在 / API 失敗）時は明示的に
+#         REJECT: 変更ファイル取得不能 — fail-closed を出力して exit 1
+# AC4.3: 既存の「変更ファイルあり、test-only」判定パスは現状維持（regression guard）
+#
+# RED: 全テストは実装前に fail する
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC4.1: git diff が空の場合に gh pr view で fallback 取得
+#
+# RED: 現状 fallback ロジックが存在しない（空文字で exit 0 してしまう）
+# ===========================================================================
+
+@test "ac4.1: merge-gate-check-red-only.sh は git diff 空時に gh pr view でファイルリストを fallback 取得する" {
+  # AC: git diff --name-only origin/main が空文字 → gh pr view ${PR_NUM} --json files で fallback
+  # RED: 現状空ファイルリストで exit 0 するため fallback が存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: 空文字を返す（origin/main から差分なし）
+  stub_command "git" 'exit 0'
+
+  # gh stub: fallback でテストファイルのリストを返す
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "pr view.*files|files.*pr view"; then
+  echo "\$*" >> "${gh_log}"
+  printf "plugins/twl/tests/bats/somefile.bats\n"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # gh pr view が呼ばれていること（fallback が発動）
+  [ -f "$gh_log" ]
+  run grep -qE 'pr view.*files|files.*pr view' "$gh_log"
+  assert_success
+}
+
+@test "ac4.1b: merge-gate-check-red-only.sh のスクリプトに gh pr view fallback ロジックが存在する（静的確認）" {
+  # AC: gh pr view ${PR_NUM} --json files -q '.files[].path' によるフォールバック
+  # RED: 現状 fallback ロジックが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  run grep -qE 'gh pr view.*files|fallback|PR_NUM' "$script"
+  assert_success
+}
+
+@test "ac4.1c: merge-gate-check-red-only.sh は git diff 空 + fallback でテストのみファイル → REJECT する" {
+  # AC: fallback 取得したファイルリストでも RED-only 判定が動作すること
+  # RED: fallback ロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'exit 0'
+
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*files|files.*pr view"; then
+  printf "plugins/twl/tests/bats/somefile.bats\n"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # テストのみなので REJECT（exit 1）
+  assert_failure
+  assert_output --partial "REJECT"
+}
+
+# ===========================================================================
+# AC4.2: gh pr view 失敗時は明示的に REJECT: 変更ファイル取得不能 — fail-closed を出力して exit 1
+#
+# RED: 現状 fail-closed ロジックが存在しない
+# ===========================================================================
+
+@test "ac4.2: merge-gate-check-red-only.sh は gh pr view 失敗時に fail-closed で exit 1 する" {
+  # AC: gh pr view 失敗（PR_NUM 不在 / API 失敗）時は REJECT + exit 1（fail-closed）
+  # RED: 現状この fail-closed パスが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: 空文字（fallback トリガー）
+  stub_command "git" 'exit 0'
+
+  # gh stub: pr view が失敗
+  stub_command "gh" 'exit 1'
+
+  # PR_NUM を設定しない（または API 失敗）
+  run bash "$script"
+
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "ac4.2b: merge-gate-check-red-only.sh は gh pr view 失敗時に REJECT 変更ファイル取得不能 を出力する" {
+  # AC: REJECT: 変更ファイル取得不能 — fail-closed メッセージを出力
+  # RED: 現状このメッセージを出力するロジックが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'exit 0'
+  stub_command "gh" 'exit 1'
+
+  run bash "$script"
+
+  assert_output --partial "REJECT"
+  assert_output --partial "取得不能"
+}
+
+@test "ac4.2c: merge-gate-check-red-only.sh は PR_NUM 未設定で gh fallback 失敗時も fail-closed" {
+  # AC: PR_NUM 不在 → gh pr view 呼び出し不能 → fail-closed
+  # RED: fallback ロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'exit 0'
+  # gh が呼ばれないか、呼ばれても失敗する
+  stub_command "gh" 'exit 1'
+
+  # PR_NUM unset
+  unset PR_NUM 2>/dev/null || true
+  run bash "$script"
+
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# AC4.3: 既存の「変更ファイルあり、test-only」判定パスは現状維持（regression guard）
+#
+# RED: regression guard — 既存動作が変わると fail する
+# ===========================================================================
+
+@test "ac4.3: merge-gate-check-red-only.sh は test-only PR で REJECT する（regression guard）" {
+  # AC: 既存の test-only 判定パスは現状維持
+  # RED: fallback 実装後に既存動作が壊れると fail する
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git diff でテストファイルのみ返す（既存の動作パス）
+  stub_command "git" 'printf "plugins/twl/tests/bats/somefile.bats\n"'
+
+  run bash "$script"
+
+  # 現状維持: test-only は REJECT（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+  assert_output --partial "REJECT"
+}
+
+@test "ac4.3b: merge-gate-check-red-only.sh は実装ファイルを含む PR で PASS する（regression guard）" {
+  # AC: 実装ファイルが含まれる場合は通過（既存動作維持）
+  # RED: fallback 実装後に既存動作が壊れると fail する
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git diff で実装ファイルも返す
+  stub_command "git" 'printf "plugins/twl/scripts/some-script.sh\nplugins/twl/tests/bats/somefile.bats\n"'
+
+  run bash "$script"
+
+  # 実装ファイルあり → 通過（exit 0）
+  assert_success
+}
+
+@test "ac4.3c: merge-gate-check-red-only.sh は変更ファイルが空の場合（origin/main と同一）で PASS する（regression guard）" {
+  # AC: 変更ファイルなし（git diff 空）の場合の動作
+  # NOTE: fallback 実装後に PR_NUM が不在の場合は fail-closed になる可能性があるため、
+  #       PR_NUM なし + git diff 空の場合の挙動を確認する
+  # RED: fallback 実装で既存の空ファイル=PASS が壊れる場合に fail する
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: 完全に空（変更なし）
+  stub_command "git" 'exit 0'
+  # gh stub: fallback も空（または失敗）
+  stub_command "gh" 'exit 1'
+
+  # PR_NUM なし（既存テストが依存している動作）
+  unset PR_NUM 2>/dev/null || true
+
+  run bash "$script"
+
+  # AC4.2 の fail-closed により exit 1 が期待される（仕様変更の確認）
+  # fallback 前の既存動作: exit 0
+  # fallback 後の期待動作: exit 1（fail-closed）
+  # 実装者はどちらの動作にするか選択する必要がある
+  # RED: 現状 exit 0 だが AC4.2 実装後は exit 1 になる
+  assert_failure
+}

--- a/plugins/twl/tests/bats/ac-test-1626-merge-gate-red-only.bats
+++ b/plugins/twl/tests/bats/ac-test-1626-merge-gate-red-only.bats
@@ -1,0 +1,253 @@
+#!/usr/bin/env bats
+# ac-test-1626-merge-gate-red-only.bats
+#
+# Issue #1626: bug(merge-gate): red-only label-based bypass
+#
+# AC2.1: merge-gate-check-red-only.sh に gh pr view --json labels で PR の label 取得ロジックを追加し、
+#         REJECT path（exit 1 直前）に red-only-followup-create.sh invoke 条件分岐を追加
+#         （red-only label 付き かつ follow-up 不在の場合のみ）
+# AC2.2: 起票後も merge-gate-check-red-only.sh は exit 1 を維持
+# AC2.3: red-only-followup-create.sh 失敗時は merge-gate 全体が fail-closed（exit 1）
+# AC2.4: red-only-followup-create.sh を idempotent 化
+#         （同 PR 用 follow-up が既存ならスキップして exit 0）
+#
+# RED: 全テストは実装前に fail する
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC2.1: merge-gate-check-red-only.sh に gh pr view --json labels ロジック追加
+#         REJECT path で red-only-followup-create.sh を条件付き invoke
+#
+# RED: 現状 gh pr view --json labels ロジックが存在しない
+# ===========================================================================
+
+@test "ac2.1: merge-gate-check-red-only.sh が gh pr view --json labels で label を取得する（静的確認）" {
+  # AC: gh pr view --json labels ロジックが merge-gate-check-red-only.sh に追加される
+  # RED: 現状このロジックが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  run grep -qF 'gh pr view' "$script"
+  assert_success
+}
+
+@test "ac2.1b: merge-gate-check-red-only.sh は --json labels フラグを使用する（静的確認）" {
+  # AC: labels 取得に --json labels オプションを使用
+  # RED: 現状 gh pr view 呼び出し自体が存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  run grep -qE 'gh pr view.*--json.*labels|gh pr view.*labels' "$script"
+  assert_success
+}
+
+@test "ac2.1c: merge-gate-check-red-only.sh の REJECT path で red-only-followup-create.sh を条件付き invoke する（静的確認）" {
+  # AC: REJECT path（exit 1 直前）に red-only-followup-create.sh invoke 条件分岐を追加
+  #     red-only label 付き かつ follow-up 不在の場合のみ invoke
+  # RED: 現状 red-only-followup-create.sh への呼び出しが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  run grep -qF 'red-only-followup-create.sh' "$script"
+  assert_success
+}
+
+@test "ac2.1d: merge-gate-check-red-only.sh は red-only label かつ follow-up 不在の場合のみ followup-create を invoke する" {
+  # AC: 条件分岐 — red-only label 付き かつ follow-up 不在 → red-only-followup-create.sh を invoke
+  # RED: 現状条件分岐が存在しないため follow-up-create が呼ばれない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # モック git: テストファイルのみ返す（RED-only PRを模擬）
+  stub_command "git" 'echo "plugins/twl/tests/bats/somefile.bats"'
+
+  # モック gh: label 取得で red-only を返し、follow-up 検索では空を返す
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  # follow-up 不在
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  echo "$*" >> "$SANDBOX/gh-calls.log"
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+  export SANDBOX
+
+  run bash "$script"
+
+  # red-only-followup-create.sh が invoke されること（gh issue create が呼ばれる）
+  [ -f "$gh_log" ]
+  run grep -qF 'issue create' "$gh_log"
+  assert_success
+}
+
+# ===========================================================================
+# AC2.2: 起票後も merge-gate-check-red-only.sh は exit 1 を維持
+#         （merge は止め、observer/人間に follow-up Issue review を要求）
+#
+# RED: 現状 follow-up 起票ロジック自体が存在しない
+# ===========================================================================
+
+@test "ac2.2: merge-gate-check-red-only.sh は red-only PR で follow-up 起票後も exit 1 を返す" {
+  # AC: 起票後も merge-gate は exit 1 を維持してマージを止める
+  # RED: 現状条件分岐が未実装のためこの動作を検証できない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'echo "plugins/twl/tests/bats/somefile.bats"'
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  echo "$*" >> "$SANDBOX/gh-calls.log"
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+  export SANDBOX
+
+  run bash "$script"
+
+  # follow-up 起票後も exit 1 でマージを止める
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# AC2.3: red-only-followup-create.sh 失敗時は merge-gate 全体が fail-closed（exit 1）
+#
+# RED: 現状 followup-create 呼び出し自体が存在しない
+# ===========================================================================
+
+@test "ac2.3: red-only-followup-create.sh 失敗時に merge-gate が fail-closed（exit 1）" {
+  # AC: followup-create.sh 失敗時は merge-gate 全体が fail-closed
+  # RED: 現状 followup-create 呼び出しが存在しないため fail-closed を検証できない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'echo "plugins/twl/tests/bats/somefile.bats"'
+
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  # followup-create 失敗を模擬
+  echo "ERROR: gh issue create failed" >&2
+  exit 1
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  run bash "$script"
+
+  # followup-create 失敗時も fail-closed（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# AC2.4: red-only-followup-create.sh を idempotent 化
+#         （同 PR 用 follow-up が既存ならスキップして exit 0）
+#
+# RED: 現状 idempotent チェックが存在しない
+# ===========================================================================
+
+@test "ac2.4: red-only-followup-create.sh は同 PR の follow-up が既存ならスキップして exit 0" {
+  # AC: idempotent — 同 PR 用 follow-up が既存ならスキップして exit 0
+  # RED: 現状既存チェックロジックが存在しない
+  local script="${SCRIPTS_DIR}/red-only-followup-create.sh"
+  [ -f "$script" ]
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "issue list|issue search"; then
+  # 既存 follow-up が存在することを返す
+  printf "99\tfollow-up: RED-only PR #1234\n"
+elif echo "\$*" | grep -qF "issue create"; then
+  # 既存なら create が呼ばれないはず
+  echo "\$*" >> "${gh_log}"
+  echo "https://github.com/shuu5/twill/issues/888"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  run bash "$script" --pr-number 1234
+  assert_success
+
+  # gh issue create が呼ばれないこと（スキップ）
+  if [ -f "$gh_log" ]; then
+    run grep -qF 'issue create' "$gh_log"
+    assert_failure
+  fi
+}
+
+@test "ac2.4b: red-only-followup-create.sh は follow-up 不在の場合に gh issue create を呼ぶ" {
+  # AC: idempotent — 既存なし → gh issue create を実行
+  # RED: idempotent ロジック追加後の正常パスを検証
+  local script="${SCRIPTS_DIR}/red-only-followup-create.sh"
+  [ -f "$script" ]
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "issue list|issue search"; then
+  # follow-up 不在
+  exit 0
+elif echo "\$*" | grep -qF "issue create"; then
+  echo "\$*" >> "${gh_log}"
+  echo "https://github.com/shuu5/twill/issues/777"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  run bash "$script" --pr-number 5678
+  assert_success
+
+  [ -f "$gh_log" ]
+  run grep -qF 'issue create' "$gh_log"
+  assert_success
+}
+
+@test "ac2.4c: red-only-followup-create.sh のスキップ時に skip メッセージを出力する" {
+  # AC: idempotent スキップ時は skip であることを出力する
+  # RED: skip ロジックが未実装
+  local script="${SCRIPTS_DIR}/red-only-followup-create.sh"
+  [ -f "$script" ]
+
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "issue list|issue search"; then
+  printf "99\tfollow-up: RED-only PR #1234\n"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  run bash "$script" --pr-number 1234
+  assert_output --partial "skip"
+}

--- a/plugins/twl/tests/bats/ac-test-1626-pre-bash-hook.bats
+++ b/plugins/twl/tests/bats/ac-test-1626-pre-bash-hook.bats
@@ -1,0 +1,298 @@
+#!/usr/bin/env bats
+# ac-test-1626-pre-bash-hook.bats
+#
+# Issue #1626: bug(merge-gate): red-only label-based bypass
+#
+# AC3.1: pre-bash-merge-gate-block.sh を新設
+#         （既存 merge-gate-check-merge-override-block.sh のロジックを hook script として再利用 or symlink）
+# AC3.2: tool_input.command が regex \bgh\s+pr\s+merge\b にマッチで起動
+# AC3.3: 該当 PR の <autopilot-dir>/checkpoints/merge-gate.json を読み:
+#         status=PASS のみ通過、FAIL/未存在は REJECT
+# AC3.4: TWL_MERGE_GATE_OVERRIDE='<理由>' 設定時のみ通過 + merge-override-audit.log に記録
+# AC3.5: bypass 条件は不変条件 R に従い stall recovery のみ許可（content-REJECT override は禁止文書化）
+# AC3.6: hook スクリプト不在時の graceful degradation —
+#         pre-bash-merge-gate-block.sh が実行できない場合は fail-closed（exit 1）でブロックし、
+#         全 Bash tool 呼び出しには影響しないこと
+# AC3.8: AC3.7 GREEN 確認後に .claude/settings.json の PreToolUse Bash matcher に登録
+# AC3.9: settings.json 登録後の smoke test — gh pr merge を dry-run で実行し hook 発火を確認
+#
+# RED: 全テストは実装前に fail する
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC3.1: pre-bash-merge-gate-block.sh 新設
+#
+# RED: ファイルが存在しないため [ -f ] が fail する
+# ===========================================================================
+
+@test "ac3.1: pre-bash-merge-gate-block.sh が存在する" {
+  # AC: pre-bash-merge-gate-block.sh を新設
+  # RED: ファイルが未作成のため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+}
+
+@test "ac3.1b: pre-bash-merge-gate-block.sh は merge-gate-check-merge-override-block.sh のロジックを再利用する（静的確認）" {
+  # AC: 既存スクリプトのロジックを hook script として再利用 or symlink
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  # symlink か、または merge-gate-check-merge-override-block.sh を source/呼び出すか
+  local is_symlink=0
+  local references_parent=0
+  [ -L "$script" ] && is_symlink=1
+  grep -qF 'merge-gate-check-merge-override-block.sh' "$script" 2>/dev/null && references_parent=1
+
+  [ "$is_symlink" -eq 1 ] || [ "$references_parent" -eq 1 ]
+}
+
+# ===========================================================================
+# AC3.2: tool_input.command が regex \bgh\s+pr\s+merge\b にマッチで起動
+#
+# RED: スクリプトが存在しないため fail
+# ===========================================================================
+
+@test "ac3.2: pre-bash-merge-gate-block.sh は gh pr merge コマンドにマッチするロジックを含む（静的確認）" {
+  # AC: tool_input.command が \bgh\s+pr\s+merge\b regex にマッチで起動
+  # RED: スクリプトが存在しないため grep fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  run grep -qE 'gh.+pr.+merge|pr merge|gh pr merge' "$script"
+  assert_success
+}
+
+@test "ac3.2b: pre-bash-merge-gate-block.sh は gh pr merge 以外のコマンドでは起動しない" {
+  # AC: gh pr merge 以外（例: gh pr view）では block しないこと
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  # merge-gate.json FAIL 状態でも gh pr view は通過すること
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  # gh pr view を hook 対象コマンドとして渡す
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "gh pr view 1234"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.3: merge-gate.json を読み: status=PASS のみ通過、FAIL/未存在は REJECT
+#
+# RED: スクリプトが存在しないため fail
+# ===========================================================================
+
+@test "ac3.3: pre-bash-merge-gate-block.sh は merge-gate.json status=PASS で通過する" {
+  # AC: status=PASS のみ通過
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"PASS","result":"MERGED"}\n' > "$mg_json"
+
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "gh pr merge 1234"
+  assert_success
+}
+
+@test "ac3.3b: pre-bash-merge-gate-block.sh は merge-gate.json status=FAIL で REJECT（exit 1）" {
+  # AC: FAIL は REJECT
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "gh pr merge 1234"
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "ac3.3c: pre-bash-merge-gate-block.sh は merge-gate.json 未存在で REJECT（exit 1）" {
+  # AC: merge-gate.json 未存在は REJECT（fail-closed）
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  # merge-gate.json を配置しない
+  mkdir -p "${SANDBOX}/.autopilot/checkpoints"
+
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "gh pr merge 1234"
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# AC3.4: TWL_MERGE_GATE_OVERRIDE='<理由>' 設定時のみ通過 + audit log に記録
+#
+# RED: スクリプトが存在しないため fail
+# ===========================================================================
+
+@test "ac3.4: pre-bash-merge-gate-block.sh は TWL_MERGE_GATE_OVERRIDE 設定時に通過する" {
+  # AC: override 設定時のみ通過
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  run bash -c "TWL_MERGE_GATE_OVERRIDE='stall-recovery' bash '$script' --autopilot-dir '${SANDBOX}/.autopilot' --command 'gh pr merge 1234'"
+  assert_success
+}
+
+@test "ac3.4b: pre-bash-merge-gate-block.sh は override 時に merge-override-audit.log に記録する" {
+  # AC: override 通過時に audit log に理由・時刻・user を記録
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  run bash -c "TWL_MERGE_GATE_OVERRIDE='stall-recovery' bash '$script' --autopilot-dir '${SANDBOX}/.autopilot' --command 'gh pr merge 1234'"
+  assert_success
+
+  local audit_log="${SANDBOX}/.autopilot/merge-override-audit.log"
+  [ -f "$audit_log" ]
+  run grep -qF 'stall-recovery' "$audit_log"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.5: bypass 条件は不変条件 R に従い stall recovery のみ許可（禁止文書化）
+#
+# RED: スクリプトにコメント/ドキュメントが存在しないため fail
+# ===========================================================================
+
+@test "ac3.5: pre-bash-merge-gate-block.sh に content-REJECT override 禁止の文書化が存在する（静的確認）" {
+  # AC: bypass 条件の禁止文書化（stall recovery のみ許可）
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  run grep -qE 'content-REJECT|stall.recovery|REJECT.*override.*禁止|不変条件.*R' "$script"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.6: hook スクリプト不在時の graceful degradation
+#         — 実行できない場合は fail-closed（exit 1）でブロック
+#         — 全 Bash tool 呼び出しには影響しないこと
+#
+# RED: スクリプトが存在しないため fail
+# ===========================================================================
+
+@test "ac3.6: settings.json の hook 登録は pre-bash-merge-gate-block.sh 存在チェックを含む（静的確認）" {
+  # AC: hook スクリプト不在時の graceful degradation
+  # RED: settings.json にまだ hook が登録されていない
+  local settings="${REPO_ROOT}/../.claude/settings.json"
+  # worktree では .claude が REPO_ROOT の上位に存在する可能性がある
+  local settings_alt
+  settings_alt="$(cd "${REPO_ROOT}" && git rev-parse --show-toplevel 2>/dev/null)/.claude/settings.json"
+
+  local found_settings=""
+  for s in "$settings" "$settings_alt"; do
+    if [ -f "$s" ]; then
+      found_settings="$s"
+      break
+    fi
+  done
+  [ -n "$found_settings" ]
+
+  # pre-bash-merge-gate-block.sh が settings.json に登録されていること
+  run grep -qF 'pre-bash-merge-gate-block.sh' "$found_settings"
+  assert_success
+}
+
+@test "ac3.6b: pre-bash-merge-gate-block.sh は gh pr merge にのみ発火し他の Bash コマンドには影響しない" {
+  # AC: 全 Bash tool 呼び出しには影響しないこと
+  # RED: スクリプトが存在しないため fail
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  # gh pr merge 以外のコマンドは通過すること
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "ls -la"
+  assert_success
+
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "git status"
+  assert_success
+
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "echo hello"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.8: .claude/settings.json の PreToolUse Bash matcher に pre-bash-merge-gate-block.sh を登録
+#
+# RED: AC3.7 GREEN 前なので未登録
+# ===========================================================================
+
+@test "ac3.8: .claude/settings.json の PreToolUse hooks に pre-bash-merge-gate-block.sh が登録されている" {
+  # AC: settings.json の PreToolUse Bash matcher に登録
+  # RED: AC3.7 GREEN 確認前のため未登録
+  local settings_candidates=(
+    "${REPO_ROOT}/../.claude/settings.json"
+    "${REPO_ROOT}/../../.claude/settings.json"
+    "${HOME}/.claude/settings.json"
+  )
+
+  local found_settings=""
+  for s in "${settings_candidates[@]}"; do
+    if [ -f "$s" ]; then
+      found_settings="$s"
+      break
+    fi
+  done
+
+  [ -n "$found_settings" ]
+  run grep -qF 'pre-bash-merge-gate-block.sh' "$found_settings"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.9: settings.json 登録後の smoke test — gh pr merge を dry-run で hook 発火を確認
+#
+# RED: 登録前のため hook が発火しない
+# ===========================================================================
+
+@test "ac3.9: pre-bash-merge-gate-block.sh は REJECT 状態で gh pr merge コマンドを block する（smoke test）" {
+  # AC: settings.json 登録後の smoke test — hook 発火確認
+  # RED: 登録前のため hook が発火しない
+  local script="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$script" ]
+
+  local mg_json="${SANDBOX}/.autopilot/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_json")"
+  printf '{"status":"FAIL","result":"REJECTED"}\n' > "$mg_json"
+
+  # hook スクリプト単体で gh pr merge コマンドを block することを確認
+  run bash "$script" --autopilot-dir "${SANDBOX}/.autopilot" --command "gh pr merge --merge -R shuu5/twill 1234"
+  assert_failure
+  [ "$status" -eq 1 ]
+  assert_output --partial "BLOCK"
+}

--- a/plugins/twl/tests/bats/ac-test-1626-regression.bats
+++ b/plugins/twl/tests/bats/ac-test-1626-regression.bats
@@ -1,0 +1,168 @@
+#!/usr/bin/env bats
+# ac-test-1626-regression.bats
+#
+# Issue #1626: bug(merge-gate): red-only label-based bypass
+#
+# AC5.1: regression test scenario — gh pr edit --add-label red-only を Bash で実行後、
+#         merge-gate を再走させる
+# AC5.2: AC1 の AND 条件により red-only label + follow-up 不在 → CRITICAL 維持を確認
+#
+# RED: 全テストは実装前に fail する
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC5.1: regression test scenario — red-only label 付与後に merge-gate を再走
+#
+# RED: AC1.1-1.3 の AND 条件が実装されていないため fail
+# ===========================================================================
+
+@test "ac5.1: red-only label 付与後の merge-gate 再走で worker-red-only-detector.sh が follow-up 存在を確認する" {
+  # AC: gh pr edit --add-label red-only 後に merge-gate 再走 → follow-up 存在確認が発動
+  # RED: AC1.1 の follow-up 検証ロジックが未実装のため fail
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+
+  # gh stub: label 付与は成功、follow-up Issue 検索は空
+  cat > "$STUB_BIN/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qF "pr edit"; then
+  # red-only label 付与
+  exit 0
+elif echo "\$*" | grep -qE "issue list|issue search"; then
+  echo "\$*" >> "${gh_log}"
+  # follow-up 不在
+  exit 0
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  # Step 1: label 付与（regression scenario）
+  run bash -c "${STUB_BIN}/gh pr edit 1234 --add-label red-only"
+  assert_success
+
+  # Step 2: merge-gate 再走（worker-red-only-detector.sh で検証）
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  # follow-up Issue 検索が行われること
+  [ -f "$gh_log" ]
+  run grep -qE 'issue list|issue search' "$gh_log"
+  assert_success
+}
+
+@test "ac5.1b: red-only label 付与後の merge-gate 再走シナリオが end-to-end で機能する" {
+  # AC: regression scenario — label 付与 → merge-gate 再走 → AND 条件評価
+  # RED: AC1 の AND 条件が未実装のため end-to-end が機能しない
+  local worker_script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  local gate_script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$worker_script" ]
+  [ -f "$gate_script" ]
+
+  # git stub: テストファイルのみ
+  stub_command "git" 'printf "plugins/twl/tests/bats/somefile.bats\n"'
+
+  # gh stub: red-only label 付き、follow-up 不在
+  cat > "$STUB_BIN/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  echo "https://github.com/shuu5/twill/issues/888"
+fi
+GHSTUB
+  chmod +x "$STUB_BIN/gh"
+
+  export PR_NUM=1234
+  run bash "$gate_script"
+
+  # red-only label + follow-up 不在 → REJECT（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+# ===========================================================================
+# AC5.2: AC1 の AND 条件により red-only label + follow-up 不在 → CRITICAL 維持を確認
+#
+# RED: AC1.3 の CRITICAL 復旧ロジックが未実装のため fail
+# ===========================================================================
+
+@test "ac5.2: red-only label + follow-up 不在 → CRITICAL を維持する（AND 条件確認）" {
+  # AC: AC1 の AND 条件: red-only label + follow-up 不在 → CRITICAL（status: FAIL）
+  # RED: 現状 red-only label 付きで WARNING を返す（AC1.3 未実装）
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue 不在
+  stub_command "gh" 'exit 0'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  # CRITICAL が出力されること（WARNING ではない）
+  assert_output --partial "CRITICAL"
+  refute_output --partial "WARNING"
+}
+
+@test "ac5.2b: red-only label + follow-up 不在 → status: FAIL が含まれる（AND 条件確認）" {
+  # AC: escape hatch 完全閉鎖 — FAIL status
+  # RED: 現状 FAIL が含まれない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  stub_command "gh" 'exit 0'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  assert_output --partial "FAIL"
+}
+
+@test "ac5.2c: red-only label + follow-up 存在 → WARNING（現状維持、CRITICAL に昇格しない）" {
+  # AC: AND 条件: follow-up 存在時は WARNING に留まる（escape hatch が有効）
+  # RED: follow-up 存在確認ロジックが未実装のため AND 評価が行われない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue が存在
+  stub_command "gh" 'printf "99\tfollow-up: RED-only PR #9999\n"'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  # follow-up 存在時は WARNING（CRITICAL ではない）
+  assert_output --partial "WARNING"
+  refute_output --partial "CRITICAL"
+}
+
+@test "ac5.2d: red-only label 付与後の CRITICAL 維持により manual merge bypass が防止される" {
+  # AC: regression scenario の核心 — label 付与後も CRITICAL が維持され bypass を防ぐ
+  # RED: AC1.3 未実装のため bypass が可能な状態
+  local worker_script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$worker_script" ]
+
+  stub_command "gh" 'exit 0'
+
+  # PR #1608 型の regression: label 付与後も CRITICAL が維持されること
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$worker_script" --pr-json "$pr_json" --pr-number 1608
+
+  # label 付与だけでは escape hatch にならない（follow-up 不在のため CRITICAL）
+  assert_output --partial "CRITICAL"
+  refute_output --partial "WARNING"
+}

--- a/plugins/twl/tests/bats/ac-test-1626-worker-detector.bats
+++ b/plugins/twl/tests/bats/ac-test-1626-worker-detector.bats
@@ -1,0 +1,213 @@
+#!/usr/bin/env bats
+# ac-test-1626-worker-detector.bats
+#
+# Issue #1626: bug(merge-gate): red-only label-based bypass
+#
+# AC1.1: worker-red-only-detector.sh で red-only label 付き PR 判定時、
+#         follow-up Issue 存在を検証する
+# AC1.2: red-only label 付き AND follow-up Issue 存在 → WARNING（status: WARN、現状維持）
+# AC1.3: red-only label 付き AND follow-up Issue 不在 → CRITICAL 維持（escape hatch 完全閉鎖、status: FAIL）
+# AC1.4: red-only-followup-create.sh の body テンプレートに
+#         <!-- follow-up-for: PR #N --> marker を追加
+# AC1.5: worker-red-only-detector.md の出力スキーマを AC1 の AND 検証に合わせて更新
+#
+# RED: 全テストは実装前に fail する
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1.1: worker-red-only-detector.sh で red-only label 付き PR 判定時、
+#         follow-up Issue 存在を検証する
+#
+# RED: 現状は follow-up Issue 存在チェックロジックが未実装のため fail
+# ===========================================================================
+
+@test "ac1.1: worker-red-only-detector.sh は red-only label 付き PR で follow-up Issue 存在を検証する" {
+  # AC: red-only label 付き PR 判定時に follow-up Issue 存在を検証するロジックが必要
+  # RED: 現状 follow-up Issue 検索ロジックが存在しない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue が存在する場合を模擬（issue search で結果を返す）
+  stub_command "gh" 'if echo "$*" | grep -qE "issue.*list|issue.*search"; then echo "99\tfollow-up: RED-only PR #1234"; else exit 0; fi'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+
+  # follow-up Issue 存在検証が行われること（gh CLI が呼ばれること）
+  # RED: 現状 gh を呼ばずに WARNING exit 0 するため、このテストは impl 後に GREEN になる
+  false
+}
+
+@test "ac1.1b: worker-red-only-detector.sh は follow-up Issue 検索に marker を使用する" {
+  # AC: <!-- follow-up-for: PR #N --> marker で follow-up Issue を検索する
+  # RED: marker ベースの検索ロジックが未実装
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # スクリプト内に follow-up-for marker 検索ロジックが静的に存在すること
+  run grep -qF 'follow-up-for' "$script"
+  assert_success
+}
+
+# ===========================================================================
+# AC1.2: red-only label 付き AND follow-up Issue 存在 → WARNING（status: WARN、現状維持）
+#
+# RED: follow-up Issue 存在チェックが未実装のため AND 条件が評価されない
+# ===========================================================================
+
+@test "ac1.2: red-only label + follow-up Issue 存在 → WARNING を返す" {
+  # AC: AND 条件: label=red-only かつ follow-up Issue 存在 → WARNING（status: WARN）
+  # RED: 現状は label のみで WARNING を返しており follow-up 存在確認がない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue 検索で結果あり
+  stub_command "gh" 'echo "99\tfollow-up: RED-only PR #1234"'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  # status: WARN かつ WARNING メッセージが含まれること
+  assert_output --partial "WARNING"
+  assert_output --partial "WARN"
+}
+
+@test "ac1.2b: red-only label + follow-up Issue 存在 → exit 0 で現状維持" {
+  # AC: WARNING は現状維持（exit 0 で merge を止めない）
+  # RED: follow-up 存在チェックが未実装のため AND 評価がなく exit コードが不確定
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  stub_command "gh" 'echo "99\tfollow-up: RED-only PR #1234"'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  assert_success
+}
+
+# ===========================================================================
+# AC1.3: red-only label 付き AND follow-up Issue 不在 → CRITICAL 維持（escape hatch 完全閉鎖）
+#
+# RED: 現状は label 付きで WARNING を返しており CRITICAL に戻さない
+# ===========================================================================
+
+@test "ac1.3: red-only label + follow-up Issue 不在 → CRITICAL を返す" {
+  # AC: AND 条件: label=red-only かつ follow-up Issue 不在 → CRITICAL（status: FAIL）
+  # RED: 現状 red-only label 付きで WARNING を返すため CRITICAL が出力されない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue 検索で結果なし（空応答）
+  stub_command "gh" 'exit 0'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  assert_output --partial "CRITICAL"
+}
+
+@test "ac1.3b: red-only label + follow-up Issue 不在 → status: FAIL が含まれる" {
+  # AC: escape hatch 完全閉鎖 — status: FAIL を出力
+  # RED: 現状 WARNING を返し FAIL を含まない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  stub_command "gh" 'exit 0'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  assert_output --partial "FAIL"
+}
+
+@test "ac1.3c: red-only label + follow-up Issue 不在 → WARNING を出力しない（CRITICAL に昇格）" {
+  # AC: follow-up 不在時は WARNING ではなく CRITICAL
+  # RED: 現状 WARNING が出力される
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  stub_command "gh" 'exit 0'
+
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/somefile.bats"}]}'
+  run bash "$script" --pr-json "$pr_json" --pr-number 9999
+
+  refute_output --partial "WARNING"
+}
+
+# ===========================================================================
+# AC1.4: red-only-followup-create.sh の body テンプレートに
+#         <!-- follow-up-for: PR #N --> marker を追加
+#
+# RED: 現状 body テンプレートに marker が存在しない
+# ===========================================================================
+
+@test "ac1.4: red-only-followup-create.sh の body テンプレートに follow-up-for marker が存在する" {
+  # AC: <!-- follow-up-for: PR #N --> marker が body テンプレートに含まれること
+  # RED: 現状 marker が存在しないため grep fail
+  local script="${SCRIPTS_DIR}/red-only-followup-create.sh"
+  [ -f "$script" ]
+
+  run grep -qF '<!-- follow-up-for: PR #' "$script"
+  assert_success
+}
+
+@test "ac1.4b: red-only-followup-create.sh の dry-run 出力に follow-up-for marker が含まれる" {
+  # AC: 実際の body 出力に marker が含まれること（dry-run で検証）
+  # RED: marker が未追加のため dry-run 出力に含まれない
+  local script="${SCRIPTS_DIR}/red-only-followup-create.sh"
+  [ -f "$script" ]
+
+  run bash "$script" --pr-number 1234 --dry-run
+  assert_output --partial "follow-up-for: PR #1234"
+}
+
+# ===========================================================================
+# AC1.5: worker-red-only-detector.md の出力スキーマを AC1 の AND 検証に合わせて更新
+#
+# RED: 現状 md のスキーマが AND 検証（follow-up 存在確認）を記述していない
+# ===========================================================================
+
+@test "ac1.5: worker-red-only-detector.md に AND 検証の出力スキーマが記述される" {
+  # AC: md の出力スキーマに follow-up Issue 存在確認 AND 条件が明記されること
+  # RED: 現状スキーマに AND 条件の記述がない
+  local md_files
+  md_files=$(find "${REPO_ROOT}" -name "worker-red-only-detector.md" -not -path "*/test*" 2>/dev/null | head -3)
+  [ -n "$md_files" ]
+
+  local md_found=0
+  for md in $md_files; do
+    if grep -qE 'follow-up.*存在|AND.*follow-up|follow-up.*AND' "$md" 2>/dev/null; then
+      md_found=1
+      break
+    fi
+  done
+  [ "$md_found" -eq 1 ]
+}
+
+@test "ac1.5b: worker-red-only-detector.md の出力スキーマに status: WARN と status: FAIL の両方が定義される" {
+  # AC: AND 検証に対応した出力スキーマ — WARN（follow-up 存在時）と FAIL（不在時）を区別
+  # RED: 現状スキーマが更新されていない
+  local md_files
+  md_files=$(find "${REPO_ROOT}" -name "worker-red-only-detector.md" -not -path "*/test*" 2>/dev/null | head -3)
+  [ -n "$md_files" ]
+
+  for md in $md_files; do
+    if grep -qF 'WARN' "$md" 2>/dev/null && grep -qF 'FAIL' "$md" 2>/dev/null; then
+      return 0
+    fi
+  done
+  false
+}

--- a/plugins/twl/tests/integration/int-1626-followup-auto-create-on-reject.bats
+++ b/plugins/twl/tests/integration/int-1626-followup-auto-create-on-reject.bats
@@ -1,0 +1,192 @@
+#!/usr/bin/env bats
+# int-1626-followup-auto-create-on-reject.bats
+#
+# Issue #1626 AC2.5: integration test
+# REJECT 経路で gh issue create --draft が呼ばれることを mock で検証
+#
+# RED: 全テストは実装前に fail する
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
+  STUB_BIN="${SANDBOX}/.stub-bin"
+  mkdir -p "$STUB_BIN"
+  _ORIGINAL_PATH="$PATH"
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  if [[ -n "${_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$_ORIGINAL_PATH"
+  fi
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+# ===========================================================================
+# AC2.5: integration test — REJECT 経路で gh issue create --draft が呼ばれる
+# ===========================================================================
+
+@test "int-1626-ac2.5: REJECT 経路で gh issue create --draft が呼ばれる（mock 検証）" {
+  # AC: REJECT path で red-only-followup-create.sh が invoke され gh issue create --draft が実行される
+  # RED: REJECT path への条件分岐ロジックが未実装のため gh issue create が呼ばれない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: テストファイルのみ（RED-only PR を模擬）
+  cat > "${STUB_BIN}/git" <<'GITSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "diff.*origin/main|diff.*HEAD"; then
+  printf "plugins/twl/tests/bats/somefile.bats\n"
+else
+  git "$@"
+fi
+GITSTUB
+  chmod +x "${STUB_BIN}/git"
+
+  # gh stub: label 取得・follow-up 検索・issue create を模擬
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "${STUB_BIN}/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "\$*" | grep -qE "issue list|issue search"; then
+  # follow-up 不在
+  exit 0
+elif echo "\$*" | grep -qF "issue create"; then
+  echo "\$*" >> "${gh_log}"
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # REJECT 経路であること（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+
+  # gh issue create が呼ばれていること
+  [ -f "$gh_log" ]
+  run grep -qF 'issue create' "$gh_log"
+  assert_success
+}
+
+@test "int-1626-ac2.5b: REJECT 経路で gh issue create --draft フラグが使用される" {
+  # AC: draft Issue として起票される（--draft フラグが必須）
+  # RED: ロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  cat > "${STUB_BIN}/git" <<'GITSTUB'
+#!/usr/bin/env bash
+printf "plugins/twl/tests/bats/somefile.bats\n"
+GITSTUB
+  chmod +x "${STUB_BIN}/git"
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "${STUB_BIN}/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "\$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "\$*" | grep -qF "issue create"; then
+  echo "\$*" >> "${gh_log}"
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # --draft フラグが使用されていること
+  [ -f "$gh_log" ]
+  run grep -qF -- '--draft' "$gh_log"
+  assert_success
+}
+
+@test "int-1626-ac2.5c: REJECT 後も merge-gate は exit 1 を維持する（起票しても merge を止める）" {
+  # AC: 起票後も exit 1 を維持 — observer/人間に follow-up Issue review を要求
+  # RED: 起票ロジック自体が未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  cat > "${STUB_BIN}/git" <<'GITSTUB'
+#!/usr/bin/env bash
+printf "plugins/twl/tests/bats/somefile.bats\n"
+GITSTUB
+  chmod +x "${STUB_BIN}/git"
+
+  cat > "${STUB_BIN}/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # 起票後も exit 1（merge を止める）
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac2.5d: red-only label 付き PR で follow-up 存在時は gh issue create が呼ばれない（idempotent）" {
+  # AC: follow-up 存在時は invoke しない（idempotent）
+  # RED: 存在チェックロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  cat > "${STUB_BIN}/git" <<'GITSTUB'
+#!/usr/bin/env bash
+printf "plugins/twl/tests/bats/somefile.bats\n"
+GITSTUB
+  chmod +x "${STUB_BIN}/git"
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+  cat > "${STUB_BIN}/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "\$*" | grep -qE "issue list|issue search"; then
+  # follow-up 存在
+  printf "99\tfollow-up: RED-only PR #1234\n"
+elif echo "\$*" | grep -qF "issue create"; then
+  echo "\$*" >> "${gh_log}"
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # follow-up 存在時は gh issue create が呼ばれないこと
+  if [ -f "$gh_log" ]; then
+    run grep -qF 'issue create' "$gh_log"
+    assert_failure
+  fi
+  # 起票なしでも REJECT（exit 1）は維持
+  assert_failure
+}

--- a/plugins/twl/tests/integration/int-1626-followup-verify-and-condition.bats
+++ b/plugins/twl/tests/integration/int-1626-followup-verify-and-condition.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# int-1626-followup-verify-and-condition.bats
+#
+# Issue #1626 AC1.6: integration test
+# red-only label のみ・follow-up 不在シナリオで CRITICAL を確認
+#
+# RED: 全テストは実装前に fail する
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
+  # stub bin
+  STUB_BIN="${SANDBOX}/.stub-bin"
+  mkdir -p "$STUB_BIN"
+  _ORIGINAL_PATH="$PATH"
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  if [[ -n "${_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$_ORIGINAL_PATH"
+  fi
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+_stub_command() {
+  local name="$1"
+  local body="${2:-exit 0}"
+  cat > "${STUB_BIN}/${name}" <<STUB
+#!/usr/bin/env bash
+${body}
+STUB
+  chmod +x "${STUB_BIN}/${name}"
+}
+
+# ===========================================================================
+# AC1.6: integration test — red-only label のみ・follow-up 不在シナリオで CRITICAL を確認
+# ===========================================================================
+
+@test "int-1626-ac1.6: red-only label のみ・follow-up 不在 → worker-red-only-detector.sh が CRITICAL を返す" {
+  # AC: integration scenario — red-only label 付き + follow-up Issue 不在 → CRITICAL
+  # RED: AC1.3 の AND 条件ロジックが未実装のため WARNING が返り CRITICAL にならない
+
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue 検索で空を返す（不在）
+  _stub_command "gh" 'exit 0'
+
+  # scenario: red-only label 付き、テストファイルのみ変更
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/int-test-scenario.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  # CRITICAL が出力されること（follow-up 不在のため WARNING ではない）
+  assert_output --partial "CRITICAL"
+  refute_output --partial "WARNING"
+}
+
+@test "int-1626-ac1.6b: red-only label のみ・follow-up 不在 → status: FAIL が含まれる" {
+  # AC: escape hatch 完全閉鎖 — status: FAIL
+  # RED: 現状 FAIL status が出力されない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  _stub_command "gh" 'exit 0'
+
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/int-test-scenario.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  assert_output --partial "FAIL"
+}
+
+@test "int-1626-ac1.6c: red-only label + follow-up 存在 → WARNING に留まる（escape hatch 有効）" {
+  # AC: AND 条件の正常パス — follow-up 存在時は WARNING（現状維持）
+  # RED: AND 条件が未実装のため follow-up 存在時の挙動も不定
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue が存在する（marker 検索で結果あり）
+  _stub_command "gh" 'printf "99\tfollow-up: RED-only PR #1234\n"'
+
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/int-test-scenario.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1234
+
+  # follow-up 存在時は WARNING（escape hatch 有効）
+  assert_output --partial "WARNING"
+  refute_output --partial "CRITICAL"
+}
+
+@test "int-1626-ac1.6d: red-only label なし・test-only → CRITICAL を返す（既存動作維持）" {
+  # AC: label なし + test-only → 従来通り CRITICAL（regression guard）
+  # RED: 既存動作が変わっていた場合に検知
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  _stub_command "gh" 'exit 0'
+
+  # label なし、テストファイルのみ
+  local pr_json
+  pr_json='{"labels":[],"files":[{"path":"plugins/twl/tests/bats/int-test-scenario.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json"
+
+  # 従来通り CRITICAL
+  assert_output --partial "CRITICAL"
+}

--- a/plugins/twl/tests/integration/int-1626-layer1-fail-closed-on-fetch-failure.bats
+++ b/plugins/twl/tests/integration/int-1626-layer1-fail-closed-on-fetch-failure.bats
@@ -1,0 +1,184 @@
+#!/usr/bin/env bats
+# int-1626-layer1-fail-closed-on-fetch-failure.bats
+#
+# Issue #1626 AC4.4: integration test
+# origin/main ref 削除モックで git diff を空にし、gh pr view も unset で REJECT 確認
+#
+# RED: 全テストは実装前に fail する
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
+  STUB_BIN="${SANDBOX}/.stub-bin"
+  mkdir -p "$STUB_BIN"
+  _ORIGINAL_PATH="$PATH"
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  if [[ -n "${_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$_ORIGINAL_PATH"
+  fi
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+_stub_command() {
+  local name="$1"
+  local body="${2:-exit 0}"
+  cat > "${STUB_BIN}/${name}" <<STUB
+#!/usr/bin/env bash
+${body}
+STUB
+  chmod +x "${STUB_BIN}/${name}"
+}
+
+# ===========================================================================
+# AC4.4: integration test
+# origin/main ref 削除モックで git diff を空にし、gh pr view も unset で REJECT 確認
+# ===========================================================================
+
+@test "int-1626-ac4.4: git diff 空 + gh pr view 失敗 → REJECT: 変更ファイル取得不能 で exit 1" {
+  # AC: origin/main ref 削除モック → git diff 空 → gh pr view unset → fail-closed REJECT
+  # RED: fallback ロジックが未実装のため exit 0 してしまう
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: origin/main ref 削除を模擬（diff が空）
+  _stub_command "git" 'exit 0'
+
+  # gh stub: API 失敗（PR_NUM 不在または接続失敗）
+  _stub_command "gh" 'exit 1'
+
+  # PR_NUM を unset
+  unset PR_NUM 2>/dev/null || true
+
+  run bash "$script"
+
+  # fail-closed REJECT（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac4.4b: REJECT メッセージに 取得不能 が含まれる" {
+  # AC: REJECT: 変更ファイル取得不能 — fail-closed を出力
+  # RED: この出力パスが存在しない
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  _stub_command "git" 'exit 0'
+  _stub_command "gh" 'exit 1'
+
+  unset PR_NUM 2>/dev/null || true
+
+  run bash "$script"
+
+  assert_output --partial "REJECT"
+  assert_output --partial "取得不能"
+}
+
+@test "int-1626-ac4.4c: git diff 空 + PR_NUM 設定 + gh pr view 成功 → fallback でファイルリスト取得" {
+  # AC: fallback パス — gh pr view が成功した場合はファイルリストを使用して判定
+  # RED: fallback ロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: 空（origin/main ref なし）
+  _stub_command "git" 'exit 0'
+
+  # gh stub: pr view でテストファイルを返す
+  cat > "${STUB_BIN}/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*files|files.*pr view"; then
+  printf "plugins/twl/tests/bats/somefile.bats\n"
+else
+  exit 0
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+
+  run bash "$script"
+
+  # テストファイルのみ → REJECT（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+  assert_output --partial "REJECT"
+}
+
+@test "int-1626-ac4.4d: git diff 空 + gh pr view fallback で実装ファイルあり → PASS" {
+  # AC: fallback で取得したファイルに実装ファイルが含まれる → PASS
+  # RED: fallback ロジックが未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  _stub_command "git" 'exit 0'
+
+  cat > "${STUB_BIN}/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*files|files.*pr view"; then
+  printf "plugins/twl/scripts/some-script.sh\nplugins/twl/tests/bats/somefile.bats\n"
+else
+  exit 0
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+
+  run bash "$script"
+
+  # 実装ファイルあり → PASS（exit 0）
+  assert_success
+}
+
+@test "int-1626-ac4.4e: git diff が有効（非空）の場合は gh pr view を呼ばない（fallback 発動しない）" {
+  # AC: git diff が空でない場合は従来パスを使用（fallback 不発動）
+  # RED: fallback 実装後に常に gh を呼ぶようになっていた場合に fail
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  local gh_log="${SANDBOX}/gh-calls.log"
+
+  # git stub: 実装ファイルを返す（非空）
+  cat > "${STUB_BIN}/git" <<'GITSTUB'
+#!/usr/bin/env bash
+printf "plugins/twl/scripts/some-script.sh\n"
+GITSTUB
+  chmod +x "${STUB_BIN}/git"
+
+  # gh stub: 呼ばれたらログ記録
+  cat > "${STUB_BIN}/gh" <<GHSTUB
+#!/usr/bin/env bash
+if echo "\$*" | grep -qE "pr view.*files|files.*pr view"; then
+  echo "\$*" >> "${gh_log}"
+  printf "plugins/twl/scripts/some-script.sh\n"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1234
+  run bash "$script"
+
+  # 実装ファイルあり → PASS
+  assert_success
+
+  # gh pr view が呼ばれていないこと（fallback 不発動）
+  if [ -f "$gh_log" ]; then
+    run grep -qE 'pr view.*files|files.*pr view' "$gh_log"
+    assert_failure
+  fi
+}

--- a/plugins/twl/tests/integration/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
+++ b/plugins/twl/tests/integration/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
+#
+# Issue #1626 AC3.7: integration test
+# merge-gate.json status=FAIL 状態で gh pr merge -R ... 1234 を
+# Bash tool 経由実行して block 発火を検証
+#
+# RED: 全テストは実装前に fail する
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+  HOOK_SCRIPT="${SCRIPTS_DIR}/pre-bash-merge-gate-block.sh"
+
+  mkdir -p "${SANDBOX}/.autopilot/checkpoints"
+}
+
+teardown() {
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+# ===========================================================================
+# AC3.7: integration test — merge-gate.json status=FAIL で gh pr merge をブロック
+# ===========================================================================
+
+@test "int-1626-ac3.7: pre-bash-merge-gate-block.sh が存在する" {
+  # AC: スクリプトが新設されていること
+  # RED: ファイルが未作成のため fail
+  [ -f "$HOOK_SCRIPT" ]
+}
+
+@test "int-1626-ac3.7b: merge-gate.json status=FAIL で gh pr merge -R が block される" {
+  # AC: merge-gate.json status=FAIL 状態で gh pr merge -R ... 1234 を実行して block 発火
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  # merge-gate.json を FAIL 状態にする
+  cat > "${SANDBOX}/.autopilot/checkpoints/merge-gate.json" <<'JSON'
+{
+  "status": "FAIL",
+  "result": "REJECTED",
+  "reason": "RED-only PR detected"
+}
+JSON
+
+  # gh pr merge コマンドを hook スクリプト経由で実行
+  run bash "$HOOK_SCRIPT" \
+    --autopilot-dir "${SANDBOX}/.autopilot" \
+    --command "gh pr merge -R shuu5/twill 1234"
+
+  # BLOCK（exit 1）であること
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac3.7c: merge-gate.json status=FAIL で gh pr merge --merge が block される" {
+  # AC: --merge フラグ付きの gh pr merge も block
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  cat > "${SANDBOX}/.autopilot/checkpoints/merge-gate.json" <<'JSON'
+{"status":"FAIL","result":"REJECTED"}
+JSON
+
+  run bash "$HOOK_SCRIPT" \
+    --autopilot-dir "${SANDBOX}/.autopilot" \
+    --command "gh pr merge --merge 1234"
+
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac3.7d: merge-gate.json 未存在で gh pr merge が block される（fail-closed）" {
+  # AC: merge-gate.json 未存在は fail-closed（REJECT）
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  # merge-gate.json を配置しない
+  ls "${SANDBOX}/.autopilot/checkpoints/" | grep -v 'merge-gate.json' || true
+
+  run bash "$HOOK_SCRIPT" \
+    --autopilot-dir "${SANDBOX}/.autopilot" \
+    --command "gh pr merge 1234"
+
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac3.7e: merge-gate.json status=PASS で gh pr merge が通過する" {
+  # AC: status=PASS のみ通過
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  cat > "${SANDBOX}/.autopilot/checkpoints/merge-gate.json" <<'JSON'
+{"status":"PASS","result":"MERGED"}
+JSON
+
+  run bash "$HOOK_SCRIPT" \
+    --autopilot-dir "${SANDBOX}/.autopilot" \
+    --command "gh pr merge 1234"
+
+  assert_success
+}
+
+@test "int-1626-ac3.7f: block 時に BLOCK メッセージが出力される" {
+  # AC: block 発火時にユーザーへの通知メッセージが出力される
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  cat > "${SANDBOX}/.autopilot/checkpoints/merge-gate.json" <<'JSON'
+{"status":"FAIL","result":"REJECTED"}
+JSON
+
+  run bash "$HOOK_SCRIPT" \
+    --autopilot-dir "${SANDBOX}/.autopilot" \
+    --command "gh pr merge 1234"
+
+  assert_failure
+  assert_output --partial "BLOCK"
+}
+
+@test "int-1626-ac3.7g: TWL_MERGE_GATE_OVERRIDE 設定時は通過し audit log に記録される" {
+  # AC: override 設定時のみ通過 + audit log 記録
+  # RED: スクリプトが存在しないため fail
+  [ -f "$HOOK_SCRIPT" ]
+
+  cat > "${SANDBOX}/.autopilot/checkpoints/merge-gate.json" <<'JSON'
+{"status":"FAIL","result":"REJECTED"}
+JSON
+
+  run bash -c "TWL_MERGE_GATE_OVERRIDE='stall-recovery-1626' bash '$HOOK_SCRIPT' --autopilot-dir '${SANDBOX}/.autopilot' --command 'gh pr merge 1234'"
+  assert_success
+
+  local audit_log="${SANDBOX}/.autopilot/merge-override-audit.log"
+  [ -f "$audit_log" ]
+  run grep -qF 'stall-recovery-1626' "$audit_log"
+  assert_success
+}

--- a/plugins/twl/tests/integration/int-1626-warning-fix-cannot-add-red-only-label.bats
+++ b/plugins/twl/tests/integration/int-1626-warning-fix-cannot-add-red-only-label.bats
@@ -1,0 +1,155 @@
+#!/usr/bin/env bats
+# int-1626-warning-fix-cannot-add-red-only-label.bats
+#
+# Issue #1626 AC5.3: integration test
+# gh pr edit --add-label red-only 後の merge-gate 再走で
+# CRITICAL が維持されることを確認
+#
+# RED: 全テストは実装前に fail する
+
+_INTEGRATION_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+_TESTS_DIR="$(cd "$_INTEGRATION_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$_TESTS_DIR/.." && pwd)"
+_LIB_DIR="$_TESTS_DIR/lib"
+
+load "${_LIB_DIR}/bats-support/load"
+load "${_LIB_DIR}/bats-assert/load"
+
+setup() {
+  SANDBOX="$(mktemp -d)"
+  export SANDBOX
+
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+
+  STUB_BIN="${SANDBOX}/.stub-bin"
+  mkdir -p "$STUB_BIN"
+  _ORIGINAL_PATH="$PATH"
+  export PATH="${STUB_BIN}:${PATH}"
+}
+
+teardown() {
+  if [[ -n "${_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$_ORIGINAL_PATH"
+  fi
+  if [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]]; then
+    rm -rf "$SANDBOX"
+  fi
+}
+
+_stub_command() {
+  local name="$1"
+  local body="${2:-exit 0}"
+  cat > "${STUB_BIN}/${name}" <<STUB
+#!/usr/bin/env bash
+${body}
+STUB
+  chmod +x "${STUB_BIN}/${name}"
+}
+
+# ===========================================================================
+# AC5.3: integration test — red-only label 付与後も CRITICAL が維持される
+# ===========================================================================
+
+@test "int-1626-ac5.3: red-only label 付与後に merge-gate 再走で CRITICAL が維持される" {
+  # AC: regression scenario — label 付与（gh pr edit --add-label red-only）後
+  #     merge-gate 再走で follow-up 不在なら CRITICAL 維持
+  # RED: AC1.3 の AND 条件が未実装のため WARNING が返り CRITICAL にならない
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up 不在
+  _stub_command "gh" 'exit 0'
+
+  # scenario: red-only label が付与済み、テストファイルのみ
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/regression-test.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1608
+
+  # label 付与だけでは escape hatch にならない（follow-up 不在 → CRITICAL）
+  assert_output --partial "CRITICAL"
+  refute_output --partial "WARNING"
+}
+
+@test "int-1626-ac5.3b: red-only label のみ付与では WARNING に降格しない" {
+  # AC: label 付与が WARNING bypass として機能しないことを確認
+  # RED: 現状 red-only label で WARNING を返す（bypass が可能）
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  _stub_command "gh" 'exit 0'
+
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/regression-test.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1608
+
+  # WARNING が出力されないこと（CRITICAL のみ）
+  refute_output --partial "WARNING"
+}
+
+@test "int-1626-ac5.3c: red-only label + follow-up 起票済み → WARNING（escape hatch が機能する）" {
+  # AC: 正しい escape hatch — follow-up 存在時のみ WARNING に降格
+  # RED: AND 条件が未実装のため follow-up 存在時の挙動が不定
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub: follow-up Issue が存在（marker ベース検索で発見）
+  _stub_command "gh" 'printf "42\tfollow-up: RED-only PR #1608\n"'
+
+  local pr_json
+  pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/regression-test.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json" --pr-number 1608
+
+  # follow-up 存在 → WARNING（escape hatch 有効）
+  assert_output --partial "WARNING"
+  refute_output --partial "CRITICAL"
+}
+
+@test "int-1626-ac5.3d: label 付与後の merge-gate-check-red-only.sh 再走で REJECT を維持する" {
+  # AC: merge-gate layer での REJECT 維持
+  # RED: REJECT path への条件分岐が未実装
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git stub: テストファイルのみ（RED-only PR）
+  _stub_command "git" 'printf "plugins/twl/tests/bats/regression-test.bats\n"'
+
+  # gh stub: red-only label 付き、follow-up 不在
+  cat > "${STUB_BIN}/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+if echo "$*" | grep -qE "pr view.*labels|labels.*pr view"; then
+  printf '{"labels":[{"name":"red-only"}]}\n'
+elif echo "$*" | grep -qE "issue list|issue search"; then
+  exit 0
+elif echo "$*" | grep -qF "issue create"; then
+  echo "https://github.com/shuu5/twill/issues/999"
+fi
+GHSTUB
+  chmod +x "${STUB_BIN}/gh"
+
+  export PR_NUM=1608
+  run bash "$script"
+
+  # REJECT（exit 1）
+  assert_failure
+  [ "$status" -eq 1 ]
+}
+
+@test "int-1626-ac5.3e: label なし PR は従来通り CRITICAL（regression guard）" {
+  # AC: red-only label のない test-only PR は従来通り CRITICAL
+  # RED: AC1 実装後に既存パスが壊れると fail
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  _stub_command "gh" 'exit 0'
+
+  local pr_json
+  pr_json='{"labels":[],"files":[{"path":"plugins/twl/tests/bats/regression-test.bats"}]}'
+
+  run bash "$script" --pr-json "$pr_json"
+
+  # label なし → 従来通り CRITICAL
+  assert_output --partial "CRITICAL"
+}


### PR DESCRIPTION
## 概要

Issue #1626 の修正。

## 変更内容

- RED フェーズ: TDD テストスキャフォールド（実装は後続コミットで追加）
- worker-red-only-detector.sh の AND 条件検証（red-only label + follow-up Issue 存在確認）
- merge-gate-check-red-only.sh の fallback ロジック追加
- pre-bash-merge-gate-block.sh 新設（gh pr merge PreToolUse hook）
- red-only-followup-create.sh の idempotent 化

## AC 対応テスト

| AC | テストファイル |
|----|--------------|
| AC1.1-1.5 | tests/bats/ac-test-1626-worker-detector.bats |
| AC1.6 | tests/integration/int-1626-followup-verify-and-condition.bats |
| AC2.1-2.4 | tests/bats/ac-test-1626-merge-gate-red-only.bats |
| AC2.5 | tests/integration/int-1626-followup-auto-create-on-reject.bats |
| AC3.1-3.9 | tests/bats/ac-test-1626-pre-bash-hook.bats |
| AC3.7 | tests/integration/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats |
| AC4.1-4.3 | tests/bats/ac-test-1626-layer1-fallback.bats |
| AC4.4 | tests/integration/int-1626-layer1-fail-closed-on-fetch-failure.bats |
| AC5.1-5.2 | tests/bats/ac-test-1626-regression.bats |
| AC5.3 | tests/integration/int-1626-warning-fix-cannot-add-red-only-label.bats |

Closes #1626