### PR TITLE
fix(spawn-controller): controller_count=0 時の heartbeat check を skip (chicken-and-egg 回避)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1078,3 +1078,26 @@ issue_1602:
       red_mechanism: "mcp-restart-smoke.yml の uses 行が @v4/@v5 形式のため形式チェックで fail する"
       impl_files:
         - ".github/workflows/mcp-restart-smoke.yml"
+
+# --- Issue #1651 ---
+  - ac_index: 1
+    issue: 1651
+    ac_text: "_check_parallel_spawn_eligibility に controller_count=0 短絡 path 追加 — controller_count=0 の場合、必須条件1 (heartbeat_alive) を skip して spawn を許可"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
+    test_name: "AC1 #1651: controller_count=0 + heartbeat_alive=false → exit 0 (初回 spawn 許可)"
+    impl_files:
+      - "plugins/twl/scripts/lib/observer-parallel-check.sh"
+  - ac_index: 2
+    issue: 1651
+    ac_text: "bats test 追加 — controller_count=0 で spawn 成功する test / controller_count>0 + heartbeat 古い → DENY する test (既存挙動維持)"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
+    test_name: "AC2 #1651 regression: controller_count=1 + heartbeat_alive=false → exit 2 (既存挙動維持)"
+    impl_files:
+      - "plugins/twl/scripts/lib/observer-parallel-check.sh"
+  - ac_index: 3
+    issue: 1651
+    ac_text: "pitfalls-catalog §11.3 拡張 — 初回 spawn 例外 path を明記 (chicken-and-egg 回避 logic)"
+    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
+    test_name: "AC3 #1651: pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在する"
+    impl_files:
+      - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1080,24 +1080,23 @@ issue_1602:
         - ".github/workflows/mcp-restart-smoke.yml"
 
 # --- Issue #1651 ---
-  - ac_index: 1
-    issue: 1651
-    ac_text: "_check_parallel_spawn_eligibility に controller_count=0 短絡 path 追加 — controller_count=0 の場合、必須条件1 (heartbeat_alive) を skip して spawn を許可"
-    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
-    test_name: "AC1 #1651: controller_count=0 + heartbeat_alive=false → exit 0 (初回 spawn 許可)"
-    impl_files:
-      - "plugins/twl/scripts/lib/observer-parallel-check.sh"
-  - ac_index: 2
-    issue: 1651
-    ac_text: "bats test 追加 — controller_count=0 で spawn 成功する test / controller_count>0 + heartbeat 古い → DENY する test (既存挙動維持)"
-    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
-    test_name: "AC2 #1651 regression: controller_count=1 + heartbeat_alive=false → exit 2 (既存挙動維持)"
-    impl_files:
-      - "plugins/twl/scripts/lib/observer-parallel-check.sh"
-  - ac_index: 3
-    issue: 1651
-    ac_text: "pitfalls-catalog §11.3 拡張 — 初回 spawn 例外 path を明記 (chicken-and-egg 回避 logic)"
-    test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
-    test_name: "AC3 #1651: pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在する"
-    impl_files:
-      - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"
+issue_1651:
+  issue: 1651
+  framework: bats
+  test_file: "plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "_check_parallel_spawn_eligibility に controller_count=0 短絡 path 追加 — controller_count=0 の場合、必須条件1 (heartbeat_alive) を skip して spawn を許可"
+      test_name: "AC1 #1651: controller_count=0 + heartbeat_alive=false → exit 0 (初回 spawn 許可)"
+      impl_files:
+        - "plugins/twl/scripts/lib/observer-parallel-check.sh"
+    - ac_index: 2
+      ac_text: "bats test 追加 — controller_count=0 で spawn 成功する test / controller_count>0 + heartbeat 古い → DENY する test (既存挙動維持)"
+      test_name: "AC2 #1651 regression: controller_count=1 + heartbeat_alive=false → exit 2 (既存挙動維持)"
+      impl_files:
+        - "plugins/twl/scripts/lib/observer-parallel-check.sh"
+    - ac_index: 3
+      ac_text: "pitfalls-catalog §11.3 拡張 — 初回 spawn 例外 path を明記 (chicken-and-egg 回避 logic)"
+      test_name: "AC3 #1651: pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在する"
+      impl_files:
+        - "plugins/twl/skills/su-observer/refs/pitfalls-catalog.md"

