### PR TITLE
fix(chain-runner): IS_AUTOPILOT=true main ブランチ動作防止 cwd-guard 追加 (#1684)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1079,6 +1079,53 @@ issue_1602:
       impl_files:
         - ".github/workflows/mcp-restart-smoke.yml"
 
+# --- Issue #1684 ---
+issue_1684:
+  issue: 1684
+  framework: bats
+  test_file: "plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "IS_AUTOPILOT=true 時の worktree-create skip path 安全装置: chain-runner.sh に step_cwd_guard 関数が定義されている"
+      test_names:
+        - "ac1: chain-runner.sh に step_cwd_guard 関数が定義されている"
+        - "ac1: chain-runner.sh に cwd-guard ディスパッチが存在する"
+      status: RED
+      red_mechanism: "step_cwd_guard 関数が未実装のため grep が失敗する"
+      impl_files:
+        - "plugins/twl/scripts/chain-runner.sh"
+    - ac_index: 2
+      ac_text: "Worker の runtime cwd guard: main ブランチで exit 2 abort"
+      test_names:
+        - "ac2: cwd-guard step — main ブランチで exit 2 (abort)"
+        - "ac2: cwd-guard step — feature ブランチで success (exit 0)"
+        - "ac2: cwd-guard step — master ブランチでも exit 2 (abort)"
+      status: RED
+      red_mechanism: "step_cwd_guard 未実装のため chain-runner.sh cwd-guard が exit 1 (未知のステップ)"
+      impl_files:
+        - "plugins/twl/scripts/chain-runner.sh"
+    - ac_index: 3
+      ac_text: "bats regression: IS_AUTOPILOT=true + worktree 存在 = success (既存OK) / main ブランチ = abort (新規guard)"
+      test_names:
+        - "ac3: worktree-create — IS_AUTOPILOT=true + feature worktree で success"
+        - "ac3: cwd-guard — IS_AUTOPILOT=true + main ブランチで abort (exit 2)"
+      status: MIXED
+      note: |
+        GREEN: worktree-create は IS_AUTOPILOT=true + feature branch で skip → success (既存動作)
+        RED: cwd-guard step が未実装のため main ブランチ abort テストが fail
+      impl_files:
+        - "plugins/twl/scripts/chain-runner.sh"
+    - ac_index: 4
+      ac_text: "window naming guard: autopilot-launch.sh で main branch LAUNCH_DIR を error 化"
+      test_names:
+        - "ac4: autopilot-launch.sh に main ブランチ LAUNCH_DIR バリデーションが存在する"
+        - "ac4: autopilot-launch.sh の main fallback path が error 化されている"
+        - "ac4: autopilot-launch.sh に window name main ブロックガードが存在する"
+      status: RED
+      red_mechanism: "autopilot-launch.sh が main/ fallback を警告なしで許可しているため grep が失敗"
+      impl_files:
+        - "plugins/twl/scripts/autopilot-launch.sh"
+
 # --- Issue #1651 ---
 issue_1651:
   issue: 1651

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1090,8 +1090,7 @@ issue_1684:
       test_names:
         - "ac1: chain-runner.sh に step_cwd_guard 関数が定義されている"
         - "ac1: chain-runner.sh に cwd-guard ディスパッチが存在する"
-      status: RED
-      red_mechanism: "step_cwd_guard 関数が未実装のため grep が失敗する"
+      status: GREEN
       impl_files:
         - "plugins/twl/scripts/chain-runner.sh"
     - ac_index: 2
@@ -1100,8 +1099,8 @@ issue_1684:
         - "ac2: cwd-guard step — main ブランチで exit 2 (abort)"
         - "ac2: cwd-guard step — feature ブランチで success (exit 0)"
         - "ac2: cwd-guard step — master ブランチでも exit 2 (abort)"
-      status: RED
-      red_mechanism: "step_cwd_guard 未実装のため chain-runner.sh cwd-guard が exit 1 (未知のステップ)"
+        - "ac2: cwd-guard step — detached HEAD (空文字列) でも exit 2 (fail-closed)"
+      status: GREEN
       impl_files:
         - "plugins/twl/scripts/chain-runner.sh"
     - ac_index: 3
@@ -1109,10 +1108,7 @@ issue_1684:
       test_names:
         - "ac3: worktree-create — IS_AUTOPILOT=true + feature worktree で success"
         - "ac3: cwd-guard — IS_AUTOPILOT=true + main ブランチで abort (exit 2)"
-      status: MIXED
-      note: |
-        GREEN: worktree-create は IS_AUTOPILOT=true + feature branch で skip → success (既存動作)
-        RED: cwd-guard step が未実装のため main ブランチ abort テストが fail
+      status: GREEN
       impl_files:
         - "plugins/twl/scripts/chain-runner.sh"
     - ac_index: 4
@@ -1121,8 +1117,7 @@ issue_1684:
         - "ac4: autopilot-launch.sh に main ブランチ LAUNCH_DIR バリデーションが存在する"
         - "ac4: autopilot-launch.sh の main fallback path が error 化されている"
         - "ac4: autopilot-launch.sh に window name main ブロックガードが存在する"
-      status: RED
-      red_mechanism: "autopilot-launch.sh が main/ fallback を警告なしで許可しているため grep が失敗"
+      status: GREEN
       impl_files:
         - "plugins/twl/scripts/autopilot-launch.sh"
 

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -352,13 +352,13 @@ fi
 if [[ -n "$WORKTREE_DIR" ]]; then
   LAUNCH_DIR="$WORKTREE_DIR"
 elif [[ -d "$EFFECTIVE_PROJECT_DIR/.bare" ]]; then
-  # ERROR(#1684/invariant K/L): bare repo で worktree 作成失敗時に main/ で起動するのは危険。
-  # _launch_dir_main_guard: Worker が main ブランチで動作し invariant K/L (main 直接 push 禁止) を
-  # bypass するリスクを防ぐため、worktree 不在なら fail-closed する。
+  # ERROR(#1684/invariant B + ADR-008): bare repo で worktree 作成失敗時に main/ で起動するのは危険。
+  # _launch_dir_main_guard: Worker が main ブランチで動作するリスクを防ぐため、worktree 不在なら fail-closed。
+  # 根拠: 不変条件 B (Worktree ライフサイクル Pilot 専任) + ADR-008 (worktree lifecycle Pilot ownership)。
   echo "ERROR: Worktree creation failed for Issue #${ISSUE} and bare repo was detected." >&2
-  echo "       Refusing to launch Worker on main/ (LAUNCH_DIR main guard — invariant K/L)." >&2
+  echo "       Refusing to launch Worker on main/ (LAUNCH_DIR main guard — invariant B + ADR-008)." >&2
   echo "       Fix worktree creation or specify --worktree-dir explicitly." >&2
-  record_failure "main_launch_guard: worktree creation failed, refusing main fallback (#1684/invariant K/L)" "launch_worker"
+  record_failure "main_launch_guard: worktree creation failed, refusing main fallback (#1684/invariant B+ADR-008)" "launch_worker"
   exit 1
 else
   LAUNCH_DIR="$EFFECTIVE_PROJECT_DIR"

--- a/plugins/twl/scripts/autopilot-launch.sh
+++ b/plugins/twl/scripts/autopilot-launch.sh
@@ -352,8 +352,14 @@ fi
 if [[ -n "$WORKTREE_DIR" ]]; then
   LAUNCH_DIR="$WORKTREE_DIR"
 elif [[ -d "$EFFECTIVE_PROJECT_DIR/.bare" ]]; then
-  # fallback: bare repo で worktree 作成失敗時は main/ で起動
-  LAUNCH_DIR="$EFFECTIVE_PROJECT_DIR/main"
+  # ERROR(#1684/invariant K/L): bare repo で worktree 作成失敗時に main/ で起動するのは危険。
+  # _launch_dir_main_guard: Worker が main ブランチで動作し invariant K/L (main 直接 push 禁止) を
+  # bypass するリスクを防ぐため、worktree 不在なら fail-closed する。
+  echo "ERROR: Worktree creation failed for Issue #${ISSUE} and bare repo was detected." >&2
+  echo "       Refusing to launch Worker on main/ (LAUNCH_DIR main guard — invariant K/L)." >&2
+  echo "       Fix worktree creation or specify --worktree-dir explicitly." >&2
+  record_failure "main_launch_guard: worktree creation failed, refusing main fallback (#1684/invariant K/L)" "launch_worker"
+  exit 1
 else
   LAUNCH_DIR="$EFFECTIVE_PROJECT_DIR"
 fi

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -364,20 +364,26 @@ step_worktree_create() {
   ok "worktree-create" "完了"
 }
 
-# --- cwd-guard: Worker が main ブランチで動作していないことを確認 (Issue #1684 / invariant K/L) ---
+# --- cwd-guard: Worker が main ブランチで動作していないことを確認 (Issue #1684 / invariant B + ADR-008) ---
 # IS_AUTOPILOT=true + orchestrator early-exit で Worker が main worktree に留まるリスクへの安全装置。
+# 根拠: 不変条件 B (Worktree ライフサイクル Pilot 専任) + ADR-008 (worktree lifecycle Pilot ownership)。
 # test-scaffold など source-touching step の直前に呼ぶことで fail-closed を実現する。
 step_cwd_guard() {
   record_current_step "cwd-guard"
   local branch
-  branch="$(git branch --show-current 2>/dev/null || echo "main")"
+  # git branch --show-current は detached HEAD 時に空文字列を返す (exit 0)。
+  # 空文字列も fail-closed として扱う（ADR-008: 不明ブランチでの source 変更リスク回避）。
+  branch="$(git branch --show-current 2>/dev/null)"
+  if [[ -z "$branch" ]]; then
+    branch="main"
+  fi
   if [[ "$branch" == "main" || "$branch" == "master" ]]; then
-    echo "ERROR: Worker is running on main branch (invariant K/L violation)." >&2
+    echo "ERROR: Worker is running on main branch (invariant B + ADR-008 violation)." >&2
     echo "       IS_AUTOPILOT=true + orchestrator early-exit may have caused this." >&2
     echo "       Aborting to prevent source code contamination of main worktree." >&2
     exit 2
   fi
-  ok "cwd-guard" "branch=$branch (not main — invariant K/L satisfied)"
+  ok "cwd-guard" "branch=$branch (not main — invariant B + ADR-008 satisfied)"
 }
 
 # --- _transition_parent_epic_if_refined: 親 Epic auto-transition (Issue #1026 ADR-024 AC1+AC2) ---

--- a/plugins/twl/scripts/chain-runner.sh
+++ b/plugins/twl/scripts/chain-runner.sh
@@ -364,6 +364,22 @@ step_worktree_create() {
   ok "worktree-create" "完了"
 }
 
+# --- cwd-guard: Worker が main ブランチで動作していないことを確認 (Issue #1684 / invariant K/L) ---
+# IS_AUTOPILOT=true + orchestrator early-exit で Worker が main worktree に留まるリスクへの安全装置。
+# test-scaffold など source-touching step の直前に呼ぶことで fail-closed を実現する。
+step_cwd_guard() {
+  record_current_step "cwd-guard"
+  local branch
+  branch="$(git branch --show-current 2>/dev/null || echo "main")"
+  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+    echo "ERROR: Worker is running on main branch (invariant K/L violation)." >&2
+    echo "       IS_AUTOPILOT=true + orchestrator early-exit may have caused this." >&2
+    echo "       Aborting to prevent source code contamination of main worktree." >&2
+    exit 2
+  fi
+  ok "cwd-guard" "branch=$branch (not main — invariant K/L satisfied)"
+}
+
 # --- _transition_parent_epic_if_refined: 親 Epic auto-transition (Issue #1026 ADR-024 AC1+AC2) ---
 # 子 Issue が "In Progress" に遷移した時、親 Epic が "Refined" なら "In Progress" に遷移する。
 # Idempotent: 親 Epic が既に "In Progress" / "Done" / 他の場合は no-op。
@@ -1842,6 +1858,7 @@ main() {
   case "$step" in
     init)                step_init "$@" ;;
     worktree-create)     step_worktree_create "$@" ;;
