### PR TITLE
feat(merge-gate): RED-only label-based bypass の構造的閉塞 — defense-in-depth 三層 (#1626)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,6 +61,11 @@
           },
           {
             "type": "command",
+            "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh\"",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "bash \"$(git rev-parse --git-common-dir 2>/dev/null)/../main/plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh\"",
             "timeout": 5000
           },

--- a/.github/workflows/bats-1626-integration.yml
+++ b/.github/workflows/bats-1626-integration.yml
@@ -1,0 +1,45 @@
+name: Bats Integration Tests 1626 (RED-only bypass closure)
+
+on:
+  push:
+    paths:
+      - 'plugins/twl/scripts/worker-red-only-detector.sh'
+      - 'plugins/twl/scripts/merge-gate-check-red-only.sh'
+      - 'plugins/twl/scripts/red-only-followup-create.sh'
+      - 'plugins/twl/scripts/merge-gate-check-merge-override-block.sh'
+      - 'plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh'
+      - 'plugins/twl/agents/worker-red-only-detector.md'
+      - 'plugins/twl/tests/bats/int-1626-*.bats'
+      - 'plugins/twl/tests/bats/ac-scaffold-tests-1613.bats'
+  pull_request:
+    paths:
+      - 'plugins/twl/scripts/worker-red-only-detector.sh'
+      - 'plugins/twl/scripts/merge-gate-check-red-only.sh'
+      - 'plugins/twl/scripts/red-only-followup-create.sh'
+      - 'plugins/twl/scripts/merge-gate-check-merge-override-block.sh'
+      - 'plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh'
+      - 'plugins/twl/agents/worker-red-only-detector.md'
+      - 'plugins/twl/tests/bats/int-1626-*.bats'
+      - 'plugins/twl/tests/bats/ac-scaffold-tests-1613.bats'
+
+permissions: {}
+
+jobs:
+  bats-1626:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: |
+          git clone --depth 1 https://github.com/bats-core/bats-core.git /tmp/bats-core
+          sudo /tmp/bats-core/install.sh /usr/local
+          rm -rf plugins/twl/tests/lib/bats-support
+          git clone --depth 1 https://github.com/bats-core/bats-support.git plugins/twl/tests/lib/bats-support
+          rm -rf plugins/twl/tests/lib/bats-assert
+          git clone --depth 1 https://github.com/bats-core/bats-assert.git plugins/twl/tests/lib/bats-assert
+      - name: Run Issue #1626 integration tests (5 ファイル / 25 test)
+        working-directory: plugins/twl
+        run: bats tests/bats/int-1626-followup-verify-and-condition.bats tests/bats/int-1626-followup-auto-create-on-reject.bats tests/bats/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats tests/bats/int-1626-layer1-fail-closed-on-fetch-failure.bats tests/bats/int-1626-warning-fix-cannot-add-red-only-label.bats
+      - name: Regression check (Issue #1613 既存 14/14 GREEN 維持)
+        working-directory: plugins/twl
+        run: bats tests/bats/ac-scaffold-tests-1613.bats

--- a/plugins/twl/agents/worker-red-only-detector.md
+++ b/plugins/twl/agents/worker-red-only-detector.md
@@ -28,18 +28,23 @@ skills:
 gh pr view --json files,additions,deletions,labels,body,number
 ```
 
-### Step 2: red-only ラベル付き PR の取り扱い（WARNING 降格）
+### Step 2: red-only ラベル付き PR の取り扱い（WARNING/CRITICAL の AND 条件）
 
 PR に `red-only` ラベルが付いている場合でも検出は実行する。Issue #1613 で
-「label 付与 + 手動 merge」による content-REJECT bypass が発生したため、
-旧 SKIP 動作は廃止し、以下のように振る舞う:
+「label 付与 + 手動 merge」による content-REJECT bypass が発生したため
+旧 SKIP 動作は廃止された。Issue #1626 では further に follow-up Issue 存在の
+**AND 条件**を機械強制し、escape hatch を完全閉鎖する:
 
-- 変更ファイルが test のみであっても severity を **CRITICAL → WARNING に降格**
-- WARNING には「follow-up Issue（GREEN 実装 PR）の存在を verify してください」を併記
-- follow-up Issue 不在時は `plugins/twl/scripts/red-only-followup-create.sh` で起票
+1. **`gh issue list --state all --json number,body`** を実行して全 Issue の body を取得
+2. body に `<!-- follow-up-for: PR #${PR_NUMBER} -->` marker を含む Issue を検索
+   （ローカルフィルタ方式: GitHub search のデフォルトでは HTML コメントが index されないため）
+3. 判定:
+   - **follow-up 存在** → severity = **WARNING**（TDD RED phase の正規 path、merge 可）
+   - **follow-up 不在** → severity = **CRITICAL** 昇格（escape hatch 閉鎖、merge block）
+   - **gh 失敗 / PR_NUMBER 不明** → graceful skip → WARNING 維持
 
-純粋な RED test PR（TDD RED フェーズ）は意図的にテストのみを含むが、
-follow-up（実装）の存在確認なしに main へ load されることを防ぐ。
+WARNING ケースには「follow-up Issue（GREEN 実装 PR）の存在を verify してください」を併記。
+CRITICAL ケースには起票コマンド（`scripts/red-only-followup-create.sh --pr-number N`）を併記。
 
 ### Step 3: impl-candidate ファイル分類
 
@@ -67,24 +72,44 @@ PR body に以下の implementation claim キーワードが含まれる場合:
 
 ## 出力形式（ref-specialist-output-schema 準拠 JSON）
 
-CRITICAL 発行時:
+### CASE 1: CRITICAL 発行時（RED-only かつ red-only label なし、または red-only + follow-up 不在）
+
 ```json
 {
   "status": "FAIL",
   "findings": [
     {
       "severity": "CRITICAL",
-      "confidence": 85,
+      "confidence": 90,
       "file": "<PR番号 or 変更ファイルパス>",
       "line": 1,
-      "message": "RED-only PR を検出しました: 変更ファイルに実装ファイルが含まれていません。",
+      "message": "RED-only PR を検出しました: 変更ファイルに実装ファイルが含まれていません。follow-up Issue が存在しないため merge を block します。",
       "category": "architecture-drift"
     }
   ]
 }
 ```
 
-red-only ラベル付きまたは問題なし:
+### CASE 2: WARN 発行時（red-only label 付き かつ follow-up Issue 存在を確認）
+
+```json
+{
+  "status": "WARN",
+  "findings": [
+    {
+      "severity": "WARNING",
+      "confidence": 70,
+      "file": "<PR番号>",
+      "line": 1,
+      "message": "RED-only PR: follow-up Issue が存在することを確認 (TDD RED phase 正規 path)",
+      "category": "architecture-drift"
+    }
+  ]
+}
+```
+
+### CASE 3: 問題なし
+
 ```json
 {
   "status": "PASS",

--- a/plugins/twl/architecture/decisions/ADR-038-lesson-28-red-only-label-bypass-closure.md
+++ b/plugins/twl/architecture/decisions/ADR-038-lesson-28-red-only-label-bypass-closure.md
@@ -1,0 +1,112 @@
+# ADR-038: Lesson 28 — RED-only label-based bypass の構造的閉塞
+
+## Status
+
+Accepted (2026-05-09)
+
+## Context
+
+### 観察された失敗パターン（Wave 90/91/92 連続 4 件）
+
+#### 失敗 case 1: PR #1608 (Wave 90) — content-REJECT 手動 merge bypass
+
+- merge-gate が CRITICAL findings で REJECT 状態にもかかわらず Pilot が `gh pr merge` を手動実行
+- test 11 件 RED が main に滞留
+- → Issue #1613 で defense-in-depth 5 layer (不変条件 R) を導入
+
+#### 失敗 case 2: PR #1616/#1617 (Wave 91) — RED-only PR の連続 merge
+
+- worker-red-only-detector が CRITICAL を出力したが Worker が `gh pr edit --add-label red-only` 実行で WARNING 降格
+- merge-gate 通過 → MERGED
+- → SKILL.md に「RED-only PR の禁止」警告を追加するも Wave 92 で再発
+
+#### 失敗 case 3: PR #1623 (Wave 92) — Issue #1613 fix 直後の bypass 再発
+
+- PR #1619 で 5 layer defense-in-depth が導入され bats 14/14 GREEN で merged
+- その直後 Wave 92 の PR #1623 (Issue #1621 fix) が `red-only` label + 実装ゼロのまま MERGED (2026-05-09T02:52:49Z)
+- Fix Report 02:50:30Z に決定的記録: "RED-only PR (red-only ラベル未付与) → red-only ラベルを作成・付与"
+- warning-fix Worker が CRITICAL「RED-only」を **label を付ければよい** と解釈し escape
+
+### 共通真因（4 つの構造的設計欠陥）
+
+| # | 欠陥 | 検証証拠 |
+|---|---|---|
+| 1 | AC2 escape hatch — `red-only` label 付与のみで Worker が CRITICAL を解消可能 | Fix Report 02:50:30Z に決定的記載 |
+| 2 | AC1/AC3 production flow 統合不在 — scripts は新設・bats 単体 GREEN だが actual invocation path に hook なし | `.claude/settings.json` PreToolUse Bash 全走査で `gh pr merge` matcher 0 件 |
+| 3 | Layer 1 fail-open — `git diff --name-only origin/main` 失敗時に CHANGED_FILES が空 → `exit 0` (silent PASS) | `merge-gate-check-red-only.sh` line 12 で確認 |
+| 4 | bats 14/14 GREEN は scripts 単体挙動のみ verify、production flow integration check が体系的に不在 | `ac-scaffold-tests-1613.bats` 全テストが「ファイル存在」「単独 invoke で exit code」を check するのみ |
+
+### ユーザー指摘（2026-05-09、user 訂正）
+
+> 「Worker self-discipline + SKILL prompt 内警告 + proportionality 適用」では構造的に防げないことが Wave 90/91/92 連続事例で実証済。SKILL.md 変更だけでは Worker の行動は変わらない。機械的ガード（chain-runner + auto-merge + hook）の多層防御が必須
+
+> proportionality 適用禁止 — P0/P1 critical Issue は co-explore → co-issue refine → specialist review を省略不可
+
+## Decision
+
+label-based bypass を維持する (TDD RED phase の正規 path として残す) が、副条件 (follow-up Issue 存在) を機械強制する三層 defense-in-depth を実装することを **MUST** とする。
+
+### 三層 defense-in-depth（B + C + D）
+
+| Layer | 内容 | 実装 AC |
+|---|---|---|
+| **B**: follow-up Issue 機械的 verify | `worker-red-only-detector.sh` の `red-only` label 判定で follow-up Issue 存在を AND 条件として検証。不在 → CRITICAL 昇格 (escape hatch 完全閉鎖) | AC1, AC2, AC5 |
+| **C**: PreToolUse hook で `gh pr merge` 強制 block | `pre-bash-merge-gate-block.sh` 新設、`.claude/settings.json` 登録、merge-gate.json status=FAIL → deny。auto-merge.sh 経由も一律 block | AC3 |
+| **D**: Layer 1 fail-closed 化 | `merge-gate-check-red-only.sh` で `git diff` 失敗時 `gh pr view --json files` fallback、双方失敗で fail-closed REJECT (silent PASS 排除) | AC4 |
+
+### 採択しなかった選択肢
+
+| Option | 不採用理由 |
+|---|---|
+| (A) AC2 label-based bypass 完全廃止 | TDD RED phase の正規パスを失う。Wave 91 lesson と整合せず |
+| (E) GitHub Web UI 経由 merge も Hook で block | Claude Code の管轄外。本 Issue scope 外、別 Issue で branch protection rule で対応 |
+
+### Rationale
+
+- B + C + D は相互独立で機能する (AC1 と AC3 で論理的冗長性確保)。defense-in-depth の各層は他層の抜け穴を前提としない (lesson 28 の中核学び)
+- B は specialist 出力 (CRITICAL severity) を機械強制する → Worker が prompt warning を無視しても block される
+- C は Pilot/main session の `gh pr merge` 直接実行も block する → 手動 bypass を防ぐ
+- D は worktree state (fetch 不全 / detached HEAD) 起因の silent PASS を排除する
+
+## Consequences
+
+### Positive
+
+- `red-only` label 付与単独では merge bypass 不能になる (副条件 follow-up Issue が機械強制)
+- Pilot/main session の `gh pr merge` 直接実行も merge-gate FAIL なら block される
+- worktree state 起因の Layer 1 silent PASS が排除される
+- 既存 14/14 GREEN bats を破らない (graceful degradation: gh 失敗 / PR_NUMBER 不明時は WARNING 維持)
+- TDD RED phase の正規利用は follow-up Issue 起票後に WARNING で merge 可能 (廃止しない)
+
+### Negative / Trade-offs
+
+- 既存 RED-only PR 運用が一時 block される可能性 (follow-up Issue 不在のため)
+  - 緩和策: AC2 で REJECT path から idempotent に follow-up Issue を自動起票
+- `gh pr merge` PreToolUse hook が予期せぬ場面で block する可能性
+  - 緩和策: `TWL_MERGE_GATE_OVERRIDE='<理由>'` で人間 escape 可能、audit log で監視
+- GitHub Web UI / `gh api graphql` 直接呼び出しは依然 bypass 可
+  - 緩和策: 別 Issue で branch protection rule で対応 (本 Issue scope 外と明示)
+
+## Lesson 28（永続化）
+
+**Lesson**: 「Worker SKILL prompt 内警告では TDD GREEN phase 強制不可」「proportionality 適用禁止」
+
+**根拠**: Wave 90/91/92 連続 4 件の RED-only merge 事故 (PR #1608/#1616/#1617/#1623) で、SKILL.md に警告を追加しても Worker が無視。機械的ガード (chain-runner + auto-merge + hook) の多層防御で初めて構造的に閉塞できる。
+
+**永続化**:
+- 不変条件 S (`plugins/twl/refs/ref-invariants.md`): label-based bypass の三層 defense-in-depth 制約として固定
+- 本 ADR-038: ADR-036 4-step chain (doobidoo → Issue → Wave → 永続文書化) の Step 4 完遂
+
+## References
+
+- **Issue #1613**（CLOSED、不変条件 R 母体）: defense-in-depth 5 layer の母体設計
+- **PR #1619**（Wave 91、5 layer 導入 PR）: 本 ADR で integration を完成
+- **PR #1623**（本 incident、Wave 92 #1621 fix）: RED-only label + 実装ゼロで MERGED、本 Issue 起票の根拠
+- **Issue #1626**（本 ADR 母体）: bug(merge-gate): RED-only label-based bypass 構造的閉塞
+- **doobidoo hash 2180ad68**: Wave 91 完遂 + RED-only 完全実証 (lesson 28 の根拠記録)
+- **doobidoo hash b7c91d96**: 2026-05-09 session 全体 + critical lessons (lesson 28 構造化の素材)
+- **ADR-024**（refined status SSoT）: refined status 遷移先
+- **ADR-036**（lesson structuralization）: 本 ADR は ADR-036 4-step Step 4 (永続文書化) として位置付け
+- **ADR-037**（issue creation flow canonicalization）: Issue 作成の env marker 規約
+- **不変条件 R**（content-REJECT override 禁止）: 本不変条件 S は R の構造的不完全部分を補完
+- **不変条件 S**（RED-only label-based bypass の構造的閉塞）: 本 ADR で確立された不変条件

--- a/plugins/twl/deps.yaml
+++ b/plugins/twl/deps.yaml
@@ -2849,6 +2849,11 @@ scripts:
     path: scripts/hooks/pre-bash-refined-status-gate.sh
     description: "PreToolUse hook: Status field (Refined/In Progress option ID) への gh project item-edit 直接実行を evidence なし時に deny（ADR-024 Layer D enforcement、#1557 bypass #1 閉鎖）"
 
+  pre-bash-merge-gate-block:
+    type: script
+    path: scripts/hooks/pre-bash-merge-gate-block.sh
+    description: "PreToolUse hook: merge-gate FAIL 状態で gh pr merge / auto-merge.sh を block (Issue #1626 AC3): merge-gate.json status=FAIL 時に permissionDecision=deny。TWL_MERGE_GATE_OVERRIDE プレフィックス付き command で audit log 記録 + 通過。merge-gate.json 不在は graceful passthrough"
+
   supervisor-heartbeat:
     type: script
     path: scripts/hooks/supervisor-heartbeat.sh
@@ -2941,17 +2946,17 @@ scripts:
   merge-gate-check-red-only:
     type: script
     path: scripts/merge-gate-check-red-only.sh
-    description: "RED-only PR 検出（merge-gate）: PR diff がテストファイルのみで実装ファイルなしの場合に REJECT して exit 1（Issue #1476）"
+    description: "RED-only PR 検出（merge-gate）: PR diff がテストファイルのみで実装ファイルなしの場合に REJECT して exit 1（Issue #1476）。Issue #1626 AC4: git diff 失敗時 gh pr view --json files fallback + 双方失敗で fail-closed REJECT（silent PASS 排除）。AC2: REJECT path で red-only label PR の follow-up Issue を idempotent に自動起票"
 
   merge-gate-check-merge-override-block:
     type: script
     path: scripts/merge-gate-check-merge-override-block.sh
-    description: "Pilot 手動 merge bypass の block (Issue #1613 不変条件 R): merge-gate.json が FAIL 状態で gh pr merge を block。TWL_MERGE_GATE_OVERRIDE 設定時のみ通過し audit log に記録"
+    description: "Pilot 手動 merge bypass の block (Issue #1613 不変条件 R): merge-gate.json が FAIL 状態で gh pr merge を block。TWL_MERGE_GATE_OVERRIDE 設定時のみ通過し audit log に記録。Issue #1626 で pre-bash-merge-gate-block.sh hook が PreToolUse 経由で同等機能を実装したため CLI 専用 fallback として残置"
 
   red-only-followup-create:
     type: script
     path: scripts/red-only-followup-create.sh
-    description: "RED-only PR merge 後 follow-up Issue 自動起票 (Issue #1613 AC3): merge-gate REJECT + red-only label 付き PR で gh issue create --draft を実行し test 滞留を防止"
+    description: "RED-only PR merge 後 follow-up Issue 自動起票 (Issue #1613 AC3): merge-gate REJECT + red-only label 付き PR で gh issue create --draft を実行し test 滞留を防止。Issue #1626 AC1.4: body template に '<!-- follow-up-for: PR #N -->' marker を含み、worker-red-only-detector の AND 条件検索で利用される"
 
   issue-create-refined:
     type: script

--- a/plugins/twl/refs/ref-invariants.md
+++ b/plugins/twl/refs/ref-invariants.md
@@ -285,6 +285,43 @@ twill autopilot システムの不変条件 A-N（14 件）の正典定義。各
 
 ---
 
+## 不変条件 S: RED-only label-based bypass の構造的閉塞 (#1626)
+
+**目的**: `red-only` ラベルの付与だけで `worker-red-only-detector` の WARNING 降格 + merge-gate 通過を実現する escape hatch を機械強制で閉塞する。Wave 90/91/92 連続 4 件の RED-only merge 事故 (PR #1608/#1616/#1617/#1623) において、不変条件 R 実装後も「label 付与 → WARNING 降格 → label 付き = 正規 RED PR とみなして merge」の構造的バイパス経路が残存していたため、follow-up Issue 存在の AND 条件 + PreToolUse hook + Layer 1 fail-closed の三層 defense-in-depth で閉塞する。
+
+**制約**:
+- `red-only` ラベル付き PR で変更ファイルが test のみの場合、`worker-red-only-detector.sh` は follow-up Issue (`<!-- follow-up-for: PR #N -->` marker 付き body を持つ Issue) の存在を **AND 条件**として検証する (MUST)
+  - follow-up 存在 → severity = **WARNING** (TDD RED phase 正規 path、merge 可)
+  - follow-up 不在 → severity = **CRITICAL 昇格** (escape hatch 閉鎖、confidence 90、merge block)
+  - gh 失敗 / PR_NUMBER 不明 → graceful skip (WARNING 維持、既存テスト互換)
+- `merge-gate-check-red-only.sh` は変更ファイルリスト取得失敗時に `gh pr view --json files` で fallback を試み、双方失敗時は **fail-closed REJECT** を返す (MUST)。silent PASS (exit 0) は禁止
+- `red-only-followup-create.sh` が生成する follow-up Issue の body には `<!-- follow-up-for: PR #N -->` marker を必ず含む (MUST)。ローカルフィルタ検索で識別可能な唯一の根拠
+- merge-gate REJECT 時かつ red-only ラベル付き PR は follow-up Issue を自動起票する (SHOULD)。idempotent: marker 存在確認で重複起票を防ぐ
+- `pre-bash-merge-gate-block.sh` PreToolUse hook が `gh pr merge` / `auto-merge.sh` 実行時に merge-gate.json status を verify する (MUST)。auto-merge.sh 経由も含む一律 block (Pilot/main session の bypass を防ぐ)
+
+**違反検知**:
+- `plugins/twl/scripts/worker-red-only-detector.sh`: follow-up 不在時に CRITICAL を出力 (severity 昇格)
+- `plugins/twl/scripts/merge-gate-check-red-only.sh`: REJECT path で `red-only-followup-create.sh` を idempotent invoke + Layer 1 fail-closed (`gh pr view` fallback)
+- `plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh`: `gh pr merge` / `auto-merge.sh` 実行時に merge-gate FAIL を検出して `permissionDecision=deny` を返す (PreToolUse hook 経由)
+- bats: `int-1626-followup-verify-and-condition.bats` (5 test) / `int-1626-followup-auto-create-on-reject.bats` (4 test) / `int-1626-pre-bash-hook-blocks-gh-pr-merge.bats` (8 test) / `int-1626-layer1-fail-closed-on-fetch-failure.bats` (5 test) / `int-1626-warning-fix-cannot-add-red-only-label.bats` (3 test)
+
+**根拠**: Issue #1626 explore-summary (`.explore/1626/summary.md`、363 行) — 不変条件 R で実装された 5 layer defense-in-depth の構造的不完全部分 (AC1/AC3 production flow 統合不在 + AC2 escape hatch + Layer 1 fail-open) を、TDD RED phase の正規利用を維持しつつ機械強制で閉塞する。lesson 28 (ADR-038): 「Worker self-discipline + SKILL prompt 警告では構造的 fix 不可、機械強制 (chain-runner + auto-merge + hook) の多層防御が必須」(Wave 90/91/92 で実証)
+
+**検証方法**: bats `int-1626-*.bats` (5 ファイル、25 test、本 Issue で追加)、`ac-scaffold-tests-1613.bats` 14/14 GREEN regression 維持
+
+**影響範囲**:
+  - `plugins/twl/scripts/worker-red-only-detector.sh` (AC1 follow-up AND 条件)
+  - `plugins/twl/scripts/merge-gate-check-red-only.sh` (AC2 followup auto-invoke + AC4 fail-closed)
+  - `plugins/twl/scripts/red-only-followup-create.sh` (AC1.4 marker 追加)
+  - `plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh` (AC3 新設 hook)
+  - `plugins/twl/agents/worker-red-only-detector.md` (AC1.5 出力スキーマ更新)
+  - `.claude/settings.json` (AC3.8 hook 登録)
+  - `plugins/twl/architecture/decisions/ADR-038-lesson-28-red-only-label-bypass-closure.md` (lesson 永続文書化)
+
+**対象外**: GitHub Web UI / `gh api graphql` 直接呼び出しの block (本 Issue scope 外、別 Issue で branch protection rule で対応)
+
+---
+
 ## SU-* との境界
 
 SU-1〜SU-9 は Supervisor（su-observer）固有の application-level 制約であり、本ドキュメントの不変条件 A-N とは独立した体系である。SU-* の正典は [`architecture/domain/contexts/supervision.md`](../architecture/domain/contexts/supervision.md)（SSoT）。運用 mirror は [`skills/su-observer/refs/su-observer-constraints.md`](../skills/su-observer/refs/su-observer-constraints.md) を参照。Security gate (Layer A-D) 定義は [`skills/su-observer/refs/su-observer-security-gate.md`](../skills/su-observer/refs/su-observer-security-gate.md) を参照。

--- a/plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# PreToolUse hook: merge-gate FAIL 状態で gh pr merge / auto-merge.sh を block (Issue #1626 AC3)
+#
+# 動作:
+#   1. tool_name が "Bash" 以外 → no-op (exit 0)
+#   2. command に gh pr merge または auto-merge.sh を含まない → no-op (exit 0)
+#   3. 以下の condition で allow / deny を判定:
+#
+#   [allow path]
+#   a. command に TWL_MERGE_GATE_OVERRIDE='<理由>' プレフィックスがある
+#      → audit log に記録して通過 (stall recovery のみ許可、不変条件 R)
+#   b. merge-gate.json 不在 → graceful passthrough (gate 未実行ケース、非 autopilot PR)
+#   c. merge-gate.json status != FAIL → 通過
+#
+#   [deny path]
+#   - merge-gate.json status=FAIL かつ override 未設定 → deny + actionable message
+#
+# 既存 pre-bash-merge-guard.sh との関係:
+#   - merge-guard: Worker からの merge を AUTOPILOT_DIR 設定時に block (Pilot/main は素通り)
+#   - merge-gate-block (本 hook): Pilot/main session からの merge も merge-gate verify
+#   - 両者は AND 評価 (hooks 配列を順次評価) なので相互補完
+
+set -uo pipefail
+
+payload=$(cat 2>/dev/null || echo "")
+
+# JSON パース失敗 → no-op
+if ! printf '%s' "$payload" | jq empty 2>/dev/null; then
+  exit 0
+fi
+
+# Bash tool 以外 → no-op
+tool_name=$(printf '%s' "$payload" | jq -r '.tool_name // empty')
+if [[ "$tool_name" != "Bash" ]]; then
+  exit 0
+fi
+
+CMD=$(printf '%s' "$payload" | jq -r '.tool_input.command // empty')
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# gh pr merge または auto-merge.sh にマッチしない → no-op
+if ! printf '%s' "$CMD" | grep -qE '(gh[[:space:]]+pr[[:space:]]+merge|auto-merge\.sh)'; then
+  exit 0
+fi
+
+LOG_FILE="/tmp/merge-gate-block.log"
+log_event() {
+  printf '[%s] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*" >> "$LOG_FILE" 2>/dev/null || true
+}
+
+# autopilot dir 解決:
+#   1. AUTOPILOT_DIR env (Worker session)
+#   2. <git-common-dir>/../main/.autopilot (Pilot session、main worktree の autopilot を参照)
+#   3. .autopilot (CWD 相対デフォルト)
+_resolve_autopilot_dir() {
+  if [[ -n "${AUTOPILOT_DIR:-}" ]]; then
+    echo "$AUTOPILOT_DIR"
+    return
+  fi
+  local common_dir
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null || echo "")
+  if [[ -n "$common_dir" && -d "${common_dir}/../main/.autopilot" ]]; then
+    echo "${common_dir}/../main/.autopilot"
+    return
+  fi
+  echo ".autopilot"
+}
+
+AUTOPILOT_DIR_RESOLVED=$(_resolve_autopilot_dir)
+MG_JSON="${AUTOPILOT_DIR_RESOLVED}/checkpoints/merge-gate.json"
+
+# (b) merge-gate.json 不在 → graceful passthrough (gate 未実行 PR / 非 autopilot PR)
+if [[ ! -f "$MG_JSON" ]]; then
+  log_event "ALLOW merge-gate.json not found path=${MG_JSON}"
+  exit 0
+fi
+
+# status 取得 (jq があれば優先、無ければ grep フォールバック)
+mg_status=""
+if command -v jq >/dev/null 2>&1; then
+  mg_status=$(jq -r '.status // empty' "$MG_JSON" 2>/dev/null || echo "")
+else
+  mg_status=$(grep -oE '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$MG_JSON" 2>/dev/null \
+    | sed -E 's/.*"status"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/' \
+    | head -n1)
+fi
+
+# (c) FAIL 以外 → 通過
+if [[ "$mg_status" != "FAIL" ]]; then
+  log_event "ALLOW status=${mg_status}"
+  exit 0
+fi
+
+# (a) TWL_MERGE_GATE_OVERRIDE が command 文字列に含まれる → 通過 + audit log
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])TWL_MERGE_GATE_OVERRIDE='; then
+  REASON=$(printf '%s' "$CMD" | grep -oP "TWL_MERGE_GATE_OVERRIDE='[^']+'" | head -1 | sed "s/TWL_MERGE_GATE_OVERRIDE='//;s/'$//" 2>/dev/null \
+    || printf '%s' "$CMD" | grep -oP 'TWL_MERGE_GATE_OVERRIDE="[^"]+"' | head -1 | sed 's/TWL_MERGE_GATE_OVERRIDE="//;s/"$//' 2>/dev/null \
+    || echo "unspecified")
+  AUDIT_LOG="${AUTOPILOT_DIR_RESOLVED}/merge-override-audit.log"
+  mkdir -p "$(dirname "$AUDIT_LOG")" 2>/dev/null || true
+  ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  user="${USER:-$(id -un 2>/dev/null || echo unknown)}"
+  printf '%s\tuser=%s\treason=%s\tmerge_gate=%s\n' \
+    "$ts" "$user" "$REASON" "$MG_JSON" >> "$AUDIT_LOG" 2>/dev/null || true
+  log_event "OVERRIDE user=${user} reason=${REASON}"
+  exit 0
+fi
+
+# (deny path)
+log_event "DENY status=${mg_status} cmd_hash=$(printf '%s' "$CMD" | sha256sum | head -c8)"
+DENY_MSG="merge-gate FAIL 状態のため gh pr merge / auto-merge.sh の実行を block します。
+
+merge-gate.json: ${MG_JSON}
+status: ${mg_status}
+
+【正規の手順】
+  1. merge-gate REJECT 原因 (specialist findings) を fix
+  2. autopilot で再 merge-gate を走らせる
+  3. status=PASS / WARN になってから merge
+
+【緊急時 override】 (stall recovery のみ、不変条件 R)
+  TWL_MERGE_GATE_OVERRIDE='<理由>' を command プレフィックスに付けてください。
+  override は ${AUTOPILOT_DIR_RESOLVED}/merge-override-audit.log に記録されます。
+  content-REJECT override は不変条件 R により禁止されています。
+
+詳細: 不変条件 R / S / Issue #1626"
+
+jq -nc --arg reason "$DENY_MSG" \
+  '{hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:$reason}}'
+exit 0

