### PR TITLE
fix(session-comm): SIGHUP exit 129 テスト GREEN 確認・コメント更新 (#1682)

### DIFF
--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1211,3 +1211,17 @@ issue_1566:
       note: "SKILL.md: +1, -0 (条件達成)。bats テストと ac-test-mapping.yaml は TDD ワークフロー標準産物"
       impl_files:
         - "plugins/twl/skills/co-issue/SKILL.md"
+
+# Issue #1682
+- issue: 1682
+  title: "bug(session-comm): #1420 trap 実装で SIGHUP exit 129 RED test 失敗"
+  framework: bats
+  mappings:
+    - ac_index: 1
+      ac_text: "SIGHUP 受信時に tmux buffer cleanup + exit 129 実装"
+      test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+      test_name: "ac3[functional][RED]: SIGHUP 送信時に終了コード 129 (128+1) で終了する"
+      status: GREEN
+      note: "fix は commit 8e4c81bb (#1504) で適用済み。session-comm.sh line 437 に trap HUP が実装済み"
+      impl_files:
+        - "plugins/session/scripts/session-comm.sh"

--- a/ac-test-mapping.yaml
+++ b/ac-test-mapping.yaml
@@ -1218,10 +1218,18 @@ issue_1566:
   framework: bats
   mappings:
     - ac_index: 1
-      ac_text: "SIGHUP 受信時に tmux buffer cleanup + exit 129 実装"
+      ac_text: "SIGHUP 受信時に exit 129 実装"
       test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
-      test_name: "ac3[functional][RED]: SIGHUP 送信時に終了コード 129 (128+1) で終了する"
+      test_name: "ac3[functional]: SIGHUP 送信時に終了コード 129 (128+1) で終了する [ISSUE-1682-FIXED]"
       status: GREEN
       note: "fix は commit 8e4c81bb (#1504) で適用済み。session-comm.sh line 437 に trap HUP が実装済み"
+      impl_files:
+        - "plugins/session/scripts/session-comm.sh"
+    - ac_index: 1
+      ac_text: "SIGHUP 受信時に tmux buffer cleanup 実装"
+      test_file: "plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats"
+      test_name: "ac6[functional]: SIGHUP 受信後に session-comm-* バッファが残留しない [ISSUE-1682-FIXED]"
+      status: GREEN
+      note: "fix は commit 8e4c81bb (#1504) で適用済み。session-comm.sh line 437 に trap HUP + delete-buffer が実装済み"
       impl_files:
         - "plugins/session/scripts/session-comm.sh"

--- a/plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats
+++ b/plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats
@@ -302,13 +302,13 @@ MOCK
 }
 
 # ===========================================================================
-# test 5: ac3[functional][RED] - SIGHUP -> exit 129
-# RED: 現在の実装に trap がないため SIGHUP が正しく処理されない
+# test 5: ac3[functional] - SIGHUP -> exit 129
+# [ISSUE-1682-FIXED]: session-comm.sh に trap HUP が実装済み (#1504)
 # ===========================================================================
 
-@test "ac3[functional][RED]: SIGHUP 送信時に終了コード 129 (128+1) で終了する" {
+@test "ac3[functional]: SIGHUP 送信時に終了コード 129 (128+1) で終了する [ISSUE-1682-FIXED]" {
     # AC3: SIGHUP を受信した cmd_inject_file が exit 129 で終了すること
-    # 現在の実装には trap がないため → FAIL (RED)
+    # [ISSUE-1682-FIXED]: session-comm.sh line 437 に trap HUP 実装済み (#1504)
     _create_mock_tmux_signal_test 3
     _create_mock_session_state_input_waiting
 
@@ -608,13 +608,13 @@ MOCK
 }
 
 # ===========================================================================
-# test 12: ac6[functional][RED] - SIGHUP 受信後バッファ残留なし
-# RED: 現在の実装に trap がないためバッファが残留する
+# test 12: ac6[functional] - SIGHUP 受信後バッファ残留なし
+# [ISSUE-1682-FIXED]: session-comm.sh に trap HUP + delete-buffer が実装済み (#1504)
 # ===========================================================================
 
-@test "ac6[functional][RED]: SIGHUP 受信後に session-comm-* バッファが残留しない" {
+@test "ac6[functional]: SIGHUP 受信後に session-comm-* バッファが残留しない [ISSUE-1682-FIXED]" {
     # AC6: SIGHUP 受信時に trap handler が delete-buffer を呼び、バッファを削除すること
-    # 現在の実装には trap がないため → FAIL (RED)
+    # [ISSUE-1682-FIXED]: session-comm.sh line 437 に trap HUP + delete-buffer 実装済み (#1504)
     _create_mock_tmux_signal_test 3
     _create_mock_session_state_input_waiting
 


### PR DESCRIPTION
## 概要

Issue #1682 (Sub-D of #1678) の対応。

SIGHUP 受信時に `exit 129` で終了するテスト（test 5, test 12）が実装済み fix (#1504) で
GREEN になったことを確認し、テスト名・コメントを更新する。

## 背景

- Issue #1682: test 287 `ac3[functional][RED]: SIGHUP 送信時に終了コード 129` が FAIL
- fix は commit `8e4c81bb` (#1504) で `session-comm.sh L437` に実装済み:
  ```bash
  trap "tmux delete-buffer -b $_buf_name 2>/dev/null || true; exit 129" HUP
  ```
- この PR は stale なテスト名・コメントを GREEN 状態に揃える

## 変更内容

### `plugins/session/tests/test_1420_cmd_inject_file_signal_cleanup.bats`

- test 5: `ac3[functional][RED]` → `ac3[functional] [ISSUE-1682-FIXED]`
- test 12: `ac6[functional][RED]` → `ac6[functional] [ISSUE-1682-FIXED]`
- コメント「現在の実装には trap がない」→「#1504 で実装済み」に修正

### `ac-test-mapping.yaml`

- Issue #1682 の AC1 エントリを追記（status: GREEN）

## テスト結果

```
1..15
ok 1-15 all PASS
```

Closes #1682