### PR TITLE
fix(session-comm): SESSION_COMM_SCRIPT_DIR が SCRIPT_DIR を上書きするバグを修正

### DIFF
--- a/plugins/session/scripts/session-comm.sh
+++ b/plugins/session/scripts/session-comm.sh
@@ -12,11 +12,15 @@
 # =============================================================================
 set -euo pipefail
 
-# テスト時のみ SESSION_COMM_SCRIPT_DIR を許可（_TEST_MODE ガード必須）
-# Issue #1048: 信頼境界として「実在ディレクトリ」かつ「session-state.sh を含む」
-# ことを追加検証し、攻撃者による任意パス上書きを拒否する
+# SCRIPT_DIR は常に実スクリプトディレクトリを指す（バックエンド読み込みに使用）
+# _state_script_dir はテスト時に SESSION_COMM_SCRIPT_DIR で session-state.sh のみを差し替える
+# Issue #1048: SESSION_COMM_SCRIPT_DIR は信頼境界として「実在ディレクトリ」かつ
+# 「session-state.sh を含む」ことを検証し、攻撃者による任意パス上書きを拒否する
 # M2 (#1048 follow-up): realpath で symlink を解決して実 path に固定し、
 # check と use の間に symlink 差し替えされる TOCTOU race window を縮小する
+# Fix #1679: SCRIPT_DIR を上書きしないことで session-comm-backend-tmux.sh の
+# source に失敗するバグを修正（SESSION_COMM_SCRIPT_DIR は state script 専用）
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -n "${_TEST_MODE:-}" ]] && [[ -n "${SESSION_COMM_SCRIPT_DIR:-}" ]] \
     && [[ -d "$SESSION_COMM_SCRIPT_DIR" ]] \
     && [[ -f "$SESSION_COMM_SCRIPT_DIR/session-state.sh" ]]; then
@@ -31,13 +35,13 @@ if [[ -n "${_TEST_MODE:-}" ]] && [[ -n "${SESSION_COMM_SCRIPT_DIR:-}" ]] \
       _resolved_state=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$SESSION_COMM_SCRIPT_DIR/session-state.sh" 2>/dev/null || true)
     fi
     if [[ -n "$_resolved_state" && -f "$_resolved_state" ]]; then
-      SCRIPT_DIR=$(dirname "$_resolved_state")
+      _state_script_dir=$(dirname "$_resolved_state")
     else
-      SCRIPT_DIR="$SESSION_COMM_SCRIPT_DIR"
+      _state_script_dir="$SESSION_COMM_SCRIPT_DIR"
     fi
     unset _resolved_state
 else
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    _state_script_dir="$SCRIPT_DIR"
 fi
 MAX_INJECT_LEN=4096
 DEFAULT_CAPTURE_LINES=50
@@ -271,7 +275,7 @@ cmd_inject() {
     local retry_count=0
     local state
     while true; do
-        if ! state=$("$SCRIPT_DIR/session-state.sh" state "$window_name" 2>/dev/null); then
+        if ! state=$("${_state_script_dir}/session-state.sh" state "$window_name" 2>/dev/null); then
             echo "Warning: session-state.sh failed for '$window_name'" >&2
             state="unknown"
         fi
@@ -402,13 +406,13 @@ cmd_inject_file() {
 
     # 状態チェック: --wait 指定時は input-waiting までアクティブ待機
     if [[ "$wait_timeout" -gt 0 ]]; then
-        if ! "$SCRIPT_DIR/session-state.sh" wait "$window_name" input-waiting --timeout "$wait_timeout"; then
+        if ! "${_state_script_dir}/session-state.sh" wait "$window_name" input-waiting --timeout "$wait_timeout"; then
             echo "Error: target '$window_name' did not reach input-waiting within ${wait_timeout}s" >&2
             exit 2
         fi
     else
         local state
-        if ! state=$("$SCRIPT_DIR/session-state.sh" state "$window_name" 2>/dev/null); then
+        if ! state=$("${_state_script_dir}/session-state.sh" state "$window_name" 2>/dev/null); then
             echo "Warning: session-state.sh failed for '$window_name'" >&2
             state="unknown"
         fi
@@ -517,7 +521,7 @@ cmd_wait_ready() {
         usage
     fi
 
-    exec "$SCRIPT_DIR/session-state.sh" wait "$window_name" input-waiting --timeout "$timeout"
+    exec "${_state_script_dir}/session-state.sh" wait "$window_name" input-waiting --timeout "$timeout"
 }
 
 # =============================================================================


### PR DESCRIPTION
## 概要

Fixes #1679

テスト時に `SESSION_COMM_SCRIPT_DIR` で `SCRIPT_DIR` を上書きすることで `session-comm-backend-tmux.sh` の source に失敗し、`/tmp`・未設定・XDG_RUNTIME_DIR 配下パスで inject が exit 1 となる regression を修正。

## 変更内容

- `SCRIPT_DIR` は常に実スクリプトディレクトリを指すよう変更
- `_state_script_dir` を導入し、`session-state.sh` のモック差し替えを分離
- 全 `session-state.sh` 呼び出しを `${_state_script_dir}/session-state.sh` に更新

## テスト結果

```
bats plugins/session/tests/session-comm-lock-dir-allowlist.bats
1..8
ok 1-5 (既存 PASS 維持)
ok 6 lock-dir-allowlist[regression]: /tmp は allowlist 内で正常動作する
ok 7 lock-dir-allowlist[regression]: SESSION_COMM_LOCK_DIR 未設定時は /tmp フォールバックで正常動作する
ok 8 lock-dir-allowlist[functional][RED]: XDG_RUNTIME_DIR 配下のパスは allowlist 内として許可される
```

8/8 PASS（test 303/304/305 GREEN）

## 親 Epic

Sub-A of #1678