### PR TITLE
fix(session): --supervisor-dir パストラバーサル防御を追加 (#1680)

### DIFF
--- a/plugins/session/scripts/cld-observe-any-launcher
+++ b/plugins/session/scripts/cld-observe-any-launcher
@@ -22,6 +22,9 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CLD_OBSERVE_BIN="${SCRIPT_DIR}/cld-observe-any"
 
+# shellcheck source=lib/path-validate.sh
+source "${SCRIPT_DIR}/lib/path-validate.sh"
+
 LOCK_FILE="${CLD_OBSERVE_ANY_LOCK:-/tmp/cld-observe-any.lock}"
 LOG_FILE="${CLD_OBSERVE_ANY_LOG:-/tmp/cld-observe-any.log}"
 EVENT_DIR="${CLD_OBSERVE_ANY_EVENT_DIR:-}"
@@ -87,6 +90,14 @@ update_session_json() {
         fi
     fi
 }
+
+# SUPERVISOR_DIR パストラバーサル防御 (Issue #1165)
+if [[ -n "${SUPERVISOR_DIR:-}" ]]; then
+    if ! validate_supervisor_dir "$SUPERVISOR_DIR"; then
+        echo "[cld-observe-any-launcher] Error: invalid --supervisor-dir: ${SUPERVISOR_DIR}" >&2
+        exit 2
+    fi
+fi
 
 # テスト用シミュレーションモード
 if $SIMULATE_DAEMON_DEATH; then

--- a/plugins/session/scripts/cld-observe-any-launcher
+++ b/plugins/session/scripts/cld-observe-any-launcher
@@ -93,10 +93,12 @@ update_session_json() {
 
 # SUPERVISOR_DIR パストラバーサル防御 (Issue #1165 AC5)
 if [[ -n "${SUPERVISOR_DIR:-}" ]]; then
+    _raw_supervisor_dir="${SUPERVISOR_DIR}"
     if ! SUPERVISOR_DIR=$(validate_supervisor_dir "$SUPERVISOR_DIR"); then
-        echo "[cld-observe-any-launcher] Error: invalid --supervisor-dir: ${SUPERVISOR_DIR}" >&2
+        echo "[cld-observe-any-launcher] Error: invalid --supervisor-dir: ${_raw_supervisor_dir}" >&2
         exit 2
     fi
+    unset _raw_supervisor_dir
 fi
 
 # テスト用シミュレーションモード

--- a/plugins/session/scripts/cld-observe-any-launcher
+++ b/plugins/session/scripts/cld-observe-any-launcher
@@ -91,9 +91,9 @@ update_session_json() {
     fi
 }
 
-# SUPERVISOR_DIR パストラバーサル防御 (Issue #1165)
+# SUPERVISOR_DIR パストラバーサル防御 (Issue #1165 AC5)
 if [[ -n "${SUPERVISOR_DIR:-}" ]]; then
-    if ! validate_supervisor_dir "$SUPERVISOR_DIR"; then
+    if ! SUPERVISOR_DIR=$(validate_supervisor_dir "$SUPERVISOR_DIR"); then
         echo "[cld-observe-any-launcher] Error: invalid --supervisor-dir: ${SUPERVISOR_DIR}" >&2
         exit 2
     fi

--- a/plugins/session/scripts/lib/path-validate.sh
+++ b/plugins/session/scripts/lib/path-validate.sh
@@ -2,7 +2,8 @@
 # path-validate.sh — SUPERVISOR_DIR パストラバーサル防御 (Issue #1165)
 #
 # Usage: source path-validate.sh && validate_supervisor_dir <path>
-# Returns 0 if path is acceptable, 2 if rejected
+# On success: prints canonical path to stdout, returns 0
+# On failure: returns 2
 
 validate_supervisor_dir() {
     local raw_path="$1"
@@ -17,12 +18,15 @@ validate_supervisor_dir() {
         return 2
     fi
 
-    # 正規化（シンボリックリンク解決 + --canonicalize-missing で存在不要）
+    # 正規化（シンボリックリンク解決 + canonicalize-missing で存在不要）
+    # python3 fallback; 両方不在の場合は reject (Issue #1165 AC2)
     local canonical_path
     if command -v realpath >/dev/null 2>&1; then
         canonical_path=$(realpath -m "$raw_path" 2>/dev/null) || return 2
+    elif command -v python3 >/dev/null 2>&1; then
+        canonical_path=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$raw_path" 2>/dev/null) || return 2
     else
-        canonical_path="$raw_path"
+        return 2
     fi
 
     # whitelist: HOME / PWD / TMPDIR 配下のみ許可
@@ -30,9 +34,15 @@ validate_supervisor_dir() {
     local pwd_dir="${PWD:-}"
     local tmp_dir="${TMPDIR:-/tmp}"
 
-    [[ -n "$home_dir" && "$canonical_path" == "$home_dir/"* ]] && return 0
-    [[ -n "$pwd_dir" && "$canonical_path" == "$pwd_dir/"* ]] && return 0
-    [[ "$canonical_path" == "$tmp_dir/"* ]] && return 0
+    local accepted=false
+    [[ -n "$home_dir" && "$canonical_path" == "$home_dir/"* ]] && accepted=true
+    [[ -n "$pwd_dir" && "$canonical_path" == "$pwd_dir/"* ]] && accepted=true
+    [[ "$canonical_path" == "$tmp_dir/"* ]] && accepted=true
+
+    if $accepted; then
+        echo "$canonical_path"
+        return 0
+    fi
 
     return 2
 }

--- a/plugins/session/scripts/lib/path-validate.sh
+++ b/plugins/session/scripts/lib/path-validate.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# path-validate.sh — SUPERVISOR_DIR パストラバーサル防御 (Issue #1165)
+#
+# Usage: source path-validate.sh && validate_supervisor_dir <path>
+# Returns 0 if path is acceptable, 2 if rejected
+
+validate_supervisor_dir() {
+    local raw_path="$1"
+
+    # 空文字チェック
+    if [[ -z "$raw_path" ]]; then
+        return 2
+    fi
+
+    # .. セグメント含有チェック（raw 入力で拒否）
+    if [[ "$raw_path" == *".."* ]]; then
+        return 2
+    fi
+
+    # 正規化（シンボリックリンク解決 + --canonicalize-missing で存在不要）
+    local canonical_path
+    if command -v realpath >/dev/null 2>&1; then
+        canonical_path=$(realpath -m "$raw_path" 2>/dev/null) || return 2
+    else
+        canonical_path="$raw_path"
+    fi
+
+    # whitelist: HOME / PWD / TMPDIR 配下のみ許可
+    local home_dir="${HOME:-}"
+    local pwd_dir="${PWD:-}"
+    local tmp_dir="${TMPDIR:-/tmp}"
+
+    [[ -n "$home_dir" && "$canonical_path" == "$home_dir/"* ]] && return 0
+    [[ -n "$pwd_dir" && "$canonical_path" == "$pwd_dir/"* ]] && return 0
+    [[ "$canonical_path" == "$tmp_dir/"* ]] && return 0
+
+    return 2
+}


### PR DESCRIPTION
## 概要

Issue #1680 の失敗テスト (test 318) を修正。

## 変更内容

- `plugins/session/scripts/lib/path-validate.sh` を新規作成
  - `validate_supervisor_dir()` 実装
  - whitelist (HOME/PWD/TMPDIR) 外のパス、`..` セグメント、symlink エスケープを exit 2 で拒否
- `plugins/session/scripts/cld-observe-any-launcher` を修正
  - `path-validate.sh` を source し `--supervisor-dir` 引数を起動前にバリデーション

## テスト結果

- `plugins/session/tests/path-validate.bats`: 9/9 PASS
- `plugins/session/tests/bats/scripts/cld-observe-any-self-supervision.bats`: 12/12 PASS

Closes #1680

Co-Authored-By: Claude <noreply@anthropic.com>