--- a/plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh
+++ b/plugins/twl/scripts/hooks/pre-bash-merge-gate-block.sh
@@ -51,12 +51,18 @@ log_event() {
 }
 
 # autopilot dir 解決:
-#   1. AUTOPILOT_DIR env (Worker session)
-#   2. <git-common-dir>/../main/.autopilot (Pilot session、main worktree の autopilot を参照)
-#   3. .autopilot (CWD 相対デフォルト)
+#   1. AUTOPILOT_DIR env (Worker session、bats common_setup で export される変数名)
+#   2. AUTOPILOT_DIR_ENV env (merge-gate-check-merge-override-block.sh と同一の既存変数名互換)
+#   3. <git-common-dir>/../main/.autopilot (Pilot session、main worktree の autopilot を参照)
+#   4. AUTOPILOT_DIR_DEFAULT (merge-gate-check-merge-override-block.sh と同一)
+#   5. .autopilot (CWD 相対デフォルト)
 _resolve_autopilot_dir() {
   if [[ -n "${AUTOPILOT_DIR:-}" ]]; then
     echo "$AUTOPILOT_DIR"
+    return
+  fi
+  if [[ -n "${AUTOPILOT_DIR_ENV:-}" ]]; then
+    echo "$AUTOPILOT_DIR_ENV"
     return
   fi
   local common_dir
@@ -65,7 +71,7 @@ _resolve_autopilot_dir() {
     echo "${common_dir}/../main/.autopilot"
     return
   fi
-  echo ".autopilot"
+  echo "${AUTOPILOT_DIR_DEFAULT:-.autopilot}"
 }
 
 AUTOPILOT_DIR_RESOLVED=$(_resolve_autopilot_dir)
@@ -93,8 +99,11 @@ if [[ "$mg_status" != "FAIL" ]]; then
   exit 0
 fi
 
-# (a) TWL_MERGE_GATE_OVERRIDE が command 文字列に含まれる → 通過 + audit log
-if printf '%s' "$CMD" | grep -qE '(^|[[:space:]])TWL_MERGE_GATE_OVERRIDE='; then
+# (a) TWL_MERGE_GATE_OVERRIDE が command の env var prefix chain に含まれる → 通過 + audit log
+# strict regex: command 先頭から、env var prefix (KEY=VALUE / KEY='...' / KEY="...") を 0 個以上経由した
+# 直後に TWL_MERGE_GATE_OVERRIDE= がある場合のみマッチ。
+# false positive 防止: `echo TWL_MERGE_GATE_OVERRIDE=...` のような quoted argument は match しない
+if printf '%s' "$CMD" | grep -qE "^([[:space:]]*[A-Za-z_][A-Za-z0-9_]*=([^[:space:]]+|'[^']*'|\"[^\"]*\")[[:space:]]+)*TWL_MERGE_GATE_OVERRIDE="; then
   REASON=$(printf '%s' "$CMD" | grep -oP "TWL_MERGE_GATE_OVERRIDE='[^']+'" | head -1 | sed "s/TWL_MERGE_GATE_OVERRIDE='//;s/'$//" 2>/dev/null \
     || printf '%s' "$CMD" | grep -oP 'TWL_MERGE_GATE_OVERRIDE="[^"]+"' | head -1 | sed 's/TWL_MERGE_GATE_OVERRIDE="//;s/"$//' 2>/dev/null \
     || echo "unspecified")

--- a/plugins/twl/scripts/merge-gate-check-red-only.sh
+++ b/plugins/twl/scripts/merge-gate-check-red-only.sh
@@ -75,17 +75,25 @@ if [[ "$has_impl_file" == "false" ]]; then
   if [[ -n "$_pr_number" && "$_has_red_only_label" == "true" ]]; then
     # follow-up Issue 存在チェック（idempotent guard）
     # ローカルフィルタ方式（HTML コメントは GitHub search のデフォルト検索対象外のため）
+    # --limit 200: gh issue list のデフォルトは 30 件。30 件超で false absence を防ぐ
     _marker="<!-- follow-up-for: PR #${_pr_number} -->"
-    _existing=$(gh issue list --state all --json number,body 2>/dev/null \
-      | jq --arg m "$_marker" \
-          '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null || echo "0")
+    _issues_json=$(gh issue list --state all --limit 200 --json number,body 2>/dev/null || echo "")
+    if [[ -n "$_issues_json" ]]; then
+      _existing=$(printf '%s' "$_issues_json" \
+        | jq --arg m "$_marker" \
+            '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null || echo "")
+    else
+      _existing=""
+    fi
 
-    if [[ "${_existing:-0}" -eq 0 ]]; then
+    # _existing が空 (gh / jq 失敗) または 0 → 起票試行（idempotent: 失敗時は warn のみ）
+    if [[ -z "$_existing" || "${_existing:-0}" -eq 0 ]]; then
       _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      # follow-up-create の出力を audit trail として stderr に集約
       bash "${_script_dir}/red-only-followup-create.sh" \
         --pr-number "$_pr_number" \
         --merge-gate-result REJECTED \
-        --labels "red-only-followup" >&2 2>&1 || \
+        --labels "red-only-followup" >&2 || \
         echo "WARN: follow-up Issue 起票失敗（手動起票が必要）" >&2
     else
       echo "INFO: follow-up Issue 起票済み（idempotent skip）" >&2

--- a/plugins/twl/scripts/merge-gate-check-red-only.sh
+++ b/plugins/twl/scripts/merge-gate-check-red-only.sh
@@ -3,16 +3,36 @@
 #
 # PR の変更ファイルがテストファイルのみ（実装ファイルなし）の場合を検出して REJECT する。
 # Issue #1476: PR #1470 が test のみで実装欠落のまま merge された問題の再発防止。
+# Issue #1626 AC4: git diff 失敗時 gh pr view fallback + 双方失敗で fail-closed REJECT。
+# Issue #1626 AC2: REJECT path で red-only label PR の follow-up Issue を自動起票（idempotent）。
 #
 # 呼び出し: bash "${CLAUDE_PLUGIN_ROOT}/scripts/merge-gate-check-red-only.sh"
 
-set -euo pipefail
+set -uo pipefail
 
-# 変更ファイルリストを取得
-CHANGED_FILES=$(git diff --name-only origin/main 2>/dev/null || git diff --name-only HEAD 2>/dev/null || true)
+# 変更ファイルリストを取得（fail-closed 二段式: git diff → gh pr view fallback）
+CHANGED_FILES=""
 
+# Primary: git diff --name-only origin/main → HEAD fallback
+if _files=$(git diff --name-only origin/main 2>/dev/null) && [[ -n "$_files" ]]; then
+  CHANGED_FILES="$_files"
+elif _files=$(git diff --name-only HEAD 2>/dev/null) && [[ -n "$_files" ]]; then
+  CHANGED_FILES="$_files"
+fi
+
+# Fallback: gh pr view --json files (PR コンテキストがある場合のみ)
+# AC4: git diff が空 (fetch 不全 / origin ref 不在) の場合に gh API で再試行
 if [[ -z "$CHANGED_FILES" ]]; then
-  exit 0
+  if _files=$(gh pr view --json files -q '.files[].path' 2>/dev/null) && [[ -n "$_files" ]]; then
+    CHANGED_FILES="$_files"
+  fi
+fi
+
+# AC4: 双方失敗 → fail-closed REJECT (silent PASS を排除)
+if [[ -z "$CHANGED_FILES" ]]; then
+  echo "REJECT: 変更ファイル取得不能 (git diff + gh pr view 双方 fail) — fail-closed" >&2
+  echo "  fail-closed: RED-only 検出不能のため merge を block します" >&2
+  exit 1
 fi
 
 # テストファイルパターン判定
@@ -45,6 +65,33 @@ if [[ "$has_impl_file" == "false" ]]; then
   echo "REJECT: RED-only PR を検出しました。変更ファイルがテストファイルのみで実装ファイルが含まれていません" >&2
   echo "変更ファイル:" >&2
   echo "$CHANGED_FILES" | sed 's/^/  /' >&2
+
+  # AC2: red-only label 付き PR で follow-up Issue が不在なら自動起票（idempotent guard 付き）
+  # PR 番号と label を gh pr view で取得（失敗時は起票スキップ、REJECT 自体は確実に exit 1）
+  _pr_number=$(gh pr view --json number -q '.number' 2>/dev/null || echo "")
+  _has_red_only_label=$(gh pr view --json labels \
+    -q '[.labels[]?.name] | map(select(. == "red-only")) | length > 0' 2>/dev/null || echo "false")
+
+  if [[ -n "$_pr_number" && "$_has_red_only_label" == "true" ]]; then
+    # follow-up Issue 存在チェック（idempotent guard）
+    # ローカルフィルタ方式（HTML コメントは GitHub search のデフォルト検索対象外のため）
+    _marker="<!-- follow-up-for: PR #${_pr_number} -->"
+    _existing=$(gh issue list --state all --json number,body 2>/dev/null \
+      | jq --arg m "$_marker" \
+          '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null || echo "0")
+
+    if [[ "${_existing:-0}" -eq 0 ]]; then
+      _script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+      bash "${_script_dir}/red-only-followup-create.sh" \
+        --pr-number "$_pr_number" \
+        --merge-gate-result REJECTED \
+        --labels "red-only-followup" >&2 2>&1 || \
+        echo "WARN: follow-up Issue 起票失敗（手動起票が必要）" >&2
+    else
+      echo "INFO: follow-up Issue 起票済み（idempotent skip）" >&2
+    fi
+  fi
+
   exit 1
 fi
 

--- a/plugins/twl/scripts/red-only-followup-create.sh
+++ b/plugins/twl/scripts/red-only-followup-create.sh
@@ -66,6 +66,8 @@ if [[ -n "$BODY_FILE" && -f "$BODY_FILE" ]]; then
 else
   TMP_BODY=$(mktemp)
   cat > "$TMP_BODY" <<EOF
+<!-- follow-up-for: PR #${PR_NUMBER} -->
+
 ## 概要
 
 PR #${PR_NUMBER} は RED-only test PR として merge されました。

--- a/plugins/twl/scripts/worker-red-only-detector.sh
+++ b/plugins/twl/scripts/worker-red-only-detector.sh
@@ -68,20 +68,24 @@ _is_test_file() {
 #   <!-- follow-up-for: PR #${pr_num} --> marker を body に含む Issue を検索する。
 #   GitHub search のデフォルトでは HTML コメントが index されないため、
 #   gh issue list の結果を jq でローカルフィルタする。
-# 返値: 0 = follow-up 存在, 1 = 不在, 2 = gh 失敗 (graceful skip)
+# 返値: 0 = follow-up 存在, 1 = 不在, 2 = gh / jq 失敗 (graceful skip)
 _check_followup_issue() {
   local pr_num="$1"
   [[ -z "$pr_num" ]] && return 2
   local marker="<!-- follow-up-for: PR #${pr_num} -->"
   local issues_json
-  if ! issues_json=$(gh issue list --state all --json number,body 2>/dev/null); then
+  # --limit 200: gh issue list のデフォルトは 30 件。30 件超で false absence を防ぐ
+  if ! issues_json=$(gh issue list --state all --limit 200 --json number,body 2>/dev/null); then
     return 2
   fi
   local count
-  count=$(printf '%s' "$issues_json" \
-    | jq --arg m "$marker" \
-        '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null \
-    || echo "0")
+  # jq 失敗 (非 JSON 入力 / rate limit text 返却 等) → graceful skip
+  if ! count=$(printf '%s' "$issues_json" \
+      | jq --arg m "$marker" \
+          '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null); then
+    return 2
+  fi
+  [[ -z "$count" ]] && return 2
   if [[ "${count:-0}" -gt 0 ]]; then
     return 0
   fi

--- a/plugins/twl/scripts/worker-red-only-detector.sh
+++ b/plugins/twl/scripts/worker-red-only-detector.sh
@@ -3,11 +3,13 @@
 #
 # PR JSON を受け取り、変更ファイルがテストファイルのみで実装ファイルがない場合に CRITICAL を出力する。
 # Issue #1482 AC2/AC5 の検出ロジックを bash で実装。
+# Issue #1626 AC1: red-only label 付き PR で follow-up Issue 存在の AND 条件を機械強制。
+#                   不在なら WARNING → CRITICAL 昇格 (escape hatch 完全閉鎖)。
 #
-# Usage: bash worker-red-only-detector.sh --pr-json '{"labels":[],"files":[...]}'
-# Exit: 0（常に成功、CRITICAL は stdout に出力）
+# Usage: bash worker-red-only-detector.sh --pr-json '{"labels":[],"files":[...],"number":N}'
+# Exit: 0（常に成功、CRITICAL/WARNING は stdout に出力）
 
-set -euo pipefail
+set -uo pipefail
 
 PR_JSON=""
 
@@ -35,6 +37,9 @@ fi
 # label が付いていても WARNING を発行し follow-up Issue の存在を verify する責務を残す。
 has_red_only_label=$(echo "$PR_JSON" | jq -r '[.labels[]?.name] | map(select(. == "red-only")) | length > 0')
 
+# PR 番号取得 (Issue #1626 AC1: follow-up Issue 検索の引数)
+PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number // empty')
+
 # ファイルリスト取得
 mapfile -t FILE_PATHS < <(echo "$PR_JSON" | jq -r '.files[]?.path // empty')
 
@@ -59,6 +64,30 @@ _is_test_file() {
   return 1
 }
 
+# AC1: follow-up Issue 存在チェック (ローカルフィルタ方式)
+#   <!-- follow-up-for: PR #${pr_num} --> marker を body に含む Issue を検索する。
+#   GitHub search のデフォルトでは HTML コメントが index されないため、
+#   gh issue list の結果を jq でローカルフィルタする。
+# 返値: 0 = follow-up 存在, 1 = 不在, 2 = gh 失敗 (graceful skip)
+_check_followup_issue() {
+  local pr_num="$1"
+  [[ -z "$pr_num" ]] && return 2
+  local marker="<!-- follow-up-for: PR #${pr_num} -->"
+  local issues_json
+  if ! issues_json=$(gh issue list --state all --json number,body 2>/dev/null); then
+    return 2
+  fi
+  local count
+  count=$(printf '%s' "$issues_json" \
+    | jq --arg m "$marker" \
+        '[.[] | select(.body != null and (.body | contains($m)))] | length' 2>/dev/null \
+    || echo "0")
+  if [[ "${count:-0}" -gt 0 ]]; then
+    return 0
+  fi
+  return 1
+}
+
 # impl-candidate ファイルが存在するか確認
 has_impl_file=false
 for file in "${FILE_PATHS[@]}"; do
@@ -70,11 +99,33 @@ done
 
 if [[ "$has_impl_file" == "false" ]]; then
   if [[ "$has_red_only_label" == "true" ]]; then
-    # Issue #1613 AC2: red-only label 付き RED-only PR は WARNING に降格し、
-    # follow-up Issue（実装 PR）の存在 verify を要求する。
+    # AC1: follow-up Issue AND 条件で WARNING/CRITICAL を判定
+    # - follow-up 存在 → WARNING 維持 (TDD RED phase の正規 path)
+    # - follow-up 不在 → CRITICAL 昇格 (escape hatch 閉鎖)
+    # - gh 失敗 / PR_NUMBER 不明 → WARNING 維持 (graceful skip)
+    _followup_status=2  # default: skip
+    if [[ -n "$PR_NUMBER" ]]; then
+      _check_followup_issue "$PR_NUMBER"
+      _followup_status=$?
+    fi
+
+    if [[ $_followup_status -eq 1 ]]; then
+      # follow-up 不在: CRITICAL 昇格
+      echo "CRITICAL: RED-only PR を検出しました（red-only label 付き、follow-up Issue 不在、confidence: 90）"
+      echo "変更ファイルに実装ファイルが含まれていません。"
+      echo "follow-up Issue（GREEN 実装 PR）が存在しないため merge を block します。"
+      echo "scripts/red-only-followup-create.sh --pr-number ${PR_NUMBER} で起票してください。"
+      exit 0
+    fi
+
+    # follow-up 存在 (status=0) または graceful skip (status=2) → WARNING
     echo "WARNING: RED-only PR を検出しました（red-only label 付き、confidence: 85）"
     echo "変更ファイルに実装ファイルが含まれていません。"
-    echo "follow-up Issue（GREEN 実装 PR）の存在を verify してください — 不在なら scripts/red-only-followup-create.sh で起票。"
+    if [[ $_followup_status -eq 0 ]]; then
+      echo "follow-up Issue（GREEN 実装 PR）の存在を確認しました。"
+    else
+      echo "follow-up Issue（GREEN 実装 PR）の存在を verify してください — 不在なら scripts/red-only-followup-create.sh で起票。"
+    fi
     exit 0
   fi
   echo "CRITICAL: RED-only PR を検出しました（confidence: 85）"

--- a/plugins/twl/tests/bats/int-1626-followup-auto-create-on-reject.bats
+++ b/plugins/twl/tests/bats/int-1626-followup-auto-create-on-reject.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# int-1626-followup-auto-create-on-reject.bats
+#
+# Issue #1626 AC2.5 — REJECT path から follow-up Issue 自動起票の integration test
+#
+# AC2: merge-gate-check-red-only.sh の REJECT path で red-only label 付き PR の
+#      follow-up Issue を `red-only-followup-create.sh` 経由で自動起票する。
+#      idempotent: 既存の `<!-- follow-up-for: PR #N -->` marker 付き Issue があれば skip。
+#
+# 検証シナリオ:
+#   1. red-only label 付き + follow-up 不在 → red-only-followup-create.sh が呼ばれる
+#   2. red-only label 付き + follow-up 存在 → 起票しない（idempotent）
+#   3. red-only label なし → 起票しない
+#   4. gh pr view 失敗でも REJECT は確実に exit 1
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+  # gh stub のログ取り先
+  export GH_CALL_LOG="${SANDBOX}/gh-calls.log"
+  export FOLLOWUP_INVOKED_LOG="${SANDBOX}/followup-invoked.log"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Helper: red-only-followup-create.sh を SANDBOX 内で stub に差し替える
+# ===========================================================================
+_stub_followup_create() {
+  cat > "${SANDBOX}/scripts/red-only-followup-create.sh" <<STUB_EOF
+#!/usr/bin/env bash
+echo "INVOKED: \$*" >> "${FOLLOWUP_INVOKED_LOG}"
+exit 0
+STUB_EOF
+  chmod +x "${SANDBOX}/scripts/red-only-followup-create.sh"
+}
+
+# ===========================================================================
+# AC2.5-a: red-only label + follow-up 不在 → followup-create が呼ばれる
+# ===========================================================================
+
+@test "ac2.5a: red-only label + follow-up 不在 → red-only-followup-create.sh が呼ばれる" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # SANDBOX 内のスクリプトを書き換え可能にコピー（既に common_setup でコピー済み）
+  _stub_followup_create
+
+  # git: test ファイルのみを返す（RED-only 状態）
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *) exit 0 ;;
+esac'
+
+  # gh: PR 番号 42、red-only label、follow-up Issue list は空配列
+  stub_command "gh" "
+case \"\$*\" in
+  *\"pr view\"*\"number\"*) echo '42' ;;
+  *\"pr view\"*\"labels\"*) echo 'true' ;;
+  *\"issue list\"*) echo '[]' ;;
+  *) echo \"\$*\" >> '${GH_CALL_LOG}' ;;
+esac"
+
+  # SANDBOX のスクリプトを実行
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure  # RED-only → REJECT exit 1
+
+  # red-only-followup-create.sh が呼ばれたことを確認
+  [ -f "$FOLLOWUP_INVOKED_LOG" ]
+  run grep -qF -- '--pr-number 42' "$FOLLOWUP_INVOKED_LOG"
+  assert_success
+  run grep -qF -- '--merge-gate-result REJECTED' "$FOLLOWUP_INVOKED_LOG"
+  assert_success
+}
+
+# ===========================================================================
+# AC2.5-b: red-only label + follow-up 存在 → 起票スキップ（idempotent）
+# ===========================================================================
+
+@test "ac2.5b: red-only label + follow-up 存在 → 起票しない（idempotent）" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  _stub_followup_create
+
+  # git: test ファイルのみ
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *) exit 0 ;;
+esac'
+
+  # gh: PR 番号 99、red-only label、follow-up Issue は marker 付きで存在
+  stub_command "gh" '
+case "$*" in
+  *"pr view"*"number"*) echo "99" ;;
+  *"pr view"*"labels"*) echo "true" ;;
+  *"issue list"*)
+    cat <<JSON_EOF
+[{"number":888,"body":"<!-- follow-up-for: PR #99 -->\n\n本文..."}]
+JSON_EOF
+    ;;
+  *) ;;
+esac'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure  # REJECT は維持
+  assert_output --partial "idempotent skip"
+
+  # followup-create が呼ばれていないこと
+  if [[ -f "$FOLLOWUP_INVOKED_LOG" ]]; then
+    run grep -qF -- '--pr-number 99' "$FOLLOWUP_INVOKED_LOG"
+    assert_failure
+  fi
+}
+
+# ===========================================================================
+# AC2.5-c: red-only label なし → 起票しない
+# ===========================================================================
+
+@test "ac2.5c: red-only label なし → followup-create を呼ばない" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  _stub_followup_create
+
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *) exit 0 ;;
+esac'
+
+  # gh: red-only label が付いていない
+  stub_command "gh" '
+case "$*" in
+  *"pr view"*"number"*) echo "55" ;;
+  *"pr view"*"labels"*) echo "false" ;;
+  *"issue list"*) echo "[]" ;;
+  *) ;;
+esac'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure  # REJECT
+
+  # followup-create が呼ばれていないこと
+  [ ! -f "$FOLLOWUP_INVOKED_LOG" ] || ! grep -qF -- '--pr-number 55' "$FOLLOWUP_INVOKED_LOG"
+}
+
+# ===========================================================================
+# AC2.5-d: gh pr view 失敗でも REJECT は確実に exit 1
+# ===========================================================================
+
+@test "ac2.5d: gh pr view 失敗時も REJECT は確実に exit 1（followup 起票はスキップ）" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  _stub_followup_create
+
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *) exit 0 ;;
+esac'
+
+  # gh: 全ての呼び出しが exit 1
+  stub_command "gh" 'exit 1'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure  # REJECT は確実
+  assert_output --partial "REJECT: RED-only PR"
+
+  # followup-create は呼ばれていない（PR 番号取得失敗のため）
+  [ ! -f "$FOLLOWUP_INVOKED_LOG" ]
+}

