### PR TITLE
fix(observer-parallel-check): OBSERVER_PARALLEL_CHECK_STATES の :- を - に変更 (#1662)

### DIFF
--- a/plugins/twl/scripts/lib/observer-parallel-check.sh
+++ b/plugins/twl/scripts/lib/observer-parallel-check.sh
@@ -314,7 +314,7 @@ _check_parallel_spawn_eligibility() {
   # 整数バリデーション: 非数値は 0 として扱う（bash 算術展開の暗黙 0 変換を明示化）
   [[ "$controller_count" =~ ^[0-9]+$ ]] || controller_count=0
   local monitor_cld_alive="${OBSERVER_PARALLEL_CHECK_MONITOR_CLD:-$(check_monitor_cld_observe_alive)}"
-  local controller_states="${OBSERVER_PARALLEL_CHECK_STATES:-$(get_controller_states "$snapshot_ts")}"
+  local controller_states="${OBSERVER_PARALLEL_CHECK_STATES-$(get_controller_states "$snapshot_ts")}"
   local budget_min="${OBSERVER_PARALLEL_CHECK_BUDGET_MIN:-$(get_budget_minutes_remaining)}"
   local budget_threshold="${OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD:-$(get_parallel_spawn_min_remaining_minutes)}"
 

--- a/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
+++ b/plugins/twl/tests/bats/scripts/su-observer-parallel-check.bats
@@ -1356,3 +1356,134 @@ MOCK_LIB
   echo "$output" | grep -qE '≤10|10.*整合|SU-4.*10|12.*>[[:space:]]*10' \
     || fail "AC7 実証: exit 2 だがエラー文言に新閾値 '10' が含まれていない（AC3 文言更新未実装）"
 }
+
+# ===========================================================================
+# Issue #1662: OBSERVER_PARALLEL_CHECK_STATES :- → - tech-debt fix
+# ===========================================================================
+# 背景: :- は unset と空文字列の両方でフォールバックするため、
+#        OBSERVER_PARALLEL_CHECK_STATES='' での空文字列 override が機能しない。
+#        - に変更することで空文字列 override が正しく機能するようになる。
+#
+# ${VAR:-default} → unset または空文字列 → default を使用
+# ${VAR-default}  → unset のみ           → default を使用（空文字列は preserved）
+# ===========================================================================
+
+# ---------------------------------------------------------------------------
+# AC1 #1662: L317 の OBSERVER_PARALLEL_CHECK_STATES は :- でなく - を使う
+# WHEN: observer-parallel-check.sh L317 の controller_states 代入を確認する
+# THEN: ${OBSERVER_PARALLEL_CHECK_STATES-$(get_controller_states ...)} 形式
+# RED: 修正前は :- が残存しているため fail する
+# ---------------------------------------------------------------------------
+
+@test "AC1 #1662: L317 の OBSERVER_PARALLEL_CHECK_STATES は :- でなく - を使う（空文字列 override を機能させるため）" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  # ${OBSERVER_PARALLEL_CHECK_STATES-$(get_controller_states ...)} 形式が存在すること
+  # RED: 現在 L317 に :- が残存しているため fail する
+  grep -qE '\$\{OBSERVER_PARALLEL_CHECK_STATES-\$\(' "$PARALLEL_CHECK_LIB" \
+    || fail "L317 に :- が残存（または - 形式未適用）— OBSERVER_PARALLEL_CHECK_STATES='' override が機能しない（AC1 #1662 未実装）"
+}
+
+# ---------------------------------------------------------------------------
+# AC5 #1662: Case A (unset): OBSERVER_PARALLEL_CHECK_STATES unset → get_controller_states が呼ばれる
+# WHEN: OBSERVER_PARALLEL_CHECK_STATES を unset して _check_parallel_spawn_eligibility を呼ぶ
+# THEN: get_controller_states が呼ばれ、MOCK_CALL_LOG にエントリが書き込まれる
+# NOTE: :- でも - でも unset の場合は同じ（フォールバック発動）
+# ---------------------------------------------------------------------------
+
+@test "AC5 #1662: Case A (unset): OBSERVER_PARALLEL_CHECK_STATES unset → get_controller_states が呼ばれる" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  local mock_log="$BATS_TEST_TMPDIR/mock-call-1662-a.log"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    get_controller_states() {
+      echo 'called' >> '$mock_log'
+      echo 'S-2'
+    }
+    unset OBSERVER_PARALLEL_CHECK_STATES
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  [[ -f "$mock_log" ]] \
+    || fail "OBSERVER_PARALLEL_CHECK_STATES unset の場合 get_controller_states が呼ばれるべきだが MOCK_CALL_LOG が存在しない（AC5 #1662）"
+}
+
+# ---------------------------------------------------------------------------
+# AC6 #1662: Case B (空文字列 override): OBSERVER_PARALLEL_CHECK_STATES='' → get_controller_states が呼ばれない
+# WHEN: OBSERVER_PARALLEL_CHECK_STATES='' を設定して _check_parallel_spawn_eligibility を呼ぶ
+# THEN: get_controller_states が呼ばれず、MOCK_CALL_LOG が空のまま
+# RED: 現在 :- を使っているため空文字列でもフォールバックし get_controller_states が呼ばれる
+# ---------------------------------------------------------------------------
+
+@test "AC6 #1662: Case B (空文字列 override): OBSERVER_PARALLEL_CHECK_STATES='' → get_controller_states が呼ばれない" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  local mock_log="$BATS_TEST_TMPDIR/mock-call-1662-b.log"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    get_controller_states() {
+      echo 'called' >> '$mock_log'
+      echo 'S-2'
+    }
+    OBSERVER_PARALLEL_CHECK_STATES='' \
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  # RED: 現在 :- を使っているため get_controller_states が呼ばれ MOCK_CALL_LOG が作成される
+  [[ ! -f "$mock_log" ]] \
+    || fail "OBSERVER_PARALLEL_CHECK_STATES='' override 時に get_controller_states が呼ばれた（:- tech-debt: 空文字列でもフォールバック発動）— AC6 #1662 未実装（- への変更が必要）"
+}
+
+# ---------------------------------------------------------------------------
+# AC7 #1662: Case C (値あり override): OBSERVER_PARALLEL_CHECK_STATES='S-3' → get_controller_states が呼ばれない
+# WHEN: OBSERVER_PARALLEL_CHECK_STATES='S-3' を設定して _check_parallel_spawn_eligibility を呼ぶ
+# THEN: get_controller_states が呼ばれず、controller_states='S-3' のまま
+# NOTE: :- でも - でも値あり（非空）の場合は同じ（フォールバック不発動）
+# ---------------------------------------------------------------------------
+
+@test "AC7 #1662: Case C (値あり override): OBSERVER_PARALLEL_CHECK_STATES='S-3' → get_controller_states が呼ばれない" {
+  [[ -f "$PARALLEL_CHECK_LIB" ]] \
+    || fail "observer-parallel-check.sh が存在しない: $PARALLEL_CHECK_LIB"
+
+  local mock_log="$BATS_TEST_TMPDIR/mock-call-1662-c.log"
+
+  run bash -c "
+    source '$PARALLEL_CHECK_LIB'
+    get_controller_states() {
+      echo 'called' >> '$mock_log'
+      echo 'S-2'
+    }
+    OBSERVER_PARALLEL_CHECK_STATES='S-3' \
+    OBSERVER_PARALLEL_CHECK_SNAPSHOT_TS=1000000 \
+    OBSERVER_PARALLEL_CHECK_HEARTBEAT_ALIVE=true \
+    OBSERVER_PARALLEL_CHECK_MODE=auto \
+    OBSERVER_PARALLEL_CHECK_CONTROLLER_COUNT=1 \
+    OBSERVER_PARALLEL_CHECK_MONITOR_CLD=true \
+    OBSERVER_PARALLEL_CHECK_BUDGET_MIN=200 \
+    OBSERVER_PARALLEL_CHECK_BUDGET_THRESHOLD=150 \
+    _check_parallel_spawn_eligibility
+  " 2>&1
+
+  [[ ! -f "$mock_log" ]] \
+    || fail "OBSERVER_PARALLEL_CHECK_STATES='S-3' 値あり override 時に get_controller_states が呼ばれた（値あり時はフォールバックしてはならない）— AC7 #1662"
+}


