### PR TITLE
fix(su-observer): rate-limit 検知を HTTP ヘッダ解析に変更 (#1446)

### DIFF
--- a/plugins/twl/skills/su-observer/scripts/wave-progress-watchdog.sh
+++ b/plugins/twl/skills/su-observer/scripts/wave-progress-watchdog.sh
@@ -205,7 +205,12 @@ poll_gh_api_fallback() {
   http_status=$?
 
   if [[ "$http_status" -ne 0 ]]; then
-    if echo "$response" | grep -qiE 'rate limit|API rate|exceeded'; then
+    # Extract header section only (before first blank line) to avoid false positives from JSON body
+    local header_section
+    header_section=$(echo "$response" | tr -d '\r' | awk '/^$/{exit} {print}')
+    # Rate-limit: HTTP/.*403 + X-RateLimit-Remaining: 0 in header section (AND condition)
+    if echo "$header_section" | grep -qE 'HTTP/.*403' && \
+       echo "$header_section" | grep -qiE 'X-RateLimit-Remaining:[[:space:]]*0'; then
       return 2
     fi
     echo "[wave-progress-watchdog] WARN: gh api failed (exit=${http_status})" >&2

--- a/plugins/twl/skills/su-observer/scripts/wave-progress-watchdog.sh
+++ b/plugins/twl/skills/su-observer/scripts/wave-progress-watchdog.sh
@@ -209,7 +209,7 @@ poll_gh_api_fallback() {
     local header_section
     header_section=$(echo "$response" | tr -d '\r' | awk '/^$/{exit} {print}')
     # Rate-limit: HTTP/.*403 + X-RateLimit-Remaining: 0 in header section (AND condition)
-    if echo "$header_section" | grep -qE 'HTTP/.*403' && \
+    if echo "$header_section" | grep -qE '^HTTP/.*403' && \
        echo "$header_section" | grep -qiE 'X-RateLimit-Remaining:[[:space:]]*0'; then
       return 2
     fi

--- a/plugins/twl/tests/bats/scripts/wave-progress-watchdog.bats
+++ b/plugins/twl/tests/bats/scripts/wave-progress-watchdog.bats
@@ -356,8 +356,8 @@ case "\$*" in
     count=\$((count + 1))
     echo "\${count}" > "\${count_file}"
     if [ "\${count}" -le 1 ]; then
-      echo '{"message":"API rate limit exceeded"}' >&2
-      exit 5
+      printf 'HTTP/1.1 403 Forbidden\r\nx-ratelimit-remaining: 0\r\n\r\n{"message":"API rate limit exceeded"}\n'
+      exit 1
     else
       printf '[]\n'
       exit 0


### PR DESCRIPTION
## 概要

`wave-progress-watchdog.sh` の `poll_gh_api_fallback` 関数における rate-limit 検知を、エラーメッセージ文字列マッチから HTTP ヘッダ解析に変更する。

## 変更内容

### 問題
現行実装は `grep -qiE 'rate limit|API rate|exceeded'` でエラーメッセージテキストを検索していた。GitHub API が HTTP 403 + `X-RateLimit-Remaining: 0` ヘッダを返す場合、このエラーメッセージを省略するケースで検知漏れが発生する。

### 解決策
- `HTTP/.*403` ステータスライン AND `X-RateLimit-Remaining: 0` ヘッダの **AND 条件** で rate-limit を判定
- `tr -d '\r' | awk '/^$/{exit}'` でヘッダセクションのみを切り出し（JSON body の誤検知防止）
- 旧エラーメッセージマッチを完全削除（判定基準の一本化）
- `wave-progress-watchdog.bats` ac10 fixture を HTTP ヘッダ形式に更新

## テスト結果

- `wave-progress-watchdog-1446.bats`: 13/13 PASS
- `wave-progress-watchdog.bats`: 26/26 PASS（リグレッションなし）

## Closes #1446