--- a/plugins/twl/tests/bats/int-1626-followup-verify-and-condition.bats
+++ b/plugins/twl/tests/bats/int-1626-followup-verify-and-condition.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# int-1626-followup-verify-and-condition.bats
+#
+# Issue #1626 AC1.6 — follow-up Issue 機械的 verify (AND 条件) の integration test
+#
+# AC1: worker-red-only-detector.sh の red-only label 判定で follow-up Issue 存在を
+#      AND 条件として検証する。
+#      - red-only + follow-up 不在 → CRITICAL 昇格 (escape hatch 閉鎖)
+#      - red-only + follow-up 存在 → WARNING 維持 (TDD RED phase 正規 path)
+#      - gh 失敗 / PR_NUMBER 不明 → graceful skip → WARNING 維持
+#
+# 検証シナリオ:
+#   1. red-only label + PR_NUMBER + follow-up 不在 → CRITICAL 昇格
+#   2. red-only label + PR_NUMBER + follow-up 存在 → WARNING 維持
+#   3. red-only label + PR_NUMBER + gh 失敗 → WARNING 維持 (graceful)
+#   4. red-only label + PR_NUMBER 不明 → WARNING 維持 (graceful)
+#   5. red-only label なし + RED-only → CRITICAL (既存挙動)
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1.6-a: red-only + follow-up 不在 → CRITICAL 昇格
+# ===========================================================================
+
+@test "ac1.6a: red-only label + follow-up 不在 → CRITICAL 昇格 (escape hatch 閉鎖)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh issue list が空配列 = follow-up 不在
+  stub_command "gh" 'echo "[]"'
+
+  local pr_json='{"number":42,"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success  # exit 0 常時 (CRITICAL は stdout に出る)
+  assert_output --partial "CRITICAL"
+  assert_output --partial "follow-up Issue"
+  assert_output --partial "不在"
+  refute_output --partial "WARNING"
+}
+
+# ===========================================================================
+# AC1.6-b: red-only + follow-up 存在 → WARNING 維持
+# ===========================================================================
+
+@test "ac1.6b: red-only label + follow-up 存在 → WARNING 維持 (TDD 正規 path)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh issue list が marker 付き Issue を返す = follow-up 存在
+  stub_command "gh" '
+cat <<JSON_EOF
+[{"number":888,"body":"<!-- follow-up-for: PR #42 -->\n本文"}]
+JSON_EOF'
+
+  local pr_json='{"number":42,"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "WARNING"
+  assert_output --partial "存在を確認"
+  refute_output --partial "CRITICAL"
+}
+
+# ===========================================================================
+# AC1.6-c: red-only + gh 失敗 → graceful skip (WARNING 維持)
+# ===========================================================================
+
+@test "ac1.6c: red-only label + gh 失敗 → graceful skip (WARNING 維持)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh が exit 1 (認証失敗 / API エラー)
+  stub_command "gh" 'exit 1'
+
+  local pr_json='{"number":42,"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "WARNING"
+  assert_output --partial "follow-up"
+  assert_output --partial "verify"
+  refute_output --partial "CRITICAL"
+}
+
+# ===========================================================================
+# AC1.6-d: red-only + PR_NUMBER 不明 → graceful skip (WARNING 維持、既存テスト互換)
+# ===========================================================================
+
+@test "ac1.6d: red-only label + PR_NUMBER 不明 → graceful skip (既存テスト互換)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh stub なし → デフォルト挙動でも skip 動作（PR_NUMBER 不明で skip）
+  stub_command "gh" 'echo "[]"'
+
+  # number フィールドなし
+  local pr_json='{"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "WARNING"
+  refute_output --partial "CRITICAL"
+}
+
+# ===========================================================================
+# AC1.6-e: red-only label なし → CRITICAL (既存挙動、regression guard)
+# ===========================================================================
+
+@test "ac1.6e: red-only label なし + RED-only → CRITICAL (既存挙動、regression guard)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # gh は呼ばれないが念のため stub
+  stub_command "gh" 'echo "[]"'
+
+  local pr_json='{"number":42,"labels":[],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "CRITICAL"
+  refute_output --partial "WARNING"
+}

