### PR TITLE
fix(su-observer): SKIP_*_REASON サニタイズを _sanitize_skip_reason() に統一 (#1660)

### DIFF
--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -81,6 +81,15 @@ _emit_provenance_section() {
 }
 # --- provenance section ここまで ---
 
+# ASCII reason のみを想定。UTF-8 マルチバイト文字は非印字バイト置換により破壊される可能性がある。
+# 第1引数を受け取り ${1//[^[:print:]]/ } の結果を printf '%s' で出力する (改行なし)。
+# 引数未指定または空文字の場合は空文字を出力する。
+# デフォルト値展開は呼び出し元の責務 (例: "${VAR:-default}")。
+_sanitize_skip_reason() {
+  local _r="${1:-}"
+  printf '%s' "${_r//[^[:print:]]/ }"
+}
+
 # --- #1644: feature-dev gate checks（bash 実装、tools.py の Python 版と意味的等価）---
 # 引数: $1 = ISSUE_NUMBER（正整数、呼び出し側で validate 済み）
 # 効果: 全 gate を pass したら .supervisor/feature-dev-request-<N>.json を consumed/ に atomic rename
@@ -245,9 +254,7 @@ if [[ "${SKIP_PARALLEL_CHECK:-0}" == "1" ]]; then
   {
     _supervisor_dir="${SUPERVISOR_DIR:-.supervisor}"
     mkdir -p "$_supervisor_dir"
-    _reason="${SKIP_PARALLEL_REASON:-(reason not provided)}"
-    _reason="${_reason//$'\n'/ }"
-    _reason="${_reason//$'\r'/ }"
+    _reason="$(_sanitize_skip_reason "${SKIP_PARALLEL_REASON:-(reason not provided)}")"
     printf '%s SKIP_PARALLEL_CHECK=1: %s\n' \
       "$(date -u +%FT%TZ)" \
       "$_reason" \
@@ -382,11 +389,20 @@ EOF
 
   # Gate checks（SKIP_LAYER2=1 で bypass、AC-4.6: 2 wave 維持）
   if [[ "${SKIP_LAYER2:-0}" == "1" ]]; then
-    _skip_reason="${SKIP_LAYER2_REASON:-未設定}"
-    _skip_reason="${_skip_reason//$'\n'/ }"
-    _skip_reason="${_skip_reason//$'\r'/ }"
+    _skip_reason="$(_sanitize_skip_reason "${SKIP_LAYER2_REASON:-未設定}")"
     echo "[spawn-controller] WARN: SKIP_LAYER2=1 — feature-dev gate checks bypassed (issue=${ISSUE_NUMBER}, reason=${_skip_reason})" >&2
-    echo "[spawn-controller] SKIP_LAYER2=1 bypass: feature-dev issue=${ISSUE_NUMBER}, reason=${_skip_reason}" >> "${SUPERVISOR_DIR:-.supervisor}/intervention-log.md" 2>/dev/null || true
+    {
+      _sup_dir="${SUPERVISOR_DIR:-.supervisor}"
+      mkdir -p "$_sup_dir"
+      printf '%s SKIP_LAYER2=1 bypass: feature-dev issue=%s, reason=%s\n' \
+        "$(date -u +%FT%TZ)" \
+        "$ISSUE_NUMBER" \
+        "$_skip_reason" \
+        >> "$_sup_dir/intervention-log.md"
+    } || {
+      echo "[spawn-controller] WARN: intervention-log append failed (continuing spawn)" >&2
+      true
+    }
   else
     _fd_run_gate_checks "$ISSUE_NUMBER"
   fi
@@ -513,7 +529,7 @@ ERROR: SKIP_PILOT_GATE=1 を使う場合は SKIP_PILOT_REASON を必ず指定し
 DENY
       exit 2
     fi
-    _skip_pilot_reason="${_skip_pilot_reason//[^[:print:]]/ }"
+    _skip_pilot_reason="$(_sanitize_skip_reason "$_skip_pilot_reason")"
     echo "[spawn-controller] WARN: SKIP_PILOT_GATE=1 — --with-chain --issue gate bypassed (issue=${CHAIN_ISSUE:-?}, reason=${_skip_pilot_reason})" >&2
     {
       _sup_dir="${SUPERVISOR_DIR:-.supervisor}"

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -389,7 +389,7 @@ EOF
 
   # Gate checks（SKIP_LAYER2=1 で bypass、AC-4.6: 2 wave 維持）
   if [[ "${SKIP_LAYER2:-0}" == "1" ]]; then
-    _skip_reason="$(_sanitize_skip_reason "${SKIP_LAYER2_REASON:-未設定}")"
+    _skip_reason="$(_sanitize_skip_reason "${SKIP_LAYER2_REASON:-(reason not set)}")"
     echo "[spawn-controller] WARN: SKIP_LAYER2=1 — feature-dev gate checks bypassed (issue=${ISSUE_NUMBER}, reason=${_skip_reason})" >&2
     {
       _sup_dir="${SUPERVISOR_DIR:-.supervisor}"

--- a/plugins/twl/tests/bats/scripts/ac-test-mapping.yaml
+++ b/plugins/twl/tests/bats/scripts/ac-test-mapping.yaml
@@ -1,80 +1,55 @@
 mappings:
   - ac_index: 1
-    ac_text: "phase-review + top-level architecture/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-1: phase-review + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "_sanitize_skip_reason() ヘルパー関数を spawn-controller.sh 内に定義する (ASCII-only, printf '%s' 出力)"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S6: _sanitize_skip_reason empty string returns empty"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 2
-    ac_text: "phase-review + nested-1 architecture/contexts/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-2: phase-review + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "L246-258 SKIP_PARALLEL_CHECK ブロックのサニタイズを _sanitize_skip_reason に統一"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S1: tab in SKIP_PARALLEL_REASON is replaced in intervention-log"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 2
+    ac_text: "L246-258 SKIP_PARALLEL_CHECK ブロック - ESC 文字除去"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S2: ESC char in SKIP_PARALLEL_REASON is replaced in intervention-log"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 3
-    ac_text: "phase-review + nested-2 architecture/decisions/sub/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-3: phase-review + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "L383-389 SKIP_LAYER2 ブロックのサニタイズ統一 + echo→printf 化"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S3: tab+newline+CR in SKIP_LAYER2_REASON -> single line append without tab in log"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+  - ac_index: 3
+    ac_text: "L383-389 SKIP_LAYER2 ブロック - BEL/BS 除去"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S4: BEL+BS in SKIP_LAYER2_REASON are stripped in intervention-log"
+    impl_files:
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 4
-    ac_text: "merge-gate + top-level architecture/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-4: merge-gate + top-level architecture/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "L516 SKIP_PILOT_REASON gate の DRY 化 (_sanitize_skip_reason 呼び出し)"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S5: multiline+tab+CR in SKIP_PILOT_REASON -> sanitized in intervention-log (regression)"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 5
-    ac_text: "merge-gate + nested-1 architecture/contexts/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-5: merge-gate + nested-1 architecture/contexts/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "新規 bats テスト spawn-controller-skip-reason-sanitize.bats (S1-S6)"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S1: tab in SKIP_PARALLEL_REASON is replaced in intervention-log"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 6
-    ac_text: "merge-gate + nested-2 architecture/decisions/sub/foo.md で worker-arch-doc-reviewer が含まれる"
-    test_file: "plugins/twl/tests/bats/scripts/pr-review-manifest-mode-architecture.bats"
-    test_name: "B-6: merge-gate + nested-2 architecture/decisions/sub/foo.md → worker-arch-doc-reviewer included (RED)"
+    ac_text: "既存 bats テストが全 PASS (回帰なし) + C6 コメント更新"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats"
+    test_name: "C6: 改行を含む REASON はサニタイズされてログ 1 行に収まる"
     impl_files:
-      - "plugins/twl/scripts/pr-review-manifest.sh"
-  # Issue #1561: pre-bash-refined-status-gate.sh Refined option ID 拡張
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
   - ac_index: 7
-    ac_text: "hook が gh project item-edit && \\b3d983780\\b + evidence なし で permissionDecision: deny JSON を出力する (AC1)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R1: gh project item-edit with 3d983780 (Refined option ID) + evidence なし → deny"
+    ac_text: "bash -n plugins/twl/skills/su-observer/scripts/spawn-controller.sh が syntax error なし"
+    test_file: "plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats"
+    test_name: "S6: _sanitize_skip_reason empty string returns empty"
     impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 8
-    ac_text: ".spec-review-session-*.json evidence あり → allow (AC2)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R2: gh project item-edit with 3d983780 + .spec-review-session-*.json あり → allow"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 9
-    ac_text: "Phase4-complete.json evidence あり → allow (AC2)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R3: gh project item-edit with 3d983780 + Phase4-complete.json あり → allow"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 10
-    ac_text: "既存 47fc9ee4 (In Progress option ID) check がリグレッションしない - deny (AC7)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R4: gh project item-edit with 47fc9ee4 (In Progress option ID) + evidence なし → deny (regression)"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 11
-    ac_text: "既存 47fc9ee4 check がリグレッションしない - allow with evidence (AC7)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R5: gh project item-edit with 47fc9ee4 + .spec-review-session-*.json あり → allow (regression)"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 12
-    ac_text: "3d9837801 (部分一致) は word boundary でマッチしない - no-op (AC4 bypass なし確認)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R6: 3d9837801 (partial match of 3d983780) + evidence なし → no-op (word boundary guard)"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
-  - ac_index: 13
-    ac_text: "deny メッセージに /twl:co-issue refine と ADR-024 が含まれる (AC6)"
-    test_file: "plugins/twl/tests/bats/scripts/refined-status-gate-refined-option.bats"
-    test_name: "R7: deny メッセージに /twl:co-issue refine および ADR-024 が含まれる"
-    impl_files:
-      - "plugins/twl/scripts/hooks/pre-bash-refined-status-gate.sh"
+      - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"

--- a/plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller-skip-parallel-log.bats
@@ -8,7 +8,7 @@
 # C3: SUPERVISOR_DIR=$(mktemp -d) で実 .supervisor/intervention-log.md を汚染しない
 # C4: SUPERVISOR_DIR 不在ディレクトリでも mkdir -p が成功し append される
 # C5: append 失敗時（SUPERVISOR_DIR=/dev/null/x 等）に WARN 出力 + spawn 継続（fail-open）
-# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる
+# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる (\n/\r → 空白 (helper 化後は制御文字全般))
 
 load '../helpers/common'
 
@@ -243,7 +243,7 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる
+# C6: SKIP_PARALLEL_REASON=$'line1\nline2' の場合、ログ行が 1 行に保たれる (\n/\r → 空白 (helper 化後は制御文字全般))
 # RED: 自動記録実装がないため fail する（サニタイズ実装なし）
 # ---------------------------------------------------------------------------
 

--- a/plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats
+++ b/plugins/twl/tests/bats/scripts/spawn-controller-skip-reason-sanitize.bats
@@ -1,0 +1,295 @@
+#!/usr/bin/env bats
+# spawn-controller-skip-reason-sanitize.bats - Issue #1660 RED テスト
+#
+# Coverage (AC1-AC5):
+#   S1: SKIP_PARALLEL_REASON=$'reason\twith\ttab' → intervention-log にタブが含まれない
+#   S2: SKIP_PARALLEL_REASON=$'reason\x1b[31mred\x1b[0m' → intervention-log に ESC (0x1b) が含まれない
+#   S3: SKIP_LAYER2_REASON=$'tab\there\nnewline\rcr' + SKIP_LAYER2=1 (feature-dev) → log に 1 行で append (タブなし)
+#   S4: SKIP_LAYER2_REASON=$'\x07bell\x08bs' + SKIP_LAYER2=1 (feature-dev) → 制御文字なしで append
+#   S5: SKIP_PILOT_REASON=$'multi\nline\twith\rcontrol' → 1行・タブ/制御文字なしで append (回帰テスト)
+#   S6: _sanitize_skip_reason "" → 空文字を返す (引数なし時の安全動作)
+#
+# RED フェーズ設計:
+#   S1: 現在 L249-250 は \n/\r のみ置換、タブは残る → log にタブが含まれる → FAIL
+#   S2: 現在 ESC 文字は置換されない → log に ESC が含まれる → FAIL
+#   S3: 現在 SKIP_LAYER2 ブロックはタブを置換しない + echo 使用 → FAIL
+#   S4: 現在 BEL/BS は置換されない → FAIL
+#   S5: 現在 L516 で [^[:print:]] 置換済み → PASS (回帰テスト、実装前から GREEN)
+#   S6: _sanitize_skip_reason 関数未定義 → FAIL
+
+load '../helpers/common'
+
+SPAWN_CONTROLLER=""
+CLD_SPAWN_ARGS_LOG=""
+MOCK_CLD_SPAWN=""
+AUTOPILOT_LAUNCH_LOG=""
+
+setup() {
+  common_setup
+
+  SPAWN_CONTROLLER="$REPO_ROOT/skills/su-observer/scripts/spawn-controller.sh"
+  export SPAWN_CONTROLLER
+
+  CLD_SPAWN_ARGS_LOG="$SANDBOX/cld-spawn-args.log"
+  export CLD_SPAWN_ARGS_LOG
+
+  # cld-spawn stub
+  MOCK_CLD_SPAWN="$STUB_BIN/cld-spawn"
+  cat > "$MOCK_CLD_SPAWN" <<'MOCK'
+#!/usr/bin/env bash
+echo "$@" >> "${CLD_SPAWN_ARGS_LOG:-/dev/null}"
+exit 0
+MOCK
+  chmod +x "$MOCK_CLD_SPAWN"
+  export MOCK_CLD_SPAWN
+
+  # run-spawn-controller.sh wrapper (CLD_SPAWN_OVERRIDE inject)
+  # NOTE: 非クォート heredoc を使用。$MOCK_CLD_SPAWN/$SPAWN_CONTROLLER は parent shell で展開
+  cat > "$SANDBOX/run-spawn-controller.sh" <<WRAPPER
+#!/usr/bin/env bash
+set -euo pipefail
+exec env CLD_SPAWN_OVERRIDE="$MOCK_CLD_SPAWN" bash "$SPAWN_CONTROLLER" "\$@"
+WRAPPER
+  chmod +x "$SANDBOX/run-spawn-controller.sh"
+
+  # tmux stub
+  cat > "$STUB_BIN/tmux" <<'STUB'
+#!/usr/bin/env bash
+case "$1" in
+  display-message) echo "test-session"; exit 0 ;;
+  list-panes) echo "12345"; exit 0 ;;
+  show-options) echo "0"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUB_BIN/tmux"
+
+  # autopilot-launch.sh stub（S5: co-autopilot --with-chain bypass で必要）
+  AUTOPILOT_LAUNCH_LOG="$SANDBOX/autopilot-launch.log"
+  cat > "$STUB_BIN/autopilot-launch.sh" <<STUB
+#!/usr/bin/env bash
+echo "\$@" >> "${AUTOPILOT_LAUNCH_LOG}"
+exit 0
+STUB
+  chmod +x "$STUB_BIN/autopilot-launch.sh"
+  export AUTOPILOT_LAUNCH_SH="$STUB_BIN/autopilot-launch.sh"
+  export AUTOPILOT_LAUNCH_LOG
+}
+
+teardown() {
+  common_teardown
+}
+
+# ---------------------------------------------------------------------------
+# S1: SKIP_PARALLEL_REASON にタブが含まれる場合 → intervention-log にタブが含まれないこと
+# RED: 現在 L249-250 は \n/\r のみ置換。タブ (\t) は _sanitize_skip_reason() に移動後に除去される
+# ---------------------------------------------------------------------------
+
+@test "S1: tab in SKIP_PARALLEL_REASON is replaced in intervention-log" {
+  local log_dir log_dir_rel
+  log_dir_rel="_log_s1_$$"
+  log_dir="$SANDBOX/$log_dir_rel"
+  mkdir -p "$log_dir"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  pushd "$SANDBOX" >/dev/null
+  SUPERVISOR_DIR="$log_dir_rel" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON=$'reason\twith\ttab' \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" --window-name "test-window"
+  assert_success
+
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  # タブ文字 (0x09) が含まれていないこと
+  if grep -Pq '\t' "$log_file" 2>/dev/null; then
+    fail "intervention-log にタブ文字が含まれている (S1 FAIL: _sanitize_skip_reason 未実装)"
+  fi
+
+  rm -rf "$log_dir"
+}
+
+# ---------------------------------------------------------------------------
+# S2: SKIP_PARALLEL_REASON に ESC 文字が含まれる場合 → intervention-log に ESC が含まれないこと
+# RED: 現在 ESC (0x1b) は置換されない → log に ESC が残る → FAIL
+# ---------------------------------------------------------------------------
+
+@test "S2: ESC char in SKIP_PARALLEL_REASON is replaced in intervention-log" {
+  local log_dir log_dir_rel
+  log_dir_rel="_log_s2_$$"
+  log_dir="$SANDBOX/$log_dir_rel"
+  mkdir -p "$log_dir"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+  > "$CLD_SPAWN_ARGS_LOG"
+
+  pushd "$SANDBOX" >/dev/null
+  SUPERVISOR_DIR="$log_dir_rel" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON=$'reason\x1b[31mred\x1b[0m' \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-explore "$prompt_file" --window-name "test-window"
+  assert_success
+
+  local log_file="$log_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  # ESC 文字 (0x1b) が含まれていないこと
+  if grep -Pq '\x1b' "$log_file" 2>/dev/null; then
+    fail "intervention-log に ESC 文字 (0x1b) が含まれている (S2 FAIL: _sanitize_skip_reason 未実装)"
+  fi
+
+  rm -rf "$log_dir"
+}
+
+# ---------------------------------------------------------------------------
+# S3: SKIP_LAYER2_REASON にタブ/改行/CR が含まれる場合 → log に 1 行で append (タブなし)
+# RED: 現在 SKIP_LAYER2 ブロックは \n/\r のみ置換し、タブは残る + echo 使用 → FAIL
+# ---------------------------------------------------------------------------
+
+@test "S3: tab+newline+CR in SKIP_LAYER2_REASON → single line append without tab in log" {
+  local sup_dir_rel sup_dir
+  sup_dir_rel="_sup_s3_$$"
+  sup_dir="$SANDBOX/$sup_dir_rel"
+  mkdir -p "$sup_dir"
+
+  # feature-dev はプロンプトファイル不要、ISSUE_NUMBER を直接渡す
+  # --cd $SANDBOX で worktree auto-create をスキップ
+  # SUPERVISOR_DIR は相対パスで指定（validate_supervisor_dir が絶対パスを拒否するため）
+  cd "$SANDBOX"
+  SUPERVISOR_DIR="$sup_dir_rel" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="bats test" \
+  SKIP_LAYER2=1 \
+  SKIP_LAYER2_REASON=$'tab\there\nnewline\rcr' \
+  CLD_SPAWN_OVERRIDE="$MOCK_CLD_SPAWN" \
+  run bash "$SPAWN_CONTROLLER" feature-dev 1660 --cd "$SANDBOX"
+  assert_success
+
+  local log_file="$sup_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file (S3 FAIL: SKIP_LAYER2 ブロック未修正)"
+
+  # SKIP_LAYER2 を含む行数が 1 であること
+  local matching_lines
+  matching_lines="$(grep -c "SKIP_LAYER2" "$log_file" 2>/dev/null || echo "0")"
+  [[ "$matching_lines" -eq 1 ]] \
+    || fail "SKIP_LAYER2 を含む行が $matching_lines 行（期待: 1 行）。ログ内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  # タブ文字が含まれていないこと
+  if grep -Pq '\t' "$log_file" 2>/dev/null; then
+    fail "intervention-log にタブ文字が含まれている (S3 FAIL: タブ置換未実装)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# S4: SKIP_LAYER2_REASON に BEL/BS 制御文字が含まれる場合 → 制御文字なしで append
+# RED: 現在 BEL (0x07)/BS (0x08) は置換されない → FAIL
+# ---------------------------------------------------------------------------
+
+@test "S4: BEL+BS in SKIP_LAYER2_REASON are stripped in intervention-log" {
+  local sup_dir_rel sup_dir
+  sup_dir_rel="_sup_s4_$$"
+  sup_dir="$SANDBOX/$sup_dir_rel"
+  mkdir -p "$sup_dir"
+
+  # SUPERVISOR_DIR は相対パスで指定（validate_supervisor_dir が絶対パスを拒否するため）
+  cd "$SANDBOX"
+  SUPERVISOR_DIR="$sup_dir_rel" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="bats test" \
+  SKIP_LAYER2=1 \
+  SKIP_LAYER2_REASON=$'\x07bell\x08bs' \
+  CLD_SPAWN_OVERRIDE="$MOCK_CLD_SPAWN" \
+  run bash "$SPAWN_CONTROLLER" feature-dev 1660 --cd "$SANDBOX"
+  assert_success
+
+  local log_file="$sup_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file (S4 FAIL: SKIP_LAYER2 ブロック未修正)"
+
+  # BEL (0x07) が含まれていないこと
+  if grep -Pq '\x07' "$log_file" 2>/dev/null; then
+    fail "intervention-log に BEL 文字 (0x07) が含まれている (S4 FAIL: _sanitize_skip_reason 未実装)"
+  fi
+
+  # BS (0x08) が含まれていないこと
+  if grep -Pq '\x08' "$log_file" 2>/dev/null; then
+    fail "intervention-log に BS 文字 (0x08) が含まれている (S4 FAIL: _sanitize_skip_reason 未実装)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# S5: SKIP_PILOT_REASON に改行/タブ/CR が含まれる場合 → 1行・タブ/制御文字なしで append (回帰テスト)
+# GREEN: 現在 L516 で ${_skip_pilot_reason//[^[:print:]]/ } 置換済み → PASS
+# ---------------------------------------------------------------------------
+
+@test "S5: multiline+tab+CR in SKIP_PILOT_REASON → sanitized in intervention-log (regression)" {
+  local sup_dir
+  sup_dir="$SANDBOX/.supervisor"
+  mkdir -p "$sup_dir"
+
+  local prompt_file
+  prompt_file="$SANDBOX/prompt.txt"
+  echo "test prompt" > "$prompt_file"
+
+  pushd "$SANDBOX" >/dev/null
+  SUPERVISOR_DIR=".supervisor" \
+  SKIP_PARALLEL_CHECK=1 \
+  SKIP_PARALLEL_REASON="bats test" \
+  SKIP_PILOT_GATE=1 \
+  SKIP_PILOT_REASON=$'multi\nline\twith\rcontrol' \
+  run bash "$SANDBOX/run-spawn-controller.sh" co-autopilot "$prompt_file" \
+    --with-chain --issue 1660
+  assert_success
+
+  local log_file="$sup_dir/intervention-log.md"
+  [[ -f "$log_file" ]] \
+    || fail "intervention-log.md が作成されていない: $log_file"
+
+  # SKIP_PILOT_GATE を含む行数が 1 であること（改行が除去されていること）
+  local matching_lines
+  matching_lines="$(grep -c "SKIP_PILOT_GATE" "$log_file" 2>/dev/null || echo "0")"
+  [[ "$matching_lines" -eq 1 ]] \
+    || fail "SKIP_PILOT_GATE を含む行が $matching_lines 行（期待: 1 行）。ログ内容: $(cat "$log_file" 2>/dev/null || echo '(empty)')"
+
+  # タブ文字が含まれていないこと
+  if grep -Pq '\t' "$log_file" 2>/dev/null; then
+    fail "intervention-log にタブ文字が含まれている"
+  fi
+
+  # 制御文字 (0x00-0x1f) が含まれていないこと（改行は除く: grep -P で確認）
+  if LC_ALL=C grep -Pq '[\x00-\x08\x0b-\x0c\x0e-\x1f\x7f]' "$log_file" 2>/dev/null; then
+    fail "intervention-log に制御文字が含まれている"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# S6: _sanitize_skip_reason "" → 空文字を返す (引数なし時の安全動作)
+# RED: _sanitize_skip_reason 関数が未定義 → FAIL
+# ---------------------------------------------------------------------------
+
+@test "S6: _sanitize_skip_reason empty string returns empty" {
+  # spawn-controller.sh にはソースガードがないため直接 source できない。
+  # awk で関数定義のみを取り出し eval する。
+  local fn_def
+  fn_def=$(awk '/_sanitize_skip_reason\(\)/{found=1} found{print; if(/^\}/){exit}}' "$SPAWN_CONTROLLER" 2>/dev/null || echo "")
+
+  if [[ -z "$fn_def" ]]; then
+    fail "_sanitize_skip_reason() not found in spawn-controller.sh (AC1 not yet implemented)"
+  fi
+
+  eval "$fn_def"
+
+  local result
+  result="$(_sanitize_skip_reason "" 2>/dev/null || echo "FUNCTION_ERROR")"
+  [[ -z "$result" ]] || fail "Expected empty string, got: '$result'"
+}


### PR DESCRIPTION
## 概要

`spawn-controller.sh` 内の SKIP_*_REASON 環境変数サニタイズを `[^[:print:]]` 統一実装に統一。

共通ヘルパー関数 `_sanitize_skip_reason()` を追加し、DRY 化と制御文字全般（タブ・ESC・BEL 等）の除去を実現。

## 変更内容

- **AC1**: `_sanitize_skip_reason()` ヘルパー関数を追加（ASCII-only 前提、printf '%s' 出力）
- **AC2**: SKIP_PARALLEL_CHECK=1 ブロック — `\n`/`\r` 限定置換 → `_sanitize_skip_reason` に統一
- **AC3**: SKIP_LAYER2=1 ブロック — `\n`/`\r` 限定置換 + `echo` → `_sanitize_skip_reason` + `printf` + fail-open パターンに統一
- **AC4**: SKIP_PILOT_REASON gate — `${var//[^[:print:]]/ }` 直接置換 → `_sanitize_skip_reason` DRY 化
- **AC5**: `spawn-controller-skip-reason-sanitize.bats` 追加（S1-S6: tab/ESC/BEL/BS/multiline 各ケース）
- **AC6**: 既存テスト回帰なし（C4/C5 は pre-existing failures、本 Issue スコープ外）
- **AC7**: `bash -n` syntax clean

## テスト結果

- `spawn-controller-skip-reason-sanitize.bats`: 6/6 PASS (S1-S6)
- `spawn-controller-pilot-gate.bats`: 7/7 PASS
- `spawn-controller-skip-parallel-log.bats`: C1-C3, C6 PASS（C4/C5 は pre-existing failures）
- `bash -n spawn-controller.sh`: syntax clean

Closes #1660