### PR TITLE
fix(ci): mcp-restart-smoke.yml の GitHub Actions を SHA ピン留めに置換 (#1602)

### DIFF
--- a/.github/workflows/mcp-restart-smoke.yml
+++ b/.github/workflows/mcp-restart-smoke.yml
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Rewrite .mcp.json absolute paths for CI ($GITHUB_WORKSPACE)
         run: |
@@ -46,7 +46,7 @@ jobs:
           " || echo "WARN: .mcp.json path rewrite failed; CI runner path may differ"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.11'
 

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1038,3 +1038,43 @@ issue_1451:
       impl_files:
         - "plugins/session/scripts/lib/llm-indicators.sh"
         - "plugins/session/scripts/cld-observe-any"
+
+# --- Issue #1602 ---
+issue_1602:
+  issue: 1602
+  framework: bats
+  test_file: "plugins/twl/tests/unit/ci-mcp-smoke-sha-pin/ci-mcp-smoke-sha-pin.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "actions/checkout@v4 を actions/checkout@<40-char SHA> # v<major>.<minor>.<patch> 形式に置換する"
+      test_name: "ac1: actions/checkout は 40 文字 SHA ピン留め形式になっている"
+      status: RED
+      red_mechanism: "mcp-restart-smoke.yml に actions/checkout@v4 が残存しているため mutable tag 検出で fail する"
+      impl_files:
+        - ".github/workflows/mcp-restart-smoke.yml"
+    - ac_index: 2
+      ac_text: "actions/setup-python@v5 を actions/setup-python@<40-char SHA> # v<major>.<minor>.<patch> 形式に置換する"
+      test_name: "ac2: actions/setup-python は 40 文字 SHA ピン留め形式になっている"
+      status: RED
+      red_mechanism: "mcp-restart-smoke.yml に actions/setup-python@v5 が残存しているため mutable tag 検出で fail する"
+      impl_files:
+        - ".github/workflows/mcp-restart-smoke.yml"
+    - ac_index: 3
+      ac_text: "PR description 内で gh api 出力との一致を実装者本人が手動確認した旨を記載すること"
+      test_name: "ac3: PR description に SHA 手動確認の記載がある (プロセス AC — 手動検証)"
+      status: RED
+      red_mechanism: "プロセス AC のため常に fail (ローカル自動検証不可)"
+      impl_files: []
+    - ac_index: 4
+      ac_text: "修正後の mcp-restart-smoke.yml を PR 上の workflow run で 1 回成功させ PR description にその run URL を記載すること"
+      test_name: "ac4: PR の workflow run が 1 回成功し run URL が PR description に記載されている (CI AC)"
+      status: RED
+      red_mechanism: "CI AC のため常に fail (ローカル自動検証不可)"
+      impl_files: []
+    - ac_index: 5
+      ac_text: "表記が add-to-project.yml の既存パターン (<action>@<sha> # v<semver>) と一致すること"
+      test_name: "ac5: uses 行は @<40-char-sha> # v<semver> 形式に準拠している"
+      status: RED
+      red_mechanism: "mcp-restart-smoke.yml の uses 行が @v4/@v5 形式のため形式チェックで fail する"
+      impl_files:
+        - ".github/workflows/mcp-restart-smoke.yml"

--- a/plugins/twl/tests/unit/ci-mcp-smoke-sha-pin/ci-mcp-smoke-sha-pin.bats
+++ b/plugins/twl/tests/unit/ci-mcp-smoke-sha-pin/ci-mcp-smoke-sha-pin.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# ci-mcp-smoke-sha-pin.bats
+# Requirement: Issue #1602 — mcp-restart-smoke.yml の GitHub Actions バージョンを SHA ピン留め
+# Coverage: --type=unit --coverage=ac1,ac2,ac5
+#
+# テスト対象: .github/workflows/mcp-restart-smoke.yml
+#   AC1: actions/checkout@v4 → actions/checkout@<40-char SHA> # v<semver> に置換
+#   AC2: actions/setup-python@v5 → actions/setup-python@<40-char SHA> # v<semver> に置換
+#   AC5: 表記が add-to-project.yml の既存パターン (@<sha> # v<semver>) と一致
+#
+# AC3 (PR description に SHA 確認の記載) / AC4 (CI run URL 記載) は
+# プロセスレベル AC のため本テストファイルでは検証不可 — RED placeholder のみ
+
+WORKFLOW_FILE="$(cd "$(dirname "$BATS_TEST_FILENAME")/../../../../.." && pwd)/.github/workflows/mcp-restart-smoke.yml"
+
+# ---------------------------------------------------------------------------
+# AC1: actions/checkout が SHA ピン留め形式になっている
+# WHEN mcp-restart-smoke.yml を読む
+# THEN `uses: actions/checkout@<40-char-sha> # v...` 形式であること
+# ---------------------------------------------------------------------------
+
+@test "ac1: actions/checkout は 40 文字 SHA ピン留め形式になっている" {
+  [ -f "$WORKFLOW_FILE" ] || skip "workflow file not found: $WORKFLOW_FILE"
+
+  # @v4 のような mutable tag が残っていれば FAIL
+  if grep -qE 'uses:[[:space:]]*actions/checkout@v[0-9]' "$WORKFLOW_FILE"; then
+    echo "actions/checkout は mutable tag (@v4 等) を使用している — SHA ピン留めに置換が必要" >&2
+    return 1
+  fi
+
+  # 40 文字 SHA 形式 (@[a-f0-9]{40}) が存在しなければ FAIL
+  grep -qE 'uses:[[:space:]]*actions/checkout@[a-f0-9]{40}' "$WORKFLOW_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# AC2: actions/setup-python が SHA ピン留め形式になっている
+# WHEN mcp-restart-smoke.yml を読む
+# THEN `uses: actions/setup-python@<40-char-sha> # v...` 形式であること
+# ---------------------------------------------------------------------------
+
+@test "ac2: actions/setup-python は 40 文字 SHA ピン留め形式になっている" {
+  [ -f "$WORKFLOW_FILE" ] || skip "workflow file not found: $WORKFLOW_FILE"
+
+  # @v5 のような mutable tag が残っていれば FAIL
+  if grep -qE 'uses:[[:space:]]*actions/setup-python@v[0-9]' "$WORKFLOW_FILE"; then
+    echo "actions/setup-python は mutable tag (@v5 等) を使用している — SHA ピン留めに置換が必要" >&2
+    return 1
+  fi
+
+  # 40 文字 SHA 形式が存在しなければ FAIL
+  grep -qE 'uses:[[:space:]]*actions/setup-python@[a-f0-9]{40}' "$WORKFLOW_FILE"
+}
+
+# ---------------------------------------------------------------------------
+# AC5: uses 行すべてが `@<sha> # v<semver>` 形式に準拠している
+# WHEN mcp-restart-smoke.yml の uses 行を列挙する
+# THEN 各行が `actions/checkout@<sha> # v<major>.<minor>.<patch>` 形式に一致すること
+# ---------------------------------------------------------------------------
+
+@test "ac5: uses 行は @<40-char-sha> # v<semver> 形式に準拠している" {
+  [ -f "$WORKFLOW_FILE" ] || skip "workflow file not found: $WORKFLOW_FILE"
+
+  # uses 行を抽出して形式チェック
+  local bad_lines
+  bad_lines=$(grep -E 'uses:[[:space:]]*[^@]+@' "$WORKFLOW_FILE" | \
+    grep -vE 'uses:[[:space:]]*[^@]+@[a-f0-9]{40}[[:space:]]+#[[:space:]]*v[0-9]+\.[0-9]+\.[0-9]+' || true)
+
+  if [ -n "$bad_lines" ]; then
+    echo "以下の uses 行が規約違反 (@<sha> # v<semver> 形式になっていない):"
+    echo "$bad_lines"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# AC3: PR description に SHA 確認の記載 (プロセス AC — ローカルでは検証不可)
+# RED placeholder: 常に fail させる
+# ---------------------------------------------------------------------------
+
+@test "ac3: PR description に SHA 手動確認の記載がある (プロセス AC — 手動検証)" {
+  # AC3 は PR description の内容を検証するプロセスレベル AC。
+  # ローカルテストでは自動検証不可のため RED placeholder として保持する。
+  # GREEN にするには PR 作成後に PR description を手動確認すること。
+  false  # RED: プロセス AC のため常に fail
+}
+
+# ---------------------------------------------------------------------------
+# AC4: PR に紐づく workflow run が成功している (CI レベル AC — ローカルでは検証不可)
+# RED placeholder: 常に fail させる
+# ---------------------------------------------------------------------------
+
+@test "ac4: PR の workflow run が 1 回成功し run URL が PR description に記載されている (CI AC)" {
+  # AC4 は GitHub Actions の実際の CI run を検証する CI レベル AC。
+  # ローカルテストでは自動検証不可のため RED placeholder として保持する。
+  # GREEN にするには GitHub CI run の成功後、PR description に run URL を記載すること。
+  false  # RED: CI AC のため常に fail
+}


### PR DESCRIPTION
## 概要

`.github/workflows/mcp-restart-smoke.yml` で利用している GitHub Actions (`actions/checkout@v4`, `actions/setup-python@v5`) を SHA ピン留め形式に置換する。

Closes #1602

## 変更内容

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- `actions/setup-python@v5` → `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`

## AC3: SHA 手動確認（再現性証跡）

実装時点（2026-05-11）に以下コマンドで SHA を取得・確認した:

```bash
# actions/checkout v4
gh api /repos/actions/checkout/git/refs/tags/v4 | jq -r '.object.sha'
# → 34e114876b0b11c390a56381ad16ebd13914f8d5  (v4.3.1 の HEAD)

# actions/setup-python v5
gh api /repos/actions/setup-python/git/refs/tags/v5 | jq -r '.object.sha'
# → a26af69be951a213d495a4c3e4e4022e16d87065  (v5.6.0 の HEAD)
```

上記出力値が mcp-restart-smoke.yml に記載した SHA と一致することを確認済み。

## AC4: CI run URL

> PR push 後に mcp-restart-smoke workflow が pass した run URL をここに記載する（PR 作成直後は未確認）

## 検証

- AC1 ✅: `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`
- AC2 ✅: `actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`
- AC3 ✅: 上記 SHA 手動確認の記載済み
- AC4 ⏳: CI run 確認後に更新
- AC5 ✅: `add-to-project.yml` のパターン `@<sha> # v<semver>` に準拠