--- a/plugins/twl/tests/bats/int-1626-layer1-fail-closed-on-fetch-failure.bats
+++ b/plugins/twl/tests/bats/int-1626-layer1-fail-closed-on-fetch-failure.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+# int-1626-layer1-fail-closed-on-fetch-failure.bats
+#
+# Issue #1626 AC4.4 — Layer 1 fail-closed の integration test
+#
+# AC4: merge-gate-check-red-only.sh で `git diff --name-only origin/main` が
+#      失敗した場合に `gh pr view --json files` で fallback。双方失敗時は
+#      fail-closed REJECT (exit 1)。silent PASS (exit 0) は禁止。
+#
+# 検証シナリオ:
+#   1. git diff origin/main 失敗 + git diff HEAD 失敗 + gh pr view 失敗 → exit 1 (fail-closed)
+#   2. git diff origin/main 失敗 + gh pr view 成功（test ファイルのみ） → REJECT exit 1
+#   3. git diff origin/main 失敗 + gh pr view 成功（impl ファイル含む） → exit 0 (PASS)
+#   4. git diff origin/main 成功（impl ファイル含む） → exit 0 (PASS、fallback 不要)
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC4.4-a: 全 fetch 失敗 → fail-closed REJECT
+# ===========================================================================
+
+@test "ac4.4a: git diff + gh pr view 双方失敗 → fail-closed REJECT (exit 1)" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git diff も gh pr view も全て失敗（exit 1）
+  stub_command "git" 'exit 1'
+  stub_command "gh" 'exit 1'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure
+  assert_output --partial "fail-closed"
+  assert_output --partial "変更ファイル取得不能"
+}
+
+# ===========================================================================
+# AC4.4-b: git diff 失敗 + gh pr view 成功（test only） → REJECT
+# ===========================================================================
+
+@test "ac4.4b: git diff 失敗 + gh pr view fallback (test only) → REJECT" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git diff 全失敗
+  stub_command "git" 'exit 1'
+
+  # gh pr view --json files は test ファイルのみ返す
+  stub_command "gh" '
+case "$*" in
+  *"pr view"*"files"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *"pr view"*"number"*) echo "" ;;  # PR 番号取得失敗
+  *"pr view"*"labels"*) echo "false" ;;
+  *"issue list"*) echo "[]" ;;
+  *) exit 1 ;;
+esac'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure
+  assert_output --partial "REJECT: RED-only PR"
+}
+
+# ===========================================================================
+# AC4.4-c: git diff 失敗 + gh pr view 成功（impl 含む） → PASS
+# ===========================================================================
+
+@test "ac4.4c: git diff 失敗 + gh pr view fallback (impl 含む) → PASS exit 0" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  stub_command "git" 'exit 1'
+
+  # gh pr view が impl ファイルを含む変更ファイルリストを返す
+  stub_command "gh" '
+case "$*" in
+  *"pr view"*"files"*)
+    echo "plugins/twl/scripts/some-impl.sh"
+    echo "plugins/twl/tests/bats/sample.bats"
+    ;;
+  *) exit 1 ;;
+esac'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_success
+}
+
+# ===========================================================================
+# AC4.4-d: git diff 成功 (impl 含む) → PASS（fallback 不要）
+# ===========================================================================
+
+@test "ac4.4d: git diff 成功 (impl 含む) → PASS exit 0（fallback 不要）" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # git diff origin/main が impl ファイルを返す（gh は呼ばれないはず）
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*)
+    echo "plugins/twl/scripts/some-impl.sh"
+    ;;
+  *) exit 1 ;;
+esac'
+
+  # gh は呼ばれない想定だが念のため stub
+  stub_command "gh" 'exit 1'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_success
+}
+
+# ===========================================================================
+# AC4.4-e: git diff origin/main 失敗 + git diff HEAD 成功 → 通常 path
+# ===========================================================================
+
+@test "ac4.4e: git diff origin/main 失敗 + HEAD 成功 (test only) → REJECT" {
+  local script="${SCRIPTS_DIR}/merge-gate-check-red-only.sh"
+  [ -f "$script" ]
+
+  # origin/main は失敗、HEAD は成功
+  stub_command "git" '
+case "$*" in
+  *"diff"*"--name-only"*"origin/main"*) exit 1 ;;
+  *"diff"*"--name-only"*"HEAD"*) echo "plugins/twl/tests/bats/sample.bats" ;;
+  *) exit 1 ;;
+esac'
+
+  stub_command "gh" '
+case "$*" in
+  *"pr view"*"number"*) echo "" ;;
+  *) exit 1 ;;
+esac'
+
+  run bash "${SANDBOX}/scripts/merge-gate-check-red-only.sh"
+  assert_failure
+  assert_output --partial "REJECT: RED-only PR"
+}

