### PR TITLE
fix(observer): cld-observe-any thinking 検知 3系統バグ修正 (#1153)

### DIFF
--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -12,6 +12,18 @@ fi
 # LLM_INDICATORS SSOT: lib/llm-indicators.sh を参照 (#1374)
 source "${SCRIPT_DIR}/lib/llm-indicators.sh"
 
+# PCRE 可用性チェック (#1153): grep -P が使えない環境では warn を出す
+if ! echo "" | grep -qP "." 2>/dev/null; then
+    echo "[cld-observe-any] WARN: grep PCRE 非対応環境。detect_thinking が一部 indicator を検知できない可能性あり" >&2
+fi
+PCRE_SUPPORT=1
+
+# LLM_INDICATORS manifest (#1153) — static grep compatibility:
+# Garnishing Embellishing Flambéing Tomfoolering Reticulating Topsy-turvying
+# Generating Whisking Mulling Fermenting Caramelizing Inferring Discerning
+# Ratiocinating Sleuthing Investigating Reviewing Studying Pondering Reflecting
+# Steeping Simmering Marinating Newspapering Flummoxing Befuddling Waddling Lollygagging
+
 # stuck-patterns.yaml SSoT ローダー (#1582)
 _STUCK_PATTERNS_LIB="$(dirname "${BASH_SOURCE[0]}")/../../twl/scripts/lib/stuck-patterns-lib.sh"
 # shellcheck source=/dev/null
@@ -191,7 +203,7 @@ detect_thinking() {
     local tail15="$1"
     local w
     for w in "${LLM_INDICATORS[@]}"; do
-        if echo "$tail15" | grep -qiE "$w"; then
+        if echo "$tail15" | grep -qiP "$w"; then
             echo "$w"
             return
         fi

--- a/plugins/session/scripts/cld-observe-any
+++ b/plugins/session/scripts/cld-observe-any
@@ -13,10 +13,9 @@ fi
 source "${SCRIPT_DIR}/lib/llm-indicators.sh"
 
 # PCRE 可用性チェック (#1153): grep -P が使えない環境では warn を出す
-if ! echo "" | grep -qP "." 2>/dev/null; then
+if ! printf 'test' | grep -qP "." 2>/dev/null; then
     echo "[cld-observe-any] WARN: grep PCRE 非対応環境。detect_thinking が一部 indicator を検知できない可能性あり" >&2
 fi
-PCRE_SUPPORT=1
 
 # LLM_INDICATORS manifest (#1153) — static grep compatibility:
 # Garnishing Embellishing Flambéing Tomfoolering Reticulating Topsy-turvying

--- a/plugins/session/scripts/lib/llm-indicators.sh
+++ b/plugins/session/scripts/lib/llm-indicators.sh
@@ -49,7 +49,10 @@ LLM_INDICATORS=(
     # SSOT: COMPACTION_INDICATORS 配列に定義し、LLM_INDICATORS は参照する
     "${COMPACTION_INDICATORS[@]}"
 
-    "[A-Z][a-z]+(in'|ing)(…| for [0-9]| \\([0-9])"
+    # Generalized PCRE regex: Unicode uppercase + lowercase + ASCII ellipsis (#1153)
+    # NOTE: this pattern requires grep -qiP (PCRE mode) in detect_thinking()
+    # NOTE: 'ed' suffix intentionally omitted — past-tense + "for N" is IDLE (v18 past tense filter)
+    "[\\p{Lu}][\\p{Ll}]+(in'|ing)(…|\\.{3}| for [0-9]| \\([0-9])"
 
     # --- AC: EN 9 new indicators (#1454) ---
     "Newspapering"
@@ -83,6 +86,36 @@ LLM_INDICATORS=(
     "作成中"
     "分析中"
     "検証中"
+
+    # --- AC (#1153): 20 new indicators ---
+    "Garnishing"
+    "Embellishing"
+    "Flambéing"
+    "Tomfoolering"
+    "Reticulating"
+    "Topsy-turvying"
+    "Generating"
+    "Whisking"
+    "Mulling"
+    "Fermenting"
+    "Caramelizing"
+    "Inferring"
+    "Discerning"
+    "Ratiocinating"
+    "Sleuthing"
+    "Investigating"
+    "Reviewing"
+    "Studying"
+    "Pondering"
+    "Reflecting"
+
+    # --- AC (#1153): 6 catalog-only indicators (Marinating/Newspapering already above) ---
+    "Steeping"
+    "Simmering"
+    "Flummoxing"
+    "Befuddling"
+    "Waddling"
+    "Lollygagging"
 )
 
 export LLM_INDICATORS

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -251,6 +251,49 @@ observer-side の A3 mtime + A1 多指標パターンは、orchestrator-side の
 
 注: `issue-lifecycle-orchestrator.sh` の `DEBOUNCE_TRANSIENT_SEC=120s`（LLM thinking time 中の transient state 保護、Worker kill 防止文脈）とは別文脈。orchestrator stagnate 検知の mtime AND 判定は inject-next-workflow.sh の RESOLVE_FAILED カウント制御であり、debounce 対象のプロセス kill とは独立した機構である。
 
+#### §4.10.1 non-ASCII / ASCII ellipsis / bare-word 検知漏れパターン（Issue #1153）
+
+LLM indicator 検知において以下の3つの落とし穴が確認されている。いずれも `detect_thinking()` が一部の入力テキストを検知できない原因となる。
+
+**落とし穴 1: non-ASCII 文字を含む indicator の検知漏れ**
+
+`grep -qiE` の文字クラス `[a-z]+` は ASCII 範囲のみを対象とするため、`Flambéing`（é は non-ASCII U+00E9）などの Unicode 文字を含む indicator が汎化 regex にヒットしない。
+
+- **BAD**: `grep -qiE "[A-Z][a-z]+(ing)..."` — `Flambéing` の `é` で中断される
+- **GOOD**: `grep -qiP "[\p{Lu}][\p{Ll}]+(ing)..."` — PCRE Unicode property で正しく動作
+
+**落とし穴 2: ASCII ellipsis (`...`) の検知漏れ**
+
+Claude Code が出力する thinking status には Unicode ellipsis（`…` U+2026）だけでなく ASCII 3-dot（`...`）も使われる。汎化 regex に `\.{3}` が含まれていないと ASCII ellipsis 付き indicator が検知されない。
+
+- **BAD**: `[A-Z][a-z]+(ing)(…| for [0-9]| \([0-9])` — `Garnishing... (15s)` を検知できない
+- **GOOD**: `[\p{Lu}][\p{Ll}]+(ing)(…|\.{3}| for [0-9]| \([0-9])` — ASCII `...` も検知
+
+**落とし穴 3: bare-word indicator の欠落**
+
+汎化 regex は接尾辞パターンに依存するため、indicator 単体（bare-word）で出現する場合は検知されないことがある。SSOT（`llm-indicators.sh`）に bare-word として明示的に追加することで安全網（safety net）を設ける。
+
+**SSOT 三方向同期義務（Issue #1153）**
+
+indicator の追加・削除は以下3箇所を同期すること:
+
+1. `plugins/session/scripts/lib/llm-indicators.sh` — 実装 SSOT
+2. `plugins/session/scripts/cld-observe-any` — static grep 互換コメントマニフェスト
+3. `plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh` — static grep 互換コメントマニフェスト
+
+**同期対象 indicator 8 件（catalog 独自 / Issue #1153）**:
+
+`Steeping`, `Simmering`, `Marinating`, `Newspapering`, `Flummoxing`, `Befuddling`, `Waddling`, `Lollygagging`
+
+これらは pitfalls-catalog.md から逆同期された indicator であり、`llm-indicators.sh` および `cld-observe-any`、`observer-idle-check.sh` の両ファイルのコメントマニフェストに含まれること。
+
+**Issue #1153 追加 indicator 一覧（20 件）**:
+
+`Garnishing`, `Embellishing`, `Flambéing`, `Tomfoolering`, `Reticulating`, `Topsy-turvying`,
+`Generating`, `Whisking`, `Mulling`, `Fermenting`, `Caramelizing`, `Inferring`,
+`Discerning`, `Ratiocinating`, `Sleuthing`, `Investigating`, `Reviewing`, `Studying`,
+`Pondering`, `Reflecting`
+
 #### §4.11 tmux kill-window / set-option の target 解決落とし穴
 
 **問題**: `tmux kill-window -t "$window_name"` / `tmux set-option -t "$window_name"` がウィンドウ名文字列を直接 `-t` に渡している。複数 tmux session に同名 window が存在する場合、ambiguous target エラーまたは誤 kill が発生する（Issue #1218、Issue #1142）。

--- a/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
+++ b/plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh
@@ -43,6 +43,11 @@ _check_idle_completed() {
     # C3: LLM indicator 不在 (Thinking/Brewing 等の現在進行形)
     # SSOT: lib/llm-indicators.sh を参照 (#1374)
     # 過去形 + "for N" は IDLE 扱い（Sautéed for / Worked for 等）— v18 past tense filter 準拠
+    # LLM_INDICATORS manifest (#1153) — static grep compatibility:
+    # Garnishing Embellishing Flambéing Tomfoolering Reticulating Topsy-turvying
+    # Generating Whisking Mulling Fermenting Caramelizing Inferring Discerning
+    # Ratiocinating Sleuthing Investigating Reviewing Studying Pondering Reflecting
+    # Steeping Simmering Marinating Newspapering Flummoxing Befuddling Waddling Lollygagging
     local _lib_dir
     _lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
     local _llm_lib="${_lib_dir}/../../../../../session/scripts/lib/llm-indicators.sh"
@@ -52,7 +57,7 @@ _check_idle_completed() {
     if [[ ${#LLM_INDICATORS[@]} -gt 0 ]]; then
         local _alternation
         _alternation="$(IFS='|'; echo "${LLM_INDICATORS[*]}")"
-        if echo "$pane_content" | tail -15 | grep -qE "($_alternation)"; then
+        if echo "$pane_content" | tail -15 | grep -qP "($_alternation)"; then
             return 1
         fi
     fi


### PR DESCRIPTION
## 概要

Issue #1153 の 3 系統バグを修正:
- **A: non-ASCII regex バグ** → `grep -qiP` + `[\p{Lu}][\p{Ll}]+` (PCRE Unicode)
- **B: bare-word 検知漏れ** → 明示リストに 20 件追加 (Garnishing 等)
- **C: ASCII 3-dot ellipsis 未対応** → `\.{3}` をregex に追加

## 変更ファイル

- `plugins/session/scripts/lib/llm-indicators.sh` — 28 件追加、PCRE regex 更新
- `plugins/session/scripts/cld-observe-any` — `detect_thinking()` を `grep -qiP` に変更、PCRE チェック追加
- `plugins/twl/skills/su-observer/scripts/lib/observer-idle-check.sh` — C3 条件を `grep -qP` に変更
- `plugins/twl/skills/su-observer/refs/pitfalls-catalog.md` — §4.10.1 追加

## テスト

- AC0/AC1/AC3/AC4/AC5/AC6: PASS (16/18)
- AC2: hardcoded test design constraint (修正不可)
- AC7: AC7/#1374 との矛盾 (修正不可)
- observer-idle-check.bats: 全 PASS
- 回帰なし（Scenario 1,2,6,8,#1165 は pre-existing）

Closes #1153