### PR TITLE
fix(size-guard): prompt 行数 WARN の threshold regression を修正 (closes #1683)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1275,3 +1275,32 @@ issue_1566:
       note: "fix は commit 8e4c81bb (#1504) で適用済み。session-comm.sh line 437 に trap HUP + delete-buffer が実装済み"
       impl_files:
         - "plugins/session/scripts/session-comm.sh"
+# --- Issue #1683 ---
+issue_1683:
+  issue: 1683
+  framework: bats
+  test_file: "plugins/twl/tests/bats/scripts/spawn-controller-prompt-size.bats"
+  mappings:
+    - ac_index: 1
+      ac_text: "30 行以下の prompt は WARN なし"
+      test_name: "size-guard: 30 行以下の prompt は stderr に WARN が出力されない"
+      status: RED
+      red_mechanism: "EFFECTIVE_LIMIT = 30 - PROVENANCE_LINES(5) = 25 のため 30 > 25 → WARN 発火する（regression）"
+      impl_files:
+        - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+
+    - ac_index: 2
+      ac_text: "29 行 (threshold-1) で WARN なし"
+      test_name: "size-guard: 29 行（threshold-1）の prompt は WARN が出力されない"
+      status: RED
+      red_mechanism: "EFFECTIVE_LIMIT = 25 のため 29 > 25 → WARN 発火する（regression）"
+      impl_files:
+        - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"
+
+    - ac_index: 3
+      ac_text: "31 行で WARN に行数が含まれる"
+      test_name: "size-guard: 31 行の WARN に行数が含まれる"
+      status: RED
+      red_mechanism: "WARN メッセージが 'exceeds recommended 25 lines (30 - 5 provenance lines)' になり 'exceeds recommended 30' を含まない"
+      impl_files:
+        - "plugins/twl/skills/su-observer/scripts/spawn-controller.sh"

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -659,15 +659,14 @@ PROMPT_BODY="$(cat "$PROMPT_FILE")"
 
 # size guard: §10 spawn prompt 最小化原則（MUST NOT）
 PROMPT_LINE_COUNT=$(printf '%s\n' "$PROMPT_BODY" | wc -l)
-EFFECTIVE_LIMIT=$((30 - PROVENANCE_LINES))
 FORCE_LARGE=false
 for arg in "$@"; do
   [[ "$arg" == "--force-large" ]] && FORCE_LARGE=true
 done
 
-if [[ "$FORCE_LARGE" == "false" && $PROMPT_LINE_COUNT -gt $EFFECTIVE_LIMIT ]]; then
+if [[ "$FORCE_LARGE" == "false" && $PROMPT_LINE_COUNT -gt 30 ]]; then
   cat >&2 <<WARN
-WARN: prompt size ${PROMPT_LINE_COUNT} lines exceeds recommended ${EFFECTIVE_LIMIT} lines (30 - ${PROVENANCE_LINES} provenance lines).
+WARN: prompt size ${PROMPT_LINE_COUNT} lines exceeds recommended 30 lines.
 §10 spawn prompt 最小化原則: skill 自律取得可能な情報を prompt に転記しないこと。
 詳細: plugins/twl/skills/su-observer/refs/pitfalls-catalog.md §10
 suppress する場合: --force-large + prompt 冒頭に REASON: 行

--- a/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
+++ b/plugins/twl/skills/su-observer/scripts/spawn-controller.sh
@@ -649,7 +649,7 @@ done
 
 # NOTE: _get_host_alias / _emit_provenance_section は冒頭（Issue #1644 で feature-dev path 用に移動）で定義済み
 
-# provenance section を先に取得し、サイズガードの実効上限（EFFECTIVE_LIMIT）を調整
+# provenance section を先に取得し、PROVENANCE_LINES を logging する（AC8）
 PROVENANCE="$(_emit_provenance_section)"
 PROVENANCE_LINES=$(printf '%s\n' "$PROVENANCE" | wc -l)
 echo "[spawn-controller] PROVENANCE_LINES=${PROVENANCE_LINES}" >&2


### PR DESCRIPTION
## 概要

size-guard の prompt 行数 WARN が regression していた問題を修正。

## 変更内容

- `EFFECTIVE_LIMIT = 30 - PROVENANCE_LINES` ロジックを廃止
- size guard の threshold を 30 行に固定（` -gt 30`）
- WARN メッセージを `exceeds recommended 30 lines` に統一

## 原因

#1305 (PR: feat(#1274): provenance section 追加) で `EFFECTIVE_LIMIT = 30 - PROVENANCE_LINES` が導入され、PROVENANCE_LINES=5 時に effective threshold が 25 になった。これにより 30 行以下の prompt でも WARN が発火する regression が発生。

## テスト

- `spawn-controller-prompt-size.bats` 全 20 件 PASS（修正前: 3 件失敗）
- test 1483: 30 行以下は WARN なし ✓
- test 1485: 29 行（threshold-1）は WARN なし ✓  
- test 1487: 31 行の WARN に行数と 'exceeds recommended 30' が含まれる ✓

closes #1683