--- a/plugins/twl/tests/bats/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
+++ b/plugins/twl/tests/bats/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
@@ -192,3 +192,36 @@ _make_merge_gate_json() {
   assert_success
   [ -z "$output" ]
 }
+
+# ===========================================================================
+# AC3.7-i: TWL_MERGE_GATE_OVERRIDE strict regex security test
+#   echo TWL_MERGE_GATE_OVERRIDE='r' gh pr merge ... の bypass 試行を block する
+# ===========================================================================
+
+@test "ac3.7i: echo TWL_MERGE_GATE_OVERRIDE=... による bypass 試行 → deny (strict regex)" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  # `echo` は env var prefix でないため strict regex で false → override 不認定 → deny
+  local payload
+  payload=$(_make_payload "echo TWL_MERGE_GATE_OVERRIDE='bypass' && gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  assert_output --partial '"permissionDecision":"deny"'
+}
+
+@test "ac3.7j: 複数 env var prefix chain (FOO=x BAR=y TWL_MERGE_GATE_OVERRIDE=z) → 通過" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  # 複数 env var を chain した場合も strict regex で正常認識
+  local payload
+  payload=$(_make_payload "FOO=x BAR='val' TWL_MERGE_GATE_OVERRIDE='multi-env' gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  refute_output --partial '"permissionDecision":"deny"'
+}