+    cwd-guard)           step_cwd_guard "$@" ;;
     board-status-update) step_board_status_update "$@" ;;
     project-board-status-update) step_board_status_update "$@" ;;
     board-archive)       step_board_archive "$@" ;;

--- a/plugins/twl/skills/workflow-test-ready/SKILL.md
+++ b/plugins/twl/skills/workflow-test-ready/SKILL.md
@@ -45,6 +45,16 @@ CONTEXT_FILE="${AUTOPILOT_DIR}/issues/issue-${ISSUE_NUM}-context.md"
 [[ -n "$ISSUE_NUM" && -f "$CONTEXT_FILE" ]] && echo "=== 前 workflow コンテキスト ===" && cat "$CONTEXT_FILE"
 ```
 
+### Step 0.5: cwd-guard（main ブランチ動作防止、Issue #1684 / invariant B + ADR-008）
+
+```bash
+bash "$CR" cwd-guard
+```
+
+main/master ブランチで動作している場合は exit 2 で abort（IS_AUTOPILOT=true + orchestrator early-exit 対策）。
+source-touching step (test-scaffold) の直前に呼ぶことで fail-closed を実現する。
+失敗（exit 2）は即座に停止し、Pilot に報告すること。
+
 ### Step 1: test-scaffold（AC-based）
 
 `bash "$CR" llm-delegate "test-scaffold" "$ISSUE_NUM"` を実行し、`commands/test-scaffold.md` を Read → 実行。

--- a/plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats
+++ b/plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats
@@ -1,0 +1,225 @@
+#!/usr/bin/env bats
+# issue-1684-autopilot-main-guard.bats
+#
+# Issue #1684: IS_AUTOPILOT=true worktree skip + orchestrator early-exit で
+# Worker が main 直接動作する (P0 invariant K/L risk)
+#
+# AC1: IS_AUTOPILOT=true 時の worktree-create skip path 安全装置
+# AC2: Worker の runtime cwd guard（main worktree なら abort）
+# AC3: bats test (regression)
+#   - IS_AUTOPILOT=true + worktree 存在 = success
+#   - IS_AUTOPILOT=true + worktree 不在 = abort (新規 guard)
+#   - Worker cwd=main = abort (新規 guard)
+# AC4: window naming guard (autopilot-launch.sh で main branch 選択を error 化)
+
+load 'helpers/common'
+
+SCRIPTS_DIR=""
+CHAIN_RUNNER=""
+AUTOPILOT_LAUNCH=""
+
+setup() {
+  common_setup
+  local bats_dir
+  bats_dir="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+  local tests_dir
+  tests_dir="$(cd "${bats_dir}/.." && pwd)"
+  local plugin_root_dir
+  plugin_root_dir="$(cd "${tests_dir}/.." && pwd)"
+  SCRIPTS_DIR="${plugin_root_dir}/scripts"
+  CHAIN_RUNNER="${SCRIPTS_DIR}/chain-runner.sh"
+  AUTOPILOT_LAUNCH="${SCRIPTS_DIR}/autopilot-launch.sh"
+}
+
+teardown() {
+  common_teardown
+}
+
+# ===========================================================================
+# AC1/AC2: step_cwd_guard 関数が chain-runner.sh に存在する（static）
+#
+# RED: 現在 chain-runner.sh に step_cwd_guard 関数が存在しない
+# GREEN: step_cwd_guard 実装後に PASS
+# ===========================================================================
+
+@test "ac1: chain-runner.sh に step_cwd_guard 関数が定義されている" {
+  # AC: step_cwd_guard 関数が chain-runner.sh に存在する
+  # RED: 現在は未実装
+  run grep -q "step_cwd_guard" "${CHAIN_RUNNER}"
+  assert_success
+}
+
+@test "ac1: chain-runner.sh に cwd-guard ディスパッチが存在する" {
+  # AC: case ブロックに cwd-guard) エントリが存在する
+  # RED: 現在は未実装
+  run grep -q 'cwd-guard)' "${CHAIN_RUNNER}"
+  assert_success
+}
+
+# ===========================================================================
+# AC2: cwd-guard step — main ブランチなら exit 2 で abort（dynamic）
+#
+# RED: chain-runner.sh cwd-guard は現在「未知のステップ」で exit 1
+# GREEN: step_cwd_guard 実装後、main ブランチで exit 2
+# ===========================================================================
+
+@test "ac2: cwd-guard step — main ブランチで exit 2 (abort)" {
+  # git stub: main ブランチを返す
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo "main"
+  exit 0
+fi
+# worktree list --porcelain など他の git コマンドはパススルー
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  # python3 stub: autopilot state は running (IS_AUTOPILOT=true)
+  cat > "$STUB_BIN/python3" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *"autopilot.state"* ]]; then
+  # state read → running
+  echo "running"
+  exit 0
+fi
+exec /usr/bin/python3 "$@"
+STUB
+  chmod +x "$STUB_BIN/python3"
+
+  cd "$SANDBOX"
+  # AUTOPILOT_DIR は common_setup で設定済み
+  run bash "${CHAIN_RUNNER}" cwd-guard
+  # main ブランチで abort → exit 2
+  assert_failure
+  [ "$status" -eq 2 ]
+  echo "$output" | grep -qi "main"
+}
+
+@test "ac2: cwd-guard step — feature ブランチで success (exit 0)" {
+  # git stub: feature ブランチを返す
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo "fix/1684-bugchain"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  cd "$SANDBOX"
+  run bash "${CHAIN_RUNNER}" cwd-guard
+  assert_success
+}
+
+@test "ac2: cwd-guard step — master ブランチでも exit 2 (abort)" {
+  # git stub: master ブランチを返す（legacy repo 対応）
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo "master"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  cd "$SANDBOX"
+  run bash "${CHAIN_RUNNER}" cwd-guard
+  assert_failure
+  [ "$status" -eq 2 ]
+}
+
+# ===========================================================================
+# AC3 regression: IS_AUTOPILOT=true + worktree 存在 = success
+#
+# worktree-create step が IS_AUTOPILOT=true + 非 main ブランチで
+# "既に worktree 内" skip メッセージを出力し exit 0 すること
+# ===========================================================================
+
+@test "ac3: worktree-create — IS_AUTOPILOT=true + feature worktree で success" {
+  # git stub: feature ブランチを返す
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo "fix/1684-test-worktree"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  export IS_AUTOPILOT=true
+  cd "$SANDBOX"
+  run bash "${CHAIN_RUNNER}" worktree-create "#1684"
+  assert_success
+  echo "$output" | grep -qi "スキップ"
+}
+
+# ===========================================================================
+# AC3 regression: IS_AUTOPILOT=true + worktree 不在 (main ブランチ) = abort
+#
+# setup chain が main ブランチで実行された場合、source-touching step の前に
+# cwd-guard が abort すること（新規 guard）
+# ===========================================================================
+
+@test "ac3: cwd-guard — IS_AUTOPILOT=true + main ブランチで abort (exit 2)" {
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo "main"
+  exit 0
+fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  export IS_AUTOPILOT=true
+  cd "$SANDBOX"
+  run bash "${CHAIN_RUNNER}" cwd-guard
+  assert_failure
+  [ "$status" -eq 2 ]
+}
+
+# ===========================================================================
+# AC4: autopilot-launch.sh に main branch LAUNCH_DIR バリデーションが存在する
+#
+# bare repo で worktree 作成失敗時、main/ fallback への分岐を error 化するガードが
+# autopilot-launch.sh に存在すること
+#
+# RED: 現在 autopilot-launch.sh は main/ fallback を警告なしで許可している
+# GREEN: main/ fallback を error 化するガード追加後に PASS
+# ===========================================================================
+
+@test "ac4: autopilot-launch.sh に main ブランチ LAUNCH_DIR バリデーションが存在する" {
+  # AC: autopilot-launch.sh が LAUNCH_DIR=main/ を error として扱うガードを持つ
+  # RED: 現在は fallback として main/ を許可している
+  run grep -qE 'main.*ERROR|ERROR.*main|launch_dir.*main.*abort|main.*invariant' "${AUTOPILOT_LAUNCH}"
+  assert_success
+}
+
+@test "ac4: autopilot-launch.sh の main fallback path が error 化されている" {
+  # AC: "fallback: bare repo で worktree 作成失敗時は main/ で起動" のコメント行が
+  # error 処理に変更されている（または削除されている）
+  # RED: 現在は LAUNCH_DIR="$EFFECTIVE_PROJECT_DIR/main" という fallback が存在する
+  run bash -c "grep -q 'fallback.*bare.*main' '${AUTOPILOT_LAUNCH}' && grep '# fallback.*bare.*main' '${AUTOPILOT_LAUNCH}' | grep -v 'error\|ERROR\|abort\|abort'"
+  # GREEN 後: fallback コメントが error ハンドリングに置き換わっているため、
+  # "fallback" コメントを grep して error/abort パターンが一緒にあること
+  # このテストは「fallback が警告なし」の場合に FAIL する設計
+  assert_failure
+}
+
+# ===========================================================================
+# AC4: window naming guard (static) — autopilot-launch.sh に
+# window name に "main" が含まれるケースを block するコードが存在する
+# ===========================================================================
+
+@test "ac4: autopilot-launch.sh に window name main ブロックガードが存在する" {
+  # AC: LAUNCH_DIR が main/ を指す場合に abort するガードが存在する
+  # guard パターン: LAUNCH_DIR ends in /main かつ exit or error を含む行
+  # RED: 現在はガードなし（fallback として main/ を許可）
+  run grep -qE 'LAUNCH_DIR.*main.*exit [12]|main.*\bLAUNCH_DIR\b.*invariant|_launch_dir_main_guard|main_launch_guard' "${AUTOPILOT_LAUNCH}"
+  assert_success
+}

--- a/plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats
+++ b/plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats
@@ -132,6 +132,25 @@ STUB
   [ "$status" -eq 2 ]
 }
 
+@test "ac2: cwd-guard step — detached HEAD (空文字列) でも exit 2 (fail-closed)" {
+  # detached HEAD: git branch --show-current は空文字列を返す (exit 0)
+  # fail-closed 設計: 空文字列も main と同等に扱い abort する (ADR-008)
+  cat > "$STUB_BIN/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == "branch --show-current" ]]; then
+  echo ""
+  exit 0
+fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$STUB_BIN/git"
+
+  cd "$SANDBOX"
+  run bash "${CHAIN_RUNNER}" cwd-guard
+  assert_failure
+  [ "$status" -eq 2 ]
+}
+
 # ===========================================================================
 # AC3 regression: IS_AUTOPILOT=true + worktree 存在 = success
 #


### PR DESCRIPTION
## 概要

Issue #1684 の修正。IS_AUTOPILOT=true + orchestrator early-exit (#1674) の組み合わせで Worker が main worktree 直接動作するリスクへの安全装置を追加。

## 変更内容

### chain-runner.sh: step_cwd_guard() 追加 (AC1/AC2)
- `cwd-guard` ステップ追加：main/master ブランチで exit 2 abort
- IS_AUTOPILOT=true かつ worktree 未作成（main ブランチ）でチェーン継続をブロック
- test-scaffold 等の source-touching step 直前に呼ぶことで fail-closed を実現

### autopilot-launch.sh: main/ fallback を fail-closed に変更 (AC4)
- bare repo で worktree 作成失敗時の `LAUNCH_DIR=main/` fallback を削除
- `_launch_dir_main_guard`: worktree 不在なら exit 1 で Worker 起動を拒否
- invariant K/L (main 直接 push 禁止) の構造的補強

## テスト

`plugins/twl/tests/bats/issue-1684-autopilot-main-guard.bats` 10件追加（全 GREEN）
- AC1: step_cwd_guard 関数・dispatch 存在確認
- AC2: main/master ブランチで exit 2、feature ブランチで success
- AC3: regression テスト
- AC4: autopilot-launch.sh guard 存在確認

## 関連

- Closes #1684
- 関連: #1674 (orchestrator early-exit)