### PR DESCRIPTION
## 概要

Issue #1662 の fix。

`observer-parallel-check.sh` L317 の `${OBSERVER_PARALLEL_CHECK_STATES:-$(get_controller_states "$snapshot_ts")}` を
`${OBSERVER_PARALLEL_CHECK_STATES-$(get_controller_states "$snapshot_ts")}` に変更。

## 変更内容

- `:-` は unset と空文字列の両方でフォールバックするため、`OBSERVER_PARALLEL_CHECK_STATES=''` での空文字列 override が機能しなかった
- `-` に変更することで unset のみフォールバック、空文字列は preserved

## テスト追加

`su-observer-parallel-check.bats` に #1662 テスト4件追加:
- AC1: L317 に `-` 形式が適用されていることを構文チェック（RED → GREEN）
- AC5: Case A (unset) → get_controller_states が呼ばれる（既存挙動確認）
- AC6: Case B (空文字列) → get_controller_states が呼ばれない（RED → GREEN）
- AC7: Case C (値あり) → get_controller_states が呼ばれない（既存挙動確認）

## 影響テスト

- `bats tests/bats/scripts/su-observer-parallel-check.bats`: 61/61 PASS
- `bats tests/bats/scripts/issue-1651-initial-spawn.bats`: PASS
- `bats tests/bats/observer/spawn-controller-monitor-reset.bats`: PASS

Closes #1662