--- a/plugins/twl/tests/bats/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
+++ b/plugins/twl/tests/bats/int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# int-1626-pre-bash-hook-blocks-gh-pr-merge.bats
+#
+# Issue #1626 AC3.7 — PreToolUse hook で gh pr merge 強制 block の integration test
+#
+# AC3: pre-bash-merge-gate-block.sh が以下を行う:
+#   - tool_input.command が gh pr merge または auto-merge.sh にマッチ → 起動
+#   - merge-gate.json status=FAIL → deny (permissionDecision=deny)
+#   - merge-gate.json 不在 → graceful passthrough (gate 未実行 PR)
+#   - merge-gate.json status=PASS/WARN → 通過
+#   - TWL_MERGE_GATE_OVERRIDE='<理由>' 設定で通過 + audit log
+#
+# 検証シナリオ:
+#   1. gh pr merge + status=FAIL → deny JSON 出力
+#   2. auto-merge.sh + status=FAIL → deny JSON 出力 (一律 block)
+#   3. gh pr merge + TWL_MERGE_GATE_OVERRIDE → 通過 + audit log
+#   4. gh pr merge + merge-gate.json 不在 → graceful passthrough
+#   5. gh pr merge + status=PASS → 通過
+#   6. git status (無関係 command) → no-op
+
+load 'helpers/common'
+
+HOOKS_DIR=""
+
+setup() {
+  common_setup
+  HOOKS_DIR="${REPO_ROOT}/scripts/hooks"
+  # AUTOPILOT_DIR は common_setup で SANDBOX/.autopilot に設定済み
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# Helper: HookOutput JSON payload を生成
+# ===========================================================================
+_make_payload() {
+  local cmd="$1"
+  jq -nc --arg c "$cmd" \
+    '{tool_name:"Bash", tool_input:{command:$c}}'
+}
+
+# Helper: merge-gate.json を SANDBOX 配下に配置
+_make_merge_gate_json() {
+  local status="$1"
+  local mg_path="${AUTOPILOT_DIR}/checkpoints/merge-gate.json"
+  mkdir -p "$(dirname "$mg_path")"
+  printf '{"status":"%s","result":"REJECTED","critical_count":1,"findings":[]}\n' "$status" > "$mg_path"
+}
+
+# ===========================================================================
+# AC3.7-a: gh pr merge + status=FAIL → deny JSON
+# ===========================================================================
+
+@test "ac3.7a: gh pr merge + merge-gate FAIL → deny JSON 出力" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  local payload
+  payload=$(_make_payload "gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success  # hook 自体は exit 0 (deny は JSON で表現)
+  assert_output --partial '"permissionDecision":"deny"'
+  assert_output --partial 'merge-gate FAIL'
+}
+
+# ===========================================================================
+# AC3.7-b: auto-merge.sh + status=FAIL → deny JSON (一律 block)
+# ===========================================================================
+
+@test "ac3.7b: auto-merge.sh + merge-gate FAIL → deny JSON (一律 block)" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  local payload
+  payload=$(_make_payload "bash plugins/twl/scripts/auto-merge.sh --issue 42 --pr 123")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  assert_output --partial '"permissionDecision":"deny"'
+}
+
+# ===========================================================================
+# AC3.7-c: TWL_MERGE_GATE_OVERRIDE 付き → 通過 + audit log
+# ===========================================================================
+
+@test "ac3.7c: TWL_MERGE_GATE_OVERRIDE プレフィックス付き → 通過 + audit log 記録" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  local payload
+  payload=$(_make_payload "TWL_MERGE_GATE_OVERRIDE='stall-recovery: e2e timeout' gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  refute_output --partial '"permissionDecision":"deny"'
+
+  # audit log が記録されている
+  local audit_log="${AUTOPILOT_DIR}/merge-override-audit.log"
+  [ -f "$audit_log" ]
+  run grep -qF 'stall-recovery: e2e timeout' "$audit_log"
+  assert_success
+}
+
+# ===========================================================================
+# AC3.7-d: merge-gate.json 不在 → graceful passthrough
+# ===========================================================================
+
+@test "ac3.7d: merge-gate.json 不在 → graceful passthrough (no deny)" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  # merge-gate.json は作らない
+  local payload
+  payload=$(_make_payload "gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  refute_output --partial '"permissionDecision":"deny"'
+  [ -z "$output" ]  # 出力なし
+}
+
+# ===========================================================================
+# AC3.7-e: status=PASS → 通過
+# ===========================================================================
+
+@test "ac3.7e: merge-gate.json status=PASS → 通過 (no deny)" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "PASS"
+  local payload
+  payload=$(_make_payload "gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  refute_output --partial '"permissionDecision":"deny"'
+}
+
+# ===========================================================================
+# AC3.7-f: status=WARN → 通過
+# ===========================================================================
+
+@test "ac3.7f: merge-gate.json status=WARN → 通過 (no deny)" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "WARN"
+  local payload
+  payload=$(_make_payload "gh pr merge 123 --squash")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  refute_output --partial '"permissionDecision":"deny"'
+}
+
+# ===========================================================================
+# AC3.7-g: 無関係コマンド → no-op
+# ===========================================================================
+
+@test "ac3.7g: git status (無関係 command) → no-op" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"  # FAIL でも無関係コマンドは通過
+  local payload
+  payload=$(_make_payload "git status")
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  [ -z "$output" ]
+}
+
+# ===========================================================================
+# AC3.7-h: tool_name が Bash 以外 → no-op
+# ===========================================================================
+
+@test "ac3.7h: tool_name=Read → no-op" {
+  local hook="${HOOKS_DIR}/pre-bash-merge-gate-block.sh"
+  [ -f "$hook" ]
+
+  _make_merge_gate_json "FAIL"
+  local payload
+  payload=$(jq -nc '{tool_name:"Read", tool_input:{file_path:"/tmp/foo"}}')
+
+  run bash "$hook" <<< "$payload"
+  assert_success
+  [ -z "$output" ]
+}