--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -319,6 +319,16 @@ _check_parallel_spawn_eligibility() {
   # --- 必須条件評価（3つ, causally decisive） ---
   local missing_must=()
 
+  # [#1651] controller_count=0 短絡 path: 初回 spawn は heartbeat check skip
+  # chicken-and-egg 回避: controller 不在時は heartbeat が出ないため、
+  # controller_count=0 の場合のみ heartbeat_alive を true とみなす。
+  # states も空扱い（controller が 0 なら検証対象の state も 0 件）。
+  if (( controller_count == 0 )); then
+    echo "[parallel-check] INFO: controller_count=0 (initial spawn) — heartbeat check skipped" >&2
+    heartbeat_alive=true
+    controller_states=''
+  fi
+
   # 必須条件1: controller heartbeat alive (≤ 5min)
   if [[ "$heartbeat_alive" != "true" ]]; then
     missing_must+=("heartbeat_alive=false: controller の heartbeat が 5分以内に更新されていない（§11.1）")

--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -311,6 +311,8 @@ _check_parallel_spawn_eligibility() {
   local heartbeat_alive="${OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE:-$(check_controller_heartbeat_alive "$snapshot_ts")}"
   local mode="${OBSERVER_PARALLEL_CHECK_MODE:-$(check_observer_mode)}"
   local controller_count="${OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT:-$(count_eligible_controllers "$snapshot_ts")}"
+  # 整数バリデーション: 非数値は 0 として扱う（bash 算術展開の暗黙 0 変換を明示化）
+  [[ "$controller_count" =~ ^[0-9]+$ ]] || controller_count=0
   local monitor_cld_alive="${OBSERVER_PARALLEL_CHECK_MONITOR_CLD:-$(check_monitor_cld_observe_alive)}"
   local controller_states="${OBSERVER_PARALLEL_CHECK_STATES:-$(get_controller_states "$snapshot_ts")}"
   local budget_min="${OBSERVER_PARALLEL_CHECK_BUDGET_MIN:-$(get_budget_minutes_remaining)}"

--- a/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
+++ b/plugins/twl/skills/su-observer/refs/pitfalls-catalog.md
@@ -664,6 +664,32 @@ spawn 前評価:
 5. **既存 controller が S-2/S-3/S-4 のいずれか** — S-1 IDLE は §4.10 で cleanup 対象（#1117 で格上げ予定）
 6. **budget 残量 ≥ 150 分** — `.supervisor/budget-config.json` の `parallel_spawn_min_remaining_minutes`（default 150）。既存 `[BUDGET-LOW]` 閾値(40分)とは独立
 
+### 初回 spawn 例外 path（controller_count=0, #1651 chicken-and-egg 回避）
+
+**問題**: 前 Wave の Pilot kill 後 (`controller_count=0`) に新 Wave を spawn しようとすると、
+`must_1`（heartbeat_alive）が false → exit 2 で spawn が完全 DENY される deadlock が発生する。
+controller を起動しないと heartbeat が出ず、heartbeat がないと controller を起動できない
+（chicken-and-egg 問題）。
+
+**解決策（`_check_parallel_spawn_eligibility()` #1651 実装）**:
+`controller_count == 0` の場合、`must_1` の heartbeat check を skip して spawn を許可する:
+
+```bash
+if (( controller_count == 0 )); then
+  # 初回 spawn は heartbeat_alive=true とみなす (chicken-and-egg 回避, #1651)
+  echo "[parallel-check] INFO: controller_count=0 (initial spawn) — heartbeat check skipped" >&2
+  heartbeat_alive=true
+fi
+```
+
+**適用条件**: `controller_count=0` のみ。`controller_count > 0` の並列 spawn では `must_1` は引き続き有効。
+**`must_2`（mode）・`must_3`（SU-4 上限）は `controller_count=0` でも適用される**（heartbeat のみスキップ）。
+
+**観測されたケース（2026-05-11 ipatho2, Wave U.audit-fix-A）**:
+- Wave U.Z Pilot kill 後、`.supervisor/events/heartbeat-*` が全て age > 5min
+- `controller_count=0` で `OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true` env var bypass が必要だった（規約違反）
+- 本修正で env var bypass 不要となり、正規の初回 spawn が可能になる
+
 ### 失敗時 degrade
 
 - 必須条件 1 つでも false → **spawn 完全禁止 (exit 2)**、stderr に欠落必須条件

--- a/plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats
+++ b/plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats
@@ -12,6 +12,8 @@
 # AC3: pitfalls-catalog §11.3 拡張
 #      初回 spawn 例外 path を明記 (chicken-and-egg 回避 logic)
 
+bats_require_minimum_version 1.5.0
+
 load '../helpers/common'
 
 PARALLEL_CHECK_LIB=""
@@ -111,7 +113,7 @@ teardown() {
   [[ -f "$PARALLEL_CHECK_LIB" ]] \
     || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
 
-  run bash -c "
+  run --separate-stderr bash -c "
     source '$PARALLEL_CHECK_LIB'
     OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
     OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
@@ -122,9 +124,9 @@ teardown() {
     OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
     OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
     _check_parallel_spawn_eligibility
-  " 2>&1
+  "
 
-  echo "$output" | grep -qiE 'initial spawn|controller_count=0|初回|heartbeat.*skip|skip.*heartbeat' \
+  echo "$stderr" | grep -qiE 'initial spawn|controller_count=0|初回|heartbeat.*skip|skip.*heartbeat' \
     || fail "controller_count=0 時に初回 spawn に関する INFO ログが出力されていない（AC1 未実装）"
 }
 

--- a/plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats
+++ b/plugins/twl/tests/bats/scripts/issue-1651-initial-spawn.bats
@@ -1,0 +1,229 @@
+#!/usr/bin/env bats
+# issue-1651-initial-spawn.bats - Issue #1651 RED テスト
+#
+# bug(spawn-controller): 初回 controller spawn が heartbeat_alive check で
+# 構造的に block される (chicken-and-egg)
+#
+# AC1: _check_parallel_spawn_eligibility に controller_count=0 短絡 path 追加
+#      controller_count=0 の場合、必須条件1 (heartbeat_alive) を skip して spawn を許可
+# AC2: bats test 追加
+#      - controller_count=0 で spawn 成功する test
+#      - controller_count>0 + heartbeat 古い → DENY する test (既存挙動維持)
+# AC3: pitfalls-catalog §11.3 拡張
+#      初回 spawn 例外 path を明記 (chicken-and-egg 回避 logic)
+
+load '../helpers/common'
+
+PARALLEL_CHECK_LIB=""
+
+setup() {
+  common_setup
+  PARALLEL_CHECK_LIB="$REPO_ROOT/scripts/lib/observer-parallel-check.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1: controller_count=0 短絡 path の実装確認
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: observer-parallel-check.sh に controller_count=0 の短絡 path が存在する
+# WHEN: observer-parallel-check.sh の内容を確認する
+# THEN: controller_count == 0 の分岐が存在する
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC1 #1651: observer-parallel-check.sh に controller_count=0 短絡 path が存在する" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  grep -qE 'controller_count[[:space:]]*==[[:space:]]*0|controller_count[[:space:]]*-eq[[:space:]]*0' "$PARALLEL_CHECK_LIB" \
+    || fail "observer-parallel-check.sh に controller_count=0 の短絡 path が存在しない（AC1 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count=0 + heartbeat_alive=false → exit 0 (初回 spawn 許可)
+# WHEN: controller_count=0, heartbeat_alive=false, mode=auto で呼び出す
+# THEN: exit 0（初回 spawn は heartbeat check を skip して許可される）
+# RED: 現状は heartbeat_alive=false → exit 2 を返す
+# ---------------------------------------------------------------------------
+
+@test "AC1 #1651: controller_count=0 + heartbeat_alive=false → exit 0 (初回 spawn 許可)" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=0 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  assert_success \
+    || fail "controller_count=0 + heartbeat_alive=false で exit $status が返った（期待: exit 0 / AC1 未実装: 現状は heartbeat check で exit 2）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count=0 + heartbeat_alive=false → NOT exit 2 (spawn 完全禁止にならない)
+# WHEN: controller_count=0 で heartbeat check をスキップする場合
+# THEN: exit 2 にはならない（spawn 許可 or degrade は許容）
+# RED: 現状は exit 2 を返す
+# ---------------------------------------------------------------------------
+
+@test "AC1 #1651: controller_count=0 + heartbeat_alive=false → spawn が DENY されない" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=0 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  [[ "$status" -ne 2 ]] \
+    || fail "controller_count=0 + heartbeat_alive=false で exit 2（spawn 完全禁止）が返った — 初回 spawn は heartbeat check を skip すべき（AC1 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count=0 で INFO ログが出力される
+# WHEN: controller_count=0 で呼び出す
+# THEN: stderr に initial spawn に関するログメッセージが出力される
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC1 #1651: controller_count=0 初回 spawn 時に INFO ログが stderr に出力される" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=0 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  echo "$output" | grep -qiE 'initial spawn|controller_count=0|初回|heartbeat.*skip|skip.*heartbeat' \
+    || fail "controller_count=0 時に初回 spawn に関する INFO ログが出力されていない（AC1 未実装）"
+}
+
+# ===========================================================================
+# AC2: bats テスト追加（既存挙動維持の回帰テスト）
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count>0 + heartbeat_alive=false → DENY (exit 2) - 既存挙動維持
+# WHEN: controller_count=1, heartbeat_alive=false で呼び出す（Pilot 存在ケース）
+# THEN: exit 2（並列 spawn 時は heartbeat check が有効のまま）
+# GREEN: 既存動作のため実装前後ともに PASS
+# ---------------------------------------------------------------------------
+
+@test "AC2 #1651 regression: controller_count=1 + heartbeat_alive=false → exit 2 (既存挙動維持)" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='S-3' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  [[ "$status" -eq 2 ]] \
+    || fail "controller_count=1 + heartbeat_alive=false で exit $status が返った（期待: exit 2 — 並列 spawn 時は heartbeat check を維持すべき）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: controller_count=0 + mode=default → exit 2 (mode 必須条件は適用される)
+# WHEN: controller_count=0 でも mode が invalid な場合
+# THEN: exit 2（heartbeat check のみ skip、mode check は適用）
+# RED: 未実装のため fail する（現状は controller_count で分岐なし）
+# ---------------------------------------------------------------------------
+
+@test "AC2 #1651: controller_count=0 + mode=default → mode 必須条件は適用される (exit 2)" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=false \
+    OBSERVER_PARALLEL_CHECK_MODE=default \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=0 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_STATES='' \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  "
+
+  [[ "$status" -eq 2 ]] \
+    || fail "controller_count=0 + mode=default で exit $status が返った（期待: exit 2 — mode check は controller_count=0 でも適用すべき）"
+}
+
+# ===========================================================================
+# AC3: pitfalls-catalog §11.3 拡張
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在する
+# WHEN: pitfalls-catalog.md §11.3 セクションを参照する
+# THEN: chicken-and-egg または初回 spawn 例外 path の記述が存在する
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC3 #1651: pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在する" {
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  grep -qiE 'chicken.and.egg|初回.*spawn|initial.*spawn|controller_count.*=.*0.*skip|heartbeat.*skip' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に chicken-and-egg 回避の記述が存在しない（AC3 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: pitfalls-catalog.md §11.3 に controller_count=0 の例外 path が明記されている
+# WHEN: pitfalls-catalog.md §11.3 セクションを参照する
+# THEN: controller_count=0 の case の記述が存在する
+# RED: 未実装のため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC3 #1651: pitfalls-catalog.md §11.3 に controller_count=0 例外 path が明記されている" {
+  local catalog
+  catalog="$REPO_ROOT/skills/su-observer/refs/pitfalls-catalog.md"
+
+  [[ -f "$catalog" ]] \
+    || fail "pitfalls-catalog.md が存在しない: $catalog"
+
+  grep -qE 'controller_count[[:space:]]*==[[:space:]]*0|controller_count[[:space:]]*=[[:space:]]*0|初回.*spawn.*例外|#1651' "$catalog" \
+    || fail "pitfalls-catalog.md §11.3 に controller_count=0 例外 path の記述が存在しない（AC3 未実装）"
+}


### PR DESCRIPTION
## 概要

Issue #1651 の修正。初回 controller spawn 時（前 Wave の Pilot kill 後など controller_count=0 の状況）に `heartbeat_alive=false` で spawn が完全 DENY される chicken-and-egg 問題を解消する。

## 変更内容

### observer-parallel-check.sh
`_check_parallel_spawn_eligibility()` に `controller_count=0` 短絡 path を追加：
- `controller_count=0` の場合、必須条件1（heartbeat_alive）のチェックを skip して spawn を許可
- states check も skip（controller 不在 = 検証対象 state も 0 件）
- mode check（必須条件2）は `controller_count=0` でも引き続き適用
- INFO ログを stderr に出力してトレーサビリティを確保

### pitfalls-catalog.md §11.3
chicken-and-egg 問題と回避 logic を明記した新セクションを追加。

### テスト（issue-1651-initial-spawn.bats）
- AC1: controller_count=0 短絡 path の実装確認（4 件）
- AC2: 既存挙動維持の回帰テスト（2 件）
- AC3: pitfalls-catalog §11.3 拡張確認（2 件）

## テスト結果
- 新規 8 件: ALL PASS
- 既存 su-observer-parallel-check.bats 57 件: ALL PASS（回帰なし）

Closes #1651