### PR TITLE
fix(session): window-manifest セキュリティ修正 (#1681)

### DIFF
--- a/plugins/session/scripts/window-manifest.sh
+++ b/plugins/session/scripts/window-manifest.sh
@@ -10,6 +10,12 @@
 _MANIFEST_SCHEMA_VERSION=1
 WINDOW_MANIFEST_FILE="${WINDOW_MANIFEST_FILE:-$HOME/.local/share/twl/window-manifest.json}"
 
+# Security: WINDOW_MANIFEST_FILE must be under $HOME
+if [[ "$WINDOW_MANIFEST_FILE" != "$HOME/"* ]]; then
+    echo "WINDOW_MANIFEST_FILE must be under \$HOME (got: $WINDOW_MANIFEST_FILE)" >&2
+    exit 1
+fi
+
 # _manifest_atomic_write <json>
 # temp ファイル生成 → rename でアトミック上書きする。
 _manifest_atomic_write() {
@@ -72,6 +78,12 @@ manifest_append_entry() {
     dir="$(dirname "$WINDOW_MANIFEST_FILE")"
     mkdir -p "$dir"
 
+    # Security: reject symlink lockfile
+    if [[ -L "$lockfile" ]]; then
+        echo "lockfile is a symlink: $lockfile" >&2
+        return 1
+    fi
+
     (
         flock -x 9
         local current
@@ -110,6 +122,12 @@ manifest_tombstone_entry() {
     local dir
     dir="$(dirname "$WINDOW_MANIFEST_FILE")"
     mkdir -p "$dir"
+
+    # Security: reject symlink lockfile
+    if [[ -L "$lockfile" ]]; then
+        echo "lockfile is a symlink: $lockfile" >&2
+        return 1
+    fi
 
     (
         flock -x 9

--- a/plugins/session/scripts/window-manifest.sh
+++ b/plugins/session/scripts/window-manifest.sh
@@ -10,15 +10,19 @@
 _MANIFEST_SCHEMA_VERSION=1
 WINDOW_MANIFEST_FILE="${WINDOW_MANIFEST_FILE:-$HOME/.local/share/twl/window-manifest.json}"
 
-# Security: WINDOW_MANIFEST_FILE must be under $HOME
+# Security: WINDOW_MANIFEST_FILE must be under $HOME (path traversal prevention)
 if [[ -z "$HOME" ]]; then
     echo "WINDOW_MANIFEST_FILE must be under \$HOME (HOME is not set)" >&2
     return 1 2>/dev/null || exit 1
 fi
-if [[ "$WINDOW_MANIFEST_FILE" != "$HOME/"* ]]; then
+# Normalize via realpath to prevent $HOME/../../etc/passwd traversal
+_MANIFEST_CANONICAL="$(realpath -m -- "$WINDOW_MANIFEST_FILE" 2>/dev/null || printf '%s' "$WINDOW_MANIFEST_FILE")"
+if [[ "$_MANIFEST_CANONICAL" != "$HOME/"* ]]; then
     echo "WINDOW_MANIFEST_FILE must be under \$HOME (got: $WINDOW_MANIFEST_FILE)" >&2
+    unset _MANIFEST_CANONICAL
     return 1 2>/dev/null || exit 1
 fi
+unset _MANIFEST_CANONICAL
 
 # _manifest_atomic_write <json>
 # temp ファイル生成 → rename でアトミック上書きする。

--- a/plugins/session/scripts/window-manifest.sh
+++ b/plugins/session/scripts/window-manifest.sh
@@ -11,9 +11,13 @@ _MANIFEST_SCHEMA_VERSION=1
 WINDOW_MANIFEST_FILE="${WINDOW_MANIFEST_FILE:-$HOME/.local/share/twl/window-manifest.json}"
 
 # Security: WINDOW_MANIFEST_FILE must be under $HOME
+if [[ -z "$HOME" ]]; then
+    echo "WINDOW_MANIFEST_FILE must be under \$HOME (HOME is not set)" >&2
+    return 1 2>/dev/null || exit 1
+fi
 if [[ "$WINDOW_MANIFEST_FILE" != "$HOME/"* ]]; then
     echo "WINDOW_MANIFEST_FILE must be under \$HOME (got: $WINDOW_MANIFEST_FILE)" >&2
-    exit 1
+    return 1 2>/dev/null || exit 1
 fi
 
 # _manifest_atomic_write <json>

--- a/plugins/session/tests/window-manifest.bats
+++ b/plugins/session/tests/window-manifest.bats
@@ -186,6 +186,7 @@ teardown() {
     # WHEN: WINDOW_MANIFEST_FILE=/tmp/evil.json を設定した状態でスクリプトを source する
     # THEN: stderr に「WINDOW_MANIFEST_FILE must be under $HOME」を含むエラーを出力し、exit ステータス 1 を返す
     run bash -c "
+        set -e
         export HOME='$HOME'
         export WINDOW_MANIFEST_FILE='/tmp/evil.json'
         source '$MANIFEST_LIB'

--- a/plugins/session/tests/window-manifest.bats
+++ b/plugins/session/tests/window-manifest.bats
@@ -7,11 +7,16 @@ MANIFEST_LIB="$SCRIPT_DIR/window-manifest.sh"
 
 setup() {
     SANDBOX="$(mktemp -d)"
-    export WINDOW_MANIFEST_FILE="$SANDBOX/window-manifest.json"
+    # Use $HOME-based path to satisfy WINDOW_MANIFEST_FILE security policy
+    local _manifest_dir="$HOME/.local/share/twl"
+    mkdir -p "$_manifest_dir"
+    export WINDOW_MANIFEST_FILE="$_manifest_dir/window-manifest-test-${BATS_TEST_NUMBER:-0}.json"
 }
 
 teardown() {
     [[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"
+    rm -f "$WINDOW_MANIFEST_FILE" "${WINDOW_MANIFEST_FILE}.lock" 2>/dev/null || true
+    rm -f "${WINDOW_MANIFEST_FILE}".* 2>/dev/null || true
 }
 
 # ---------------------------------------------------------------------------
@@ -53,9 +58,11 @@ teardown() {
         "/home/user/projects/twill" "/home/user/projects/twill" "wt"
 
     # 中間 .XXXXXX 一時ファイルが残っていないことを確認（.lock ファイルは除外）
-    local leftover
-    leftover=$(find "$SANDBOX" -name "window-manifest.json.*" \
-        ! -name "window-manifest.json.lock" 2>/dev/null || true)
+    local manifest_dir manifest_base leftover
+    manifest_dir="$(dirname "$WINDOW_MANIFEST_FILE")"
+    manifest_base="$(basename "$WINDOW_MANIFEST_FILE")"
+    leftover=$(find "$manifest_dir" -name "$manifest_base.*" \
+        ! -name "$manifest_base.lock" 2>/dev/null || true)
     [[ -z "$leftover" ]]
 }
 
@@ -192,7 +199,7 @@ teardown() {
     # Scenario: $HOME 配下パス設定時の正常動作
     # WHEN: WINDOW_MANIFEST_FILE=$HOME/.local/share/twl/custom.json を設定した状態でスクリプトを source する
     # THEN: エラーなく正常に source される
-    local custom_path="$SANDBOX/custom.json"
+    local custom_path="$HOME/.local/share/twl/custom-test.json"
     run bash -c "
         export HOME='$HOME'
         export WINDOW_MANIFEST_FILE='$custom_path'

--- a/plugins/session/tests/window-manifest.bats
+++ b/plugins/session/tests/window-manifest.bats
@@ -235,6 +235,7 @@ teardown() {
         echo \"exit:\$?\"
     "
     [[ "$output" == *"lockfile is a symlink"* ]]
+    [[ "$output" == *"exit:1"* ]]
 }
 
 @test "security: manifest_tombstone_entry rejects symlink lockfile" {
@@ -261,4 +262,5 @@ teardown() {
         echo \"exit:\$?\"
     "
     [[ "$output" == *"lockfile is a symlink"* ]]
+    [[ "$output" == *"exit:1"* ]]
 }


### PR DESCRIPTION
## 概要

Issue #1681 の修正。window-manifest.sh の security regression を修復する。

## 変更内容

### window-manifest.sh
- `WINDOW_MANIFEST_FILE` が `$HOME` 外の場合、source 時に `exit 1` でエラー終了（AC1）
- `manifest_append_entry()` で lockfile が symlink の場合は "lockfile is a symlink" エラーを出力して return 1（AC2）
- `manifest_tombstone_entry()` で lockfile が symlink の場合は "lockfile is a symlink" エラーを出力して return 1（AC3）

### window-manifest.bats
- `setup()` を `$HOME` ベースのパスに変更してセキュリティポリシーに準拠（全テストのインフラ修正）
- テスト13 の `custom_path` バグ修正（`$SANDBOX` → `$HOME` 配下）
- テスト3 の find コマンドをパス変更に対応

## テスト結果

全15テスト PASS（修正前: 3失敗 → 修正後: 0失敗）

## 関連 Issue

- Closes #1681
- Sub-C of epic #1678 (bats silent rot audit, Wave U.audit-fix-H)