--- a/plugins/twl/tests/bats/int-1626-warning-fix-cannot-add-red-only-label.bats
+++ b/plugins/twl/tests/bats/int-1626-warning-fix-cannot-add-red-only-label.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# int-1626-warning-fix-cannot-add-red-only-label.bats
+#
+# Issue #1626 AC5.3 — warning-fix label add escape hatch 閉鎖の regression test
+#
+# AC5: warning-fix Worker が `gh pr edit --add-label red-only` を実行して
+#      AC2 escape hatch を悪用しようとしても、AC1 の AND 条件 (follow-up Issue 不在) で
+#      再度 CRITICAL が発行される（label add だけでは escape できない）。
+#
+# 検証シナリオ:
+#   1. 初回: red-only label なし + RED-only → CRITICAL (既存)
+#   2. warning-fix Worker が red-only label を追加 (gh pr edit --add-label red-only)
+#   3. 再 merge-gate 実行: red-only label 付き + follow-up 不在 → AC1 で CRITICAL 維持
+#   4. follow-up Issue 起票後の再実行: red-only + follow-up 存在 → WARNING 降格
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+
+setup() {
+  common_setup
+  SCRIPTS_DIR="${REPO_ROOT}/scripts"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC5.3-a: 初回 (label なし) → CRITICAL
+# ===========================================================================
+
+@test "ac5.3a: 初回 RED-only PR (label なし) → CRITICAL (regression baseline)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  stub_command "gh" 'echo "[]"'
+
+  local pr_json='{"number":42,"labels":[],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "CRITICAL"
+}
+
+# ===========================================================================
+# AC5.3-b: warning-fix で label 付与 → AC1 で CRITICAL 維持 (escape 不能)
+# ===========================================================================
+
+@test "ac5.3b: warning-fix が red-only label add → AC1 で CRITICAL 維持 (escape 不能)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # warning-fix Worker が gh pr edit --add-label red-only 実行後を模擬
+  # PR JSON は label 付き、follow-up Issue は未起票のまま
+  stub_command "gh" 'echo "[]"'
+
+  local pr_json='{"number":42,"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  # AC1: follow-up 不在のため WARNING ではなく CRITICAL になる (escape hatch 閉鎖)
+  assert_output --partial "CRITICAL"
+  assert_output --partial "follow-up Issue"
+  refute_output --partial "WARNING"
+}
+
+# ===========================================================================
+# AC5.3-c: follow-up 起票後 → WARNING 降格 (TDD 正規 path)
+# ===========================================================================
+
+@test "ac5.3c: follow-up Issue 起票後の再実行 → WARNING 降格 (TDD 正規 path 復活)" {
+  local script="${SCRIPTS_DIR}/worker-red-only-detector.sh"
+  [ -f "$script" ]
+
+  # 起票済み follow-up Issue
+  stub_command "gh" '
+cat <<JSON_EOF
+[{"number":888,"body":"<!-- follow-up-for: PR #42 -->\n## 概要..."}]
+JSON_EOF'
+
+  local pr_json='{"number":42,"labels":[{"name":"red-only"}],"files":[{"path":"plugins/twl/tests/bats/sample.bats"}]}'
+  run bash "$script" --pr-json "$pr_json"
+  assert_success
+  assert_output --partial "WARNING"
+  assert_output --partial "存在を確認"
+  refute_output --partial "CRITICAL"
+}


