### PR TITLE
fix(ci): pin uv version to 0.11.13 in mcp-restart-smoke.yml (#1603)

### DIFF
--- a/.github/workflows/mcp-restart-smoke.yml
+++ b/.github/workflows/mcp-restart-smoke.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install uv
         run: |
           set -euo pipefail
-          pip install uv
+          pip install "uv==0.11.13"
 
       - name: Sync dependencies
         working-directory: cli/twl

--- a/plugins/twl/tests/bats/ac-scaffold-tests-1603.bats
+++ b/plugins/twl/tests/bats/ac-scaffold-tests-1603.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# ac-scaffold-tests-1603.bats
+#
+# Issue #1603: .github/workflows/mcp-restart-smoke.yml の pip install uv をバージョン固定に修正
+#
+# AC1: .github/workflows/mcp-restart-smoke.yml の `pip install uv` (現 line 56) を
+#      `pip install "uv==<X.Y.Z>"` 形式に置換する。
+# AC2: 採用バージョンが PR description に記載されていること（プロセス AC、機械的検証不可）
+# AC3: 修正後の workflow run で 1 回成功させ、PR description にその run URL を記載すること
+#      （プロセス AC、機械的検証不可）
+# AC4: grep -nE '^\s*pip install\s+"uv==[0-9]+\.[0-9]+(\.[0-9]+)?"' .github/workflows/mcp-restart-smoke.yml
+#      が 1 行以上 match すること
+# AC5: バージョン未指定の `pip install uv` が同ファイル内に残存しないこと
+#
+# RED: 全テストは実装前に fail する（現状 pip install uv が未固定のため）
+# GREEN: pip install "uv==X.Y.Z" 形式に修正後に PASS する
+
+load 'helpers/common'
+
+WORKFLOW_FILE=""
+REPO_GIT_ROOT=""
+
+setup() {
+  common_setup
+  # REPO_ROOT は plugins/twl を指す。モノリポルートは git rev-parse で取得する。
+  local bats_dir
+  bats_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  local plugin_root
+  plugin_root="$(cd "${tests_dir}/.." && pwd)"
+  REPO_GIT_ROOT="$(cd "${plugin_root}" && git rev-parse --show-toplevel 2>/dev/null || echo "")"
+  WORKFLOW_FILE="${REPO_GIT_ROOT}/.github/workflows/mcp-restart-smoke.yml"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: pip install uv を pip install "uv==<X.Y.Z>" 形式に置換する
+#
+# RED: 現状 `pip install uv`（バージョン未固定）であるため
+#      バージョン固定形式の grep が fail する
+# ===========================================================================
+
+@test "ac1: mcp-restart-smoke.yml に pip install uv のバージョン固定形式が存在する" {
+  # AC: pip install uv (現 line 56) を pip install "uv==<X.Y.Z>" 形式に置換する
+  # RED: 現状はバージョン未固定のため grep が match しない → fail
+  [ -f "$WORKFLOW_FILE" ]
+
+  run grep -E '^\s*pip install\s+"uv==[0-9]+\.[0-9]+(\.[0-9]+)?"' "$WORKFLOW_FILE"
+  assert_success
+}
+
+# ===========================================================================
+# AC2: 採用バージョンが PR description に記載されていること（プロセス AC）
+# ===========================================================================
+
+@test "ac2: PR description にバージョン記載（プロセス AC）" {
+  # AC: 採用バージョンが PR description に記載されていること
+  # プロセス AC のため機械的検証不可
+  skip "process AC: verified via PR description"
+}
+
+# ===========================================================================
+# AC3: 修正後の workflow run で 1 回成功させ、PR description に run URL を記載（プロセス AC）
+# ===========================================================================
+
+@test "ac3: workflow run 成功と PR description への run URL 記載（プロセス AC）" {
+  # AC: 修正後の workflow run で 1 回成功させ、PR description にその run URL を記載すること
+  # プロセス AC のため機械的検証不可
+  skip "process AC: verified via PR description (run URL)"
+}
+
+# ===========================================================================
+# AC4: バージョン固定形式が 1 行以上 match すること
+#
+# grep -nE '^\s*pip install\s+"uv==[0-9]+\.[0-9]+(\.[0-9]+)?"' mcp-restart-smoke.yml
+#
+# RED: 現状 pip install uv（バージョン未固定）のため grep が 0 件 → fail
+# ===========================================================================
+
+@test "ac4: grep でバージョン固定形式の pip install uv が 1 行以上 match する" {
+  # AC: grep -nE '^\s*pip install\s+"uv==[0-9]+\.[0-9]+(\.[0-9]+)?"' が 1 行以上 match すること
+  # RED: 現状バージョン未固定のため grep が match しない → fail
+  [ -f "$WORKFLOW_FILE" ]
+
+  run grep -nE '^\s*pip install\s+"uv==[0-9]+\.[0-9]+(\.[0-9]+)?"' "$WORKFLOW_FILE"
+  assert_success
+  assert [ "${#lines[@]}" -ge 1 ]
+}
+
+# ===========================================================================
+# AC5: バージョン未指定の `pip install uv` が残存しないこと
+#
+# ! grep -nE '^\s*pip install\s+uv\s*$' mcp-restart-smoke.yml
+#
+# RED: 現状 `pip install uv`（line 56）が残存しているため grep が match → fail
+# ===========================================================================
+
+@test "ac5: バージョン未指定の pip install uv が残存しない" {
+  # AC: ! grep -nE '^\s*pip install\s+uv\s*$' .github/workflows/mcp-restart-smoke.yml
+  # RED: 現状 pip install uv（バージョン未指定）が line 56 に残存しているため
+  #      grep が match する → assert_failure が fail（= RED として意図通り fail）
+  [ -f "$WORKFLOW_FILE" ]
+
+  run grep -nE '^\s*pip install\s+uv\s*$' "$WORKFLOW_FILE"
+  assert_failure
+}

--- a/plugins/twl/tests/bats/ac-test-mapping-1603.yaml
+++ b/plugins/twl/tests/bats/ac-test-mapping-1603.yaml
@@ -1,0 +1,35 @@
+mappings:
+  - ac_index: 1
+    ac_text: ".github/workflows/mcp-restart-smoke.yml の `pip install uv` (現 line 56) を `pip install \"uv==<X.Y.Z>\"` 形式に置換する。"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1603.bats"
+    test_name: "ac1: mcp-restart-smoke.yml に pip install uv のバージョン固定形式が存在する"
+    impl_files:
+      - ".github/workflows/mcp-restart-smoke.yml"
+
+  - ac_index: 2
+    ac_text: "採用バージョンが PR description に記載されていること（プロセス AC、機械的検証不可）"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1603.bats"
+    test_name: "ac2: PR description にバージョン記載（プロセス AC）"
+    impl_files: []
+    # impl_files: プロセス AC のため実装ファイルなし（skip テスト）
+
+  - ac_index: 3
+    ac_text: "修正後の workflow run で 1 回成功させ、PR description にその run URL を記載すること（プロセス AC、機械的検証不可）"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1603.bats"
+    test_name: "ac3: workflow run 成功と PR description への run URL 記載（プロセス AC）"
+    impl_files: []
+    # impl_files: プロセス AC のため実装ファイルなし（skip テスト）
+
+  - ac_index: 4
+    ac_text: "grep -nE '^\\s*pip install\\s+\"uv==[0-9]+\\.[0-9]+(\\.[0-9]+)?\"' .github/workflows/mcp-restart-smoke.yml が 1 行以上 match すること"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1603.bats"
+    test_name: "ac4: grep でバージョン固定形式の pip install uv が 1 行以上 match する"
+    impl_files:
+      - ".github/workflows/mcp-restart-smoke.yml"
+
+  - ac_index: 5
+    ac_text: "バージョン未指定の `pip install uv` が同ファイル内に残存しないこと: ! grep -nE '^\\s*pip install\\s+uv\\s*$' .github/workflows/mcp-restart-smoke.yml"
+    test_file: "plugins/twl/tests/bats/ac-scaffold-tests-1603.bats"
+    test_name: "ac5: バージョン未指定の pip install uv が残存しない"
+    impl_files:
+      - ".github/workflows/mcp-restart-smoke.yml"


### PR DESCRIPTION
## 概要

`.github/workflows/mcp-restart-smoke.yml` の `pip install uv` をバージョン固定に修正します。

## 変更内容

```diff
-          pip install uv
+          pip install "uv==0.11.13"
```

## バージョン採用根拠（AC2 証跡）

PyPI JSON API による確認（2026-05-11 実施）:

```
$ curl -s https://pypi.org/pypi/uv/json | python3 -c "
import json, sys
from packaging.version import Version
data = json.load(sys.stdin)
versions = sorted(data['releases'].keys(), key=Version, reverse=True)[:5]
print('Latest stable:', data['info']['version'])
for v in versions: print(' ', v)
"
Latest stable: 0.11.13
  0.11.13
  0.11.12
  0.11.11
  0.11.10
  0.11.9
```

採用バージョン: **uv==0.11.13**

## CI ワークフロー run URL（AC3）

mcp-restart-smoke が SUCCESS:
https://github.com/shuu5/twill/actions/runs/25658880302/job/75314069518

## テスト

- `bats plugins/twl/tests/bats/ac-scaffold-tests-1603.bats` → 5/5 PASS
  - ac1: バージョン固定形式が存在する ✅
  - ac2: PR description にバージョン記載（process AC / skip）
  - ac3: workflow run URL 記載（process AC / skip）
  - ac4: grep で 1 行以上 match ✅
  - ac5: バージョン未指定の pip install uv が残存しない ✅

## 関連

- Issue #1603