### PR DESCRIPTION
Closes #1626

## 概要

merge-gate の **RED-only label-based bypass** 構造的閉塞。Wave 90/91/92 連続 4 件の RED-only merge 事故 (PR #1608/#1616/#1617/#1623) で実証された 4 つの構造的設計欠陥を、TDD RED phase の正規利用を維持しつつ機械強制で閉塞する。

3 層 defense-in-depth (B + C + D):
- **B**: follow-up Issue 機械的 verify (AC1, AC2, AC5) — `red-only` label + follow-up 不在で CRITICAL 昇格 (escape hatch 完全閉鎖)
- **C**: PreToolUse hook で `gh pr merge` / `auto-merge.sh` 強制 block (AC3) — `merge-gate.json` status=FAIL 時に deny
- **D**: Layer 1 fail-closed 化 (AC4) — `gh pr view` fallback + 双方失敗で REJECT (silent PASS 排除)

## AC 達成状況

| AC | 実装 | bats |
|---|---|---|
| AC1 follow-up AND 条件 (sh + md) | `worker-red-only-detector.sh` `_check_followup_issue` 関数追加 + md スキーマ 3 ケース化 | `int-1626-followup-verify-and-condition.bats` 5 test |
| AC1.4 marker 追加 | `red-only-followup-create.sh` body に `<!-- follow-up-for: PR #N -->` | (idempotent guard で利用) |
| AC2 REJECT path 自動起票 | `merge-gate-check-red-only.sh` で followup-create を idempotent invoke | `int-1626-followup-auto-create-on-reject.bats` 4 test |
| AC3 PreToolUse hook | `pre-bash-merge-gate-block.sh` 新設 + `.claude/settings.json` 登録 | `int-1626-pre-bash-hook-blocks-gh-pr-merge.bats` 10 test |
| AC4 Layer 1 fail-closed | `merge-gate-check-red-only.sh` で `gh pr view` fallback | `int-1626-layer1-fail-closed-on-fetch-failure.bats` 5 test |
| AC5 warning-fix regression | label add → CRITICAL 維持の AC1 実証 | `int-1626-warning-fix-cannot-add-red-only-label.bats` 3 test |
| AC6 不変条件 S | `plugins/twl/refs/ref-invariants.md` 追記 | (既存 invariant test と同形式) |
| AC7 lesson 28 永続化 | `plugins/twl/architecture/decisions/ADR-038-*.md` 新規 | (ADR-036 4-step Step 4) |

## bats 結果 (全 41 test GREEN)

```
1..27  int-1626-*.bats (5 ファイル新設)
1..14  ac-scaffold-tests-1613.bats (Issue #1613 既存、regression 維持)
合計   41 test GREEN
```

## commit 一覧

- `e9e46a37` L0: AC2/AC4 — red-only followup marker + fail-closed fetch
- `eaf00546` L1: AC1/AC5 — follow-up AND 条件 + warning-fix regression test
- `cffb32a2` L1.5: AC3 — pre-bash-merge-gate-block hook 登録
- `1e62b5c9` L2: AC6/AC7 — 不変条件 S + ADR-038 lesson-28 + CI 統合
- `dadcbbfe` L3 fix: Phase 6 review findings 対応 (CRITICAL/HIGH 6 件)

## Phase 6 Review fix 内容 (L3 commit)

code-reviewer agent 3 並列 review で検出された CRITICAL/HIGH findings:
- **C-1**: `gh issue list` `--limit 200` 追加 (default 30 件で false absence 防止)
- **C-2**: `merge-gate-check-red-only.sh` リダイレクト順序修正
- **I-1**: jq parse 失敗時 graceful skip 化 (副次効果で I-2 既存 bats も自動 PASS)
- **I-3**: `TWL_MERGE_GATE_OVERRIDE` strict regex (echo bypass 試行を deny)
- **#2**: `_resolve_autopilot_dir` で `AUTOPILOT_DIR_ENV` / `AUTOPILOT_DIR_DEFAULT` 既存変数名互換

## 変更ファイル (16 ファイル / +1293/-42 行)

```
plugins/twl/scripts/
  worker-red-only-detector.sh                                    (+76/-19) AC1 + I-1 fix
  merge-gate-check-red-only.sh                                   (+58/-7)  AC2/AC4 + C-1/C-2 fix
  red-only-followup-create.sh                                    (+2)      AC1.4 marker

plugins/twl/scripts/hooks/
  pre-bash-merge-gate-block.sh                                   (+143)    AC3 hook + I-3/#2 fix

plugins/twl/agents/
  worker-red-only-detector.md                                    (+30/-19) AC1.5 スキーマ更新

plugins/twl/refs/
  ref-invariants.md                                              (+37)     AC6 不変条件 S

plugins/twl/architecture/decisions/
  ADR-038-lesson-28-red-only-label-bypass-closure.md             (+112)    AC7 lesson 永続化

plugins/twl/tests/bats/
  int-1626-followup-auto-create-on-reject.bats                   (+181)    AC2.5 (4 test)
  int-1626-followup-verify-and-condition.bats                    (+129)    AC1.6 (5 test)
  int-1626-layer1-fail-closed-on-fetch-failure.bats              (+146)    AC4.4 (5 test)
  int-1626-pre-bash-hook-blocks-gh-pr-merge.bats                 (+227)    AC3.7 (10 test)
  int-1626-warning-fix-cannot-add-red-only-label.bats            (+86)     AC5.3 (3 test)

plugins/twl/deps.yaml                                            (+11)     新 hook + 既存 description 更新
.claude/settings.json                                            (+5)      AC3.8 hook 登録
.github/workflows/bats-1626-integration.yml                      (+45)     CI 追加
```

## scope 外 (別 Issue 推奨)

- **DRY**: `_check_followup_issue` / `_is_test_file` 重複 (Pragmatic A 採用時の判断、`lib/red-only-lib.sh` 化は別 Issue)
- **GitHub Web UI / `gh api graphql` 経由 merge block**: Claude Code の管轄外、branch protection rule で対応 (別 Issue)
- **cosmetic**: bats `HOOKS_DIR` 命名統一、不変条件 S `**対象外**:` field 整合、ADR-038 `## Rationale` 独立 section 化 (低優先 follow-up)
- **YAML フロントマター bats `grep -qF '---'` の grep option 誤認 bug**: 既存テストの別 Issue (本 PR 範囲外、修正前から RED)

## 関連

- **PR #1619** (Wave 91、本 fix の補強対象、5 layer 導入 PR)
- **Issue #1613** (CLOSED、不変条件 R 母体)
- **PR #1623** (本 incident、Wave 92 #1621 fix、RED-only label + 実装ゼロで MERGED)
- **doobidoo hash 2180ad68 / b7c91d96** (lesson 28 根拠記録)
- **ADR-036** (lesson structuralization、本 ADR-038 は Step 4 永続文書化)
- **ADR-024** (refined status SSoT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)